### PR TITLE
Fix empty address fieldsets being returned in the data object

### DIFF
--- a/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
+++ b/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
@@ -78,8 +78,8 @@ export default class OpenInvoiceContainer extends UIElement {
             ...(telephoneNumber && { telephoneNumber }),
             ...(shopperEmail && { shopperEmail }),
             ...(billingAddress?.country && { countryCode: billingAddress.country }),
-            billingAddress,
-            deliveryAddress: deliveryAddress || billingAddress
+            ...(billingAddress && { billingAddress }),
+            ...((deliveryAddress || billingAddress) && { deliveryAddress: deliveryAddress || billingAddress })
         };
     }
 

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -41,8 +41,14 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         const fieldsetsAreValid = checkFieldsets();
         const consentCheckboxValid = !hasConsentCheckbox || !!valid.consentCheckbox;
         const isValid = fieldsetsAreValid && consentCheckboxValid;
+        const newData = Object.keys(data)
+            .filter(fieldset => activeFieldsets[fieldset])
+            .reduce((acc, cur) => {
+                acc[cur] = data[cur];
+                return acc;
+            }, {});
 
-        props.onChange({ data, isValid });
+        props.onChange({ data: newData, isValid });
     }, [data, valid, errors]);
 
     const handleFieldset = key => state => {


### PR DESCRIPTION
## Summary
The open invoice is currently returning `undefined` when the delivery or the billing addresses are set as `hidden`.

## Tested scenarios
Tested in both shown and hidden fieldsets.