### PR TITLE
Handle different autoComplete formats

### DIFF
--- a/src/components/internal/SecuredFields/lib/core/utils/processAutoComplete.ts
+++ b/src/components/internal/SecuredFields/lib/core/utils/processAutoComplete.ts
@@ -13,7 +13,9 @@ export function processAutoComplete(pFeedbackObj: SFFeedbackObj): void {
 
     // Send date info to relevant secured fields
     if (pFeedbackObj.name === 'cc-exp') {
-        const dateValArr: string[] = pFeedbackObj.value.split('/');
+        const splittableDateVal = pFeedbackObj.value.replace(/[^0-9]/gi, '/'); // Replace any non-digits with a fwd-slash so we can always split it
+
+        const dateValArr: string[] = splittableDateVal.split('/');
 
         if (dateValArr.length !== 2) return; // To avoid bug in some versions of Safari where date doesn't come through as expected
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Previously we have expected the date that needs to be auto-completed to come through as a forward-slash separated string e.g. "10/2020". 
But on some browsers it can come through separated by a full stop e.g. "10.2020"
To handle this we now replace all non-numerical characters in the date string with a forward slash so our date processing code will always be able to run

## Tested scenarios
Tested dates strings separated with ".", "-" and"/"


**Fixed issue**:  <!-- #-prefixed issue number -->
