### PR TITLE
Await comp, by default, calls onAdditionalDetails for error/refused responses

### DIFF
--- a/src/components/internal/Await/Await.tsx
+++ b/src/components/internal/Await/Await.tsx
@@ -76,13 +76,17 @@ function Await(props: AwaitComponentProps) {
 
     const onError = (status: StatusObject): StatusObject => {
         setExpired(true);
-        props.onError({
-            status,
-            data: {
-                details: { payload: status.props.payload },
-                paymentData: props.paymentData
-            }
-        });
+        // Send error response to onAdditionalDetails
+        props.onComplete(
+            {
+                data: {
+                    details: { payload: status.props.payload },
+                    paymentData: props.paymentData
+                }
+            },
+            this
+        );
+
         return status;
     };
 

--- a/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -57,7 +57,7 @@ const actionTypes = {
             ...action,
             ...props,
             onComplete: props.onAdditionalDetails,
-            onError: props.onError,
+            onError: props.onAdditionalDetails,
             statusType: 'custom'
         });
     }

--- a/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -57,7 +57,7 @@ const actionTypes = {
             ...action,
             ...props,
             onComplete: props.onAdditionalDetails,
-            onError: props.onAdditionalDetails,
+            onError: props.onError,
             statusType: 'custom'
         });
     }


### PR DESCRIPTION
**Description**
The Await comp will now always call `onAdditionalDetails` when it receives an `error` (which covers the `error` & `refused` responses from the `/status` endpoint)

**Tested scenarios**
error (refused), success (authorised), timeout error

**Fixed issue**:  <!-- #-prefixed issue number -->
