### PR TITLE
Fix null value issues on PaymentMethodsResponse

### DIFF
--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/PaymentMethodsResponse.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/PaymentMethodsResponse.ts
@@ -8,8 +8,8 @@ class PaymentMethodsResponse {
     constructor(response, options = {}) {
         checkPaymentMethodsResponse(response);
 
-        this.paymentMethods = response ? processPaymentMethods(response, options) : [];
-        this.storedPaymentMethods = response ? processStoredPaymentMethods(response, options) : [];
+        this.paymentMethods = response ? processPaymentMethods(response.paymentMethods, options) : [];
+        this.storedPaymentMethods = response ? processStoredPaymentMethods(response.storedPaymentMethods, options) : [];
     }
 
     has(paymentMethod: string): boolean {

--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/utils.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/utils.ts
@@ -1,4 +1,4 @@
-import { PaymentMethod, PaymentMethodsResponseInterface } from '../../../types';
+import { PaymentMethod, StoredPaymentMethod } from '../../../types';
 import {
     filterAllowedPaymentMethods,
     filterEcomStoredPaymentMethods,
@@ -11,20 +11,17 @@ const processStoredPaymentMethod = (pm): PaymentMethod => ({
     storedPaymentMethodId: pm.id
 });
 
-export const processPaymentMethods = (
-    paymentMethodsResponse: PaymentMethodsResponseInterface,
-    { allowPaymentMethods = [], removePaymentMethods = [] }
-): PaymentMethod[] => {
-    const { paymentMethods = [] } = paymentMethodsResponse;
+export const processPaymentMethods = (paymentMethods: PaymentMethod[], { allowPaymentMethods = [], removePaymentMethods = [] }): PaymentMethod[] => {
+    if (!paymentMethods) return [];
 
     return paymentMethods.filter(filterAllowedPaymentMethods, allowPaymentMethods).filter(filterRemovedPaymentMethods, removePaymentMethods);
 };
 
 export const processStoredPaymentMethods = (
-    paymentMethodsResponse: any = {},
+    storedPaymentMethods: StoredPaymentMethod[],
     { allowPaymentMethods = [], removePaymentMethods = [] }
 ): PaymentMethod[] => {
-    const { storedPaymentMethods = [] } = paymentMethodsResponse;
+    if (!storedPaymentMethods) return [];
 
     return storedPaymentMethods
         .filter(filterSupportedStoredPaymentMethods) // only display supported stored payment methods


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes an issue where initialization could fail if a `paymentMethodsResponse` value would contain `null` values.

## Tested scenarios
- `paymentMethodsResponse.paymentMethods = null` defaults to an empty array
- `paymentMethodsResponse.storedPaymentMethods = null` defaults to an empty array