### PR TITLE
Use default brands for binLookup if none have been defined

### DIFF
--- a/packages/lib/src/components/Card/triggerBinLookUp.ts
+++ b/packages/lib/src/components/Card/triggerBinLookUp.ts
@@ -1,5 +1,6 @@
 import fetchJSONData from '../../utils/fetch-json-data';
 import { CbObjOnError } from '../internal/SecuredFields/lib/types';
+import { DEFAULT_CARD_GROUP_TYPES } from '../internal/SecuredFields/lib/configuration/constants';
 import { getError } from '../../core/Errors/utils';
 import { ERROR_MSG_UNSUPPORTED_CARD_ENTERED } from '../../core/Errors/constants';
 
@@ -23,7 +24,7 @@ export default function triggerBinLookUp(callbackObj) {
                 contentType: 'application/json'
             },
             {
-                supportedBrands: this.props.brands,
+                supportedBrands: this.props.brands || DEFAULT_CARD_GROUP_TYPES,
                 encryptedBin: callbackObj.encryptedBin,
                 requestId: callbackObj.uuid // Pass id of request
             }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`/binLookup` was failing to recognise any card brands if a `brands` array was not specified in the config object. 
This is because it relies on this array to provide the `supportedBrands` used by the service.
Now we use the default brands array if none has been specified

## Tested scenarios
If no brands array specified then the default is used and the `/binLookup` can recognise the card brand as being supported

