### PR TITLE
Fix state field validation in the Card component

### DIFF
--- a/src/components/Card/components/CardInput/CardInput.tsx
+++ b/src/components/Card/components/CardInput/CardInput.tsx
@@ -131,7 +131,10 @@ class CardInput extends Component<CardInputProps, CardInputState> {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (prevState.billingAddress && prevState.billingAddress.country !== this.state.billingAddress.country) {
+        const { country: prevCountry, stateOrProvince: prevStateOrProvince } = prevState.billingAddress || {};
+        const { country, stateOrProvince } = this.state.billingAddress || {};
+
+        if (prevCountry !== country || prevStateOrProvince !== stateOrProvince) {
             this.validateCardInput();
         }
     }


### PR DESCRIPTION
## Summary
Countries with state datasets now get correctly validated when the state field value changes.

## Tested scenarios
* Regular card payments.
* Countries with state datasets.
* Countries with no state datasets.
* Countries with state datasets with prefilled country.
* Countries with no state datasets with prefilled country.
