### PR TITLE
Fix validation on stored cards when billingAddress was required

### DIFF
--- a/src/components/Card/Card.test.ts
+++ b/src/components/Card/Card.test.ts
@@ -1,6 +1,13 @@
 import { CardElement } from './Card';
 
 describe('Card', () => {
+    describe('formatProps', function() {
+        test('should not require a billingAddress if it is a stored card', () => {
+            const card = new CardElement({ billingAddressRequired: true, storedPaymentMethodId: 'test' });
+            expect(card.props.billingAddressRequired).toBe(false);
+        });
+    });
+
     describe('get data', () => {
         test('always returns a type', () => {
             const card = new CardElement({});

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -44,6 +44,8 @@ export class CardElement extends UIElement<CardElementProps> {
             holderNameRequired: !props.hasHolderName ? false : props.holderNameRequired,
             // Special catch for recurring bcmc (i.e. card with no cvc field). Scenario?? - Dropin - One click with no details
             hasCVC: !((props.brand && props.brand === 'bcmc') || props.hideCVC),
+            // billingAddressRequired only available for non-stored cards
+            billingAddressRequired: props.storedPaymentMethodId ? false : props.billingAddressRequired,
             ...(props.brands && !props.groupTypes && { groupTypes: props.brands }),
             type: props.type === 'scheme' ? 'card' : props.type
         };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Fix validation on stored cards when billingAddress was required

## Tested scenarios
- Set `billingAddressRequired` on a stored card, click pay.

