### PR TITLE
Add extra transactionInfo fields to Google Pay payment request

### DIFF
--- a/packages/lib/src/components/GooglePay/requests.test.ts
+++ b/packages/lib/src/components/GooglePay/requests.test.ts
@@ -4,7 +4,7 @@ import defaultProps from './defaultProps';
 describe('Google Pay Requests', () => {
     describe('getTransactionInfo', () => {
         test('should transform a normal currency amount', () => {
-            const transactionInfo = getTransactionInfo('USD', 1234);
+            const transactionInfo = getTransactionInfo({ currencyCode: 'USD', totalPrice: 1234 });
 
             expect(transactionInfo.currencyCode).toBe('USD');
             expect(transactionInfo.totalPrice).toBe('12.34');
@@ -12,7 +12,7 @@ describe('Google Pay Requests', () => {
         });
 
         test('should transform a normal currency with amount ZERO', () => {
-            const transactionInfo = getTransactionInfo('EUR', 0);
+            const transactionInfo = getTransactionInfo({ currencyCode: 'EUR', totalPrice: 0 });
 
             expect(transactionInfo.currencyCode).toBe('EUR');
             expect(transactionInfo.totalPrice).toBe('0');
@@ -20,7 +20,7 @@ describe('Google Pay Requests', () => {
         });
 
         test('should default to a ZERO amount', () => {
-            const transactionInfo = getTransactionInfo(undefined, undefined);
+            const transactionInfo = getTransactionInfo({});
 
             expect(transactionInfo.currencyCode).toBe('USD');
             expect(transactionInfo.totalPrice).toBe('0');
@@ -28,11 +28,31 @@ describe('Google Pay Requests', () => {
         });
 
         test('should transform a non decimal currency amount', () => {
-            const transactionInfo = getTransactionInfo('JPY', 1234);
+            const transactionInfo = getTransactionInfo({ currencyCode: 'JPY', totalPrice: 1234 });
 
             expect(transactionInfo.currencyCode).toBe('JPY');
             expect(transactionInfo.totalPrice).toBe('1234');
             expect(transactionInfo.totalPriceStatus).toBe('FINAL');
+        });
+
+        test('should allow other transactionInfo values', () => {
+            const transactionInfo = getTransactionInfo({
+                currencyCode: 'JPY',
+                totalPrice: 1234,
+                transactionInfo: {
+                    displayItems: [
+                        {
+                            label: 'Subtotal',
+                            type: 'SUBTOTAL',
+                            price: '11.00'
+                        }
+                    ]
+                }
+            });
+
+            expect(transactionInfo.currencyCode).toBe('JPY');
+            expect(transactionInfo.totalPrice).toBe('1234');
+            expect(transactionInfo.displayItems).toHaveLength(1);
         });
     });
 

--- a/packages/lib/src/components/GooglePay/requests.ts
+++ b/packages/lib/src/components/GooglePay/requests.ts
@@ -39,19 +39,21 @@ export function isReadyToPayRequest({
  * @see {@link https://developers.google.com/pay/api/web/reference/object#TransactionInfo|TransactionInfo}
  * @returns transaction info, suitable for use as transactionInfo property of PaymentDataRequest
  */
-export function getTransactionInfo(
+export function getTransactionInfo({
     currencyCode = 'USD',
     totalPrice = 0,
-    totalPriceStatus: google.payments.api.TotalPriceStatus = 'FINAL',
-    countryCode = 'US'
-): google.payments.api.TransactionInfo {
+    countryCode = 'US',
+    totalPriceStatus = 'FINAL',
+    ...props
+}): google.payments.api.TransactionInfo {
     const formattedPrice = String(getDecimalAmount(totalPrice, currencyCode));
 
     return {
         countryCode,
         currencyCode,
         totalPrice: formattedPrice,
-        totalPriceStatus // Price will not change
+        totalPriceStatus: totalPriceStatus as google.payments.api.TotalPriceStatus,
+        ...props.transactionInfo
     };
 }
 
@@ -59,7 +61,7 @@ export function initiatePaymentRequest({ configuration, ...props }: GooglePayPro
     return {
         apiVersion: config.API_VERSION,
         apiVersionMinor: config.API_VERSION_MINOR,
-        transactionInfo: getTransactionInfo(props.amount.currency, props.amount.value, props.totalPriceStatus, props.countryCode),
+        transactionInfo: getTransactionInfo(props),
         merchantInfo: {
             merchantId: configuration.merchantId,
             merchantName: configuration.merchantName


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Add extra [transactionInfo](https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo) fields to Google Pay payment request 

```js
const googlepay = checkout.create("paywithgoogle", {
  // ...
  transactionInfo: {
    // ...
  }
});
```