### PR TITLE
accessor "current" was missing form this.sfp reference

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/handlers.ts
+++ b/packages/lib/src/components/Card/components/CardInput/handlers.ts
@@ -126,7 +126,7 @@ function handleAdditionalDataSelection(e: Event): void {
 
     // Pass brand into SecuredFields
     if (this.state.additionalSelectType === 'brandSwitcher') {
-        this.sfp.processBinLookupResponse({ supportedBrands: [value] });
+        this.sfp.current.processBinLookupResponse({ supportedBrands: [value] });
     }
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Recent refactor had missed adding a ref to "current" when accessing SFP functionality

## Tested scenarios
Functionality now works

