### PR TITLE
BinLookup response changed: brands renamed to supportedBrands

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -121,7 +121,7 @@ export class CardElement extends UIElement {
                 if (data && data.requestId === this.currentRequestId) {
                     // ...call processBinLookupResponse with the response object
                     // if it contains at least one brand (a failed lookup will just contain requestId)
-                    if (data.brands && data.brands.length) {
+                    if (data.supportedBrands && data.supportedBrands.length) {
                         this.processBinLookupResponse(data);
                     }
                 }

--- a/src/components/Card/components/CardInput/handlers.ts
+++ b/src/components/Card/components/CardInput/handlers.ts
@@ -126,7 +126,7 @@ function handleAdditionalDataSelection(e: Event): void {
 
     // Pass brand into SecuredFields
     if (this.state.additionalSelectType === 'brandSwitcher') {
-        this.sfp.processBinLookupResponse({ brands: [value] });
+        this.sfp.processBinLookupResponse({ supportedBrands: [value] });
     }
 }
 

--- a/src/components/Card/components/CardInput/processBinLookup.js
+++ b/src/components/Card/components/CardInput/processBinLookup.js
@@ -11,24 +11,24 @@ export default function processBinLookupResponse(binValueObject) {
     }
 
     // RESULT: binLookup has found a result so proceed accordingly
-    if (binValueObject.brands && binValueObject.brands.length) {
+    if (binValueObject.supportedBrands && binValueObject.supportedBrands.length) {
         // 1) Multiple options found - add to the UI & inform SFP if appropriate
-        if (binValueObject.brands.length > 1) {
+        if (binValueObject.supportedBrands.length > 1) {
             // --
-            const switchObj = createCardVariantSwitcher(binValueObject.brands, 'brandSwitcher');
+            const switchObj = createCardVariantSwitcher(binValueObject.supportedBrands, 'brandSwitcher');
 
             // Set properties on state to trigger a Select element in the UI
             this.setState(switchObj.stateObject); // Don't need to call validateCardInput - this will be called by the brandChange from SFP
 
             // Pass an object through to SFP
-            this.sfp.processBinLookupResponse({ brands: [switchObj.leadType] });
+            this.sfp.processBinLookupResponse({ supportedBrands: [switchObj.leadType] });
 
             // 2) Single option found (binValueObject.brands.length === 1)
         } else {
             this.resetAdditionalSelectState(); // Reset UI
 
             // Set (single) value from binLookup so it will be added to the 'brand' property in the paymentMethod object
-            this.setState({ additionalSelectValue: binValueObject.brands[0] });
+            this.setState({ additionalSelectValue: binValueObject.supportedBrands[0] });
 
             // Pass object through to SFP
             this.sfp.processBinLookupResponse(binValueObject);

--- a/src/components/internal/SecuredFields/lib/core/utils/handleBrandFromBinLookup.ts
+++ b/src/components/internal/SecuredFields/lib/core/utils/handleBrandFromBinLookup.ts
@@ -23,7 +23,7 @@ export function handleBrandFromBinLookup(brandsObj: BinLookupObject): void {
         return;
     }
 
-    const passedBrand: string = brandsObj.brands[0];
+    const passedBrand: string = brandsObj.supportedBrands[0];
 
     const card: CardObject = cardType.getCardByBrand(passedBrand);
 

--- a/src/components/internal/SecuredFields/lib/types.ts
+++ b/src/components/internal/SecuredFields/lib/types.ts
@@ -229,5 +229,5 @@ export interface ShiftTabObject {
 export interface BinLookupObject {
     issuingCountryCode: string;
     requestId: string;
-    brands?: string[];
+    supportedBrands?: string[];
 }

--- a/src/components/internal/SecuredFields/lib/utilities/cardType.js
+++ b/src/components/internal/SecuredFields/lib/utilities/cardType.js
@@ -7,6 +7,7 @@ CardType.cards = [];
 
 CardType.cards.push({
     cardType: 'mc',
+    displayName: 'Mastercard',
     startingRules: [51, 52, 53, 54, 55, 22, 23, 24, 25, 26, 27],
     permittedLengths: [16],
     pattern: /^(5[1-5][0-9]{0,14}|2[2-7][0-9]{0,14})$/,


### PR DESCRIPTION
**Description**
The response from the `binLookup` backend has changed. The property `brands` has been renamed to `supportedBrands` - so the necessary files have been changed to reflect this

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
