### PR TITLE
Fix Google Pay button padding on non-default scenarios

### DIFF
--- a/src/components/GooglePay/components/GooglePayButton.scss
+++ b/src/components/GooglePay/components/GooglePayButton.scss
@@ -2,7 +2,6 @@
     &,
     &.long,
     &.short {
-        padding: 15px 24px 13px;
         height: 48px;
         transition: background-color 0.3s ease-out, box-shadow 0.3s ease-out;
 
@@ -10,6 +9,11 @@
             box-shadow: 0 0 0 2px #99c2ff;
             outline: 0;
         }
+    }
+
+    // Default button
+    &.gpay-button {
+        padding: 15px 24px 13px;
     }
 
     &.long {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Fix Google Pay button padding on dynamic buttons

## Tested scenarios
- Button styles work on a default button
- Button styles work on a dynamic button


