### PR TITLE
Use merchantName as totalPriceLabel if totalPriceLabel is not defined

### DIFF
--- a/src/components/ApplePay/ApplePay.test.ts
+++ b/src/components/ApplePay/ApplePay.test.ts
@@ -21,6 +21,16 @@ describe('ApplePay', () => {
             expect(applepay.props.amount.value).toEqual(0);
             expect(applepay.props.amount.currency).toEqual('USD');
         });
+
+        test('uses merchantName if no totalPriceLabel was defined', () => {
+            const applepay = new ApplePay({ ...defaultProps, configuration: { merchantName: 'Test' } });
+            expect(applepay.props.totalPriceLabel).toEqual('Test');
+        });
+
+        test('can set totalPriceLabel', () => {
+            const applepay = new ApplePay({ ...defaultProps, configuration: { merchantName: 'Test' }, totalPriceLabel: 'Total' });
+            expect(applepay.props.totalPriceLabel).toEqual('Total');
+        });
     });
 
     describe('get data', () => {

--- a/src/components/ApplePay/ApplePay.tsx
+++ b/src/components/ApplePay/ApplePay.tsx
@@ -27,6 +27,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
             onAuthorized: resolve => resolve(),
             onValidateMerchant: (resolve, reject) => reject('onValidateMerchant event not implemented'),
             ...props,
+            totalPriceLabel: props.totalPriceLabel || props.configuration?.merchantName,
             amount,
             onCancel: event => props.onError(event)
         };

--- a/src/components/ApplePay/defaultProps.ts
+++ b/src/components/ApplePay/defaultProps.ts
@@ -10,7 +10,7 @@ const defaultProps = {
     countryCode: 'US',
 
     totalPriceStatus: 'final',
-    totalPriceLabel: '',
+    totalPriceLabel: undefined,
 
     configuration: {
         merchantName: '',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Apple Pay will use the `configuration.merchantName` property as a label for the total line item by default.
This prevents issues with the biometric handoff where if the label is empty (the old default) the process would fail.

## Tested scenarios
- Paying from a Mac without touchbar and authorising the payment on a linked iOS device works
- If the `totalPriceLabel` property exists, it will take precedence.

