### PR TITLE
Remove `details` dependency

### DIFF
--- a/packages/lib/src/components/Dragonpay/Dragonpay.tsx
+++ b/packages/lib/src/components/Dragonpay/Dragonpay.tsx
@@ -25,10 +25,6 @@ export class DragonpayElement extends UIElement {
         };
     }
 
-    formatProps(props) {
-        return props;
-    }
-
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>

--- a/packages/lib/src/components/Dragonpay/Dragonpay.tsx
+++ b/packages/lib/src/components/Dragonpay/Dragonpay.tsx
@@ -26,10 +26,7 @@ export class DragonpayElement extends UIElement {
     }
 
     formatProps(props) {
-        return {
-            ...props,
-            items: props.details && props.details.length ? (props.details.find(d => d.key === 'issuer') || {}).items : props.items
-        };
+        return props;
     }
 
     render() {
@@ -48,6 +45,7 @@ export class DragonpayElement extends UIElement {
                         ref={ref => {
                             this.componentRef = ref;
                         }}
+                        items={this.props.issuers}
                         {...this.props}
                         onChange={this.setState}
                         onSubmit={this.submit}

--- a/packages/lib/src/components/Dragonpay/types.ts
+++ b/packages/lib/src/components/Dragonpay/types.ts
@@ -9,8 +9,7 @@ export interface DragonpayInputIssuerItem {
 
 export interface DragonpayElementProps {
     type?: string;
-    details?: DragonpayInputIssuerItem[];
-    items?: DragonpayInputIssuerItem[];
+    issuers?: DragonpayInputIssuerItem[];
     loadingContext?: string;
     reference?: string;
     i18n?: Language;

--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -20,8 +20,8 @@ const createElements = (components: PaymentMethod[] = [], props, componentsConfi
 
         let componentInstance = getComponent(component.type, componentProps);
 
-        // Fallback to redirect if payment method not available and no details are required
-        if (!componentInstance && !component.details) {
+        // Fallback to redirect if payment method not available
+        if (!componentInstance) {
             componentInstance = getComponent(FALLBACK_COMPONENT, componentProps);
         }
 

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -47,10 +47,6 @@ class IssuerListContainer extends UIElement<IssuerListProps> {
         loadingContext: FALLBACK_CONTEXT
     };
 
-    protected formatProps(props) {
-        return props;
-    }
-
     /**
      * Formats the component data output
      */

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -9,8 +9,7 @@ import Language from '../../language/Language';
 interface IssuerListProps extends UIElementProps {
     showImage?: boolean;
     placeholder?: string;
-    items?: IssuerItem[];
-    details?: { key: string; items: IssuerItem[] };
+    issuers?: IssuerItem[];
     i18n: Language;
     loadingContext: string;
 }
@@ -34,7 +33,7 @@ class IssuerListContainer extends UIElement<IssuerListProps> {
         if (this.props.showImage) {
             const getIssuerIcon = getIssuerImageUrl({ loadingContext: this.props.loadingContext }, this.constructor['type']);
 
-            this.props.items = this.props.items.map(item => ({
+            this.props.issuers = this.props.issuers.map(item => ({
                 ...item,
                 icon: getIssuerIcon(item.id)
             }));
@@ -44,18 +43,12 @@ class IssuerListContainer extends UIElement<IssuerListProps> {
     protected static defaultProps = {
         showImage: true,
         onValid: () => {},
-        items: [],
+        issuers: [],
         loadingContext: FALLBACK_CONTEXT
     };
 
-    /**
-     * Formats props on construction time
-     */
-    formatProps(props) {
-        return {
-            ...props,
-            items: props.details && props.details.length ? (props.details.find(d => d.key === 'issuer') || {}).items : props.items
-        };
+    protected formatProps(props) {
+        return props;
     }
 
     /**
@@ -84,6 +77,7 @@ class IssuerListContainer extends UIElement<IssuerListProps> {
                     ref={ref => {
                         this.componentRef = ref;
                     }}
+                    items={this.props.issuers}
                     {...this.props}
                     {...this.state}
                     onChange={this.setState}

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -156,13 +156,10 @@ class Core {
         }
 
         /**
-         * If we are trying to create a payment method that is in the paymentMethodsResponse & it doesn't require any details - treat it as a redirect
+         * If we are trying to create a payment method that is in the paymentMethodsResponse & does not explicitily
+         * implement a component, it will default to a redirect component
          */
-        if (
-            typeof PaymentMethod === 'string' &&
-            this.paymentMethodsResponse.has(PaymentMethod) &&
-            !this.paymentMethodsResponse.find(PaymentMethod).details
-        ) {
+        if (typeof PaymentMethod === 'string' && this.paymentMethodsResponse.has(PaymentMethod)) {
             const paymentMethodsConfiguration = getComponentConfiguration(PaymentMethod, options.paymentMethodsConfiguration);
             return this.handleCreate(paymentMethods.redirect, {
                 ...this.paymentMethodsResponse.find(PaymentMethod),


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Remove `/paymentMethods` response `details` property dependencies
- IssuerList components (iDEAL, DotPay, EPS...) use the new `issuers` property
- We assume every payment method not listed in the `componentsMap` follows a redirect flow.
