### PR TITLE
Autofill holderName only when holderName is enabled

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/handlers.ts
+++ b/packages/lib/src/components/Card/components/CardInput/handlers.ts
@@ -76,7 +76,7 @@ function handleInstallments(installments): void {
 function handleSecuredFieldsChange(newState: SFPState): void {
     const sfState: SFPState = newState;
 
-    const tempHolderName: string = sfState.autoCompleteName ? sfState.autoCompleteName : this.state.data.holderName;
+    const tempHolderName: string = sfState.autoCompleteName && this.props.hasHolderName ? sfState.autoCompleteName : this.state.data.holderName;
 
     const setSfpData = (prevState: SFPState): SFPState => ({
         ...prevState,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When holderName is disabled, it could still get populated by the autofill functionality of secured fields and set on `state.data`.


## Tested scenarios
`paymentMethod` object no longer has `holderName` value after autoFill if `hasHolderName` is set to false
`paymentMethod` object does have `holderName` value after autoFill if `hasHolderName` is set to true


**Fixed issue**:  COWEB-752