### PR TITLE
Disable allowJs in tsconfig

### DIFF
--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,8 +1,5 @@
 {
     "compilerOptions": {
-        "allowJs": true,
-        "checkJs": false,
-
         "outDir": "./dist/",
         "declaration": true,
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Since all lib code has been migrated to TypeScript, we can `allowJs`.