### PR TITLE
revolving installments alignment issue

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.scss
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.scss
@@ -110,7 +110,7 @@
 }
 
 .adyen-checkout__fieldset--revolving-plan {
-    .adyen-checkout__fieldset__fields{
+    .adyen-checkout__fieldset__fields {
         justify-content: left;
     }
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.scss
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.scss
@@ -110,6 +110,10 @@
 }
 
 .adyen-checkout__fieldset--revolving-plan {
+    .adyen-checkout__fieldset__fields{
+        justify-content: left;
+    }
+
     .adyen-checkout__radio_group {
         display: flex;
         flex-direction: column;
@@ -123,6 +127,6 @@
 .adyen-checkout__field--revolving-plan-installments{
     position: relative;
     top: 42px;
-    right: 37%;
     width: 30%;
+    margin-left: 15px;
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed possibility that the installments dropdown could overlap the text by removing fixed position and adding margin-left

## Tested scenarios
As the label text changes (due to translations) - the dropdown stays the required distance to the right

