### PR TITLE
Fix Card component's data brand property

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -56,7 +56,7 @@ export class CardElement extends UIElement {
      */
     formatData(): CardElementData {
         const cardBrand = this.state.additionalSelectValue || this.props.brand;
-        console.log(cardBrand);
+
         return {
             paymentMethod: {
                 type: CardElement.type,


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository!  -->

**Description**
This fixes an issue where with the addition of `additionalSelectValue`, stored cards stopped propagating their brand back on the output data. 

**Tested scenarios**
- Stored Card payment