### PR TITLE
Prevent generation of comments files on the dist folder

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -161,7 +161,8 @@ module.exports = merge(webpackConfig, {
                 parallel: true,
                 // Enable file caching
                 cache: true,
-                sourceMap: shouldUseSourceMap
+                sourceMap: shouldUseSourceMap,
+                extractComments: false
             })
             // new OptimizeCSSAssetsPlugin()
         ]


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository!  -->

**Description**
After the TerserPlugin update, an extra file with comments was being generated on `build`. This PR disables that file generation.
