### PR TITLE
Fix Google Pay amount property

### DIFF
--- a/packages/lib/src/components/GooglePay/requests.test.ts
+++ b/packages/lib/src/components/GooglePay/requests.test.ts
@@ -4,7 +4,7 @@ import defaultProps from './defaultProps';
 describe('Google Pay Requests', () => {
     describe('getTransactionInfo', () => {
         test('should transform a normal currency amount', () => {
-            const transactionInfo = getTransactionInfo({ currencyCode: 'USD', totalPrice: 1234 });
+            const transactionInfo = getTransactionInfo({ amount: { value: 1234, currency: 'USD' } });
 
             expect(transactionInfo.currencyCode).toBe('USD');
             expect(transactionInfo.totalPrice).toBe('12.34');
@@ -12,23 +12,15 @@ describe('Google Pay Requests', () => {
         });
 
         test('should transform a normal currency with amount ZERO', () => {
-            const transactionInfo = getTransactionInfo({ currencyCode: 'EUR', totalPrice: 0 });
+            const transactionInfo = getTransactionInfo({ amount: { value: 0, currency: 'EUR' } });
 
             expect(transactionInfo.currencyCode).toBe('EUR');
             expect(transactionInfo.totalPrice).toBe('0');
             expect(transactionInfo.totalPriceStatus).toBe('FINAL');
         });
 
-        test('should default to a ZERO amount', () => {
-            const transactionInfo = getTransactionInfo({});
-
-            expect(transactionInfo.currencyCode).toBe('USD');
-            expect(transactionInfo.totalPrice).toBe('0');
-            expect(transactionInfo.totalPriceStatus).toBe('FINAL');
-        });
-
         test('should transform a non decimal currency amount', () => {
-            const transactionInfo = getTransactionInfo({ currencyCode: 'JPY', totalPrice: 1234 });
+            const transactionInfo = getTransactionInfo({ amount: { value: 1234, currency: 'JPY' } });
 
             expect(transactionInfo.currencyCode).toBe('JPY');
             expect(transactionInfo.totalPrice).toBe('1234');
@@ -37,8 +29,7 @@ describe('Google Pay Requests', () => {
 
         test('should allow other transactionInfo values', () => {
             const transactionInfo = getTransactionInfo({
-                currencyCode: 'JPY',
-                totalPrice: 1234,
+                amount: { value: 1234, currency: 'JPY' },
                 transactionInfo: {
                     displayItems: [
                         {

--- a/packages/lib/src/components/GooglePay/requests.ts
+++ b/packages/lib/src/components/GooglePay/requests.ts
@@ -40,17 +40,16 @@ export function isReadyToPayRequest({
  * @returns transaction info, suitable for use as transactionInfo property of PaymentDataRequest
  */
 export function getTransactionInfo({
-    currencyCode = 'USD',
-    totalPrice = 0,
+    amount,
     countryCode = 'US',
     totalPriceStatus = 'FINAL',
     ...props
-}): google.payments.api.TransactionInfo {
-    const formattedPrice = String(getDecimalAmount(totalPrice, currencyCode));
+}: GooglePayProps): google.payments.api.TransactionInfo {
+    const formattedPrice = String(getDecimalAmount(amount.value, amount.currency));
 
     return {
         countryCode,
-        currencyCode,
+        currencyCode: amount.currency,
         totalPrice: formattedPrice,
         totalPriceStatus: totalPriceStatus as google.payments.api.TotalPriceStatus,
         ...props.transactionInfo

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -113,7 +113,7 @@ export interface GooglePayProps extends UIElementProps {
     /**
      * @see https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo
      */
-    transactionInfo?: google.payments.api.TransactionInfo;
+    transactionInfo?: Partial<google.payments.api.TransactionInfo>;
 
     // Button
 

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -110,6 +110,11 @@ export interface GooglePayProps extends UIElementProps {
      */
     paymentDataCallbacks?: google.payments.api.PaymentDataCallbacks;
 
+    /**
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo
+     */
+    transactionInfo?: google.payments.api.TransactionInfo;
+
     // Button
 
     /**

--- a/packages/playground/src/pages/Wallets/Wallets.js
+++ b/packages/playground/src/pages/Wallets/Wallets.js
@@ -57,7 +57,6 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
         // onError: console.error,
 
         // Payment info
-        amount: { value: 10, currency: 'EUR' }, // 0.1 EUR (minor units)
         countryCode: 'NL',
 
         // Merchant config (required)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix Google Pay's `amount` property, amount will be displayed correctly again on the payment sheet.