### PR TITLE
Add prop types to Google Pay, add callbackIntents support

### DIFF
--- a/src/components/GooglePay/GooglePay.test.ts
+++ b/src/components/GooglePay/GooglePay.test.ts
@@ -7,4 +7,36 @@ describe('GooglePay', () => {
             expect(gpay.data.paymentMethod.type).toBe('paywithgoogle');
         });
     });
+
+    describe('isAvailable', () => {
+        test('resolves if is available', () => {
+            const gpay = new GooglePay({});
+            gpay.isReadyToPay = jest.fn(() => {
+                return Promise.resolve({ result: true });
+            });
+            gpay.isAvailable().then(result => {
+                expect(result).toBe(true);
+            });
+        });
+
+        test('rejects if is not available', () => {
+            const gpay = new GooglePay({});
+            gpay.isReadyToPay = jest.fn(() => {
+                return Promise.resolve({ result: false });
+            });
+            gpay.isAvailable().then(result => {
+                expect(result).toBe(false);
+            });
+        });
+
+        test('checks paymentMethodPresent if present', () => {
+            const gpay = new GooglePay({});
+            gpay.isReadyToPay = jest.fn(() => {
+                return Promise.resolve({ result: true, paymentMethodPresent: false });
+            });
+            gpay.isAvailable().then(result => {
+                expect(result).toBe(false);
+            });
+        });
+    });
 });

--- a/src/components/GooglePay/GooglePay.tsx
+++ b/src/components/GooglePay/GooglePay.tsx
@@ -84,8 +84,7 @@ class GooglePay extends UIElement<GooglePayProps> {
 
                 return true;
             })
