### PR TITLE
Fix paymentMethodsResponse warning message

### DIFF
--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/utils.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/utils.ts
@@ -49,7 +49,7 @@ export const checkPaymentMethodsResponse = response => {
         );
     }
 
-    if (!response?.paymentMethods?.length && !response?.storePaymentMethods?.length) {
+    if (response && !response?.paymentMethods?.length && !response?.storePaymentMethods?.length) {
         console.warn('paymentMethodsResponse was provided but no payment methods were found.');
     }
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Fix a `paymentMethodsResponse` warning message that would trigger even when no `paymentMethodsResponse` was provided.
