### PR TITLE
DropinComponent - add public method 'closeActivePaymentMethod'

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -24,4 +24,15 @@ describe('Dropin', () => {
             expect(() => dropin.submit()).toThrow();
         });
     });
+
+    describe('closeActivePaymentMethod', () => {
+        test('should close active payment method', () => {
+            const dropin = new Dropin({});
+            mount(dropin.render());
+            expect(dropin.dropinRef.state.activePaymentMethod).toBeDefined();
+
+            dropin.closeActivePaymentMethod();
+            expect(dropin.dropinRef.state.activePaymentMethod).toBeNull();
+        });
+    })
 });

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -99,6 +99,10 @@ class DropinElement extends UIElement<DropinElementProps> {
         return null;
     }
 
+    resetActivePaymentMethod() {
+        this.dropinRef.resetActivePaymentMethod();
+    }
+
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -99,8 +99,8 @@ class DropinElement extends UIElement<DropinElementProps> {
         return null;
     }
 
-    resetActivePaymentMethod() {
-        this.dropinRef.resetActivePaymentMethod();
+    closeActivePaymentMethod() {
+        this.dropinRef.closeActivePaymentMethod();
     }
 
     render() {

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -98,6 +98,10 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
             });
     };
 
+    resetActivePaymentMethod() {
+        this.setState({ activePaymentMethod: null });
+    }
+
     render(props, { elements, status, activePaymentMethod, cachedPaymentMethods }) {
         const isLoading = status.type === 'loading';
         const isRedirecting = status.type === 'redirect';

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -98,7 +98,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
             });
     };
 
-    resetActivePaymentMethod() {
+    closeActivePaymentMethod() {
         this.setState({ activePaymentMethod: null });
     }
 


### PR DESCRIPTION
DropIn component has a few methods and props to control and handle selection, like `openFirstPaymentMethod` or `onSelect()`.

But in some cases I need to reset the selected payment method in an already mounted component.
At the moment there's no public API for that.

So, this PR adds `closeActivePaymentMethod ` to reset selected payment method.