### PR TITLE
Include storePaymentMethod in data output when unchecked

### DIFF
--- a/src/components/Card/Card.test.ts
+++ b/src/components/Card/Card.test.ts
@@ -15,13 +15,13 @@ describe('Card', () => {
         });
 
         test('should return storePaymentMethod if enableStoreDetails is enabled', () => {
-            const card = new CardElement({ enableStoreDetails: true, i18n: i18nMock, originKey: '' });
+            const card = new CardElement({ enableStoreDetails: true });
             card.setState({ storePaymentMethod: true });
             expect(card.data.storePaymentMethod).toBe(true);
         });
 
         test('should not return storePaymentMethod if enableStoreDetails is disabled', () => {
-            const card = new CardElement({ enableStoreDetails: false, i18n: i18nMock, originKey: '' });
+            const card = new CardElement({ enableStoreDetails: false });
             card.setState({ storePaymentMethod: true });
             expect(card.data.storePaymentMethod).not.toBeDefined();
         });

--- a/src/components/Card/Card.test.ts
+++ b/src/components/Card/Card.test.ts
@@ -13,6 +13,18 @@ describe('Card', () => {
             card.setState({ data: { card: '123' }, isValid: true });
             expect(card.data.paymentMethod.card).toBe('123');
         });
+
+        test('should return storePaymentMethod if enableStoreDetails is enabled', () => {
+            const card = new CardElement({ enableStoreDetails: true, i18n: i18nMock, originKey: '' });
+            card.setState({ storePaymentMethod: true });
+            expect(card.data.storePaymentMethod).toBe(true);
+        });
+
+        test('should not return storePaymentMethod if enableStoreDetails is disabled', () => {
+            const card = new CardElement({ enableStoreDetails: false, i18n: i18nMock, originKey: '' });
+            card.setState({ storePaymentMethod: true });
+            expect(card.data.storePaymentMethod).not.toBeDefined();
+        });
     });
 
     describe('isValid', () => {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -14,7 +14,7 @@ export interface CardElementProps extends UIElementProps {
     groupTypes?: string[];
 
     brands?: string[];
-
+    enableStoreDetails?: boolean;
     hideCVC?: boolean;
     hasHolderName?: boolean;
     holderNameRequired?: boolean;
@@ -56,6 +56,7 @@ export class CardElement extends UIElement {
      */
     formatData(): CardElementData {
         const cardBrand = this.state.additionalSelectValue || this.props.brand;
+        const includeStorePaymentMethod = this.props.enableStoreDetails && typeof this.state.storePaymentMethod !== 'undefined';
 
         return {
             paymentMethod: {
@@ -66,7 +67,7 @@ export class CardElement extends UIElement {
                 ...(this.props.fundingSource && { fundingSource: this.props.fundingSource })
             },
             ...(this.state.billingAddress && { billingAddress: this.state.billingAddress }),
-            ...(this.state.storePaymentMethod && { storePaymentMethod: this.state.storePaymentMethod }),
+            ...(includeStorePaymentMethod && { storePaymentMethod: Boolean(this.state.storePaymentMethod) }),
             ...(this.state.installments && this.state.installments.value && { installments: this.state.installments }),
             browserInfo: this.browserInfo
         };


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository!  -->

**Description**
If the "store payment method" checkbox is present, include the `storePaymentMethod` property in the component output (even if `false`). Only exclude it if the checkbox is not shown.

**Tested scenarios**
- `enableStoreDetails` is on, and checkbox is on
- `enableStoreDetails` is on, and checkbox is off

- `enableStoreDetails` is off, and checkbox is on
- `enableStoreDetails` is off, and checkbox is off

