### PR TITLE
Handle errors in gift card flow

### DIFF
--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -64,7 +64,7 @@ export class GiftcardElement extends UIElement {
                 }
             })
             .catch(error => {
-                this.setStatus('ready');
+                this.setStatus('error');
                 if (this.props.onError) this.props.onError(error);
             });
     };
@@ -92,7 +92,8 @@ export class GiftcardElement extends UIElement {
                     }}
                     {...this.props}
                     onChange={this.setState}
-                    onSubmit={this.onBalanceCheck}
+                    onBalanceCheck={this.onBalanceCheck}
+                    onSubmit={this.submit}
                     payButton={this.payButton}
                 />
             </CoreProvider>

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -2,6 +2,7 @@ import { Component, h } from 'preact';
 import classNames from 'classnames';
 import SecuredFieldsProvider from '../../../components/internal/SecuredFields/SecuredFieldsProvider';
 import Field from '../../internal/FormFields/Field';
+import Alert from '../../internal/Alert';
 import GiftcardResult from './GiftcardResult';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import { PaymentAmount } from '../../../types';
@@ -11,6 +12,7 @@ interface GiftcardComponentProps {
     onFocus: (event) => void;
     onBlur: (event) => void;
     onSubmit: (event) => void;
+    onBalanceCheck: (event) => void;
 
     amount: PaymentAmount;
     showPayButton?: boolean;
@@ -70,11 +72,13 @@ class Giftcard extends Component<GiftcardComponentProps> {
 
         const hasEnoughBalance = balance?.value >= this.props.amount?.value;
         if (balance && hasEnoughBalance) {
-            return <GiftcardResult balance={balance} {...props} />;
+            return <GiftcardResult balance={balance} onSubmit={props.onSubmit} {...props} />;
         }
 
         return (
             <div className="adyen-checkout__giftcard">
+                {this.state.status === 'error' && <Alert>{i18n.get('error.message.unknown')}</Alert>}
+
                 <SecuredFieldsProvider
                     {...this.props}
                     ref={ref => {
@@ -133,7 +137,7 @@ class Giftcard extends Component<GiftcardComponentProps> {
                 {this.props.showPayButton &&
                     this.props.payButton({
                         status: this.state.status,
-                        onClick: this.props.onSubmit,
+                        onClick: this.props.onBalanceCheck,
                         label: i18n.get('applyGiftcard')
                     })}
             </div>

--- a/packages/lib/src/components/internal/Alert/Alert.scss
+++ b/packages/lib/src/components/internal/Alert/Alert.scss
@@ -1,0 +1,23 @@
+@import '../../../style/index';
+
+.adyen-checkout__alert-message {
+    display: flex;
+    border-radius: $border-radius-medium;
+    margin: 0 0 $spacing-medium;
+    text-align: left;
+    padding: $spacing-small $spacing-medium;
+    font-size: $font-size-small;
+}
+
+.adyen-checkout__alert-message--error {
+    background: $color-red-light;
+}
+
+
+.adyen-checkout__alert-message--warning {
+    background: $color-orange-light;
+}
+
+.adyen-checkout__alert-message--info {
+    background: $color-blue-lighter;
+}

--- a/packages/lib/src/components/internal/Alert/Alert.tsx
+++ b/packages/lib/src/components/internal/Alert/Alert.tsx
@@ -1,0 +1,15 @@
+import { ComponentChildren, h } from 'preact';
+import cx from 'classnames';
+import './Alert.scss';
+
+const ALERT_TYPES = ['error', 'warning', 'success'];
+
+interface AlertProps {
+    children: ComponentChildren;
+    classNames?: string[];
+    type?: typeof ALERT_TYPES[number];
+}
+
+export default function Alert({ children, classNames = [], type = 'error' }: AlertProps) {
+    return <div className={cx('adyen-checkout__alert-message', `adyen-checkout__alert-message--${type}`, classNames)}>{children}</div>;
+}

--- a/packages/lib/src/components/internal/Alert/index.ts
+++ b/packages/lib/src/components/internal/Alert/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Alert';

--- a/packages/lib/src/style/colors.scss
+++ b/packages/lib/src/style/colors.scss
@@ -15,6 +15,7 @@ $color-orange: #ffae42;
 $color-orange-light: #ffeacc;
 $color-orange-dark: #7f4a00;
 $color-red: #d10244;
+$color-red-light: #fbe6ed;
 
 // Application
 $color-primary: $color-blue;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Display an error message when a balance check can't be completed successfully (not enough balance, different currency, incorrect giftcard number)
- Correctly call `submit()` from the `GiftcardResult` component
