### PR TITLE
Fix amount value not being able to be set as 0 in the playground.

### DIFF
--- a/packages/playground/src/config/commonConfig.js
+++ b/packages/playground/src/config/commonConfig.js
@@ -9,10 +9,10 @@ const merchantAccount = urlParams.merchantAccount;
 export const shopperLocale = urlParams.shopperLocale || DEFAULT_LOCALE;
 export const countryCode = urlParams.countryCode || DEFAULT_COUNTRY;
 export const currency = getCurrency(countryCode);
-export const amountValue = parseInt(urlParams.amount, 10) || 25900;
+export const amountValue = urlParams.amount ?? 25900;
 export const amount = {
     currency,
-    value: amountValue
+    value: Number(amountValue)
 };
 
 export default {


### PR DESCRIPTION
## Summary
In our playground it is possible to set the amount as a URL search parameter like this `?amount=123` to make quick tests, but setting it to `0` doesn't work. This fixes that issue.

## Tested scenarios
- No amount
- Amount set as `0`
- Amount set as `100`