### PR TITLE
FEAT_iban: populate field from properties

### DIFF
--- a/src/components/Sepa/components/IbanInput/IbanInput.js
+++ b/src/components/Sepa/components/IbanInput/IbanInput.js
@@ -13,14 +13,29 @@ class IbanInput extends Component {
         this.state = {
             status: 'ready',
             data: {
-                'sepa.ownerName': '',
-                'sepa.ibanNumber': ''
+                'sepa.ownerName': props.ownerName ? props.ownerName : '',
+                'sepa.ibanNumber': props.ibanNumber ? props.ibanNumber : ''
             },
             isValid: false,
             cursor: 0,
             errors: {},
             valid: {}
         };
+
+        if (this.state.data['sepa.ibanNumber']) {
+            const electronicFormatIban = electronicFormat(this.state.data['sepa.ibanNumber']); // example: NL13TEST0123456789
+            const iban = formatIban(electronicFormatIban); // example: NL13 TEST 0123 4567 89
+            this.state.data['sepa.ibanNumber'] = iban;
+        }
+
+        if(this.state.data['sepa.ibanNumber'] || this.state.data['sepa.ownerName']){
+            const holderNameValid = this.props.holderName ? isValidHolder(this.state.data['sepa.ownerName']) : '';
+            const ibanValid = this.state.data['sepa.ibanNumber'] ? checkIbanStatus(this.state.data['sepa.ibanNumber']).status === 'valid' : '';
+            const isValid = ibanValid && holderNameValid;
+            const data = { data: this.state.data, isValid };
+    
+            this.props.onChange(data);
+        }
 
         this.ibanNumber = {};
     }

--- a/src/components/Sepa/components/IbanInput/IbanInput.js
+++ b/src/components/Sepa/components/IbanInput/IbanInput.js
@@ -13,8 +13,8 @@ class IbanInput extends Component {
         this.state = {
             status: 'ready',
             data: {
-                'sepa.ownerName': props.ownerName ? props.ownerName : '',
-                'sepa.ibanNumber': props.ibanNumber ? props.ibanNumber : ''
+                'sepa.ownerName': props?.data?.ownerName || '',
+                'sepa.ibanNumber': props?.data?.ibanNumber || ''
             },
             isValid: false,
             cursor: 0,

--- a/src/components/Sepa/components/IbanInput/IbanInput.test.js
+++ b/src/components/Sepa/components/IbanInput/IbanInput.test.js
@@ -63,4 +63,36 @@ describe('IbanInput', () => {
             expect(wrapper.find('input[name="sepa.ownerName"]').prop('placeholder')).toBe('test');
         });
     });
+
+    describe('Send values from outside', () => {
+
+        test('Set ibanNumber', () => {
+            const wrapper = createWrapper({ data: { 'sepa.ibanNumber': 'NL13TEST0123456789'} });
+            setTimeout(()=>{
+                expect(wrapper.find('input[name="sepa.ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
+            });
+        });
+
+        test('Set ibanNumber formatted', () => {
+            const wrapper = createWrapper({ data: { 'sepa.ibanNumber': 'NL13 TEST 0123 4567 89'} });
+            setTimeout(()=>{
+                expect(wrapper.find('input[name="sepa.ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
+            });
+        });
+
+        test('Set ownerName', () => {
+            const wrapper = createWrapper({ data: { 'sepa.ownerName': 'Hello World'} });
+            setTimeout(()=>{
+                expect(wrapper.find('input[name="sepa.ownerName"]').text()).toBe('Hello World');
+            });
+        });
+
+        test('Set ibanNumber and ownerName', () => {
+            const wrapper = createWrapper({ data: { 'sepa.ibanNumber': 'NL13TEST0123456789', 'sepa.ownerName': 'Hello World'} });
+            setTimeout(()=>{
+                expect(wrapper.find('input[name="sepa.ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
+                expect(wrapper.find('input[name="sepa.ownerName"]').text()).toBe('Hello World');
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Populate the IBAN based on the **paymentMethodsConfiguration** **ownerName** and **ibanNumber** from **sepadirectdebit** property.

## Tested scenarios

[✔️] Fill the ownerName and ibanNumber
[✔️] Fill the ownerName 
[✔️] Fill the ibanNumber
[✔️] Leave it blank.