### PR TITLE
Fix Google Pay existingPaymentMethodRequired issues

### DIFF
--- a/packages/lib/src/components/Dropin/elements/filters.ts
+++ b/packages/lib/src/components/Dropin/elements/filters.ts
@@ -4,7 +4,7 @@ export const filterPresent = paymentMethod => !!paymentMethod;
 // filter payment methods that are available to the user
 export const filterAvailable = paymentMethod => {
     if (paymentMethod.isAvailable) {
-        const timeout = new Promise((resolve, reject) => setTimeout(reject, 1000));
+        const timeout = new Promise((resolve, reject) => setTimeout(reject, 5000));
         return Promise.race([paymentMethod.isAvailable(), timeout]);
     }
 

--- a/packages/lib/src/components/GooglePay/GooglePayService.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayService.ts
@@ -2,7 +2,6 @@ import { isReadyToPayRequest, initiatePaymentRequest } from './requests';
 import { resolveEnvironment } from './utils';
 import Script from '../../utils/Script';
 import config from './config';
-import wait from '../../utils/wait';
 
 class GooglePayService {
     public readonly paymentsClient: Promise<google.payments.api.PaymentsClient>;
@@ -29,7 +28,6 @@ class GooglePayService {
         if (!window.google?.payments) {
             const script = new Script(config.URL);
             await script.load();
-            await wait(100);
         }
 
         return new google.payments.api.PaymentsClient(paymentOptions);

--- a/packages/lib/src/components/GooglePay/defaultProps.ts
+++ b/packages/lib/src/components/GooglePay/defaultProps.ts
@@ -2,7 +2,7 @@ export default {
     environment: 'TEST',
 
     // isReadyToPayRequest
-    existingPaymentMethodRequired: true,
+    existingPaymentMethodRequired: false,
 
     // ButtonOptions
     // https://developers.google.com/pay/api/web/reference/object#ButtonOptions

--- a/packages/lib/src/components/GooglePay/requests.test.ts
+++ b/packages/lib/src/components/GooglePay/requests.test.ts
@@ -54,7 +54,7 @@ describe('Google Pay Requests', () => {
             expect(readyToPayRequest.allowedPaymentMethods.length).toBeGreaterThan(0);
             expect(readyToPayRequest.apiVersion).toBeDefined();
             expect(readyToPayRequest.apiVersionMinor).toBeDefined();
-            expect(readyToPayRequest.existingPaymentMethodRequired).toBe(true);
+            expect(readyToPayRequest.existingPaymentMethodRequired).toBe(false);
         });
     });
 });

--- a/packages/lib/src/components/GooglePay/requests.ts
+++ b/packages/lib/src/components/GooglePay/requests.ts
@@ -11,7 +11,7 @@ import { GooglePayProps } from './types';
 export function isReadyToPayRequest({
     allowedAuthMethods,
     allowedCardNetworks,
-    existingPaymentMethodRequired = true
+    existingPaymentMethodRequired = false
 }): google.payments.api.IsReadyToPayRequest {
     return {
         apiVersion: config.API_VERSION,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Default `existingPaymentMethodRequired` to false on Google Pay component.
- Disable timeouts when loading the Google Pay Web SDK file automatically.
- Increment Drop-in timeout for payment methods that use the `isAvailable()` function.