### PR TITLE
Feature/automatically render kcp fields

### DIFF
--- a/playground/pages/Cards/Cards.js
+++ b/playground/pages/Cards/Cards.js
@@ -69,7 +69,7 @@ getOriginKey()
             .create('bcmc', {
                 type: 'bcmc',
                 hasHolderName: true,
-                // holderNameRequired: true,
+                //                holderNameRequired: true,
                 enableStoreDetails: false
             })
             .mount('.bancontact-field');
@@ -112,6 +112,7 @@ getOriginKey()
                 type: 'scheme',
                 brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
                 koreanAuthenticationRequired: true
+                //                countryCode: 'KR'
             })
             .mount('.card-kcp-field');
     });

--- a/playground/pages/Cards/Cards.js
+++ b/playground/pages/Cards/Cards.js
@@ -69,7 +69,7 @@ getOriginKey()
             .create('bcmc', {
                 type: 'bcmc',
                 hasHolderName: true,
-                //                holderNameRequired: true,
+                // holderNameRequired: true,
                 enableStoreDetails: false
             })
             .mount('.bancontact-field');

--- a/playground/pages/Cards/Cards.js
+++ b/playground/pages/Cards/Cards.js
@@ -112,7 +112,7 @@ getOriginKey()
                 type: 'scheme',
                 brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
                 koreanAuthenticationRequired: true
-                //                countryCode: 'KR'
+                // countryCode: 'KR'
             })
             .mount('.card-kcp-field');
     });

--- a/src/components/Card/Card.test.ts
+++ b/src/components/Card/Card.test.ts
@@ -6,6 +6,11 @@ describe('Card', () => {
             const card = new CardElement({ billingAddressRequired: true, storedPaymentMethodId: 'test' });
             expect(card.props.billingAddressRequired).toBe(false);
         });
