### PR TITLE
Deprecate origin key

### DIFF
--- a/packages/lib/src/components/Ach/components/AchInput/defaultProps.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/defaultProps.ts
@@ -20,8 +20,6 @@ export default {
     onFocus: () => {},
     onChange: () => {},
 
-    originKey: null,
-
     // Values
     holderName: '',
     data: {

--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -38,14 +38,13 @@ class BlikElement extends UIElement {
 
     render() {
         if (this.props.paymentData) {
-            const accessKey = this.props.originKey || this.props.clientKey;
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
                     <Await
                         ref={ref => {
                             this.componentRef = ref;
                         }}
-                        accessKey={accessKey}
+                        clientKey={this.props.clientKey}
                         paymentData={this.props.paymentData}
                         onError={this.props.onError}
                         onComplete={this.onComplete}

--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -28,8 +28,6 @@ export default {
     onFocus: () => {},
     onChange: () => {},
 
-    originKey: null,
-
     // Values
     holderName: '',
     data: {

--- a/packages/lib/src/components/Dropin/components/utils.ts
+++ b/packages/lib/src/components/Dropin/components/utils.ts
@@ -16,7 +16,6 @@ export function getCommonProps(props) {
         onBalanceCheck: props.onBalanceCheck,
         onOrderRequest: props.onOrderRequest,
         onSubmit: props.onSubmit,
-        originKey: props.originKey,
         clientKey: props.clientKey,
         showPayButton: props.showPayButton
     };

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -44,14 +44,13 @@ export class MBWayElement extends UIElement {
 
     render() {
         if (this.props.paymentData) {
-            const accessKey = this.props.originKey || this.props.clientKey;
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
                     <Await
                         ref={ref => {
                             this.componentRef = ref;
                         }}
-                        accessKey={accessKey}
+                        clientKey={this.props.clientKey}
                         paymentData={this.props.paymentData}
                         onError={this.props.onError}
                         onComplete={this.onComplete}

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -60,9 +60,9 @@ function Await(props: AwaitComponentProps) {
     };
 
     const checkStatus = (): void => {
-        const { paymentData, accessKey } = props;
+        const { paymentData, clientKey } = props;
 
-        checkPaymentStatus(paymentData, accessKey, loadingContext)
+        checkPaymentStatus(paymentData, clientKey, loadingContext)
             .then(processResponse)
             .catch(({ message, ...response }) => ({
                 type: 'network-error',

--- a/packages/lib/src/components/internal/Await/types.ts
+++ b/packages/lib/src/components/internal/Await/types.ts
@@ -20,7 +20,7 @@ export interface AwaitComponentProps {
     url?: string;
     shouldRedirectOnMobile?: boolean;
     classNameModifiers?: string[];
-    accessKey: string;
+    clientKey: string;
     onError: (error, component) => void;
     onComplete: (status, component) => void;
     brandLogo: string;

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -127,9 +127,9 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
     }
 
     checkStatus() {
-        const { paymentData, originKey, clientKey, loadingContext } = this.props;
-        const accessKey = clientKey ? clientKey : originKey;
-        return checkPaymentStatus(paymentData, accessKey, loadingContext)
+        const { paymentData, clientKey, loadingContext } = this.props;
+
+        return checkPaymentStatus(paymentData, clientKey, loadingContext)
             .then(processResponse)
             .catch(response => ({ type: 'network-error', props: response }))
             .then(status => {

--- a/packages/lib/src/components/internal/QRLoader/types.ts
+++ b/packages/lib/src/components/internal/QRLoader/types.ts
@@ -12,7 +12,6 @@ export interface QRLoaderProps {
     url?: string;
     type?: string;
     paymentData?: string;
-    originKey?: string;
     clientKey?: string;
     loadingContext?: string;
     qrCodeData?: string;

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -134,7 +134,6 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
         const csfSetupObj: SetupObject = {
             rootNode: root,
             type: this.props.type,
-            originKey: this.props.originKey,
             clientKey: this.props.clientKey,
             cardGroupTypes: this.props.groupTypes,
             allowedDOMAccess: this.props.allowedDOMAccess,

--- a/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
@@ -20,7 +20,7 @@ export interface SFPProps {
     onFieldValid?;
     onFocus?;
     onLoad?;
-    originKey?: string;
+    clientKey?: string;
     placeholders?: object;
     rootNode?: HTMLElement;
     showWarnings?: boolean;
@@ -83,7 +83,6 @@ export default {
     type: 'card',
 
     // Settings
-    originKey: null,
     keypadFix: true,
     rootNode: null,
     loadingContext: null,

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
@@ -57,11 +57,9 @@ export function handleConfig(): void {
     let sfBundleType: string = this.config.isCreditCardType ? 'card' : this.props.type;
     if (sfBundleType.indexOf('sepa') > -1) sfBundleType = 'iban';
 
-    // During the transition period accept clientKey & originKey, giving clientKey preference
-    const accessKey: string = this.props.clientKey ? this.props.clientKey : this.props.originKey;
     // Add a hash of the origin to ensure urls are different across domains
     const d = btoa(window.location.origin);
-    this.config.iframeSrc = `${this.config.loadingContext}securedfields/${accessKey}/${SF_VERSION}/securedFields.html?type=${sfBundleType}&d=${d}`;
+    this.config.iframeSrc = `${this.config.loadingContext}securedfields/${this.props.clientKey}/${SF_VERSION}/securedFields.html?type=${sfBundleType}&d=${d}`;
 
     // TODO###### FOR QUICK LOCAL TESTING of sf
     if (process.env.NODE_ENV === 'development' && process.env.__SF_ENV__ !== 'build') {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/initCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/initCSF.ts
@@ -22,10 +22,8 @@ const initCSF = (pSetupObj: SetupObject): CSFReturnObject => {
         return null;
     }
 
-    if (falsy(setupObj.clientKey) && falsy(setupObj.originKey)) {
-        logger.warn(
-            'WARNING: Checkout configuration object is missing a "clientKey" property.\nFor a transition period the originKey will be accepted instead but this will eventually be deprecated'
-        );
+    if (falsy(setupObj.clientKey)) {
+        logger.warn('WARNING: AdyenCheckout configuration object is missing a "clientKey" property.');
         return null;
     }
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -33,7 +33,6 @@ interface CSFCommonProps {
 
 export interface SetupObject extends CSFCommonProps {
     type: string;
-    originKey: string;
     clientKey: string;
     rootNode: string | HTMLElement;
     callbacks?: object;

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -11,7 +11,7 @@ describe('Analytics', () => {
     });
 
     test('Creates an Analytics module with defaultProps', () => {
-        const analytics = new Analytics({ analytics: {}, loadingContext: '', locale: '', originKey: '', clientKey: '' });
+        const analytics = new Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
         expect(analytics.props.enabled).toBe(true);
         expect(analytics.props.telemetry).toBe(true);
         expect(analytics.props.conversion).toBe(false);
@@ -20,12 +20,12 @@ describe('Analytics', () => {
 
     test('Calls the collectId endpoint if conversion is enabled', () => {
         mockedCollectId.mockResolvedValueOnce({ name: 'test' });
-        new Analytics({ analytics: { conversion: true }, loadingContext: '', locale: '', originKey: '', clientKey: '' });
+        new Analytics({ analytics: { conversion: true }, loadingContext: '', locale: '', clientKey: '' });
         expect(collectId).toHaveBeenCalled();
     });
 
     test('Will not call the collectId endpoint if conversion is disabled', () => {
-        new Analytics({ analytics: { conversion: false }, loadingContext: '', locale: '', originKey: '', clientKey: '' });
+        new Analytics({ analytics: { conversion: false }, loadingContext: '', locale: '', clientKey: '' });
         expect(collectId).not.toHaveBeenCalled();
     });
 });

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -18,11 +18,10 @@ class Analytics {
     private readonly logTelemetry;
     private readonly queue = new EventsQueue();
 
-    constructor({ loadingContext, locale, originKey, clientKey, analytics }: AnalyticsProps) {
+    constructor({ loadingContext, locale, clientKey, analytics }: AnalyticsProps) {
         this.props = { ...Analytics.defaultProps, ...analytics };
-        const accessKey = clientKey || originKey;
         this.logEvent = logEvent({ loadingContext, locale });
-        this.logTelemetry = postTelemetry({ loadingContext, locale, accessKey });
+        this.logTelemetry = postTelemetry({ loadingContext, locale, clientKey });
 
         const { conversion, enabled } = this.props;
 
@@ -32,7 +31,7 @@ class Analytics {
                 this.queue.run(this.conversionId);
             } else {
                 // If no conversionId is provided, fetch a new one
-                collectId({ loadingContext, accessKey })
+                collectId({ loadingContext, clientKey })
                     .then(conversionId => {
                         this.conversionId = conversionId;
                         this.queue.run(this.conversionId);

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -23,7 +23,6 @@ export interface AnalyticsOptions {
 export interface AnalyticsProps {
     loadingContext: string;
     locale?: string;
-    originKey?: string;
     clientKey?: string;
     analytics?: AnalyticsOptions;
 }

--- a/packages/lib/src/core/RiskModule/components/DeviceFingerprint/DeviceFingerprint.tsx
+++ b/packages/lib/src/core/RiskModule/components/DeviceFingerprint/DeviceFingerprint.tsx
@@ -8,11 +8,10 @@ class DeviceFingerprint extends Component<DeviceFingerprintProps, DeviceFingerpr
     constructor(props) {
         super(props);
 
-        const accessKey = props.clientKey || props.originKey;
-        if (accessKey) {
+        if (props.clientKey) {
             this.state = {
                 status: 'retrievingFingerPrint',
-                dfpURL: `${this.props.loadingContext}assets/html/${accessKey}/dfp.${DF_VERSION}.html`
+                dfpURL: `${this.props.loadingContext}assets/html/${props.clientKey}/dfp.${DF_VERSION}.html`
             };
         }
     }

--- a/packages/lib/src/core/Services/collect-id.ts
+++ b/packages/lib/src/core/Services/collect-id.ts
@@ -4,7 +4,7 @@
  * @returns a promise containing the response of the call
  */
 const collectId = config => {
-    if (!config.accessKey) {
+    if (!config.clientKey) {
         return Promise.reject();
     }
 
@@ -16,7 +16,7 @@ const collectId = config => {
         }
     };
 
-    return fetch(`${config.loadingContext}v1/analytics/id?token=${config.accessKey}`, options)
+    return fetch(`${config.loadingContext}v1/analytics/id?token=${config.clientKey}`, options)
         .then(response => {
             if (response.ok) return response.json();
             throw new Error('Collect ID not available');

--- a/packages/lib/src/core/Services/post-telemetry.ts
+++ b/packages/lib/src/core/Services/post-telemetry.ts
@@ -3,7 +3,7 @@
  * @param config -
  */
 const logTelemetry = config => event => {
-    if (!config.accessKey) {
+    if (!config.clientKey) {
         return Promise.reject();
     }
 
@@ -27,7 +27,7 @@ const logTelemetry = config => event => {
         body: JSON.stringify(telemetryEvent)
     };
 
-    return fetch(`${config.loadingContext}v1/analytics/log?token=${config.accessKey}`, options)
+    return fetch(`${config.loadingContext}v1/analytics/log?token=${config.clientKey}`, options)
         .then(response => response.ok)
         .catch(() => {});
 };

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -11,12 +11,6 @@ export interface CoreOptions {
     environment?: 'test' | 'live' | 'live-us' | 'live-au' | string;
 
     /**
-     * A client-side key linked to your website, used to validate Adyen’s Web component library. Use the {@link https://docs.adyen.com/api-explorer/#/CheckoutUtility/v1/originKeys | /originKeys} endpoint to generate one.
-     * For more information, refer to {@link https://docs.adyen.com/user-management/how-to-get-an-origin-key | How to get an origin key}.
-     */
-    originKey?: string;
-
-    /**
      * A public key linked to your web service user, used for {@link https://docs.adyen.com/user-management/client-side-authentication | client-side authentication}.
      */
     clientKey?: string;

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -1,148 +1,142 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
-import { getPaymentMethods, getOriginKey } from '../../services';
+import { getPaymentMethods } from '../../services';
 import { handleSubmit, handleAdditionalDetails, handleError } from '../../handlers';
 import { amount, shopperLocale } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
 
-getOriginKey()
-    .then(originKey => {
-        window.originKey = originKey;
-    })
-    .then(() => getPaymentMethods({ amount, shopperLocale }))
-    .then(paymentMethodsResponse => {
-        window.checkout = new AdyenCheckout({
-            amount, // Optional. Used to display the amount in the Pay Button.
-            originKey,
-            clientKey: process.env.__CLIENT_KEY__,
-            paymentMethodsResponse,
-            locale: shopperLocale,
-            environment: 'test',
-            showPayButton: true,
-            onSubmit: handleSubmit,
-            onAdditionalDetails: handleAdditionalDetails,
-            onError: handleError,
-            risk: {
-                enabled: true, // Means that "riskdata" will then show up in the data object sent to the onChange event. Also accessible via
-                // checkout.modules.risk.data
-                //                node: '.merchant-checkout__form', // Element that DF iframe is briefly added to (defaults to body)
-                //                onComplete: obj => {},
-                onError: console.error
-            }
-            //            analytics: {
-            //                conversion: true,
-            //                telemetry: true
-            //            }
-        });
-
-        // Stored Card
-        if (checkout.paymentMethodsResponse.storedPaymentMethods && checkout.paymentMethodsResponse.storedPaymentMethods.length > 0) {
-            const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[0];
-            window.storedCard = checkout.create('card', storedCardData).mount('.storedcard-field');
+getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
+    window.checkout = new AdyenCheckout({
+        amount, // Optional. Used to display the amount in the Pay Button.
+        clientKey: process.env.__CLIENT_KEY__,
+        paymentMethodsResponse,
+        locale: shopperLocale,
+        environment: 'test',
+        showPayButton: true,
+        onSubmit: handleSubmit,
+        onAdditionalDetails: handleAdditionalDetails,
+        onError: handleError,
+        risk: {
+            enabled: true, // Means that "riskdata" will then show up in the data object sent to the onChange event. Also accessible via
+            // checkout.modules.risk.data
+            //                node: '.merchant-checkout__form', // Element that DF iframe is briefly added to (defaults to body)
+            //                onComplete: obj => {},
+            onError: console.error
         }
-
-        // Credit card with installments
-        window.card = checkout
-            .create('card', {
-                type: 'scheme',
-                brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-                hasHolderName: false,
-                // holderNameRequired: true,
-                enableStoreDetails: false,
-                installmentOptions: {
-                    // card: {
-                    //     values: [1, 2]
-                    // },
-                    mc: {
-                        values: [1, 2, 3]
-                    },
-                    visa: {
-                        values: [1, 2, 3, 4],
-                        plans: ['regular', 'revolving']
-                    }
-                },
-                showInstallmentAmounts: true,
-                ariaLabels: {
-                    lang: 'en-GB',
-                    encryptedCardNumber: {
-                        label: 'Credit or debit card number field',
-                        iframeTitle: 'cc number field iframe'
-                        //                        error: { 'error.ve.gen.01': 'something is wrong', 'error.ve.sf-cc-num.02': 'another error' }
-                    },
-                    encryptedExpiryDate: {
-                        label: 'put your date in here'
-                    }
-                }
-                //                placeholders: {
-                //                    encryptedSecurityCode: '8888'
-                //                }
-                //                onError: objdobj => {
-                //                    console.log('component level merchant defined error handler for Card objdobj=', objdobj);
-                //                }
-            })
-            .mount('.card-field');
-
-        // Bancontact card
-        window.bancontact = checkout
-            .create('bcmc', {
-                type: 'bcmc',
-                hasHolderName: true,
-                // holderNameRequired: true,
-                enableStoreDetails: false
-            })
-            .mount('.bancontact-field');
-
-        // Credit card with AVS
-        window.cardAvs = checkout
-            .create('card', {
-                type: 'scheme',
-                brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-                enableStoreDetails: true,
-
-                // holderName config:
-                hasHolderName: true,
-                holderNameRequired: true,
-                holderName: 'J. Smith',
-
-                // billingAddress config:
-                billingAddressRequired: true,
-                billingAddressAllowedCountries: ['US', 'CA', 'BR', 'IT'],
-                // billingAddressRequiredFields: ['postalCode', 'country'],
-
-                // data:
-                data: {
-                    holderName: 'J. Smith',
-                    billingAddress: {
-                        street: 'Infinite Loop',
-                        postalCode: '95014',
-                        city: 'Cupertino',
-                        houseNumberOrName: '1',
-                        country: 'US',
-                        stateOrProvince: 'CA'
-                    }
-                },
-                onError: objdobj => {
-                    console.log('component level merchant defined error handler for Card objdobj=', objdobj);
-                }
-            })
-            .mount('.card-avs-field');
-
-        // Credit card with KCP Authentication
-        window.kcpCard = checkout
-            .create('card', {
-                type: 'scheme',
-                brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-                // USE either separate koreanAuthenticationRequired prop...
-                koreanAuthenticationRequired: true,
-                // ...OR, preferably, wrap it in a configuration object
-                configuration: {
-                    koreanAuthenticationRequired: true
-                },
-                countryCode: 'KR'
-            })
-            .mount('.card-kcp-field');
+        //            analytics: {
+        //                conversion: true,
+        //                telemetry: true
+        //            }
     });
+
+    // Stored Card
+    if (checkout.paymentMethodsResponse.storedPaymentMethods && checkout.paymentMethodsResponse.storedPaymentMethods.length > 0) {
+        const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[0];
+        window.storedCard = checkout.create('card', storedCardData).mount('.storedcard-field');
+    }
+
+    // Credit card with installments
+    window.card = checkout
+        .create('card', {
+            type: 'scheme',
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+            hasHolderName: false,
+            // holderNameRequired: true,
+            enableStoreDetails: false,
+            installmentOptions: {
+                // card: {
+                //     values: [1, 2]
+                // },
+                mc: {
+                    values: [1, 2, 3]
+                },
+                visa: {
+                    values: [1, 2, 3, 4],
+                    plans: ['regular', 'revolving']
+                }
+            },
+            showInstallmentAmounts: true,
+            ariaLabels: {
+                lang: 'en-GB',
+                encryptedCardNumber: {
+                    label: 'Credit or debit card number field',
+                    iframeTitle: 'cc number field iframe'
+                    //                        error: { 'error.ve.gen.01': 'something is wrong', 'error.ve.sf-cc-num.02': 'another error' }
+                },
+                encryptedExpiryDate: {
+                    label: 'put your date in here'
+                }
+            }
+            //                placeholders: {
+            //                    encryptedSecurityCode: '8888'
+            //                }
+            //                onError: objdobj => {
+            //                    console.log('component level merchant defined error handler for Card objdobj=', objdobj);
+            //                }
+        })
+        .mount('.card-field');
+
+    // Bancontact card
+    window.bancontact = checkout
+        .create('bcmc', {
+            type: 'bcmc',
+            hasHolderName: true,
+            // holderNameRequired: true,
+            enableStoreDetails: false
+        })
+        .mount('.bancontact-field');
+
+    // Credit card with AVS
+    window.cardAvs = checkout
+        .create('card', {
+            type: 'scheme',
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+            enableStoreDetails: true,
+
+            // holderName config:
+            hasHolderName: true,
+            holderNameRequired: true,
+            holderName: 'J. Smith',
+
+            // billingAddress config:
+            billingAddressRequired: true,
+            billingAddressAllowedCountries: ['US', 'CA', 'BR', 'IT'],
+            // billingAddressRequiredFields: ['postalCode', 'country'],
+
+            // data:
+            data: {
+                holderName: 'J. Smith',
+                billingAddress: {
+                    street: 'Infinite Loop',
+                    postalCode: '95014',
+                    city: 'Cupertino',
+                    houseNumberOrName: '1',
+                    country: 'US',
+                    stateOrProvince: 'CA'
+                }
+            },
+            onError: objdobj => {
+                console.log('component level merchant defined error handler for Card objdobj=', objdobj);
+            }
+        })
+        .mount('.card-avs-field');
+
+    // Credit card with KCP Authentication
+    window.kcpCard = checkout
+        .create('card', {
+            type: 'scheme',
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+            // USE either separate koreanAuthenticationRequired prop...
+            koreanAuthenticationRequired: true,
+            // ...OR, preferably, wrap it in a configuration object
+            configuration: {
+                koreanAuthenticationRequired: true
+            },
+            countryCode: 'KR'
+        })
+        .mount('.card-kcp-field');
+});
 //    .catch(error => {
 //        console.error('### Cards::CATCH:: error=', error);
 //    });

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -2,114 +2,106 @@ import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
 import '../../../config/polyfills';
 import '../../style.scss';
-import { getPaymentMethods, getOriginKey } from '../../services';
+import { getPaymentMethods } from '../../services';
 import { handleChange, handleSubmit, handleAdditionalDetails } from '../../handlers';
 import { amount, shopperLocale } from '../../config/commonConfig';
 
-getOriginKey()
-    .then(originKey => {
-        window.originKey = originKey;
-    })
-    .then(() => getPaymentMethods({ amount, shopperLocale }))
-    .then(paymentMethodsResponse => {
-        window.checkout = new AdyenCheckout({
-            amount, // Optional. Used to display the amount in the Pay Button.
-            originKey,
-            clientKey: process.env.__CLIENT_KEY__,
-            paymentMethodsResponse,
-            locale: shopperLocale,
-            // environment: 'http://localhost:8080/checkoutshopper/',
-            // environment: 'https://checkoutshopper-beta.adyen.com/checkoutshopper/',
-            environment: 'test',
-            onChange: handleChange,
-            onSubmit: handleSubmit,
-            onAdditionalDetails: handleAdditionalDetails,
-            onError: console.error,
-            showPayButton: true
-            // risk: {
-            //     node: '.merchant-checkout__form',
-            //     onComplete: riskData => {
-            //         console.log('handleOnRiskData riskData=', riskData);
-            //     },
-            //     onError: console.error,
-            //     enabled: true
-            // }
-        });
-
-        // Adyen Giving
-        window.donation = checkout
-            .create('donation', {
-                onDonate: (state, component) => console.log({ state, component }),
-                url: 'https://example.org',
-                amounts: {
-                    currency: 'EUR',
-                    values: [300, 500, 1000]
-                },
-                backgroundUrl:
-                    'https://www.patagonia.com/static/on/demandware.static/-/Library-Sites-PatagoniaShared/default/dwb396273f/content-banners/100-planet-hero-desktop.jpg',
-                description: 'Lorem ipsum...',
-                logoUrl: 'https://i.ebayimg.com/images/g/aTwAAOSwfu9dfX4u/s-l300.jpg',
-                name: 'Test Charity'
-            })
-            .mount('.donation-field');
-
-        const ariaLabels = {
-            lang: 'en-GB',
-            encryptedBankAccountNumber: {
-                label: 'Custom aria bank accnt label',
-                iframeTitle: 'Iframe for bank accnt number',
-                error: 'Ongeldig kaartnummer'
-            }
-        };
-
-        // MBWay
-        window.mbway = checkout.create('mbway').mount('.mbway-field');
-
-        // ACH
-        window.ach = checkout
-            .create('ach', {
-                // holderNameRequired: false,
-                // hasHolderName: false,
-                ariaLabels,
-                onConfigSuccess: obj => {
-                    console.log('### Components::onConfigSuccess:: obj', obj);
-                },
-                // billingAddressRequired: false,
-                // billingAddressAllowedCountries: ['US', 'PR'],
-                data: {
-                    // holderName: 'B. Fish',
-                    billingAddress: {
-                        street: 'Infinite Loop',
-                        postalCode: '95014',
-                        city: 'Cupertino',
-                        houseNumberOrName: '1',
-                        country: 'US',
-                        stateOrProvince: 'CA'
-                    }
-                }
-            })
-            .mount('.ach-field');
-
-        // SEPA Direct Debit
-        window.sepa = checkout
-            .create('sepadirectdebit', {
-                countryCode: 'NL',
-                holderName: true
-            })
-            .mount('.sepa-field');
-
-        // Qiwi
-        window.qiwi = checkout.create('qiwiwallet', {}).mount('.qiwi-field');
-
-        // SEPA Direct Debit
-        window.vipps = checkout.create('vipps').mount('.vipps-field');
-
-        // BLIK
-        window.blik = checkout.create('blik', {}).mount('.blik-field');
-
-        // Giropay
-        window.giropay = checkout.create('giropay').mount('.giropay-field');
-
-        // Redirect
-        // window.redirect = checkout.create('paypal').mount('.redirect-field');
+getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
+    window.checkout = new AdyenCheckout({
+        amount, // Optional. Used to display the amount in the Pay Button.
+        clientKey: process.env.__CLIENT_KEY__,
+        paymentMethodsResponse,
+        locale: shopperLocale,
+        environment: 'test',
+        onChange: handleChange,
+        onSubmit: handleSubmit,
+        onAdditionalDetails: handleAdditionalDetails,
+        onError: console.error,
+        showPayButton: true
+        // risk: {
+        //     node: '.merchant-checkout__form',
+        //     onComplete: riskData => {
+        //         console.log('handleOnRiskData riskData=', riskData);
+        //     },
+        //     onError: console.error,
+        //     enabled: true
+        // }
     });
+
+    // Adyen Giving
+    window.donation = checkout
+        .create('donation', {
+            onDonate: (state, component) => console.log({ state, component }),
+            url: 'https://example.org',
+            amounts: {
+                currency: 'EUR',
+                values: [300, 500, 1000]
+            },
+            backgroundUrl:
+                'https://www.patagonia.com/static/on/demandware.static/-/Library-Sites-PatagoniaShared/default/dwb396273f/content-banners/100-planet-hero-desktop.jpg',
+            description: 'Lorem ipsum...',
+            logoUrl: 'https://i.ebayimg.com/images/g/aTwAAOSwfu9dfX4u/s-l300.jpg',
+            name: 'Test Charity'
+        })
+        .mount('.donation-field');
+
+    const ariaLabels = {
+        lang: 'en-GB',
+        encryptedBankAccountNumber: {
+            label: 'Custom aria bank accnt label',
+            iframeTitle: 'Iframe for bank accnt number',
+            error: 'Ongeldig kaartnummer'
+        }
+    };
+
+    // MBWay
+    window.mbway = checkout.create('mbway').mount('.mbway-field');
+
+    // ACH
+    window.ach = checkout
+        .create('ach', {
+            // holderNameRequired: false,
+            // hasHolderName: false,
+            ariaLabels,
+            onConfigSuccess: obj => {
+                console.log('### Components::onConfigSuccess:: obj', obj);
+            },
+            // billingAddressRequired: false,
+            // billingAddressAllowedCountries: ['US', 'PR'],
+            data: {
+                // holderName: 'B. Fish',
+                billingAddress: {
+                    street: 'Infinite Loop',
+                    postalCode: '95014',
+                    city: 'Cupertino',
+                    houseNumberOrName: '1',
+                    country: 'US',
+                    stateOrProvince: 'CA'
+                }
+            }
+        })
+        .mount('.ach-field');
+
+    // SEPA Direct Debit
+    window.sepa = checkout
+        .create('sepadirectdebit', {
+            countryCode: 'NL',
+            holderName: true
+        })
+        .mount('.sepa-field');
+
+    // Qiwi
+    window.qiwi = checkout.create('qiwiwallet', {}).mount('.qiwi-field');
+
+    // SEPA Direct Debit
+    window.vipps = checkout.create('vipps').mount('.vipps-field');
+
+    // BLIK
+    window.blik = checkout.create('blik', {}).mount('.blik-field');
+
+    // Giropay
+    window.giropay = checkout.create('giropay').mount('.giropay-field');
+
+    // Redirect
+    // window.redirect = checkout.create('paypal').mount('.redirect-field');
+});

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -8,10 +8,10 @@ import '../../utils';
 import '../../style.scss';
 
 window.checkout = new AdyenCheckout({
+    clientKey: process.env.__CLIENT_KEY__,
     locale: shopperLocale,
     countryCode,
     environment: 'test',
-    clientKey: process.env.__CLIENT_KEY__,
     onChange: handleChange,
     onSubmit: handleSubmit,
     showPayButton: true,

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.js
@@ -10,6 +10,7 @@ window.paymentData = {};
 
 getPaymentMethods().then(paymentMethodsData => {
     window.checkout = new AdyenCheckout({
+        clientKey: process.env.__CLIENT_KEY__,
         locale: shopperLocale,
         paymentMethodsResponse: paymentMethodsData,
         environment: 'test',

--- a/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
+++ b/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
@@ -10,6 +10,7 @@ window.paymentData = {};
 
 getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsData => {
     window.checkout = new AdyenCheckout({
+        clientKey: process.env.__CLIENT_KEY__,
         locale: shopperLocale,
         paymentMethodsResponse: paymentMethodsData,
         environment: 'test',

--- a/packages/playground/src/pages/QRCodes/QRCodes.js
+++ b/packages/playground/src/pages/QRCodes/QRCodes.js
@@ -1,79 +1,74 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
-import { makePayment, getOriginKey } from '../../services';
+import { makePayment } from '../../services';
 import { shopperLocale } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../utils';
 import '../../style.scss';
 import './QRCodes.scss';
 
-getOriginKey().then(originKey => {
-    window.originKey = originKey;
+window.checkout = new AdyenCheckout({
+    clientKey: process.env.__CLIENT_KEY__,
+    locale: shopperLocale,
+    environment: 'test',
+    risk: { node: 'body', onError: console.error }
+});
 
-    window.checkout = new AdyenCheckout({
-        originKey,
-        clientKey: process.env.__CLIENT_KEY__,
-        locale: shopperLocale,
-        environment: 'test',
-        risk: { node: 'body', onError: console.error }
+// WechatPay QR
+makePayment({
+    paymentMethod: {
+        type: 'wechatpayQR'
+    },
+    countryCode: 'CN',
+    amount: {
+        currency: 'CNY',
+        value: 1000
+    }
+})
+    .then(result => {
+        if (result.action) {
+            window.wechatpayqr = checkout.createFromAction(result.action).mount('#wechatpayqr-container');
+        }
+    })
+    .catch(error => {
+        throw Error(error);
     });
 
-    // WechatPay QR
-    makePayment({
-        paymentMethod: {
-            type: 'wechatpayQR'
-        },
-        countryCode: 'CN',
-        amount: {
-            currency: 'CNY',
-            value: 1000
+// BCMC Mobile
+makePayment({
+    paymentMethod: {
+        type: 'bcmc_mobile_QR'
+    },
+    countryCode: 'BE',
+    amount: {
+        currency: 'EUR',
+        value: 1000
+    }
+})
+    .then(result => {
+        if (result.action) {
+            window.bcmcmobileqr = checkout.createFromAction(result.action).mount('#bcmcqr-container');
         }
     })
-        .then(result => {
-            if (result.action) {
-                window.wechatpayqr = checkout.createFromAction(result.action).mount('#wechatpayqr-container');
-            }
-        })
-        .catch(error => {
-            throw Error(error);
-        });
+    .catch(error => {
+        throw Error(error);
+    });
 
-    // BCMC Mobile
-    makePayment({
-        paymentMethod: {
-            type: 'bcmc_mobile_QR'
-        },
-        countryCode: 'BE',
-        amount: {
-            currency: 'EUR',
-            value: 1000
+makePayment({
+    paymentMethod: {
+        type: 'swish'
+    },
+    countryCode: 'SE',
+    amount: {
+        currency: 'SEK',
+        value: 1000
+    }
+})
+    .then(result => {
+        if (result.action) {
+            window.swish = checkout.createFromAction(result.action).mount('#swish-container');
         }
     })
-        .then(result => {
-            if (result.action) {
-                window.bcmcmobileqr = checkout.createFromAction(result.action).mount('#bcmcqr-container');
-            }
-        })
-        .catch(error => {
-            throw Error(error);
-        });
-
-    makePayment({
-        paymentMethod: {
-            type: 'swish'
-        },
-        countryCode: 'SE',
-        amount: {
-            currency: 'SEK',
-            value: 1000
-        }
-    })
-        .then(result => {
-            if (result.action) {
-                window.swish = checkout.createFromAction(result.action).mount('#swish-container');
-            }
-        })
-        .catch(error => {
-            throw Error(error);
-        });
-});
+    .catch(error => {
+        throw Error(error);
+    });

--- a/packages/playground/src/pages/SecuredFields/SecuredFields.js
+++ b/packages/playground/src/pages/SecuredFields/SecuredFields.js
@@ -1,6 +1,6 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
-import { makePayment, makeDetailsCall, getOriginKey } from '../../services';
+import { makePayment, makeDetailsCall } from '../../services';
 import { styles, placeholders, ariaLabels, setCCErrors, setFocus, onBrand, onConfigSuccess } from './securedFields.config';
 import { styles_si, onConfigSuccess_si, onFieldValid_si, onBrand_si, onError_si, onFocus_si } from './securedFields-si.config';
 import { fancyStyles, fancyChangeBrand, fancyErrors, fancyFieldValid, fancyFocus } from './securedFields-fancy.config';
@@ -28,103 +28,100 @@ const createMaterialLabelListener = () => {
     });
 };
 
-getOriginKey().then(originKey => {
-    window.checkout = new AdyenCheckout({
-        originKey,
-        clientKey: process.env.__CLIENT_KEY__,
-        locale: shopperLocale,
-        //        environment: 'http://localhost:8080/checkoutshopper/',
-        environment: 'test',
-        onChange: handleOnChange,
-        //        onValid: handleOnValid,
-        onError: console.error,
-        risk: {
-            enabled: true, // Means that "riskdata" will then show up in the data object sent to the onChange event
-            // Also accessible via checkout.modules.risk.data
-            node: '.merchant-checkout__form', // Element that DF iframe is briefly added to
-            //            onComplete: handleOnRiskData,
-            onError: console.error
-        }
-    });
-
-    // SECURED FIELDS
-    window.securedFields = checkout
-        .create('securedfields', {
-            type: 'card',
-            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-            styles,
-            placeholders,
-            ariaLabels,
-            onConfigSuccess,
-            onBrand,
-            onBinValue: cbObj => {
-                //                console.log('onBinValue', cbObj);
-            },
-            onError: setCCErrors,
-            onFocus: setFocus
-            //            onFieldValid: obj => {
-            //                console.log('### SecuredFields::onFieldValid:: obj=', obj);
-            //            }
-        })
-        .mount('.secured-fields');
-
-    createPayButton('.secured-fields', window.securedFields, 'securedfields');
-
-    // COMMENT IN TO HIDE ADDITIONAL SF EXAMPLES
-    //    const extraSFs = Array.prototype.slice.call(document.querySelectorAll('.extra-sf'));
-    //    extraSFs.forEach(elem => {
-    //        elem.style.display = 'none';
-    //    });
-    //    return;
-    // - END
-
-    window.securedFieldsSi = checkout
-        .create('securedfields', {
-            type: 'card',
-            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-            styles: styles_si,
-            trimTrailingSeparator: true,
-            onConfigSuccess: onConfigSuccess_si,
-            onFieldValid: onFieldValid_si,
-            onBrand: onBrand_si,
-            onError: onError_si,
-            onFocus: onFocus_si
-        })
-        .mount('.secured-fields-si');
-
-    window.fancySecuredFields = checkout
-        .create('securedfields', {
-            type: 'card',
-            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-            styles: fancyStyles,
-            ariaLabels,
-            autoFocus: false,
-            onFieldValid: fancyFieldValid,
-            onBrand: fancyChangeBrand,
-            onError: fancyErrors,
-            onFocus: fancyFocus
-        })
-        .mount('.fancy-secured-fields');
-
-    window.materialDesignSecuredFields = checkout
-        .create('securedfields', {
-            type: 'card',
-            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-            styles: materialStyles,
-            placeholders: {
-                encryptedCardNumber: '',
-                encryptedExpiryDate: '',
-                encryptedSecurityCode: ''
-            },
-            onFocus: materialFocus,
-            onError: handleMaterialError,
-            onChange: console.log,
-            onBinValue: console.log,
-            onFieldValid: onMaterialFieldValid,
-            onConfigSuccess: createMaterialLabelListener
-        })
-        .mount('.material-secured-fields-container');
+window.checkout = new AdyenCheckout({
+    clientKey: process.env.__CLIENT_KEY__,
+    locale: shopperLocale,
+    //        environment: 'http://localhost:8080/checkoutshopper/',
+    environment: 'test',
+    onChange: handleOnChange,
+    //        onValid: handleOnValid,
+    onError: console.error,
+    risk: {
+        enabled: true, // Means that "riskdata" will then show up in the data object sent to the onChange event
+        // Also accessible via checkout.modules.risk.data
+        node: '.merchant-checkout__form', // Element that DF iframe is briefly added to
+        //            onComplete: handleOnRiskData,
+        onError: console.error
+    }
 });
+
+// SECURED FIELDS
+window.securedFields = checkout
+    .create('securedfields', {
+        type: 'card',
+        brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+        styles,
+        placeholders,
+        ariaLabels,
+        onConfigSuccess,
+        onBrand,
+        onBinValue: cbObj => {
+            //                console.log('onBinValue', cbObj);
+        },
+        onError: setCCErrors,
+        onFocus: setFocus
+        //            onFieldValid: obj => {
+        //                console.log('### SecuredFields::onFieldValid:: obj=', obj);
+        //            }
+    })
+    .mount('.secured-fields');
+
+createPayButton('.secured-fields', window.securedFields, 'securedfields');
+
+// COMMENT IN TO HIDE ADDITIONAL SF EXAMPLES
+//    const extraSFs = Array.prototype.slice.call(document.querySelectorAll('.extra-sf'));
+//    extraSFs.forEach(elem => {
+//        elem.style.display = 'none';
+//    });
+//    return;
+// - END
+
+window.securedFieldsSi = checkout
+    .create('securedfields', {
+        type: 'card',
+        brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+        styles: styles_si,
+        trimTrailingSeparator: true,
+        onConfigSuccess: onConfigSuccess_si,
+        onFieldValid: onFieldValid_si,
+        onBrand: onBrand_si,
+        onError: onError_si,
+        onFocus: onFocus_si
+    })
+    .mount('.secured-fields-si');
+
+window.fancySecuredFields = checkout
+    .create('securedfields', {
+        type: 'card',
+        brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+        styles: fancyStyles,
+        ariaLabels,
+        autoFocus: false,
+        onFieldValid: fancyFieldValid,
+        onBrand: fancyChangeBrand,
+        onError: fancyErrors,
+        onFocus: fancyFocus
+    })
+    .mount('.fancy-secured-fields');
+
+window.materialDesignSecuredFields = checkout
+    .create('securedfields', {
+        type: 'card',
+        brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+        styles: materialStyles,
+        placeholders: {
+            encryptedCardNumber: '',
+            encryptedExpiryDate: '',
+            encryptedSecurityCode: ''
+        },
+        onFocus: materialFocus,
+        onError: handleMaterialError,
+        onChange: console.log,
+        onBinValue: console.log,
+        onFieldValid: onMaterialFieldValid,
+        onConfigSuccess: createMaterialLabelListener
+    })
+    .mount('.material-secured-fields-container');
 
 const handle3DS2ComponentResponse = retrievedData => {
     console.log('handle3DS2ComponentResponse data=', retrievedData);

--- a/packages/playground/src/pages/Vouchers/Vouchers.js
+++ b/packages/playground/src/pages/Vouchers/Vouchers.js
@@ -7,6 +7,7 @@ import '../../utils';
 import './Vouchers.scss';
 
 window.checkout = new AdyenCheckout({
+    clientKey: process.env.__CLIENT_KEY__,
     locale: shopperLocale,
     environment: 'test',
     showPayButton: true

--- a/packages/playground/src/pages/Wallets/Wallets.js
+++ b/packages/playground/src/pages/Wallets/Wallets.js
@@ -1,130 +1,124 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
-import { getPaymentMethods, getOriginKey } from '../../services';
+import { getPaymentMethods } from '../../services';
 import { handleChange, handleSubmit, handleAdditionalDetails } from '../../handlers';
 import { amount, shopperLocale } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
 
-getOriginKey()
-    .then(originKey => {
-        window.originKey = originKey;
-    })
-    .then(() => getPaymentMethods({ amount, shopperLocale }))
-    .then(paymentMethodsResponse => {
-        window.checkout = new AdyenCheckout({
-            amount, // Optional. Used to display the amount in the Pay Button.
-            originKey,
-            clientKey: process.env.__CLIENT_KEY__,
-            paymentMethodsResponse,
-            locale: shopperLocale,
-            // environment: 'http://localhost:8080/checkoutshopper/',
-            // environment: 'https://checkoutshopper-beta.adyen.com/checkoutshopper/',
-            environment: 'test',
-            onChange: handleChange,
-            onSubmit: handleSubmit,
-            onAdditionalDetails: handleAdditionalDetails,
-            onError: console.error,
-            showPayButton: true
-        });
+getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
+    window.checkout = new AdyenCheckout({
+        amount, // Optional. Used to display the amount in the Pay Button.
+        clientKey: process.env.__CLIENT_KEY__,
+        paymentMethodsResponse,
+        locale: shopperLocale,
+        // environment: 'http://localhost:8080/checkoutshopper/',
+        // environment: 'https://checkoutshopper-beta.adyen.com/checkoutshopper/',
+        environment: 'test',
+        onChange: handleChange,
+        onSubmit: handleSubmit,
+        onAdditionalDetails: handleAdditionalDetails,
+        onError: console.error,
+        showPayButton: true
+    });
 
-        // PAYPAL
-        window.paypalButtons = checkout
-            .create('paypal', {
-                // merchantId: '5RZKQX2FC48EA', // automatic ?
-                // intent: 'capture', // 'capture' [Default] / 'authorize'
-                //                configuration: {
-                //                    merchantId: '5RZKQX2FC48EA',
-                //                    intent: 'capture'
-                //                },
-                // commit: true, // true [Default] / false
-                // style: {},
+    // PAYPAL
+    window.paypalButtons = checkout
+        .create('paypal', {
+            // merchantId: '5RZKQX2FC48EA', // automatic ?
+            // intent: 'capture', // 'capture' [Default] / 'authorize'
+            //                configuration: {
+            //                    merchantId: '5RZKQX2FC48EA',
+            //                    intent: 'capture'
+            //                },
+            // commit: true, // true [Default] / false
+            // style: {},
 
-                // Events
-                onError: (error, component) => {
-                    component.setStatus('ready');
-                    console.log('paypal onError', error);
-                },
-
-                onCancel: (data, component) => {
-                    component.setStatus('ready');
-                    console.log('paypal onCancel', data);
-                }
-            })
-            .mount('.paypal-field');
-
-        // GOOGLE PAY
-        const googlepay = checkout.create('paywithgoogle', {
-            // environment: 'PRODUCTION',
-            environment: 'TEST',
-
-            // Callbacks
-            onAuthorized: console.info,
-            // onError: console.error,
-
-            // Payment info
-            amount: { value: 10, currency: 'EUR' }, // 0.1 EUR (minor units)
-            countryCode: 'NL',
-
-            // Merchant config (required)
-            //            configuration: {
-            //                gatewayMerchantId: 'TestMerchant', // name of MerchantAccount
-            //                merchantName: 'Adyen Test merchant', // Name to be displayed
-            //                merchantId: '06946223745213860250' // Required in Production environment. Google's merchantId: https://developers.google.com/pay/api/web/guides/test-and-deploy/deploy-production-environment#obtain-your-merchantID
-            //            },
-
-            // Shopper info (optional)
-            emailRequired: true,
-            shippingAddressRequired: true,
-            shippingAddressParameters: {}, // https://developers.google.com/pay/api/web/reference/object#ShippingAddressParameters
-
-            // Button config (optional)
-            buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-            buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-        });
-
-        // First, check availability. If environment is TEST, Google Pay will always be considered available.
-        googlepay
-            .isAvailable()
-            .then(() => {
-                googlepay.mount('.googlepay-field');
-            })
-            .catch(e => console.warn(e));
-
-        window.googlepay = googlepay;
-
-        // APPLE PAY
-        const applepay = checkout.create('applepay', {
-            // Callbacks
-            onAuthorized: console.info,
-            // onError: console.error,
-
-            // Payment info
-            currencyCode: 'EUR', // Required. The three-letter ISO 4217 currency code for the payment.
-            amount: 10, // 0.1 EUR (minor units)
-            countryCode: 'DE', // Required. The merchant’s two-letter ISO 3166 country code.
-
-            // Merchant config (required)
-            configuration: {
-                merchantName: 'Adyen Test merchant', // Name to be displayed
-                merchantIdentifier: '000000000200001' // Required. https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951611-merchantidentifier
+            // Events
+            onError: (error, component) => {
+                component.setStatus('ready');
+                console.log('paypal onError', error);
             },
 
-            // Button config (optional)
-            buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-            buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-        });
+            onCancel: (data, component) => {
+                component.setStatus('ready');
+                console.log('paypal onCancel', data);
+            }
+        })
+        .mount('.paypal-field');
 
-        applepay
-            .isAvailable()
-            .then(isAvailable => {
-                // Demo only
-                if (isAvailable) document.querySelector('#applepay').classList.remove('merchant-checkout__payment-method--hidden');
+    // GOOGLE PAY
+    const googlepay = checkout.create('paywithgoogle', {
+        // environment: 'PRODUCTION',
+        environment: 'TEST',
 
-                // If Available mount it in the dom
-                if (isAvailable) applepay.mount('.applepay-field');
-            })
-            .catch(e => {
-                console.warn(e);
-            });
+        // Callbacks
+        onAuthorized: console.info,
+        // onError: console.error,
+
+        // Payment info
+        amount: { value: 10, currency: 'EUR' }, // 0.1 EUR (minor units)
+        countryCode: 'NL',
+
+        // Merchant config (required)
+        //            configuration: {
+        //                gatewayMerchantId: 'TestMerchant', // name of MerchantAccount
+        //                merchantName: 'Adyen Test merchant', // Name to be displayed
+        //                merchantId: '06946223745213860250' // Required in Production environment. Google's merchantId: https://developers.google.com/pay/api/web/guides/test-and-deploy/deploy-production-environment#obtain-your-merchantID
+        //            },
+
+        // Shopper info (optional)
+        emailRequired: true,
+        shippingAddressRequired: true,
+        shippingAddressParameters: {}, // https://developers.google.com/pay/api/web/reference/object#ShippingAddressParameters
+
+        // Button config (optional)
+        buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
+        buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
     });
+
+    // First, check availability. If environment is TEST, Google Pay will always be considered available.
+    googlepay
+        .isAvailable()
+        .then(() => {
+            googlepay.mount('.googlepay-field');
+        })
+        .catch(e => console.warn(e));
+
+    window.googlepay = googlepay;
+
+    // APPLE PAY
+    const applepay = checkout.create('applepay', {
+        // Callbacks
+        onAuthorized: console.info,
+        // onError: console.error,
+
+        // Payment info
+        currencyCode: 'EUR', // Required. The three-letter ISO 4217 currency code for the payment.
+        amount: 10, // 0.1 EUR (minor units)
+        countryCode: 'DE', // Required. The merchant’s two-letter ISO 3166 country code.
+
+        // Merchant config (required)
+        configuration: {
+            merchantName: 'Adyen Test merchant', // Name to be displayed
+            merchantIdentifier: '000000000200001' // Required. https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951611-merchantidentifier
+        },
+
+        // Button config (optional)
+        buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
+        buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
+    });
+
+    applepay
+        .isAvailable()
+        .then(isAvailable => {
+            // Demo only
+            if (isAvailable) document.querySelector('#applepay').classList.remove('merchant-checkout__payment-method--hidden');
+
+            // If Available mount it in the dom
+            if (isAvailable) applepay.mount('.applepay-field');
+        })
+        .catch(e => {
+            console.warn(e);
+        });
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Remove originKey references, accepting only clientKey. (https://docs.adyen.com/development-resources/client-side-authentication/migrate-from-origin-key-to-client-key#availability-compatibility)
