### PR TITLE
Default Bancontact Card brand

### DIFF
--- a/src/components/Card/Bancontact.ts
+++ b/src/components/Card/Bancontact.ts
@@ -7,6 +7,7 @@ class BancontactElement extends CardElement {
 
     formatProps(props: CardElementProps) {
         return {
+            brand: 'bcmc',
             ...super.formatProps(props),
             // Override only display brands (groupTypes are decided earlier on super.formatProps)
             brands: ['bcmc', 'maestro']


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Default Bancontact Card brand to `bcmc`

## Tested scenarios
- Create a `bcmc` component without props
