### PR TITLE
Bump riskModule timeout

### DIFF
--- a/packages/lib/src/core/RiskModule/constants.ts
+++ b/packages/lib/src/core/RiskModule/constants.ts
@@ -2,7 +2,7 @@ export const RISK_DATA_VERSION = '1.0.0';
 export const DF_VERSION = '1.0.0';
 
 export const DEVICE_FINGERPRINT = 'deviceFingerprint';
-export const DF_TIMEOUT = 10000;
+export const DF_TIMEOUT = 20000;
 
 export const FAILED_DFP_RESOLVE_OBJECT_TIMEOUT = {
     result: {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In response to a merchant issue that the riskModule was showing an error in the console about "timing-out" - give the riskModule longer to load