### PR TITLE
Set default, translated, placeholders for separate date fields

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/utils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/utils.ts
@@ -91,6 +91,8 @@ export const getErrorObject = (fieldType, rootNode, state) => {
 export const resolvePlaceholders = (i18n?: Language) => ({
     [ENCRYPTED_CARD_NUMBER]: i18n.get && i18n.get('creditCard.numberField.placeholder'),
     [ENCRYPTED_EXPIRY_DATE]: i18n.get && i18n.get('creditCard.expiryDateField.placeholder'),
+    [ENCRYPTED_EXPIRY_MONTH]: i18n.get && i18n.get('creditCard.expiryDateField.month.placeholder'),
+    [ENCRYPTED_EXPIRY_YEAR]: i18n.get && i18n.get('creditCard.expiryDateField.year.placeholder'),
     [ENCRYPTED_SECURITY_CODE]: i18n.get && i18n.get('creditCard.cvcField.placeholder'),
     [ENCRYPTED_PWD_FIELD]: i18n.get && i18n.get('creditCard.encryptedPassword.placeholder')
 });

--- a/packages/playground/src/pages/SecuredFields/securedFields.config.js
+++ b/packages/playground/src/pages/SecuredFields/securedFields.config.js
@@ -18,7 +18,9 @@ export const styles = {
 
 export const placeholders = {
     encryptedCardNumber: '9999 9999 9999 9999',
-    encryptedExpiryDate: 'mm/dd',
+    encryptedExpiryDate: 'mm/yy',
+    encryptedExpiryMonth: 'mm',
+    encryptedExpiryYear: 'yy',
     encryptedSecurityCode: '8888'
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The separate date fields, if used in the custom card component, weren't getting default, translated, placeholders (used when the merchant didn't specify their own placeholders)

## Tested scenarios
If no placeholders for these fields are specified then default ones are set from the translation files

