### PR TITLE
Fix PayPal onCancel event not propagating the right component reference

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -106,6 +106,7 @@ class DropinElement extends UIElement<DropinElementProps> {
                     {...this.props}
                     onChange={this.setState}
                     onSubmit={this.handleSubmit}
+                    elementRef={this.elementRef}
                     ref={dropinRef => {
                         this.dropinRef = dropinRef;
                     }}


### PR DESCRIPTION
## Summary
Fix `elementRef` not being propagated to the `DropinComponent`.
Because of this, the PayPal component was not sending the right reference in the `onCancel` and the `onError`.