### PR TITLE
Google pay onClick event

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -43,7 +43,7 @@ class GooglePay extends UIElement<GooglePayProps> {
     public loadPayment = () => {
         const { onSubmit = () => {}, onAuthorized = () => {} } = this.props;
 
-        return new Promise((resolve, reject) => (this.props.onClick ? this.props?.onClick(resolve, reject) : resolve()))
+        return new Promise((resolve, reject) => (this.props.onClick ? this.props.onClick(resolve, reject) : resolve()))
             .then(() => this.googlePay.initiatePayment(this.props))
             .then(paymentData => {
                 // setState will trigger an onChange event

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -43,8 +43,8 @@ class GooglePay extends UIElement<GooglePayProps> {
     public loadPayment = () => {
         const { onSubmit = () => {}, onAuthorized = () => {} } = this.props;
 
-        return this.googlePay
-            .initiatePayment(this.props)
+        return new Promise((resolve, reject) => (this.props.onClick ? this.props?.onClick(resolve, reject) : resolve()))
+            .then(() => this.googlePay.initiatePayment(this.props))
             .then(paymentData => {
                 // setState will trigger an onChange event
                 this.setState({

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -43,7 +43,7 @@ class GooglePay extends UIElement<GooglePayProps> {
     public loadPayment = () => {
         const { onSubmit = () => {}, onAuthorized = () => {} } = this.props;
 
-        return new Promise((resolve, reject) => (this.props.onClick ? this.props.onClick(resolve, reject) : resolve()))
+        return new Promise((resolve, reject) => this.props.onClick(resolve, reject))
             .then(() => this.googlePay.initiatePayment(this.props))
             .then(paymentData => {
                 // setState will trigger an onChange event

--- a/packages/lib/src/components/GooglePay/defaultProps.ts
+++ b/packages/lib/src/components/GooglePay/defaultProps.ts
@@ -33,6 +33,7 @@ export default {
     onError: () => {},
     onAuthorized: params => params,
     onSubmit: () => {},
+    onClick: resolve => resolve(),
 
     // CardParameters
     // https://developers.google.com/pay/api/web/reference/object#CardParameters

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -120,6 +120,6 @@ export interface GooglePayProps extends UIElementProps {
     buttonType?: google.payments.api.ButtonType;
 
     // Events
-
+    onClick?: (resolve, reject) => void;
     onAuthorized?: (paymentData: google.payments.api.PaymentData) => void;
 }

--- a/packages/playground/src/pages/Wallets/Wallets.js
+++ b/packages/playground/src/pages/Wallets/Wallets.js
@@ -1,130 +1,124 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
-import { getPaymentMethods, getOriginKey } from '../../services';
+import { getPaymentMethods } from '../../services';
 import { handleChange, handleSubmit, handleAdditionalDetails } from '../../handlers';
 import { amount, shopperLocale } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
 
-getOriginKey()
-    .then(originKey => {
-        window.originKey = originKey;
-    })
-    .then(() => getPaymentMethods({ amount, shopperLocale }))
-    .then(paymentMethodsResponse => {
-        window.checkout = new AdyenCheckout({
-            amount, // Optional. Used to display the amount in the Pay Button.
-            originKey,
-            clientKey: process.env.__CLIENT_KEY__,
-            paymentMethodsResponse,
-            locale: shopperLocale,
-            // environment: 'http://localhost:8080/checkoutshopper/',
-            // environment: 'https://checkoutshopper-beta.adyen.com/checkoutshopper/',
-            environment: 'test',
-            onChange: handleChange,
-            onSubmit: handleSubmit,
-            onAdditionalDetails: handleAdditionalDetails,
-            onError: console.error,
-            showPayButton: true
-        });
+getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
+    window.checkout = new AdyenCheckout({
+        amount, // Optional. Used to display the amount in the Pay Button.
+        clientKey: process.env.__CLIENT_KEY__,
+        paymentMethodsResponse,
+        locale: shopperLocale,
+        // environment: 'http://localhost:8080/checkoutshopper/',
+        // environment: 'https://checkoutshopper-beta.adyen.com/checkoutshopper/',
+        environment: 'test',
+        onChange: handleChange,
+        onSubmit: handleSubmit,
+        onAdditionalDetails: handleAdditionalDetails,
+        onError: console.error,
+        showPayButton: true
+    });
 
-        // PAYPAL
-        window.paypalButtons = checkout
-            .create('paypal', {
-                // merchantId: '5RZKQX2FC48EA', // automatic ?
-                // intent: 'capture', // 'capture' [Default] / 'authorize'
-                //                configuration: {
-                //                    merchantId: '5RZKQX2FC48EA',
-                //                    intent: 'capture'
-                //                },
-                // commit: true, // true [Default] / false
-                // style: {},
+    // PAYPAL
+    window.paypalButtons = checkout
+        .create('paypal', {
+            // merchantId: '5RZKQX2FC48EA', // automatic ?
+            // intent: 'capture', // 'capture' [Default] / 'authorize'
+            //                configuration: {
+            //                    merchantId: '5RZKQX2FC48EA',
+            //                    intent: 'capture'
+            //                },
+            // commit: true, // true [Default] / false
+            // style: {},
 
-                // Events
-                onError: (error, component) => {
-                    component.setStatus('ready');
-                    console.log('paypal onError', error);
-                },
-
-                onCancel: (data, component) => {
-                    component.setStatus('ready');
-                    console.log('paypal onCancel', data);
-                }
-            })
-            .mount('.paypal-field');
-
-        // GOOGLE PAY
-        const googlepay = checkout.create('paywithgoogle', {
-            // environment: 'PRODUCTION',
-            environment: 'TEST',
-
-            // Callbacks
-            onAuthorized: console.info,
-            // onError: console.error,
-
-            // Payment info
-            amount: { value: 10, currency: 'EUR' }, // 0.1 EUR (minor units)
-            countryCode: 'NL',
-
-            // Merchant config (required)
-            //            configuration: {
-            //                gatewayMerchantId: 'TestMerchant', // name of MerchantAccount
-            //                merchantName: 'Adyen Test merchant', // Name to be displayed
-            //                merchantId: '06946223745213860250' // Required in Production environment. Google's merchantId: https://developers.google.com/pay/api/web/guides/test-and-deploy/deploy-production-environment#obtain-your-merchantID
-            //            },
-
-            // Shopper info (optional)
-            emailRequired: true,
-            shippingAddressRequired: true,
-            shippingAddressParameters: {}, // https://developers.google.com/pay/api/web/reference/object#ShippingAddressParameters
-
-            // Button config (optional)
-            buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-            buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-        });
-
-        // First, check availability. If environment is TEST, Google Pay will always be considered available.
-        googlepay
-            .isAvailable()
-            .then(() => {
-                googlepay.mount('.googlepay-field');
-            })
-            .catch(e => console.warn(e));
-
-        window.googlepay = googlepay;
-
-        // APPLE PAY
-        const applepay = checkout.create('applepay', {
-            // Callbacks
-            onAuthorized: console.info,
-            // onError: console.error,
-
-            // Payment info
-            currencyCode: 'EUR', // Required. The three-letter ISO 4217 currency code for the payment.
-            amount: 10, // 0.1 EUR (minor units)
-            countryCode: 'DE', // Required. The merchant’s two-letter ISO 3166 country code.
-
-            // Merchant config (required)
-            configuration: {
-                merchantName: 'Adyen Test merchant', // Name to be displayed
-                merchantIdentifier: '000000000200001' // Required. https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951611-merchantidentifier
+            // Events
+            onError: (error, component) => {
+                component.setStatus('ready');
+                console.log('paypal onError', error);
             },
 
-            // Button config (optional)
-            buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-            buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-        });
+            onCancel: (data, component) => {
+                component.setStatus('ready');
+                console.log('paypal onCancel', data);
+            }
+        })
+        .mount('.paypal-field');
 
-        applepay
-            .isAvailable()
-            .then(isAvailable => {
-                // Demo only
-                if (isAvailable) document.querySelector('#applepay').classList.remove('merchant-checkout__payment-method--hidden');
+    // GOOGLE PAY
+    const googlepay = checkout.create('paywithgoogle', {
+        // environment: 'PRODUCTION',
+        environment: 'TEST',
 
-                // If Available mount it in the dom
-                if (isAvailable) applepay.mount('.applepay-field');
-            })
-            .catch(e => {
-                console.warn(e);
-            });
+        // Callbacks
+        onAuthorized: console.info,
+        // onError: console.error,
+
+        // Payment info
+        amount: { value: 10, currency: 'EUR' }, // 0.1 EUR (minor units)
+        countryCode: 'NL',
+
+        // Merchant config (required)
+        //            configuration: {
+        //                gatewayMerchantId: 'TestMerchant', // name of MerchantAccount
+        //                merchantName: 'Adyen Test merchant', // Name to be displayed
+        //                merchantId: '06946223745213860250' // Required in Production environment. Google's merchantId: https://developers.google.com/pay/api/web/guides/test-and-deploy/deploy-production-environment#obtain-your-merchantID
+        //            },
+
+        // Shopper info (optional)
+        emailRequired: true,
+        shippingAddressRequired: true,
+        shippingAddressParameters: {}, // https://developers.google.com/pay/api/web/reference/object#ShippingAddressParameters
+
+        // Button config (optional)
+        buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
+        buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
     });
+
+    // First, check availability. If environment is TEST, Google Pay will always be considered available.
+    googlepay
+        .isAvailable()
+        .then(() => {
+            googlepay.mount('.googlepay-field');
+        })
+        .catch(e => console.warn(e));
+
+    window.googlepay = googlepay;
+
+    // APPLE PAY
+    const applepay = checkout.create('applepay', {
+        // Callbacks
+        onAuthorized: console.info,
+        // onError: console.error,
+
+        // Payment info
+        currencyCode: 'EUR', // Required. The three-letter ISO 4217 currency code for the payment.
+        amount: 10, // 0.1 EUR (minor units)
+        countryCode: 'DE', // Required. The merchant’s two-letter ISO 3166 country code.
+
+        // Merchant config (required)
+        configuration: {
+            merchantName: 'Adyen Test merchant', // Name to be displayed
+            merchantIdentifier: '000000000200001' // Required. https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951611-merchantidentifier
+        },
+
+        // Button config (optional)
+        buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
+        buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
+    });
+
+    applepay
+        .isAvailable()
+        .then(isAvailable => {
+            // Demo only
+            if (isAvailable) document.querySelector('#applepay').classList.remove('merchant-checkout__payment-method--hidden');
+
+            // If Available mount it in the dom
+            if (isAvailable) applepay.mount('.applepay-field');
+        })
+        .catch(e => {
+            console.warn(e);
+        });
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Add an `onClick` event to the Google Pay component. It will be triggered when the button is clicked, and gives the merchant an opportunity to perform a validation.

```
onClick: (resolve, reject) => {
  // validate some external form
  resolve(); // or reject();
}