### PR TITLE
Pass issuingCountryCode when selecting a dual brand

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/handlers.ts
+++ b/packages/lib/src/components/Card/components/CardInput/handlers.ts
@@ -132,7 +132,7 @@ function handleAdditionalDataSelection(e: Event): void {
 
     // Pass brand into SecuredFields
     if (this.state.additionalSelectType === 'brandSwitcher') {
-        this.sfp.current.processBinLookupResponse({ supportedBrands: [value] });
+        this.sfp.current.processBinLookupResponse({ issuingCountryCode: this.state.issuingCountryCode, supportedBrands: [value] });
     }
 }
 

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -268,7 +268,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             if (this.csf) this.csf.hasUnsupportedCard(ENCRYPTED_CARD_NUMBER, '');
         }
 
-        this.issuingCountryCode = binValueObject?.issuingCountryCode.toLowerCase();
+        this.issuingCountryCode = binValueObject?.issuingCountryCode?.toLowerCase();
 
         // Scenarios:
         // RESET (binValueObject === null): The number of digits in number field has dropped below threshold for BIN lookup


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In addition to the fix in [#514](https://github.com/Adyen/adyen-web/pull/514) we also need to pass the `issuingCountryCode` in the object sent when a shopper clicks on one of the dual branding icons

## Tested scenarios
Clicking on one of the dual branding icons doesn't cause an error.
e2e tests now exist for dualBranding scenarios.
