### PR TITLE
Release 3.18.2

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "umd:main": "dist/adyen.js",
     "types": "dist/types",
     "typings": "dist/types",
-    "version": "3.18.1",
+    "version": "3.18.2",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -47,6 +47,6 @@
         "whatwg-fetch": "^3.4.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.18.1"
+        "@adyen/adyen-web": "3.18.2"
     }
 }


### PR DESCRIPTION
## Fixes

* Use default brands for binLookup if none have been defined (#512)
* Incompatibility with dual branded cards (and latest KCP fixes) (#514)

