### PR TITLE
Update OpenInvoice to show the delivery address when prefilled

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Checkbox/Checkbox.tsx
+++ b/packages/lib/src/components/internal/FormFields/Checkbox/Checkbox.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import './Checkbox.scss';
 
 interface CheckboxProps {
+    checked?: boolean;
     classNameModifiers?: string[];
     label: string | ComponentChild;
     name?: string;

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
@@ -32,6 +32,12 @@ describe('OpenInvoice', () => {
         expect(wrapper.find('Checkbox')).toHaveLength(0);
     });
 
+    test('should not show the separate delivery checkbox if the billing address is set to hidden', () => {
+        const visibility = { billingAddress: 'hidden' };
+        const wrapper = getWrapper({ visibility });
+        expect(wrapper.find('Checkbox')).toHaveLength(0);
+    });
+
     test('should render a consent checkbox if a consentCheckboxLabel is passed as a prop', () => {
         const wrapper = getWrapper({ consentCheckboxLabel: 'TEST' });
         expect(wrapper.find('ConsentCheckbox')).toHaveLength(1);

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -7,23 +7,31 @@ import Address from '../Address';
 import Checkbox from '../FormFields/Checkbox';
 import ConsentCheckbox from '../FormFields/ConsentCheckbox';
 import { getActiveFieldsData, getInitialActiveFieldsets } from './utils';
-import { ActiveFieldsets, FieldsetsRefs, OpenInvoiceProps, OpenInvoiceStateData, OpenInvoiceStateError, OpenInvoiceStateValid } from './types';
+import {
+    OpenInvoiceActiveFieldsets,
+    OpenInvoiceFieldsetsRefs,
+    OpenInvoiceProps,
+    OpenInvoiceStateData,
+    OpenInvoiceStateError,
+    OpenInvoiceStateValid
+} from './types';
 import './OpenInvoice.scss';
 
-const fieldsetsSchema = ['companyDetails', 'personalDetails', 'billingAddress', 'deliveryAddress'];
+export const fieldsetsSchema = ['companyDetails', 'personalDetails', 'billingAddress', 'deliveryAddress'];
 
 export default function OpenInvoice(props: OpenInvoiceProps) {
     const { countryCode, visibility } = props;
     const { i18n } = useCoreContext();
-    const initialActiveFieldsets: ActiveFieldsets = getInitialActiveFieldsets(fieldsetsSchema, visibility, props.data);
-    const [activeFieldsets, setActiveFieldsets] = useState<ActiveFieldsets>(initialActiveFieldsets);
-    const fieldsetsRefs: FieldsetsRefs = fieldsetsSchema.reduce((acc, fieldset) => {
+    const initialActiveFieldsets: OpenInvoiceActiveFieldsets = getInitialActiveFieldsets(visibility, props.data);
+    const [activeFieldsets, setActiveFieldsets] = useState<OpenInvoiceActiveFieldsets>(initialActiveFieldsets);
+    const fieldsetsRefs: OpenInvoiceFieldsetsRefs = fieldsetsSchema.reduce((acc, fieldset) => {
         acc[fieldset] = createRef();
         return acc;
     }, {});
 
     const checkFieldsets = () => Object.keys(activeFieldsets).every(fieldset => !activeFieldsets[fieldset] || !!valid[fieldset]);
     const hasConsentCheckbox = !!props.consentCheckboxLabel;
+    const showSeparateDeliveryAddressCheckbox = visibility.deliveryAddress === 'editable' && visibility.billingAddress !== 'hidden';
 
     const [data, setData] = useState<OpenInvoiceStateData>({
         ...props.data,
@@ -38,10 +46,10 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
     };
 
     useEffect(() => {
-        const fieldsetsAreValid = checkFieldsets();
-        const consentCheckboxValid = !hasConsentCheckbox || !!valid.consentCheckbox;
-        const isValid = fieldsetsAreValid && consentCheckboxValid;
-        const newData = getActiveFieldsData(data, activeFieldsets);
+        const fieldsetsAreValid: boolean = checkFieldsets();
+        const consentCheckboxValid: boolean = !hasConsentCheckbox || !!valid.consentCheckbox;
+        const isValid: boolean = fieldsetsAreValid && consentCheckboxValid;
+        const newData: OpenInvoiceStateData = getActiveFieldsData(activeFieldsets, data);
 
         props.onChange({ data: newData, isValid });
     }, [data, activeFieldsets]);
@@ -107,7 +115,7 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
                 />
             )}
 
-            {visibility.deliveryAddress === 'editable' && (
+            {showSeparateDeliveryAddressCheckbox && (
                 <Checkbox
                     label={i18n.get('separateDeliveryAddress')}
                     checked={activeFieldsets.deliveryAddress}

--- a/packages/lib/src/components/internal/OpenInvoice/types.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/types.ts
@@ -1,6 +1,13 @@
 import { AddressSchema, FieldsetVisibility, PersonalDetailsSchema } from '../../../types';
 import { CompanyDetailsSchema } from '../CompanyDetails/types';
 
+export interface OpenInvoiceVisibility {
+    companyDetails?: FieldsetVisibility;
+    personalDetails?: FieldsetVisibility;
+    billingAddress?: FieldsetVisibility;
+    deliveryAddress?: FieldsetVisibility;
+}
+
 export interface OpenInvoiceProps {
     allowedCountries?: string[];
     consentCheckboxLabel: any;
@@ -14,12 +21,7 @@ export interface OpenInvoiceProps {
     onChange: Function;
     payButton: any;
     showPayButton?: boolean;
-    visibility?: {
-        companyDetails?: FieldsetVisibility;
-        personalDetails?: FieldsetVisibility;
-        billingAddress?: FieldsetVisibility;
-        deliveryAddress?: FieldsetVisibility;
-    };
+    visibility?: OpenInvoiceVisibility;
     personalDetailsRequiredFields?: string[];
 }
 

--- a/packages/lib/src/components/internal/OpenInvoice/types.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/types.ts
@@ -31,7 +31,6 @@ export interface OpenInvoiceStateData {
     billingAddress?: AddressSchema;
     deliveryAddress?: AddressSchema;
     consentCheckbox?: boolean;
-    separateDeliveryAddress?: boolean;
 }
 
 export interface OpenInvoiceStateError {
@@ -50,14 +49,14 @@ export interface OpenInvoiceStateValid {
     personalDetails?: boolean;
 }
 
-export interface ActiveFieldsets {
+export interface OpenInvoiceActiveFieldsets {
     companyDetails: boolean;
     personalDetails: boolean;
     billingAddress: boolean;
     deliveryAddress: boolean;
 }
 
-export interface FieldsetsRefs {
+export interface OpenInvoiceFieldsetsRefs {
     companyDetails?;
     personalDetails?;
     billingAddress?;

--- a/packages/lib/src/components/internal/OpenInvoice/utils.test.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/utils.test.ts
@@ -1,0 +1,62 @@
+import { getActiveFieldsData, getInitialActiveFieldsets } from './utils';
+import { OpenInvoiceActiveFieldsets, OpenInvoiceStateData, OpenInvoiceVisibility } from './types';
+
+describe('OpenInvoice utils', () => {
+    describe('getActiveFieldsData', () => {
+        test('should return only the state of the active fieldsets', () => {
+            const activeFieldsets: OpenInvoiceActiveFieldsets = {
+                companyDetails: false,
+                personalDetails: true,
+                billingAddress: false,
+                deliveryAddress: false
+            };
+
+            const data: OpenInvoiceStateData = {
+                personalDetails: { firstName: 'shopper' },
+                billingAddress: { country: 'NL' },
+                deliveryAddress: { country: 'NL' }
+            };
+
+            expect(getActiveFieldsData(activeFieldsets, data).personalDetails).toBeDefined();
+            expect(getActiveFieldsData(activeFieldsets, data).billingAddress).not.toBeDefined();
+        });
+    });
+
+    describe('getInitialActiveFieldsets', () => {
+        test('should return false for hidden fieldsets', () => {
+            const visibility: OpenInvoiceVisibility = {
+                personalDetails: 'editable',
+                billingAddress: 'readOnly',
+                deliveryAddress: 'hidden'
+            };
+
+            expect(getInitialActiveFieldsets(visibility).personalDetails).toBe(true);
+            expect(getInitialActiveFieldsets(visibility).billingAddress).toBe(true);
+            expect(getInitialActiveFieldsets(visibility).deliveryAddress).toBe(false);
+        });
+
+        test('should return true for delivery address when it is not set to hidden and it is prefilled', () => {
+            const data: OpenInvoiceStateData = {
+                deliveryAddress: {
+                    street: 'Test',
+                    country: 'NL'
+                }
+            };
+
+            const visibility: OpenInvoiceVisibility = {
+                deliveryAddress: 'editable'
+            };
+
+            expect(getInitialActiveFieldsets(visibility, data).deliveryAddress).toBe(true);
+        });
+
+        test('should return true for delivery address when it is not set to hidden and the billing address is hidden', () => {
+            const visibility: OpenInvoiceVisibility = {
+                billingAddress: 'hidden',
+                deliveryAddress: 'editable'
+            };
+
+            expect(getInitialActiveFieldsets(visibility).deliveryAddress).toBe(true);
+        });
+    });
+});

--- a/packages/lib/src/components/internal/OpenInvoice/utils.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/utils.ts
@@ -17,6 +17,8 @@ export const getInitialActiveFieldsets = (visibility: OpenInvoiceVisibility, dat
         const isDeliveryAddress = fieldset === 'deliveryAddress';
         const billingAddressIsHidden = visibility?.billingAddress === 'hidden';
 
+        // The delivery address will be active not only when set as visible
+        // but also when the billing address is hidden or when it has prefilled data
         acc[fieldset] = isVisible && (!isDeliveryAddress || billingAddressIsHidden || isPrefilled(data[fieldset]));
         return acc;
     }, {} as OpenInvoiceActiveFieldsets);

--- a/packages/lib/src/components/internal/OpenInvoice/utils.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/utils.ts
@@ -1,8 +1,9 @@
-import { ActiveFieldsets, OpenInvoiceStateData, OpenInvoiceVisibility } from './types';
+import { OpenInvoiceActiveFieldsets, OpenInvoiceStateData, OpenInvoiceVisibility } from './types';
+import { fieldsetsSchema } from './OpenInvoice';
 
 const isPrefilled = (fieldsetData: OpenInvoiceStateData = {}): boolean => Object.keys(fieldsetData).length > 1;
 
-const getActiveFieldsData = (data: OpenInvoiceStateData, activeFieldsets: ActiveFieldsets): OpenInvoiceStateData =>
+export const getActiveFieldsData = (activeFieldsets: OpenInvoiceActiveFieldsets, data: OpenInvoiceStateData): OpenInvoiceStateData =>
     Object.keys(data)
         .filter(fieldset => activeFieldsets[fieldset])
         .reduce((acc, cur) => {
@@ -10,11 +11,12 @@ const getActiveFieldsData = (data: OpenInvoiceStateData, activeFieldsets: Active
             return acc;
         }, {});
 
-const getInitialActiveFieldsets = (fieldsets, visibility: OpenInvoiceVisibility, data: OpenInvoiceStateData): ActiveFieldsets =>
-    fieldsets.reduce((acc, fieldset) => {
+export const getInitialActiveFieldsets = (visibility: OpenInvoiceVisibility, data: OpenInvoiceStateData = {}): OpenInvoiceActiveFieldsets =>
+    fieldsetsSchema.reduce((acc, fieldset) => {
         const isVisible = visibility[fieldset] !== 'hidden';
-        acc[fieldset] = isVisible && (fieldset !== 'deliveryAddress' || isPrefilled(data[fieldset]));
-        return acc;
-    }, {});
+        const isDeliveryAddress = fieldset === 'deliveryAddress';
+        const billingAddressIsHidden = visibility?.billingAddress === 'hidden';
 
-export { getActiveFieldsData, getInitialActiveFieldsets };
+        acc[fieldset] = isVisible && (!isDeliveryAddress || billingAddressIsHidden || isPrefilled(data[fieldset]));
+        return acc;
+    }, {} as OpenInvoiceActiveFieldsets);

--- a/packages/lib/src/components/internal/OpenInvoice/utils.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/utils.ts
@@ -1,7 +1,20 @@
-const getInitialActiveFieldsets = (fieldsets, visibility) =>
+import { ActiveFieldsets, OpenInvoiceStateData, OpenInvoiceVisibility } from './types';
+
+const isPrefilled = (fieldsetData: OpenInvoiceStateData = {}): boolean => Object.keys(fieldsetData).length > 1;
+
+const getActiveFieldsData = (data: OpenInvoiceStateData, activeFieldsets: ActiveFieldsets): OpenInvoiceStateData =>
+    Object.keys(data)
+        .filter(fieldset => activeFieldsets[fieldset])
+        .reduce((acc, cur) => {
+            acc[cur] = data[cur];
+            return acc;
+        }, {});
+
+const getInitialActiveFieldsets = (fieldsets, visibility: OpenInvoiceVisibility, data: OpenInvoiceStateData): ActiveFieldsets =>
     fieldsets.reduce((acc, fieldset) => {
-        acc[fieldset] = visibility[fieldset] !== 'hidden';
+        const isVisible = visibility[fieldset] !== 'hidden';
+        acc[fieldset] = isVisible && (fieldset !== 'deliveryAddress' || isPrefilled(data[fieldset]));
         return acc;
     }, {});
 
-export { getInitialActiveFieldsets };
+export { getActiveFieldsData, getInitialActiveFieldsets };


### PR DESCRIPTION
## Summary
Payment methods such as AfterPay have a Checkout component that can query for separate billing and delivery address. These fields can be pre-populated upon loading the Checkout script.

Upon initial loading the component is collapsed and only shows the billing address fields. Even if shipping address has been pre-populated in the script. The `state.data` object also will duplicate the billing address into the shipping address object. Only if ticked the "Specify a separate delivery address" box the delivery address fields will appear and will be used for state.data.

This changes this behaviour to expand the component with the billing address fields visible upon initial component loading, in case this data has been pre-populated. Also, if the delivery address is pre-populated and read-only, that we would not show the checkbox "specify a separate delivery address", as the delivery address can not be changed anyway.

**Fixed issue**:  COWEB-839