+
+        test('should format countryCode to lowerCase', () => {
+            const card = new CardElement({ countryCode: 'KR' });
+            expect(card.props.countryCode).toEqual('kr');
+        });
     });
 
     describe('get data', () => {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -22,7 +22,8 @@ export class CardElement extends UIElement<CardElementProps> {
             // billingAddressRequired only available for non-stored cards
             billingAddressRequired: props.storedPaymentMethodId ? false : props.billingAddressRequired,
             ...(props.brands && !props.groupTypes && { groupTypes: props.brands }),
-            type: props.type === 'scheme' ? 'card' : props.type
+            type: props.type === 'scheme' ? 'card' : props.type,
+            countryCode: props.countryCode ? props.countryCode.toLowerCase() : null
         };
     }
 

--- a/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 import { h } from 'preact';
 import CardInput from './CardInput';
-import CSF from '../../../internal/SecuredFields/lib';
 
 jest.mock('../../../internal/SecuredFields/lib');
 const i18n = { get: key => key };
@@ -50,5 +49,85 @@ describe('CardInput', () => {
     test('valid holderName not required', () => {
         const wrapper = mount(<CardInput hasHolderName={true} i18n={i18n} />);
         expect(wrapper.state('valid').holderName).toBe(undefined);
+    });
+});
+
+describe('CardInput shows/hides KCP fields when koreanAuthenticationRequired is set to true', () => {
+    test('Renders a card form with kcp fields since countryCode is KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="KR" />);
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(1);
+    });
+
+    test('Renders a card form with kcp fields since countryCode is KR & issuingCountryCode is KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="KR" />);
+        wrapper.setState({ issuingCountryCode: 'KR' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(1);
+    });
+
+    test('Renders a card form with no kcp fields since countryCode is KR but issuingCountryCode is not KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="KR" />);
+        wrapper.setState({ issuingCountryCode: 'US' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('Renders a card form with no kcp fields since countryCode is not KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} />);
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('Renders a card form with kcp fields since countryCode is not KR but issuingCountryCode is KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} />);
+        wrapper.setState({ issuingCountryCode: 'KR' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(1);
+    });
+
+    test('Renders a card form with no kcp fields since countryCode is not KR & issuingCountryCode is not KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} />);
+        wrapper.setState({ issuingCountryCode: 'US' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+});
+
+describe('CardInput never shows KCP fields when koreanAuthenticationRequired is set to false', () => {
+    test('countryCode is KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="KR" />);
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('countryCode is KR & issuingCountryCode is KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="KR" />);
+        wrapper.setState({ issuingCountryCode: 'KR' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('countryCode is KR but issuingCountryCode is not KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="KR" />);
+        wrapper.setState({ issuingCountryCode: 'US' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('countryCode is not KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} />);
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('countryCode is not KR but issuingCountryCode is KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} />);
+        wrapper.setState({ issuingCountryCode: 'KR' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('countryCode is not KR & issuingCountryCode is not KR', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} />);
+        wrapper.setState({ issuingCountryCode: 'US' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });
 });

--- a/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -53,80 +53,80 @@ describe('CardInput', () => {
 });
 
 describe('CardInput shows/hides KCP fields when koreanAuthenticationRequired is set to true', () => {
-    test('Renders a card form with kcp fields since countryCode is KR', () => {
-        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="KR" />);
+    test('Renders a card form with kcp fields since countryCode is kr', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="kr" />);
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(1);
     });
 
-    test('Renders a card form with kcp fields since countryCode is KR & issuingCountryCode is KR', () => {
-        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="KR" />);
-        wrapper.setState({ issuingCountryCode: 'KR' });
+    test('Renders a card form with kcp fields since countryCode is kr & issuingCountryCode is kr', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="kr" />);
+        wrapper.setState({ issuingCountryCode: 'kr' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(1);
     });
 
-    test('Renders a card form with no kcp fields since countryCode is KR but issuingCountryCode is not KR', () => {
-        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="KR" />);
-        wrapper.setState({ issuingCountryCode: 'US' });
+    test('Renders a card form with no kcp fields since countryCode is kr but issuingCountryCode is not kr', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} countryCode="kr" />);
+        wrapper.setState({ issuingCountryCode: 'us' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });
 
-    test('Renders a card form with no kcp fields since countryCode is not KR', () => {
+    test('Renders a card form with no kcp fields since countryCode is not kr', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} />);
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });
 
-    test('Renders a card form with kcp fields since countryCode is not KR but issuingCountryCode is KR', () => {
+    test('Renders a card form with kcp fields since countryCode is not kr but issuingCountryCode is kr', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} />);
-        wrapper.setState({ issuingCountryCode: 'KR' });
+        wrapper.setState({ issuingCountryCode: 'kr' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(1);
     });
 
-    test('Renders a card form with no kcp fields since countryCode is not KR & issuingCountryCode is not KR', () => {
+    test('Renders a card form with no kcp fields since countryCode is not kr & issuingCountryCode is not kr', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={true} />);
-        wrapper.setState({ issuingCountryCode: 'US' });
+        wrapper.setState({ issuingCountryCode: 'us' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });
 });
 
 describe('CardInput never shows KCP fields when koreanAuthenticationRequired is set to false', () => {
-    test('countryCode is KR', () => {
-        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="KR" />);
-        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
-    });
-
-    test('countryCode is KR & issuingCountryCode is KR', () => {
-        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="KR" />);
-        wrapper.setState({ issuingCountryCode: 'KR' });
-        wrapper.update();
-        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
-    });
-
-    test('countryCode is KR but issuingCountryCode is not KR', () => {
+    test('countryCode is kr', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="kr" />);
-        wrapper.setState({ issuingCountryCode: 'US' });
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('countryCode is kr & issuingCountryCode is kr', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="kr" />);
+        wrapper.setState({ issuingCountryCode: 'kr' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });
 
-    test('countryCode is not KR', () => {
+    test('countryCode is kr but issuingCountryCode is not kr', () => {
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="kr" />);
+        wrapper.setState({ issuingCountryCode: 'us' });
+        wrapper.update();
+        expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
+    });
+
+    test('countryCode is not kr', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} />);
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });
 
-    test('countryCode is not KR but issuingCountryCode is KR', () => {
+    test('countryCode is not kr but issuingCountryCode is kr', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} />);
         wrapper.setState({ issuingCountryCode: 'kr' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });
 
-    test('countryCode is not KR & issuingCountryCode is not KR', () => {
+    test('countryCode is not kr & issuingCountryCode is not kr', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} />);
-        wrapper.setState({ issuingCountryCode: 'US' });
+        wrapper.setState({ issuingCountryCode: 'us' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });

--- a/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -106,7 +106,7 @@ describe('CardInput never shows KCP fields when koreanAuthenticationRequired is 
     });
 
     test('countryCode is KR but issuingCountryCode is not KR', () => {
-        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="KR" />);
+        const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} countryCode="kr" />);
         wrapper.setState({ issuingCountryCode: 'US' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
@@ -119,7 +119,7 @@ describe('CardInput never shows KCP fields when koreanAuthenticationRequired is 
 
     test('countryCode is not KR but issuingCountryCode is KR', () => {
         const wrapper = mount(<CardInput i18n={i18n} koreanAuthenticationRequired={false} />);
-        wrapper.setState({ issuingCountryCode: 'KR' });
+        wrapper.setState({ issuingCountryCode: 'kr' });
         wrapper.update();
         expect(wrapper.find('.adyen-checkout__card__kcp-authentication')).toHaveLength(0);
     });

--- a/src/components/Card/components/CardInput/CardInput.tsx
+++ b/src/components/Card/components/CardInput/CardInput.tsx
@@ -180,7 +180,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
     }
 
     public processBinLookupResponse(data) {
-        const issuingCountryCode = data?.issuingCountryCode ? data.issuingCountryCode : null;
+        const issuingCountryCode = data?.issuingCountryCode ? data.issuingCountryCode.toLowerCase() : null;
 
         this.setState({ issuingCountryCode }, () => {
             this.processBinLookup(data);
@@ -209,11 +209,11 @@ class CardInput extends Component<CardInputProps, CardInputState> {
         if (this.props.oneClick === true) isOneClick = true; // In the Drop-in the oneClick status may already have been decided, so give that priority
 
         // If the merchant defined countryCode is 'KR'
-        let isKorea = countryCode?.toLowerCase() === 'kr';
+        let isKorea = countryCode === 'kr';
 
         // Override the value if issuingCountryCode is set
         if (issuingCountryCode !== null) {
-            isKorea = issuingCountryCode.toLowerCase() === 'kr';
+            isKorea = issuingCountryCode === 'kr';
         }
 
         return (

--- a/src/components/Card/components/CardInput/CardInput.tsx
+++ b/src/components/Card/components/CardInput/CardInput.tsx
@@ -120,7 +120,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
         this.handleOnStoreDetails = handlers.handleOnStoreDetails.bind(this);
         this.handleAdditionalDataSelection = handlers.handleAdditionalDataSelection.bind(this);
 
-        this.processBinLookup = processBinLookup;
+        this.processBinLookup = processBinLookup.bind(this);
     }
 
     public static defaultProps = defaultProps;

--- a/src/components/Card/components/CardInput/CardInput.tsx
+++ b/src/components/Card/components/CardInput/CardInput.tsx
@@ -14,7 +14,7 @@ import defaultStyles from './defaultStyles';
 import styles from './CardInput.module.scss';
 import getImage from '../../../../utils/get-image';
 import './CardInput.scss';
-import processBinLookupResponse from './processBinLookup';
+import processBinLookup from './processBinLookup';
 import Language from '../../../../language/Language';
 
 interface CardInputProps {
@@ -56,6 +56,7 @@ interface CardInputState {
     isValid: boolean;
     status: string;
     valid?: object;
+    issuingCountryCode: string;
 }
 
 class CardInput extends Component<CardInputProps, CardInputState> {
@@ -69,7 +70,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
     private handleSecuredFieldsChange;
     private handleOnStoreDetails;
     private handleAdditionalDataSelection;
-    private processBinLookupResponse;
+    private processBinLookup;
 
     public state;
     public props;
@@ -104,7 +105,8 @@ class CardInput extends Component<CardInputProps, CardInputState> {
             focusedElement: '',
             additionalSelectElements: [],
             additionalSelectValue: '',
-            additionalSelectType: ''
+            additionalSelectType: '',
+            issuingCountryCode: null
         };
 
         this.validateCardInput = handlers.validateCardInput.bind(this);
@@ -118,7 +120,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
         this.handleOnStoreDetails = handlers.handleOnStoreDetails.bind(this);
         this.handleAdditionalDataSelection = handlers.handleAdditionalDataSelection.bind(this);
 
-        this.processBinLookupResponse = processBinLookupResponse;
+        this.processBinLookup = processBinLookup;
     }
 
     public static defaultProps = defaultProps;
@@ -177,6 +179,14 @@ class CardInput extends Component<CardInputProps, CardInputState> {
         if (this.kcpAuthenticationRef) this.kcpAuthenticationRef.showValidation();
     }
 
+    public processBinLookupResponse(data) {
+        const issuingCountryCode = data?.issuingCountryCode ? data.issuingCountryCode : null;
+
+        this.setState({ issuingCountryCode }, () => {
+            this.processBinLookup(data);
+        });
+    }
+
     private handleSecuredFieldsRef = ref => {
         this.sfp = ref;
     };
@@ -189,11 +199,22 @@ class CardInput extends Component<CardInputProps, CardInputState> {
         this.kcpAuthenticationRef = ref;
     };
 
-    render({ loadingContext, hasHolderName, hasCVC, installmentOptions, enableStoreDetails }, { status, hideCVCForBrand, focusedElement }) {
+    render(
+        { loadingContext, hasHolderName, hasCVC, countryCode, installmentOptions, enableStoreDetails },
+        { status, hideCVCForBrand, focusedElement, issuingCountryCode }
+    ) {
         const hasInstallments = !!Object.keys(installmentOptions).length;
 
         let isOneClick: boolean = this.props.storedPaymentMethodId ? true : false;
         if (this.props.oneClick === true) isOneClick = true; // In the Drop-in the oneClick status may already have been decided, so give that priority
+
+        // If the merchant defined countryCode is 'KR'
+        let isKorea = countryCode?.toLowerCase() === 'kr';
+
+        // Override the value if issuingCountryCode is set
+        if (issuingCountryCode !== null) {
+            isKorea = issuingCountryCode.toLowerCase() === 'kr';
+        }
 
         return (
             <SecuredFieldsProvider
@@ -256,7 +277,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                                     />
                                 )}
 
-                                {this.props.koreanAuthenticationRequired && (
+                                {this.props.koreanAuthenticationRequired && isKorea && (
                                     <KCPAuthentication
                                         onFocusField={setFocusOn}
                                         focusedElement={focusedElement}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Based on a combination of the config options `koreanAuthenticationRequired` & `countryCode` as well as the `issuingCountryCode` returned by the `/binLookup` endpoint - we hide/show the extra KCP fields

## Tested scenarios
- never show fields when `koreanAuthenticationRequired` is `false`
- when `koreanAuthenticationRequired` is `true`:
    - show fields at startup when `countryCode` is `"KR"`
    - don't show fields at startup if `countryCode` is not `"KR"`
    - regardless of `countryCode` show fields if `issuingCountryCode` is `"KR"`
- see all tested scenarios in `CardInput.test.tsx`

**Fixed issue**:  COWEB-782
