### PR TITLE
Bumped SF version

### DIFF
--- a/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -10,7 +10,7 @@ export const ENCRYPTED_PIN_FIELD = 'encryptedPin';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.2.3';
+export const SF_VERSION = '3.2.4';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Bumped SF version to 3.2.4 to fix bugs when null is passed as a placeholder value and for autofill in Chrome on iOS

## Tested scenarios
SecuredFields still load and work


**Fixed issue**:  <!-- #-prefixed issue number -->
