### PR TITLE
Show a dropdown of countries if no country is passed in Open Invoices

### DIFF
--- a/packages/lib/src/components/Affirm/Affirm.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.tsx
@@ -1,6 +1,5 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
-
-const ALLOWED_COUNTRIES = ['CA', 'US'];
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class Affirm extends OpenInvoiceContainer {
     public static type = 'affirm';

--- a/packages/lib/src/components/Affirm/config.ts
+++ b/packages/lib/src/components/Affirm/config.ts
@@ -1,0 +1,1 @@
+export const ALLOWED_COUNTRIES = ['CA', 'US'];

--- a/packages/lib/src/components/AfterPay/AfterPay.tsx
+++ b/packages/lib/src/components/AfterPay/AfterPay.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
 import ConsentCheckboxLabel from './components/ConsentCheckboxLabel';
 import { getConsentLinkUrl } from './utils';
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class AfterPay extends OpenInvoiceContainer {
     public static type = 'afterpay_default';
@@ -9,6 +10,7 @@ export default class AfterPay extends OpenInvoiceContainer {
     formatProps(props) {
         return {
             ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES,
             consentCheckboxLabel: <ConsentCheckboxLabel url={getConsentLinkUrl(props.countryCode, props.i18n?.locale)} />
         };
     }

--- a/packages/lib/src/components/AfterPay/AfterPayB2B.tsx
+++ b/packages/lib/src/components/AfterPay/AfterPayB2B.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
 import ConsentCheckboxLabel from './components/ConsentCheckboxLabel';
-import { AFTERPAY_B2B_CONSENT_URL } from './config';
+import { AFTERPAY_B2B_CONSENT_URL, ALLOWED_COUNTRIES } from './config';
 
 export default class AfterPayB2B extends OpenInvoiceContainer {
     public static type = 'afterpay_b2b';
@@ -20,6 +20,7 @@ export default class AfterPayB2B extends OpenInvoiceContainer {
     formatProps(props) {
         return {
             ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES,
             consentCheckboxLabel: <ConsentCheckboxLabel url={AFTERPAY_B2B_CONSENT_URL} />
         };
     }

--- a/packages/lib/src/components/AfterPay/config.ts
+++ b/packages/lib/src/components/AfterPay/config.ts
@@ -2,5 +2,6 @@ const AFTERPAY_CONSENT_URL_EN = 'https://www.afterpay.nl/en/algemeen/pay-with-af
 const AFTERPAY_CONSENT_URL_BE = 'https://www.afterpay.be/be/footer/betalen-met-afterpay/betalingsvoorwaarden';
 const AFTERPAY_CONSENT_URL_NL = 'https://www.afterpay.nl/nl/algemeen/betalen-met-afterpay/betalingsvoorwaarden';
 const AFTERPAY_B2B_CONSENT_URL = 'https://www.afterpay.nl/nl/algemeen/zakelijke-partners/betalingsvoorwaarden-zakelijk';
+const ALLOWED_COUNTRIES = ['BE', 'NL'];
 
-export { AFTERPAY_CONSENT_URL_EN, AFTERPAY_CONSENT_URL_BE, AFTERPAY_CONSENT_URL_NL, AFTERPAY_B2B_CONSENT_URL };
+export { AFTERPAY_CONSENT_URL_EN, AFTERPAY_CONSENT_URL_BE, AFTERPAY_CONSENT_URL_NL, AFTERPAY_B2B_CONSENT_URL, ALLOWED_COUNTRIES };

--- a/packages/lib/src/components/FacilyPay/FacilyPay10x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay10x.ts
@@ -1,5 +1,5 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
-import { ALLOWED_COUNTRIES, ALLOWED_COUNTRIES as allowedCountries } from './config';
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class FacilyPay10x extends OpenInvoiceContainer {
     public static type = 'facilypay_10x';

--- a/packages/lib/src/components/FacilyPay/FacilyPay10x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay10x.ts
@@ -1,5 +1,13 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
+import { ALLOWED_COUNTRIES, ALLOWED_COUNTRIES as allowedCountries } from './config';
 
 export default class FacilyPay10x extends OpenInvoiceContainer {
     public static type = 'facilypay_10x';
+
+    formatProps(props) {
+        return {
+            ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES
+        };
+    }
 }

--- a/packages/lib/src/components/FacilyPay/FacilyPay12x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay12x.ts
@@ -1,5 +1,13 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class FacilyPay12x extends OpenInvoiceContainer {
     public static type = 'facilypay_12x';
+
+    formatProps(props) {
+        return {
+            ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES
+        };
+    }
 }

--- a/packages/lib/src/components/FacilyPay/FacilyPay3x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay3x.ts
@@ -1,6 +1,13 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class FacilyPay3x extends OpenInvoiceContainer {
     public static type = 'facilypay_3x';
-}
 
+    formatProps(props) {
+        return {
+            ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES
+        };
+    }
+}

--- a/packages/lib/src/components/FacilyPay/FacilyPay4x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay4x.ts
@@ -1,5 +1,13 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class FacilyPay4x extends OpenInvoiceContainer {
     public static type = 'facilypay_4x';
+
+    formatProps(props) {
+        return {
+            ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES
+        };
+    }
 }

--- a/packages/lib/src/components/FacilyPay/FacilyPay6x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay6x.ts
@@ -1,5 +1,13 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class FacilyPay6x extends OpenInvoiceContainer {
     public static type = 'facilypay_6x';
+
+    formatProps(props) {
+        return {
+            ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES
+        };
+    }
 }

--- a/packages/lib/src/components/FacilyPay/config.ts
+++ b/packages/lib/src/components/FacilyPay/config.ts
@@ -1,0 +1,1 @@
+export const ALLOWED_COUNTRIES = ['ES', 'FR'];

--- a/packages/lib/src/components/RatePay/RatePay.ts
+++ b/packages/lib/src/components/RatePay/RatePay.ts
@@ -1,5 +1,13 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
+import { ALLOWED_COUNTRIES } from './config';
 
 export default class RatePay extends OpenInvoiceContainer {
     public static type = 'ratepay';
+
+    formatProps(props) {
+        return {
+            ...super.formatProps(props),
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES
+        };
+    }
 }

--- a/packages/lib/src/components/RatePay/config.ts
+++ b/packages/lib/src/components/RatePay/config.ts
@@ -1,0 +1,1 @@
+export const ALLOWED_COUNTRIES = ['AT', 'CH', 'DE'];

--- a/packages/lib/src/components/internal/OpenInvoice/types.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/types.ts
@@ -11,7 +11,7 @@ export interface OpenInvoiceVisibility {
 export interface OpenInvoiceProps {
     allowedCountries?: string[];
     consentCheckboxLabel: any;
-    countryCode: string;
+    countryCode?: string;
     data: {
         companyDetails?: CompanyDetailsSchema;
         personalDetails?: PersonalDetailsSchema;


### PR DESCRIPTION
## Summary
Currently the `countryCode` is required as we always show the country dropdown as read only.
Now we're aligning with Affirm and we show a dropdown if no `countryCode` is passed.
