### PR TITLE
Fix Google Pay css selectors to work with all styles

### DIFF
--- a/src/components/GooglePay/components/GooglePayButton.scss
+++ b/src/components/GooglePay/components/GooglePayButton.scss
@@ -1,5 +1,6 @@
-.adyen-checkout__paywithgoogle .gpay-button.long {
-    width: 100%;
+.adyen-checkout__paywithgoogle > div > button,
+.adyen-checkout__paywithgoogle > div > button.long,
+.adyen-checkout__paywithgoogle > div > button.short {
     padding: 15px 24px 13px;
     height: 48px;
     transition: background-color 0.3s ease-out, box-shadow 0.3s ease-out;
@@ -7,4 +8,8 @@
         box-shadow: 0 0 0 2px #99c2ff;
         outline: 0;
     }
+}
+
+.adyen-checkout__paywithgoogle > div > button.long {
+    width: 100%;
 }

--- a/src/components/GooglePay/components/GooglePayButton.scss
+++ b/src/components/GooglePay/components/GooglePayButton.scss
@@ -1,15 +1,18 @@
-.adyen-checkout__paywithgoogle > div > button,
-.adyen-checkout__paywithgoogle > div > button.long,
-.adyen-checkout__paywithgoogle > div > button.short {
-    padding: 15px 24px 13px;
-    height: 48px;
-    transition: background-color 0.3s ease-out, box-shadow 0.3s ease-out;
-    &:focus {
-        box-shadow: 0 0 0 2px #99c2ff;
-        outline: 0;
-    }
-}
+.adyen-checkout__paywithgoogle > div > button {
+    &,
+    &.long,
+    &.short {
+        padding: 15px 24px 13px;
+        height: 48px;
+        transition: background-color 0.3s ease-out, box-shadow 0.3s ease-out;
 
-.adyen-checkout__paywithgoogle > div > button.long {
-    width: 100%;
+        &:focus {
+            box-shadow: 0 0 0 2px #99c2ff;
+            outline: 0;
+        }
+    }
+
+    &.long {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Make the Google Pay styles more generic so they work with dynamic buttons.

