### PR TITLE
Change Apple Pay DOM element to button, add lang parameter

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -155,7 +155,17 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
      */
     render() {
         if (this.props.showPayButton) {
-            return <ApplePayButton buttonColor={this.props.buttonColor} buttonType={this.props.buttonType} onClick={this.submit} />;
+            return (
+                <ApplePayButton
+                    i18n={this.props.i18n}
+                    buttonColor={this.props.buttonColor}
+                    buttonType={this.props.buttonType}
+                    onClick={e => {
+                        e.preventDefault();
+                        this.submit();
+                    }}
+                />
+            );
         }
 
         return null;

--- a/packages/lib/src/components/ApplePay/components/ApplePayButton.tsx
+++ b/packages/lib/src/components/ApplePay/components/ApplePayButton.tsx
@@ -22,6 +22,8 @@ class ApplePayButton extends Component<ApplePayButtonProps> {
         /* eslint-disable jsx-a11y/no-static-element-interactions */
         return (
             <button
+                type="button"
+                aria-label={this.props.i18n.get('payButton')}
                 lang={this.props.i18n.languageCode}
                 className={cx(
                     'adyen-checkout__applepay__button',

--- a/packages/lib/src/components/ApplePay/components/ApplePayButton.tsx
+++ b/packages/lib/src/components/ApplePay/components/ApplePayButton.tsx
@@ -2,8 +2,10 @@ import { Component, h } from 'preact';
 import cx from 'classnames';
 import styles from './ApplePayButton.module.scss';
 import './ApplePayButton.scss';
+import Language from '../../../language/Language';
 
 interface ApplePayButtonProps {
+    i18n: Language;
     buttonColor: 'black' | 'white' | 'white-with-line';
     buttonType: 'plain' | 'buy' | 'donate' | 'check-out' | 'book' | 'subscribe';
     onClick: (event) => void;
@@ -19,7 +21,8 @@ class ApplePayButton extends Component<ApplePayButtonProps> {
     render({ buttonColor, buttonType }) {
         /* eslint-disable jsx-a11y/no-static-element-interactions */
         return (
-            <div
+            <button
+                lang={this.props.i18n.languageCode}
                 className={cx(
                     'adyen-checkout__applepay__button',
                     `adyen-checkout__applepay__button--${buttonColor}`,

--- a/packages/lib/src/language/Language.ts
+++ b/packages/lib/src/language/Language.ts
@@ -11,6 +11,8 @@ export class Language {
         const localesFromCustomTranslations = Object.keys(this.customTranslations);
         this.supportedLocales = [...defaultLocales, ...localesFromCustomTranslations].filter((v, i, a) => a.indexOf(v) === i); // our locales + validated custom locales
         this.locale = formatLocale(locale) || parseLocale(locale, this.supportedLocales) || FALLBACK_LOCALE;
+        const [languageCode] = this.locale.split('-');
+        this.languageCode = languageCode;
 
         this.loaded = loadTranslations(this.locale, this.customTranslations).then(translations => {
             this.translations = translations;
@@ -18,6 +20,7 @@ export class Language {
     }
 
     public readonly locale: string;
+    public readonly languageCode: string;
     private readonly supportedLocales: string[];
     public translations: object = defaultTranslation;
     public readonly customTranslations;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Apple Pay element changed from a `<div>` element to a `<button>` element
- Language parameter added (See [Localizing Apple Pay Buttons](https://developer.apple.com/documentation/apple_pay_on_the_web/localizing_apple_pay_buttons))
