### PR TITLE
Add timeout to Dropin's isAvailable filter

### DIFF
--- a/src/components/Dropin/elements/filters.ts
+++ b/src/components/Dropin/elements/filters.ts
@@ -4,7 +4,8 @@ export const filterPresent = paymentMethod => !!paymentMethod;
 // filter payment methods that are available to the user
 export const filterAvailable = paymentMethod => {
     if (paymentMethod.isAvailable) {
-        return paymentMethod.isAvailable();
+        const timeout = new Promise((resolve, reject) => setTimeout(reject, 1000));
+        return Promise.race([paymentMethod.isAvailable(), timeout]);
     }
 
     return Promise.resolve(!!paymentMethod);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes an issue that could prevent the Drop-in from loading if one of it's components failed to resolve/reject the `isAvailable` functionality in some browsers.
