### PR TITLE
Fixed bug where it was no longer possible to set empty placeholders

### DIFF
--- a/src/components/internal/SecuredFields/lib/core/utils/init/processPlaceholders.ts
+++ b/src/components/internal/SecuredFields/lib/core/utils/init/processPlaceholders.ts
@@ -5,9 +5,10 @@ import { PlaceholdersObject } from '../../AbstractSecuredField';
  * Checks if the merchant has defined an placeholder config object and if not create one with a value from the relevant translation file
  */
 export function processPlaceholders(configObj, fieldType, i18n) {
+    // Use the merchant defined value - even if an empty string or null
     let placeholderFieldValue: string = configObj.iframeUIConfig.placeholders ? configObj.iframeUIConfig.placeholders[fieldType] : undefined;
 
-    // If no value set by merchant - get translated one
+    // Only if the value is truly "undefined" then get a translated one
     if (typeof placeholderFieldValue === 'undefined') {
         placeholderFieldValue = resolvePlaceholders(i18n)[fieldType];
     }

--- a/src/components/internal/SecuredFields/lib/core/utils/init/processPlaceholders.ts
+++ b/src/components/internal/SecuredFields/lib/core/utils/init/processPlaceholders.ts
@@ -1,4 +1,3 @@
-import getProp from '../../../../../../../utils/getProp';
 import { resolvePlaceholders } from '../../../../utils';
 import { PlaceholdersObject } from '../../AbstractSecuredField';
 
@@ -6,10 +5,10 @@ import { PlaceholdersObject } from '../../AbstractSecuredField';
  * Checks if the merchant has defined an placeholder config object and if not create one with a value from the relevant translation file
  */
 export function processPlaceholders(configObj, fieldType, i18n) {
-    let placeholderFieldValue: string = getProp(configObj, `iframeUIConfig.placeholders.${fieldType}`);
+    let placeholderFieldValue: string = configObj.iframeUIConfig.placeholders ? configObj.iframeUIConfig.placeholders[fieldType] : undefined;
 
     // If no value set by merchant - get translated one
-    if (!placeholderFieldValue) {
+    if (typeof placeholderFieldValue === 'undefined') {
         placeholderFieldValue = resolvePlaceholders(i18n)[fieldType];
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The recent change to always set a default, translated, placeholder if one wasn't defined by the merchant no longer allowed the merchant to set `null` or `''` as a means to clear the placeholder

## Tested scenarios
Default placeholders are applied unless the merchant has set them.
If the merchant has set `''` or `null` then no placeholder is set
