### PR TITLE
Incompatibility with dual branded cards (and latest KCP fixes)

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
+++ b/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
@@ -22,7 +22,10 @@ export default function processBinLookupResponse(binValueObject: BinValueObject)
             this.setState(switchObj.stateObject); // Don't need to call validateCardInput - this will be called by the brandChange from SFP
 
             // Pass an object through to SFP
-            this.sfp.current.processBinLookupResponse({ supportedBrands: [switchObj.leadType] });
+            this.sfp.current.processBinLookupResponse({
+                issuingCountryCode: binValueObject.issuingCountryCode,
+                supportedBrands: [switchObj.leadType]
+            });
 
             // 2) Single option found (binValueObject.brands.length === 1)
         } else {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For compatibility with the latest fixes for KCP [#469](https://github.com/Adyen/adyen-web/pull/469) - when binLookup detects dual branded cards it also needs to pass `issuingCountryCode` into `SecuredFieldsProvider`

## Tested scenarios
Detection of dual branded cards works without throwing an error in SecuredFieldsProvider

