### PR TITLE
MBWay/Blik allows Await to call onError prop (which receives full res…

### DIFF
--- a/playground/events.js
+++ b/playground/events.js
@@ -2,7 +2,7 @@ import { makePayment, makeDetailsCall } from './services';
 
 export function handleResponse(response, component) {
     const type = component.data.paymentMethod ? component.data.paymentMethod.type : component.constructor.name;
-    console.log(type, response);
+    console.log('type=', type, 'response=', response);
 
     if (response.action) {
         component.handleAction(response.action);

--- a/src/components/Blik/Blik.tsx
+++ b/src/components/Blik/Blik.tsx
@@ -49,7 +49,7 @@ class BlikElement extends UIElement {
                         originKey={this.props.originKey}
                         clientKey={this.props.clientKey}
                         paymentData={this.props.paymentData}
-                        onError={this.onError}
+                        onError={this.props.onError}
                         onComplete={this.onComplete}
                         brandLogo={this.icon}
                         type={config.type}

--- a/src/components/MBWay/MBWay.tsx
+++ b/src/components/MBWay/MBWay.tsx
@@ -52,7 +52,7 @@ export class MBWayElement extends UIElement {
                         originKey={this.props.originKey}
                         clientKey={this.props.clientKey}
                         paymentData={this.props.paymentData}
-                        onError={this.onError}
+                        onError={this.props.onError}
                         onComplete={this.onComplete}
                         brandLogo={this.icon}
                         type={config.type}

--- a/src/components/internal/Await/Await.tsx
+++ b/src/components/internal/Await/Await.tsx
@@ -76,7 +76,15 @@ function Await(props: AwaitComponentProps) {
 
     const onError = (status: StatusObject): StatusObject => {
         setExpired(true);
-        props.onError(status);
+        props.onError(
+            {
+                status,
+                data: {
+                    details: { payload: status.props.payload },
+                    paymentData: props.paymentData
+                }
+            }
+        );
         return status;
     };
 


### PR DESCRIPTION
MBWay/Blik allows Await to call onError prop (which receives full response object - so merchant can make call to /payments/details)

### Description of the Change

The `onError` property the merchant set on the component (MBWay & Blik) was not being correctly passed to the Await component (to be called if the `/status` call returns an error).
Also now, when the `onError`, handler is called it receives an object containing both the response from the `/status` call as well as a full `data` object. The merchant can use the latter to send to `/payments/details` endpoint in order to get a pspreference

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Checkout Component's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use "Not applicable" here.

Examples:

- Molpay Ebanking payment methods added (MY/TH/VN) (COWEB-360)
- OpenBanking UK payment method added (GB) (COWEB-374)
- Secured Fields updated to v2.0.5

-->

### Pull Request checklist

-   [ ] Did you lint your code?
-   [ ] Did you add the necessary tests for your changes?
-   [ ] If relevant, did you update the Docs and create issues for the documentation team?
-   [ ] If relevant, did you add the list of strings to be translated?