-            .catch((error: Error) => {
-                console.error(error.message);
+            .catch(() => {
                 return false;
             });
     };

--- a/src/components/GooglePay/GooglePay.tsx
+++ b/src/components/GooglePay/GooglePay.tsx
@@ -3,11 +3,12 @@ import UIElement from '../UIElement';
 import GooglePayService from './GooglePayService';
 import GooglePayButton from './components/GooglePayButton';
 import defaultProps from './defaultProps';
+import { GooglePayProps } from './types';
 
-class GooglePay extends UIElement {
+class GooglePay extends UIElement<GooglePayProps> {
     public static type = 'paywithgoogle';
     public static defaultProps = defaultProps;
-    protected googlePay = new GooglePayService(this.props.environment);
+    protected googlePay = new GooglePayService(this.props);
 
     /**
      * Formats the component data input
@@ -96,6 +97,9 @@ class GooglePay extends UIElement {
         return this.googlePay.isReadyToPay(this.props);
     };
 
+    /**
+     * Use this method to prefetch a PaymentDataRequest configuration to improve loadPaymentData execution time on later user interaction. No value is returned.
+     */
     public prefetch = (): void => {
         return this.googlePay.prefetchPaymentData(this.props);
     };

--- a/src/components/GooglePay/GooglePayService.ts
+++ b/src/components/GooglePay/GooglePayService.ts
@@ -4,12 +4,12 @@ import { resolveEnvironment } from './utils';
 class GooglePayService {
     public readonly paymentsClient: google.payments.api.PaymentsClient;
 
-    constructor(environment) {
-        const env = resolveEnvironment(environment);
-        if (env === 'TEST') {
+    constructor(props) {
+        const environment = resolveEnvironment(props.environment);
+        if (environment === 'TEST') {
             console.warn('Google Pay initiated in TEST mode. Request non-chargeable payment methods suitable for testing.');
         }
-        this.paymentsClient = this.getGooglePaymentsClient(env);
+        this.paymentsClient = this.getGooglePaymentsClient({ environment, paymentDataCallbacks: props.paymentDataCallbacks });
     }
 
     /**
@@ -18,9 +18,9 @@ class GooglePayService {
      * @see {@link https://developers.google.com/pay/api/web/reference/client#PaymentsClient|PaymentsClient constructor}
      * @returns Google Pay API client
      */
-    getGooglePaymentsClient(environment): google.payments.api.PaymentsClient {
+    getGooglePaymentsClient(paymentOptions: google.payments.api.PaymentOptions): google.payments.api.PaymentsClient {
         if (window.google && window.google.payments) {
-            return new google.payments.api.PaymentsClient({ environment });
+            return new google.payments.api.PaymentsClient(paymentOptions);
         }
 
         return null;

--- a/src/components/GooglePay/GooglePayService.ts
+++ b/src/components/GooglePay/GooglePayService.ts
@@ -6,7 +6,7 @@ class GooglePayService {
 
     constructor(props) {
         const environment = resolveEnvironment(props.environment);
-        if (environment === 'TEST') {
+        if (environment === 'TEST' && process.env.NODE_ENV === 'development') {
             console.warn('Google Pay initiated in TEST mode. Request non-chargeable payment methods suitable for testing.');
         }
         this.paymentsClient = this.getGooglePaymentsClient({ environment, paymentDataCallbacks: props.paymentDataCallbacks });

--- a/src/components/GooglePay/defaultProps.ts
+++ b/src/components/GooglePay/defaultProps.ts
@@ -6,8 +6,8 @@ export default {
 
     // ButtonOptions
     // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-    buttonColor: 'default', // default/black/white
-    buttonType: 'long', // long/short
+    buttonColor: 'default' as google.payments.api.ButtonColor, // default/black/white
+    buttonType: 'long' as google.payments.api.ButtonType, // long/short
     showPayButton: true, // show or hide the Google Pay button
 
     // PaymentDataRequest
@@ -27,7 +27,7 @@ export default {
     },
 
     countryCode: 'US',
-    totalPriceStatus: 'FINAL',
+    totalPriceStatus: 'FINAL' as google.payments.api.TotalPriceStatus,
 
     // Callbacks
     onError: () => {},
@@ -36,16 +36,16 @@ export default {
 
     // CardParameters
     // https://developers.google.com/pay/api/web/reference/object#CardParameters
-    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
-    allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'],
+    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'] as google.payments.api.CardAuthMethod[],
+    allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'] as google.payments.api.CardNetwork[],
     allowCreditCards: true, // Set to false if you don't support credit cards.
     allowPrepaidCards: true, // Set to false if you don't support prepaid cards.
     billingAddressRequired: false, // A billing address should only be requested if it's required to process the transaction.
-    billingAddressParameters: {}, // The expected fields returned if billingAddressRequired is set to true.
+    billingAddressParameters: undefined, // The expected fields returned if billingAddressRequired is set to true.
 
     emailRequired: false,
     shippingAddressRequired: false,
-    shippingAddressParameters: {}, // https://developers.google.com/pay/api/web/reference/object#ShippingAddressParameters
+    shippingAddressParameters: undefined, // https://developers.google.com/pay/api/web/reference/object#ShippingAddressParameters
     shippingOptionRequired: false,
     shippingOptionParameters: undefined
 };

--- a/src/components/GooglePay/requests.test.ts
+++ b/src/components/GooglePay/requests.test.ts
@@ -4,7 +4,7 @@ import defaultProps from './defaultProps';
 describe('Google Pay Requests', () => {
     describe('getTransactionInfo', () => {
         test('should transform a normal currency amount', () => {
-            const transactionInfo = getTransactionInfo('USD', '1234');
+            const transactionInfo = getTransactionInfo('USD', 1234);
 
             expect(transactionInfo.currencyCode).toBe('USD');
             expect(transactionInfo.totalPrice).toBe('12.34');
@@ -12,7 +12,7 @@ describe('Google Pay Requests', () => {
         });
 
         test('should transform a normal currency with amount ZERO', () => {
-            const transactionInfo = getTransactionInfo('EUR', '0');
+            const transactionInfo = getTransactionInfo('EUR', 0);
 
             expect(transactionInfo.currencyCode).toBe('EUR');
             expect(transactionInfo.totalPrice).toBe('0');
@@ -28,7 +28,7 @@ describe('Google Pay Requests', () => {
         });
 
         test('should transform a non decimal currency amount', () => {
-            const transactionInfo = getTransactionInfo('JPY', '1234');
+            const transactionInfo = getTransactionInfo('JPY', 1234);
 
             expect(transactionInfo.currencyCode).toBe('JPY');
             expect(transactionInfo.totalPrice).toBe('1234');

--- a/src/components/GooglePay/requests.ts
+++ b/src/components/GooglePay/requests.ts
@@ -1,5 +1,6 @@
 import { getDecimalAmount } from '~/utils/amount-util';
 import config from './config';
+import { GooglePayProps } from './types';
 
 /**
  * Configure your site's support for payment methods supported by the Google Pay API.
@@ -40,7 +41,7 @@ export function isReadyToPayRequest({
  */
 export function getTransactionInfo(
     currencyCode = 'USD',
-    totalPrice = '0',
+    totalPrice = 0,
     totalPriceStatus: google.payments.api.TotalPriceStatus = 'FINAL',
     countryCode = 'US'
 ): google.payments.api.TransactionInfo {
@@ -54,7 +55,7 @@ export function getTransactionInfo(
     };
 }
 
-export function initiatePaymentRequest({ configuration, ...props }): google.payments.api.PaymentDataRequest {
+export function initiatePaymentRequest({ configuration, ...props }: GooglePayProps): google.payments.api.PaymentDataRequest {
     return {
         apiVersion: config.API_VERSION,
         apiVersionMinor: config.API_VERSION_MINOR,
@@ -87,6 +88,7 @@ export function initiatePaymentRequest({ configuration, ...props }): google.paym
         shippingAddressRequired: props.shippingAddressRequired,
         shippingAddressParameters: props.shippingAddressParameters,
         shippingOptionRequired: props.shippingOptionRequired,
-        shippingOptionParameters: props.shippingOptionParameters
+        shippingOptionParameters: props.shippingOptionParameters,
+        callbackIntents: props.callbackIntents
     };
 }

--- a/src/components/GooglePay/types.ts
+++ b/src/components/GooglePay/types.ts
@@ -1,0 +1,122 @@
+import { UIElementProps } from '../UIElement';
+
+export interface GooglePayPropsConfiguration {
+    /**
+     * Adyen's merchant account name
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#gateway
+     */
+    gatewayMerchantId: string;
+
+    /**
+     * A Google merchant identifier issued after registration with the {@link https://pay.google.com/business/console | Google Pay Business Console}.
+     * Required when PaymentsClient is initialized with an environment property of PRODUCTION.
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#MerchantInfo
+     */
+    merchantIdentifier: string;
+
+    /**
+     * Merchant name is rendered in the payment sheet.
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#MerchantInfo
+     */
+    merchantName?: string;
+}
+
+export interface GooglePayProps extends UIElementProps {
+    environment?: google.payments.api.Environment | string;
+    configuration?: GooglePayPropsConfiguration;
+
+    /**
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#IsReadyToPayRequest
+     * @defaultValue true
+     */
+    existingPaymentMethodRequired?: boolean;
+
+    /**
+     * The status of the total price
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo
+     */
+    totalPriceStatus?: google.payments.api.TotalPriceStatus;
+
+    /**
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo
+     */
+    countryCode?: string;
+
+    allowedAuthMethods?: google.payments.api.CardAuthMethod[];
+    allowedCardNetworks?: google.payments.api.CardNetwork[];
+
+    /**
+     * Set to false if you don't support credit cards.
+     * @defaultValue true
+     */
+    allowCreditCards?: boolean;
+
+    /**
+     * Set to false if you don't support prepaid cards.
+     * @defaultValue true
+     */
+    allowPrepaidCards?: boolean;
+
+    /**
+     * Set to true if you require a billing address
+     *
+     * @remarks
+     * A billing address should only be requested if it's required to process the transaction.
+     *
+     * @defaultValue false
+     */
+    billingAddressRequired?: boolean;
+
+    /**
+     * The expected fields returned if billingAddressRequired is set to true.
+     */
+    billingAddressParameters?: google.payments.api.BillingAddressParameters;
+
+    /**
+     * Set to true to request an email address.
+     * @defaultValue false
+     */
+    emailRequired?: boolean;
+
+    /**
+     * Set to true to request a full shipping address.
+     * @defaultValue false
+     */
+    shippingAddressRequired?: boolean;
+
+    /**
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#ShippingOptionParameters
+     */
+    shippingAddressParameters?: google.payments.api.ShippingAddressParameters;
+
+    /**
+     * Set to true when the SHIPPING_OPTION callback intent is used.
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#ShippingOptionParameters
+     */
+    shippingOptionRequired?: boolean;
+
+    /**
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#ShippingOptionParameters
+     */
+    shippingOptionParameters?: google.payments.api.ShippingOptionParameters;
+
+    callbackIntents?: google.payments.api.CallbackIntent[];
+
+    /**
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#PaymentDataCallbacks
+     */
+    paymentDataCallbacks?: google.payments.api.PaymentDataCallbacks;
+
+    // Button
+
+    /**
+     * @deprecated use showPayButton
+     */
+    showButton?: boolean;
+    buttonColor?: google.payments.api.ButtonColor;
+    buttonType?: google.payments.api.ButtonType;
+
+    // Events
+
+    onAuthorized?: (paymentData: google.payments.api.PaymentData) => void;
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Add types to Google Pay props
- Add support for callbackIntents/PaymentDataCallbacks and dynamic price updates

## Tested scenarios
- Update price dynamically on shipping method change
- Update price dynamically on shipping address change
