### PR TITLE
Fix Google Pay issues in Drop-in

### DIFF
--- a/src/components/Dropin/Dropin.tsx
+++ b/src/components/Dropin/Dropin.tsx
@@ -59,18 +59,20 @@ class DropinElement extends UIElement<DropinElementProps> {
 
         this.activePaymentMethod
             .startPayment()
-            .then(() => {
-                const { data, isValid } = this.activePaymentMethod;
-
-                if (!isValid) {
-                    this.showValidation();
-                    return false;
-                }
-
-                return this.props.onSubmit({ data, isValid }, this);
-            })
+            .then(this.handleSubmit)
             .catch(error => this.props.onError(error));
     }
+
+    protected handleSubmit = () => {
+        const { data, isValid } = this.activePaymentMethod;
+
+        if (!isValid) {
+            this.showValidation();
+            return false;
+        }
+
+        return this.props.onSubmit({ data, isValid }, this);
+    };
 
     handleAction(action: PaymentAction) {
         if (!action || !action.type) throw new Error('Invalid Action');
@@ -97,7 +99,7 @@ class DropinElement extends UIElement<DropinElementProps> {
                 <DropinComponent
                     {...this.props}
                     onChange={this.setState}
-                    onSubmit={this.submit}
+                    onSubmit={this.handleSubmit}
                     ref={dropinRef => {
                         this.dropinRef = dropinRef;
                     }}

--- a/src/components/GooglePay/GooglePayService.ts
+++ b/src/components/GooglePay/GooglePayService.ts
@@ -2,6 +2,7 @@ import { isReadyToPayRequest, initiatePaymentRequest } from './requests';
 import { resolveEnvironment } from './utils';
 import Script from '../../utils/Script';
 import config from './config';
+import wait from '../../utils/wait';
 
 class GooglePayService {
     public readonly paymentsClient: Promise<google.payments.api.PaymentsClient>;
@@ -28,6 +29,7 @@ class GooglePayService {
         if (!window.google?.payments) {
             const script = new Script(config.URL);
             await script.load();
+            await wait(100);
         }
 
         return new google.payments.api.PaymentsClient(paymentOptions);

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,0 +1,9 @@
+const wait = (ms = 100) => {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve();
+        }, ms);
+    });
+};
+
+export default wait;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Fixes an issue where Google Pay could trigger the submit flow twice on the Drop-in.
- Fixes an issue where Safari could not resolve the initial `isReadyToPay` promise on Drop-in when automatically loading the Google Pay API JavaScript library.

