### PR TITLE
Call validateCardInput after binLookup detects a new brand

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
+++ b/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
@@ -13,7 +13,7 @@ export default function processBinLookupResponse(binValueObject: BinValueObject)
 
     // RESULT: binLookup has found a result so proceed accordingly
     if (binValueObject.supportedBrands?.length) {
-        // 1) Multiple options found - add to the UI & inform SFP if appropriate
+        // 1) Multiple options found - add to the UI & inform SFP
         if (binValueObject.supportedBrands.length > 1) {
             // --
             const switchObj = createCardVariantSwitcher(binValueObject.supportedBrands, 'brandSwitcher');
@@ -29,7 +29,8 @@ export default function processBinLookupResponse(binValueObject: BinValueObject)
             this.resetAdditionalSelectState(); // Reset UI
 
             // Set (single) value from binLookup so it will be added to the 'brand' property in the paymentMethod object
-            this.setState({ additionalSelectValue: binValueObject.supportedBrands[0] });
+            // Call validateCardInput so this new value ends up in state for the Card UIElement (Card.tsx)
+            this.setState({ additionalSelectValue: binValueObject.supportedBrands[0] }, this.validateCardInput());
 
             // Pass object through to SFP
             this.sfp.current.processBinLookupResponse(binValueObject);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The `brand`, detected by `/binLookup`, and set in the `paymentMethod` data for the Card component could end up with the wrong value if the shopper first entered one card and then _pasted another full, valid, number_ without doing any further actions to cause the Card component to validate it's input

## Tested scenarios
Scenarios described in issue (see below)


**Fixed issue**:  FOC-35674
