### PR TITLE
Components maintain refs to onError callback

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -89,7 +89,7 @@ class DropinElement extends UIElement<DropinElementProps> {
             isDropin: true,
             onAdditionalDetails: state => this.props.onAdditionalDetails(state, this),
             onError: this.props.onError, // Add ref to onError in case the merchant has defined one in the component options
-            ...(pmConfig?.onError && { onError: pmConfig.onError }) // Add ref to onError in case the merchant has defined one in the pmConfig options
+            ...(pmConfig?.onError && { onError: pmConfig.onError }) // Overwrite ref to onError in case the merchant has defined one in the pmConfig options
         });
 
         if (paymentAction) {

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -5,6 +5,7 @@ import DropinComponent from '../../components/Dropin/components/DropinComponent'
 import CoreProvider from '../../core/Context/CoreProvider';
 import { PaymentAction } from '../../types';
 import { DropinElementProps } from './types';
+import { getComponentConfiguration } from '../index';
 
 class DropinElement extends UIElement<DropinElementProps> {
     public static type = 'dropin';
@@ -81,9 +82,14 @@ class DropinElement extends UIElement<DropinElementProps> {
             return this.activePaymentMethod.updateWithAction(action);
         }
 
-        const paymentAction = this.props.createFromAction(action, {
+        // Extract desired props that we need to pass on from the pmConfiguration for this particular PM
+        const pmConfig = getComponentConfiguration(action.paymentMethodType, this.props.paymentMethodsConfiguration);
+
+        const paymentAction: UIElement = this.props.createFromAction(action, {
             isDropin: true,
-            onAdditionalDetails: state => this.props.onAdditionalDetails(state, this)
+            onAdditionalDetails: state => this.props.onAdditionalDetails(state, this),
+            onError: this.props.onError, // Add ref to onError in case the merchant has defined one in the component options
+            ...(pmConfig?.onError && { onError: pmConfig.onError }) // Add ref to onError in case the merchant has defined one in the pmConfig options
         });
 
         if (paymentAction) {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -110,7 +110,8 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> {
         if (!action || !action.type) throw new Error('Invalid Action');
 
         const paymentAction = this.props.createFromAction(action, {
-            onAdditionalDetails: state => this.props.onAdditionalDetails(state, this.elementRef)
+            onAdditionalDetails: state => this.props.onAdditionalDetails(state, this.elementRef),
+            onError: this.props.onError // Add ref to onError in case the merchant has defined one in the component options
         });
 
         if (paymentAction) {


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Components create as a result of `handleAction` were losing their reference to the merchant defined `onError` callback unless it was defined at _checkout configuration_ level.
So if it was defined as a _component config option_, or, with the Dropin, as a _payment method config option_ `onError` was not propagating to the actual component

## Tested scenarios
With MBWay in Dropin - tested `onError` is called no matter at what level it is defined (3 possible levels)
With MBWay in Components - tested `onError` is called no matter at what level it is defined (2 possible levels)

