### PR TITLE
KCP fixes

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -163,6 +163,8 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                 ref={this.sfp}
                 {...this.props}
                 styles={{ ...defaultStyles, ...this.props.styles }}
+                koreanAuthenticationRequired={this.props.configuration.koreanAuthenticationRequired}
+                hasKoreanFields={!!(this.props.configuration.koreanAuthenticationRequired && this.props.countryCode === 'kr')}
                 onChange={this.handleSecuredFieldsChange}
                 onBrand={this.handleOnBrand}
                 onFocus={this.handleFocus}

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -12,11 +12,7 @@ export class SecuredFieldsElement extends UIElement {
         return {
             ...props,
             type: props.type === 'scheme' ? 'card' : props.type,
-            ...(props.brands && !props.groupTypes && { groupTypes: props.brands }),
-            configuration: {
-                ...props.configuration,
-                ...(props.koreanAuthenticationRequired !== undefined && { koreanAuthenticationRequired: props.koreanAuthenticationRequired })
-            }
+            ...(props.brands && !props.groupTypes && { groupTypes: props.brands })
         };
     }
 

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -69,7 +69,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             data: {},
             cvcRequired: true,
             isSfpValid: false,
-            hasKoreanFields: !!(this.props.configuration.koreanAuthenticationRequired && this.props.countryCode === 'kr')
+            hasKoreanFields: this.props.hasKoreanFields
         };
         this.state = stateObj;
 
@@ -178,7 +178,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
 
     private checkForKCPFields() {
         let needsKoreanFields = false;
-        if (this.props.configuration.koreanAuthenticationRequired) {
+        if (this.props.koreanAuthenticationRequired) {
             needsKoreanFields = this.issuingCountryCode ? this.issuingCountryCode === 'kr' : this.props.countryCode === 'kr';
         }
 
@@ -202,7 +202,13 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
 
         // Wasn't korean, now is - show password field
         if (!this.state.hasKoreanFields && needsKoreanFields) {
-            this.setState({ hasKoreanFields: true, isSfpValid: false }, () => {
+            const setAddedFieldState = prevState => ({
+                valid: { ...prevState.valid, [ENCRYPTED_PWD_FIELD]: false },
+                hasKoreanFields: true,
+                isSfpValid: false
+            });
+
+            this.setState(setAddedFieldState, () => {
                 this.props.onChange(this.state);
             });
 

--- a/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
@@ -34,6 +34,7 @@ export interface SFPProps {
     hideCVC: boolean;
     i18n: Language;
     koreanAuthenticationRequired: boolean;
+    hasKoreanFields: boolean;
     onChange;
     oneClick: boolean;
     render;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed a couple of issues with the KCP fields:
- `CardInput` creates and sets KCP related props that it passes to the more generic `SecuredFieldsProvider` (fixes issue where `Giftcard` threw error if a configuration object with `koreanAuthenticationRequired` didn't exist)
- The dynamically added KCP password securedField is added with an entry in `state.data.valid` set to `false` (fixes issue where pressing "pay" didn't trigger a validation error on the empty password field)

## Tested scenarios
- Tested that Giftcard now works
- Tested that adding KCP securedField and pressing "pay" triggers validation error
- Unit tests all pass
- New e2e tests related to KCP fields all pass
