### PR TITLE
Increased securedFields version to 3.2.5

### DIFF
--- a/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -10,7 +10,7 @@ export const ENCRYPTED_PIN_FIELD = 'encryptedPin';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.2.4';
+export const SF_VERSION = '3.2.5';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Increased securedFields version to 3.2.5 which now marks-up inputs with `type="text"` & `inputmode="numeric"`

## Tested scenarios
Tested securedFields still load
Tested can still input into fields in Chrome, Firefox, Safari, IE11, Safari on iOS (12.x & 13.x), Chrome on Android


**Fixed issue**:  Relates to issue FOC-33752(point _2b_)
