### PR TITLE
Fix Apple Pay configuration property

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.test.ts
+++ b/packages/lib/src/components/ApplePay/ApplePay.test.ts
@@ -26,6 +26,16 @@ describe('ApplePay', () => {
             expect(applepay.props.amount.currency).toEqual('USD');
         });
 
+        test('normalizes the merchantName prop', () => {
+            const configurationMock = {
+                merchantIdentifier: 'Test1',
+                merchantDisplayName: 'Test2'
+            };
+            const applepay = new ApplePay({ defaultProps, configuration: configurationMock });
+            expect(applepay.props.configuration.merchantIdentifier).toEqual(configurationMock.merchantIdentifier);
+            expect(applepay.props.configuration.merchantName).toEqual(configurationMock.merchantDisplayName);
+        });
+
         test('uses merchantName if no totalPriceLabel was defined', () => {
             const applepay = new ApplePay({ ...defaultProps, configuration: { merchantName: 'Test' } });
             expect(applepay.props.totalPriceLabel).toEqual('Test');

--- a/packages/lib/src/components/ApplePay/ApplePay.test.ts
+++ b/packages/lib/src/components/ApplePay/ApplePay.test.ts
@@ -26,13 +26,13 @@ describe('ApplePay', () => {
             expect(applepay.props.amount.currency).toEqual('USD');
         });
 
-        test('normalizes the merchantName prop', () => {
+        test('normalizes the configuration properties', () => {
             const configurationMock = {
                 merchantIdentifier: 'Test1',
                 merchantDisplayName: 'Test2'
             };
             const applepay = new ApplePay({ defaultProps, configuration: configurationMock });
-            expect(applepay.props.configuration.merchantIdentifier).toEqual(configurationMock.merchantIdentifier);
+            expect(applepay.props.configuration.merchantId).toEqual(configurationMock.merchantIdentifier);
             expect(applepay.props.configuration.merchantName).toEqual(configurationMock.merchantDisplayName);
         });
 

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -29,11 +29,17 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     protected formatProps(props) {
         const amount = normalizeAmount(props);
         const version = props.version || resolveSupportedVersion(latestSupportedVersion);
+        const { configuration = {} } = props;
+
         return {
             onAuthorized: resolve => resolve(),
             ...props,
+            configuration: {
+                merchantIdentifier: configuration.merchantIdentifier || defaultProps.configuration.merchantIdentifier,
+                merchantName: configuration.merchantDisplayName || configuration.merchantName || defaultProps.configuration.merchantName
+            },
             version,
-            totalPriceLabel: props.totalPriceLabel || props.configuration?.merchantName,
+            totalPriceLabel: props.totalPriceLabel || configuration.merchantName,
             amount,
             onCancel: event => props.onError(event)
         };

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -35,7 +35,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
             onAuthorized: resolve => resolve(),
             ...props,
             configuration: {
-                merchantIdentifier: configuration.merchantIdentifier || defaultProps.configuration.merchantIdentifier,
+                merchantId: configuration.merchantIdentifier || configuration.merchantId || defaultProps.configuration.merchantId,
                 merchantName: configuration.merchantDisplayName || configuration.merchantName || defaultProps.configuration.merchantName
             },
             version,
@@ -104,7 +104,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     private async validateMerchant(resolve, reject) {
         const { hostname: domainName } = window.location;
         const { clientKey, configuration, loadingContext, initiative } = this.props;
-        const { merchantName: displayName, merchantIdentifier } = configuration;
+        const { merchantName: displayName, merchantId: merchantIdentifier } = configuration;
         const path = `${APPLEPAY_SESSION_ENDPOINT}?token=${clientKey}`;
         const options = { loadingContext, path, method: 'post' };
         const request: ApplePaySessionRequest = { displayName, domainName, initiative, merchantIdentifier };

--- a/packages/lib/src/components/ApplePay/defaultProps.ts
+++ b/packages/lib/src/components/ApplePay/defaultProps.ts
@@ -12,7 +12,7 @@ const defaultProps = {
 
     configuration: {
         merchantName: '',
-        merchantIdentifier: ''
+        merchantId: ''
     },
 
     initiative: 'web',

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -39,7 +39,8 @@ export interface ApplePayElementProps extends UIElementProps {
     totalPriceLabel?: string;
 
     configuration: {
-        merchantName: string;
+        merchantDisplayName?: string;
+        merchantName?: string;
         merchantIdentifier: string;
     };
 

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -41,7 +41,8 @@ export interface ApplePayElementProps extends UIElementProps {
     configuration: {
         merchantDisplayName?: string;
         merchantName?: string;
-        merchantIdentifier: string;
+        merchantId?: string;
+        merchantIdentifier?: string;
     };
 
     clientKey?: string;


### PR DESCRIPTION
## Summary
The configuration object for Apple Pay included in the `/paymentMethods` response contains the property `merchantDisplayName` while the component expects `merchantName`.

