### PR TITLE
ClientKey now used for analytics & riskModule

### DIFF
--- a/src/core/RiskModule/components/DeviceFingerprint/DeviceFingerprint.js
+++ b/src/core/RiskModule/components/DeviceFingerprint/DeviceFingerprint.js
@@ -7,7 +7,7 @@ class DeviceFingerprint extends Component {
     constructor(props) {
         super(props);
 
-        const accessKey = props.clientKey ? props.clientKey : props.originKey;
+        const accessKey = props.clientKey || props.originKey;
         if (accessKey) {
             this.state = {
                 status: 'retrievingFingerPrint',

--- a/src/core/Services/collect-id.ts
+++ b/src/core/Services/collect-id.ts
@@ -11,7 +11,7 @@ const collectId = config => {
             'Content-Type': 'application/json'
         }
     };
-    const accessKey = config.clientKey ? config.clientKey : config.originKey;
+    const accessKey = config.clientKey || config.originKey;
     return fetch(`${config.loadingContext}v1/analytics/id?token=${accessKey}`, options)
         .then(response => {
             if (response.ok) return response.json();

--- a/src/core/Services/post-telemetry.ts
+++ b/src/core/Services/post-telemetry.ts
@@ -26,7 +26,7 @@ const logTelemetry = config => event => {
         body: JSON.stringify(telemetryEvent)
     };
 
-    const accessKey = config.clientKey ? config.clientKey : config.originKey;
+    const accessKey = config.clientKey || config.originKey;
     return fetch(`${config.loadingContext}v1/analytics/log?token=${accessKey}`, options)
         .then(response => response.ok)
         .catch(() => {});


### PR DESCRIPTION
 ClientKey now used for analytics & riskModule (now backend support is in place)

### Description of the Change

As of today (28/05/20) Test environment supports using the clientKey in the urls used for analytics and the deviceFingerprinting - so the relevant components now use clientKey if it's available, originKey if not

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Checkout Component's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use "Not applicable" here.

Examples:

- Molpay Ebanking payment methods added (MY/TH/VN) (COWEB-360)
- OpenBanking UK payment method added (GB) (COWEB-374)
- Secured Fields updated to v2.0.5

-->

### Pull Request checklist

-   [ ] Did you lint your code?
-   [ ] Did you add the necessary tests for your changes?
-   [ ] If relevant, did you update the Docs and create issues for the documentation team?
-   [ ] If relevant, did you add the list of strings to be translated?
