### PR TITLE
Fix missing prop to the RadioGroup component

### DIFF
--- a/packages/lib/src/components/internal/FormFields/RadioGroup/RadioGroup.tsx
+++ b/packages/lib/src/components/internal/FormFields/RadioGroup/RadioGroup.tsx
@@ -4,7 +4,7 @@ import './RadioGroup.scss';
 import { RadioGroupProps } from './types';
 
 export default function RadioGroup(props: RadioGroupProps) {
-    const { items, i18n, onChange, value, isInvalid } = props;
+    const { items, i18n, name, onChange, value, isInvalid } = props;
 
     return (
         <div className="adyen-checkout__radio_group">
@@ -14,6 +14,7 @@ export default function RadioGroup(props: RadioGroupProps) {
                         type="radio"
                         checked={value === item.id}
                         className="adyen-checkout__radio_group__input"
+                        name={name}
                         onChange={onChange}
                         onClick={onChange}
                         value={item.id}

--- a/packages/lib/src/components/internal/FormFields/RadioGroup/types.ts
+++ b/packages/lib/src/components/internal/FormFields/RadioGroup/types.ts
@@ -10,6 +10,7 @@ export interface RadioGroupProps {
     isInvalid?: boolean;
     items: RadioGroupItem[];
     i18n: Language;
+    name?: string;
     onChange: (e) => void;
     value?: string;
 }


### PR DESCRIPTION
## Summary
Add missing `name` prop to the RadioGroup component.
This fixes an issue with the Gender radio button not being able to be selected on open invoice components (AfterPay, Oney and RatePay).