### PR TITLE
Fix/Extend locale type definition to allow custom locales.

### DIFF
--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -24,9 +24,10 @@ export interface CoreOptions {
     /**
      * The shopper's locale. This is used to set the language rendered in the UI.
      * For a list of supported locales, see {@link https://docs.adyen.com/checkout/components-web/localization-components | Localization}.
+     * For adding a custom locale, see {@link https://docs.adyen.com/checkout/components-web/localization-components#create-localization | Create localization}.
      * @defaultValue 'en-US'
      */
-    locale?: Locales;
+    locale?: Locales | string;
 
     /**
      * Custom translations and localizations


### PR DESCRIPTION
## Summary
Extend locale type definition to allow custom locales while still make it possible to autocomplete our supported locales.

**Fixed issue**:  Adyen/adyen-web#364
