### PR TITLE
Release 3.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "umd:main": "dist/adyen.js",
     "types": "dist/src",
     "typings": "dist/src",
-    "version": "3.11.3",
+    "version": "3.11.4",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Hash origin into url for SF iframes (#184)

## Tested scenarios
Tested all types of SecuredFields still load.
Confirmed different hashes are generated for different domains (even when they only differ by the country component of the url)

**Fixed issue**:  FOC-33270
