### PR TITLE
aria iframeTitle was not being read after name change on main config object

### DIFF
--- a/playground/pages/SecuredFields/securedFields.config.js
+++ b/playground/pages/SecuredFields/securedFields.config.js
@@ -25,9 +25,8 @@ export const placeholders = {
 export const ariaLabels = {
     lang: 'en-GB',
     encryptedCardNumber: {
-        label: 'Credit or debit card number field'
-        //        iframeTitle: 'Iframe for credit card number field',
-        //        placeholder: 'enter credit card number',
+        label: 'Credit or debit card number field',
+        iframeTitle: 'Iframe for credit card number field'
         //        error: "credit card number is in error"
     },
     encryptedExpiryDate: {

--- a/src/components/internal/SecuredFields/lib/core/SecuredField.ts
+++ b/src/components/internal/SecuredFields/lib/core/SecuredField.ts
@@ -57,7 +57,7 @@ class SecuredField extends AbstractSecuredField {
     }
 
     init(): SecuredField {
-        const iframeTitle: string = getProp(this.config, `pmConfig.ariaLabels.${this.fieldType}.iframeTitle`) || IFRAME_TITLE;
+        const iframeTitle: string = getProp(this.config, `iframeUIConfig.ariaLabels.${this.fieldType}.iframeTitle`) || IFRAME_TITLE;
 
         const iframeEl: HTMLIFrameElement = createIframe(`${this.iframeSrc}`, iframeTitle);
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The aria configurable property `iframeTitle` was not getting picked up due to a change to the name of the iframe specific config object (was `pmConfig` now is `iframeUIConfig`)

## Tested scenarios
iframe now gets title attribute set if it is specified 
