### PR TITLE
Frictionless flow in 3DS2 Dropin bug

### DIFF
--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -15,12 +15,12 @@ const actionTypes = {
             createFromAction: props.createFromAction,
             token: action.token,
             paymentData: action.paymentData,
-            onComplete: props.onAdditionalDetails,
             onError: props.onError,
             showSpinner: !props.isDropin,
             isDropin: !!props.isDropin,
             ...props,
             type: 'IdentifyShopper',
+            onComplete: props.onAdditionalDetails,
             statusType: 'loading'
         }),
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For the frictionless flow (fingerprint only) in 3DS2 -  Dropin was overwriting the specially defined `onComplete` function with its own default version of `onComplete`

## Tested scenarios
Frictionless flow is working again in Dropin. (And still working in standalone Card component)


**Fixed issue**:  <!-- #-prefixed issue number -->
