### PR TITLE
Disable telemetry calls when no access key is available

### DIFF
--- a/src/core/Analytics/Analytics.ts
+++ b/src/core/Analytics/Analytics.ts
@@ -20,8 +20,9 @@ class Analytics {
 
     constructor({ loadingContext, locale, originKey, clientKey, analytics }: AnalyticsProps) {
         this.props = { ...Analytics.defaultProps, ...analytics };
+        const accessKey = clientKey || originKey;
         this.logEvent = logEvent({ loadingContext, locale });
-        this.logTelemetry = postTelemetry({ loadingContext, locale, originKey, clientKey });
+        this.logTelemetry = postTelemetry({ loadingContext, locale, accessKey });
 
         const { conversion, enabled } = this.props;
 
@@ -31,7 +32,7 @@ class Analytics {
                 this.queue.run(this.conversionId);
             } else {
                 // If no conversionId is provided, fetch a new one
-                collectId({ loadingContext, originKey, clientKey })
+                collectId({ loadingContext, accessKey })
                     .then(conversionId => {
                         this.conversionId = conversionId;
                         this.queue.run(this.conversionId);
@@ -48,7 +49,7 @@ class Analytics {
 
         if (enabled === true) {
             if (telemetry === true) {
-                const telemetryTask = conversionId => this.logTelemetry({ ...event, conversionId });
+                const telemetryTask = conversionId => this.logTelemetry({ ...event, conversionId }).catch(() => {});
                 this.queue.add(telemetryTask);
 
                 // Not waiting for conversionId

--- a/src/core/Services/collect-id.ts
+++ b/src/core/Services/collect-id.ts
@@ -4,6 +4,10 @@
  * @returns a promise containing the response of the call
  */
 const collectId = config => {
+    if (!config.accessKey) {
+        return Promise.reject();
+    }
+
     const options = {
         method: 'POST',
         headers: {
@@ -11,8 +15,8 @@ const collectId = config => {
             'Content-Type': 'application/json'
         }
     };
-    const accessKey = config.clientKey || config.originKey;
-    return fetch(`${config.loadingContext}v1/analytics/id?token=${accessKey}`, options)
+
+    return fetch(`${config.loadingContext}v1/analytics/id?token=${config.accessKey}`, options)
         .then(response => {
             if (response.ok) return response.json();
             throw new Error('Collect ID not available');

--- a/src/core/Services/post-telemetry.ts
+++ b/src/core/Services/post-telemetry.ts
@@ -5,6 +5,10 @@ import { version } from '../../../package.json';
  * @param config -
  */
 const logTelemetry = config => event => {
+    if (!config.accessKey) {
+        return Promise.reject();
+    }
+
     const telemetryEvent = {
         version,
         platform: 'web',
@@ -25,8 +29,7 @@ const logTelemetry = config => event => {
         body: JSON.stringify(telemetryEvent)
     };
 
-    const accessKey = config.clientKey || config.originKey;
-    return fetch(`${config.loadingContext}v1/analytics/log?token=${accessKey}`, options)
+    return fetch(`${config.loadingContext}v1/analytics/log?token=${config.accessKey}`, options)
         .then(response => response.ok)
         .catch(() => {});
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Disable telemetry calls when no access key is available

## Tested scenarios
- Telemetry is sent when either `originKey` or `clientKey` are provided.
- Telemetry is ignored when no access key is available
