### PR TITLE
Remove invalid configuration on production sass-loader

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -102,8 +102,7 @@ module.exports = merge(webpackConfig, {
                                 options: { config: { path: 'config/' } }
                             },
                             {
-                                loader: 'sass-loader',
-                                options: { modules: true }
+                                loader: 'sass-loader'
                             }
                         ]
                     },


### PR DESCRIPTION
### Description of the Change

This invalid configuration broke the build since updating the sass dependencies. This PR fixes the build by removing the unnecessary options.