### PR TITLE
QRLoader payments call onAdditionalDetails when they fail

### DIFF
--- a/src/components/internal/QRLoader/QRLoader.js
+++ b/src/components/internal/QRLoader/QRLoader.js
@@ -111,7 +111,12 @@ class QRLoader extends Component {
     onError(status) {
         clearInterval(this.interval);
         this.setState({ expired: true, loading: false });
-        this.props.onError(status);
+        this.props.onComplete({
+            data: {
+                details: { payload: status.props.payload },
+                paymentData: this.props.paymentData
+            }
+        });
         return status;
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
QRLoader type comps call `onAdditionalDetails` when they receive an error-type response - this covers getting a "refused" response.
Works the same way as for the `Await` type comps

## Tested scenarios
- Set `onAdditionalDetails` and forced an "error" and saw that `onAdditionalDetails` was called
- Further testing is required to check that in PBL this triggers the retry button re. DEV-28283

**Fixed issue**: 
