### PR TITLE
Fix Giropay not checking the showPayButton property.

### DIFF
--- a/packages/lib/src/components/Giropay/Giropay.tsx
+++ b/packages/lib/src/components/Giropay/Giropay.tsx
@@ -6,6 +6,13 @@ import RedirectButton from '../internal/RedirectButton';
 class GiropayElement extends RedirectElement {
     public static type = 'giropay';
 
+    formatProps(props) {
+        return {
+            ...props,
+            showPayButton: props.showButton ?? props.showPayButton
+        };
+    }
+
     /**
      * Formats the component data output
      */
@@ -22,7 +29,7 @@ class GiropayElement extends RedirectElement {
     }
 
     render() {
-        if (this.props.showButton) {
+        if (this.props.showPayButton) {
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
                     <RedirectButton


### PR DESCRIPTION
## Summary
Giropay is currently checking the `showButton` instead of the `showPayButton` property.

## Tested scenarios
It now checks both the `showButton` and the `showPayButton` properties.
