### PR TITLE
Fix props override in redirect action components

### DIFF
--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -4,8 +4,8 @@ import { PaymentAction } from '../../../types';
 const actionTypes = {
     redirect: (action: PaymentAction, props) =>
         getComponent('redirect', {
-            ...action,
             ...props,
+            ...action,
             statusType: 'redirect'
         }),
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- When prefilling global data on the main instance, POST redirect actions were getting the wrong data object when redirecting.

## Tested scenarios
- POST redirect works when prefilling `data` on the main instance.
