### PR TITLE
Fix/FOC-33772 Full width characters

### DIFF
--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -1,8 +1,14 @@
 import { h } from 'preact';
 import classNames from 'classnames';
+import { convertFullToHalf } from './utils';
 
 export default function InputBase(props) {
     const { autoCorrect, classNameModifiers, isInvalid, isValid, readonly = null, spellCheck, type } = props;
+
+    const handleInput = e => {
+        e.target.value = convertFullToHalf(e.target.value);
+        props.onInput(e);
+    };
 
     const inputClassNames = classNames(
         'adyen-checkout__input',
@@ -15,7 +21,17 @@ export default function InputBase(props) {
         classNameModifiers.map(m => `adyen-checkout__input--${m}`)
     );
 
-    return <input {...props} type={type} className={inputClassNames} readOnly={readonly} spellCheck={spellCheck} autoCorrect={autoCorrect} />;
+    return (
+        <input
+            {...props}
+            type={type}
+            className={inputClassNames}
+            onInput={handleInput}
+            readOnly={readonly}
+            spellCheck={spellCheck}
+            autoCorrect={autoCorrect}
+        />
+    );
 }
 
 InputBase.defaultProps = {

--- a/packages/lib/src/components/internal/FormFields/utils.test.ts
+++ b/packages/lib/src/components/internal/FormFields/utils.test.ts
@@ -12,7 +12,7 @@ describe('convertFullToHalf util', () => {
         const hangul = '훈민정음';
 
         expect(convertFullToHalf(katakana)).toBe(katakana);
-        expect(convertFullToHalf(hiragana)).toBe(kanji);
+        expect(convertFullToHalf(hiragana)).toBe(hiragana);
         expect(convertFullToHalf(kanji)).toBe(kanji);
         expect(convertFullToHalf(hangul)).toBe(hangul);
     });

--- a/packages/lib/src/components/internal/FormFields/utils.test.ts
+++ b/packages/lib/src/components/internal/FormFields/utils.test.ts
@@ -1,8 +1,10 @@
 import { convertFullToHalf } from './utils';
 
 describe('convertFullToHalf util', () => {
-    test('convert full width characters to half width characters', () => {
-        expect(convertFullToHalf('ｔｅｓｔ１２３＠ｅｍａｉｌ．com')).toBe('test123@email.com');
+    test('convert full width characters to half width characters while not changing the half width characters', () => {
+        expect(convertFullToHalf('test123')).toBe('test123');
+        expect(convertFullToHalf('ｔｅｓｔ１２３')).toBe('test123');
+        expect(convertFullToHalf('ｔｅｓｔ＠email１２３.com')).toBe('test@email123.com');
     });
 
     test('does not convert other characters', () => {

--- a/packages/lib/src/components/internal/FormFields/utils.test.ts
+++ b/packages/lib/src/components/internal/FormFields/utils.test.ts
@@ -1,0 +1,19 @@
+import { convertFullToHalf } from './utils';
+
+describe('convertFullToHalf util', () => {
+    test('convert full width characters to half width characters', () => {
+        expect(convertFullToHalf('ｔｅｓｔ１２３＠ｅｍａｉｌ．com')).toBe('test123@email.com');
+    });
+
+    test('does not convert other characters', () => {
+        const katakana = 'パブロ';
+        const hiragana = '平仮名';
+        const kanji = '漢字';
+        const hangul = '훈민정음';
+
+        expect(convertFullToHalf(katakana)).toBe(katakana);
+        expect(convertFullToHalf(hiragana)).toBe(kanji);
+        expect(convertFullToHalf(kanji)).toBe(kanji);
+        expect(convertFullToHalf(hangul)).toBe(hangul);
+    });
+});

--- a/packages/lib/src/components/internal/FormFields/utils.ts
+++ b/packages/lib/src/components/internal/FormFields/utils.ts
@@ -1,25 +1,3 @@
-/**
- * Reference: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html
- * @private
- */
-const AUTOCOMPLETE_VALUES = {
-    city: 'address-level2',
-    country: 'country',
-    dateOfBirth: 'bday',
-    firstName: 'given-name',
-    gender: 'sex',
-    holderName: 'cc-name',
-    houseNumberOrName: 'address-line2',
-    infix: 'additional-name',
-    lastName: 'family-name',
-    postalCode: 'postal-code',
-    shopperEmail: 'email',
-    stateOrProvince: 'address-level1',
-    street: 'address-line1',
-    telephoneNumber: 'tel'
-};
+const convertFullToHalf = str => str.replace(/[！-～]/g, r => String.fromCharCode(r.charCodeAt(0) - 0xfee0));
 
-/**
- * @private
- */
-export const returnAutoComplete = key => AUTOCOMPLETE_VALUES[key] || 'on';
+export { convertFullToHalf };


### PR DESCRIPTION
Full width characters and numbers are not being correctly validated.

## Summary
- Add util function to convert full width characters to half width characters.
- Apply this util function to all inputs. 
- Add tests.
- Remove unused functionality. 

## Tested scenarios
- Convert full width numbers and letters.
- Do not convert other characters.

**Fixed issue**:  FOC-33772
