### PR TITLE
Move external @types devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
         "lint:fix": "npm run lint -- --fix"
     },
     "devDependencies": {
-        "@types/applepayjs": "^3.0.0",
-        "@types/googlepay": "^0.3.0",
         "@types/jest": "^23.3.5",
         "@typescript-eslint/eslint-plugin": "^2.34.0",
         "@typescript-eslint/parser": "^2.34.0",
@@ -84,6 +82,8 @@
         "whatwg-fetch": "^3.0.0"
     },
     "dependencies": {
+        "@types/applepayjs": "^3.0.0",
+        "@types/googlepay": "^0.3.0",
         "classnames": "^2.2.6",
         "preact": "^10.2.1"
     },


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository!  -->

**Description**
Move external types devDependencies to dependencies so library consumers get them as well.