### PR TITLE
Added aria & a11y attributes

### DIFF
--- a/src/components/Dropin/components/PaymentMethod/PaymentMethodIcon.tsx
+++ b/src/components/Dropin/components/PaymentMethod/PaymentMethodIcon.tsx
@@ -9,12 +9,14 @@ const PaymentMethodIcon = ({ src, name, disabled = false }) => {
             className={classNames('adyen-checkout__payment-method__image__wrapper', styles['adyen-checkout__payment-method__image__wrapper'], {
                 'adyen-checkout__payment-method__image__wrapper--disabled': !!disabled
             })}
+            aria-hidden="true"
         >
             <Img
                 className={`adyen-checkout__payment-method__image ${styles['adyen-checkout__payment-method__image']}`}
                 src={src}
                 alt={name}
                 aria-label={name}
+                focusable="false"
             />
         </span>
     );

--- a/src/components/internal/FormFields/Field/Field.js
+++ b/src/components/internal/FormFields/Field/Field.js
@@ -118,7 +118,11 @@ class Field extends Component {
                         )}
                     </div>
 
-                    {errorMessage && errorMessage.length && <span className={'adyen-checkout__error-text'}>{errorMessage}</span>}
+                    {errorMessage && errorMessage.length && (
+                        <span className={'adyen-checkout__error-text'} aria-live="polite">
+                            {errorMessage}
+                        </span>
+                    )}
                 </label>
             </div>
         );


### PR DESCRIPTION
…usable" attr to payment method icons

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added aria attribute `aria-live="polite"` to error spans. 
Added `aria-hidden="true"` to span that holds payment method icon in Dropin.
Added IE related `focusable="false"` attr to <img> in payment method icon

## Tested scenarios
Tested with Mac VoiceOver utility


**Fixed issue**:  Addresses issues in FOC-33752 (namely points _2i_ & _2j_)
