### PR TITLE
Migrate to Installments component to TypeScript and add tests.

### DIFF
--- a/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
+++ b/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
@@ -1,0 +1,45 @@
+import { h } from 'preact';
+import { mount } from 'enzyme';
+import Installments from './Installments';
+
+const installmentOptions = {
+    card: {
+        values: [1, 2]
+    },
+    mc: {
+        values: [1, 2, 3]
+    },
+    visa: {
+        values: [1, 2, 3, 4]
+    }
+};
+
+describe('Installments', () => {
+    const getWrapper = (props?) => mount(<Installments installmentOptions={installmentOptions} {...props} />);
+
+    test('renders the installment options', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find('Installments')).toHaveLength(1);
+    });
+
+    test('does not render any installment options if the passed amount is 0', () => {
+        const amount = { value: 0, currency: 'EUR' };
+        const wrapper = getWrapper({ amount });
+        expect(wrapper.find('.adyen-checkout__dropdown__element')).toHaveLength(0);
+    });
+
+    test('does not render any installment options by default when no card key is passed', () => {
+        const installmentOptions = {
+            mc: { values: [1, 2, 3] }
+        };
+        const wrapper = getWrapper({ installmentOptions: installmentOptions });
+        expect(wrapper.find('.adyen-checkout__dropdown__element')).toHaveLength(0);
+    });
+
+    test('renders the right amount of installment options', () => {
+        const wrapper = getWrapper();
+        expect(getWrapper().find('.adyen-checkout__dropdown__element')).toHaveLength(2);
+        expect(getWrapper({ brand: 'mc' }).find('.adyen-checkout__dropdown__element')).toHaveLength(3);
+        expect(getWrapper({ brand: 'visa' }).find('.adyen-checkout__dropdown__element')).toHaveLength(4);
+    });
+});

--- a/src/components/Card/components/CardInput/components/Installments/Installments.tsx
+++ b/src/components/Card/components/CardInput/components/Installments/Installments.tsx
@@ -3,26 +3,47 @@ import { useState, useEffect } from 'preact/hooks';
 import { renderFormField } from '~/components/internal/FormFields';
 import Field from '~/components/internal/FormFields/Field';
 import useCoreContext from '~/core/Context/useCoreContext';
+import { PaymentAmount } from '~/types';
+
+interface InstallmentOptionValues {
+    values: number[];
+}
+
+interface InstallmentOptions {
+    [key: string]: InstallmentOptionValues;
+}
+
+interface InstallmentsProps {
+    amount?: PaymentAmount;
+    brand?: string;
+    onChange?: (PaymentAmount) => any;
+    installmentOptions: InstallmentOptions;
+}
+
+interface InstallmentsItem {
+    id: number;
+    name: string;
+}
 
 /**
  * Installments generic dropdown
  */
-function Installments(props) {
+function Installments(props: InstallmentsProps) {
     const { i18n } = useCoreContext();
     const { amount, brand, onChange } = props;
     const [installmentAmount, setInstallmentAmount] = useState(1);
     const installmentOptions = props.installmentOptions[brand] || props.installmentOptions.card;
 
-    const getPartialAmount = divider => i18n.amount(amount.value / divider, amount.currency);
+    const getPartialAmount = (divider: number): string => i18n.amount(amount.value / divider, amount.currency);
 
     const onSelectInstallment = e => {
         const selectedInstallments = e.currentTarget.getAttribute('data-value');
         setInstallmentAmount(Number(selectedInstallments));
     };
 
-    const installmentItemsMapper = value => ({
+    const installmentItemsMapper = (value: number): InstallmentsItem => ({
         id: value,
-        name: amount.value ? `${value}x ${getPartialAmount(value)}` : value
+        name: amount.value ? `${value}x ${getPartialAmount(value)}` : `${value}`
     });
 
     useEffect(() => {
@@ -50,5 +71,11 @@ function Installments(props) {
         </div>
     );
 }
+
+Installments.defaultProps = {
+    brand: '',
+    amount: {},
+    onChange: () => {}
+};
 
 export default Installments;

--- a/src/components/Card/components/CardInput/components/Installments/Installments.tsx
+++ b/src/components/Card/components/CardInput/components/Installments/Installments.tsx
@@ -16,7 +16,7 @@ interface InstallmentOptions {
 interface InstallmentsProps {
     amount?: PaymentAmount;
     brand?: string;
-    onChange?: (PaymentAmount) => any;
+    onChange?: (installmentAmount: number) => void;
     installmentOptions: InstallmentOptions;
 }
 

--- a/src/components/Card/components/CardInput/components/Installments/index.ts
+++ b/src/components/Card/components/CardInput/components/Installments/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Installments';


### PR DESCRIPTION
**Description**
The Installments component was migrated to TypeScript and interfaces as well as unit tests were added.

**Tested scenarios**
- It's rendered.
- It doesn't show any option if the passed amount is set to `0`.
- It doesn't show any option if the default option `card` is not passed.
- It renders the right amount of options for each passed brand.