### PR TITLE
MBWay shopper data - expect it to be inputted the same way it is outputted

### DIFF
--- a/src/components/MBWay/MBWay.tsx
+++ b/src/components/MBWay/MBWay.tsx
@@ -10,8 +10,8 @@ export class MBWayElement extends UIElement {
 
     formatProps(props: UIElementProps): UIElementProps {
         if (props.data) {
-            props.data.email = props.data.shopperEmail || '';
-            props.data.phoneNumber = props.data.telephoneNumber || '';
+            props.data.email = props.data.shopperEmail || props.data.email;
+            props.data.phoneNumber = props.data.telephoneNumber || props.data.telephoneNumber;
         }
         return {
             ...props

--- a/src/components/MBWay/MBWay.tsx
+++ b/src/components/MBWay/MBWay.tsx
@@ -9,6 +9,10 @@ export class MBWayElement extends UIElement {
     private static type = 'mbway';
 
     formatProps(props: UIElementProps): UIElementProps {
+        if (props.data) {
+            props.data.email = props.data.shopperEmail || '';
+            props.data.phoneNumber = props.data.telephoneNumber || '';
+        }
         return {
             ...props
         };

--- a/src/components/MBWay/MBWay.tsx
+++ b/src/components/MBWay/MBWay.tsx
@@ -11,7 +11,7 @@ export class MBWayElement extends UIElement {
     formatProps(props: UIElementProps): UIElementProps {
         if (props.data) {
             props.data.email = props.data.shopperEmail || props.data.email;
-            props.data.phoneNumber = props.data.telephoneNumber || props.data.telephoneNumber;
+            props.data.phoneNumber = props.data.telephoneNumber || props.data.phoneNumber;
         }
         return {
             ...props

--- a/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -94,7 +94,7 @@ function MBWayInput(props: UIElementProps) {
                     value: data.email,
                     name: 'shopperEmail',
                     classNameModifiers: ['large'],
-                    placeholder: props.placeholders.email,
+                    placeholder: props.placeholders.shopperEmail,
                     spellcheck: false,
                     required: true,
                     autocorrect: 'off',
@@ -115,7 +115,7 @@ function MBWayInput(props: UIElementProps) {
                 {renderFormField('tel', {
                     value: data.phoneNumber,
                     className: `adyen-checkout__pm__phoneNumber__input ${styles['adyen-checkout__input']}`,
-                    placeholder: props.placeholders.phoneNumber,
+                    placeholder: props.placeholders.telephoneNumber,
                     required: true,
                     autoCorrect: 'off',
                     onInput: handleEventFor('phoneNumber', 'input')
@@ -128,7 +128,7 @@ function MBWayInput(props: UIElementProps) {
 }
 
 MBWayInput.defaultProps = {
-    placeholders: { email: 'shopper@domain.com', phoneNumber: '+351 932 123 456' }
+    placeholders: { shopperEmail: 'shopper@domain.com', telephoneNumber: '+351 932 123 456' }
 };
 
 export default MBWayInput;


### PR DESCRIPTION

**Description**
The shopper data that can be sent into the MBWay component should have the same fields as the data that is returned by the component i.e. `shopperEmail` & `telephoneNumber`.
Currently we are expecting the _internal_ names: `email` & `phoneNumber` from the data object used to configure the component

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
