### PR TITLE
Feature/Update PayPal component to accept the vault and the showPayButton props.

### DIFF
--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -104,6 +104,8 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     }
 
     render() {
+        if (!this.props.showPayButton) return null;
+
         return (
             <PaypalComponent
                 ref={ref => {

--- a/packages/lib/src/components/PayPal/defaultProps.ts
+++ b/packages/lib/src/components/PayPal/defaultProps.ts
@@ -3,6 +3,7 @@ import { PayPalElementProps } from './types';
 const defaultProps: PayPalElementProps = {
     environment: 'TEST',
     status: 'loading',
+    showPayButton: true,
 
     // Config
     /**
@@ -19,6 +20,11 @@ const defaultProps: PayPalElementProps = {
      * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#commit}
      */
     commit: true,
+
+    /**
+     * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#vault}
+     */
+    vault: false,
 
     /**
      * @see {@link https://developer.paypal.com/docs/checkout/integration-features/customize-button/}
@@ -38,11 +44,7 @@ const defaultProps: PayPalElementProps = {
         /**
          * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#intent}
          */
-        intent: null,
-        /**
-         * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#commit}
-         */
-        commit: true
+        intent: null
     },
 
     // Events

--- a/packages/lib/src/components/PayPal/types.ts
+++ b/packages/lib/src/components/PayPal/types.ts
@@ -78,6 +78,11 @@ interface PayPalCommonProps {
     commit?: boolean;
 
     /**
+     * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#vault}
+     */
+    vault?: boolean;
+
+    /**
      * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#locale}
      */
     locale?: string;
@@ -109,10 +114,6 @@ export interface PayPalConfig {
      * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#intent}
      */
     intent?: Intent;
-    /**
-     * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#commit}
-     */
-    commit?: boolean;
 }
 
 export interface PayPalElementProps extends PayPalCommonProps, UIElementProps {
@@ -123,6 +124,7 @@ export interface PayPalElementProps extends PayPalCommonProps, UIElementProps {
     onError?: (state: any, element?: UIElement) => void;
     paymentMethods?: PaymentMethod[];
     configuration?: PayPalConfig;
+    showPayButton?: boolean;
 }
 
 export interface PayPalComponentProps extends PayPalCommonProps {
@@ -146,6 +148,7 @@ export interface PaypalSettings {
     debug?: boolean;
     intent?: Intent;
     commit?: boolean;
+    vault?: boolean;
     'client-id': string;
     'integration-date': string;
     components: string;

--- a/packages/lib/src/components/PayPal/utils.ts
+++ b/packages/lib/src/components/PayPal/utils.ts
@@ -13,7 +13,16 @@ const getSupportedLocale = (locale?: string): SupportedLocale => {
 /**
  * Returns an object of settings for the PayPal SDK
  */
-const getPaypalSettings = ({ amount, countryCode, debug, environment = '', locale, configuration, commit }: PayPalElementProps): PaypalSettings => {
+const getPaypalSettings = ({
+    amount,
+    countryCode,
+    debug,
+    environment = '',
+    locale,
+    configuration,
+    commit,
+    vault
+}: PayPalElementProps): PaypalSettings => {
     const shopperLocale: SupportedLocale = getSupportedLocale(locale);
     const currency: string = amount ? amount.currency : null;
     const isTestEnvironment: boolean = environment.toLowerCase() === 'test';
@@ -29,6 +38,7 @@ const getPaypalSettings = ({ amount, countryCode, debug, environment = '', local
         ...(currency && { currency }),
         ...(intent && { intent }),
         commit,
+        vault,
         'client-id': clientId,
         'integration-date': INTEGRATION_DATE,
         components: 'buttons,funding-eligibility'


### PR DESCRIPTION
## Summary
Update PayPal component to accept the vault and the `showPayButton` props.
When `showPayButton` is set to `false`, the PayPal buttons won't render.
Keep in mind the payment flow cannot be triggered programatically so it would require to mount the PayPal component somewhere else on the page.

**Fixed issue**:  #341
