### PR TITLE
Add onClick event to Apple Pay Component

### DIFF
--- a/packages/lib/src/components/ApplePay/defaultProps.ts
+++ b/packages/lib/src/components/ApplePay/defaultProps.ts
@@ -75,6 +75,7 @@ const defaultProps = {
     applicationData: undefined, // A Base64-encoded string used to contain your application-specific data.
 
     // Events
+    onClick: resolve => resolve(),
     onSubmit: () => {},
     onError: () => {},
     onAuthorized: resolve => resolve(),

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -110,7 +110,7 @@ export interface ApplePayElementProps extends UIElementProps {
     applicationData?: string;
 
     // Events
-
+    onClick?: (resolve, reject) => void;
     onSubmit?: (state, component) => void;
     onError?: (error) => void;
     onCancel?: () => void;

--- a/packages/playground/src/pages/Dropin/Dropin.js
+++ b/packages/playground/src/pages/Dropin/Dropin.js
@@ -99,6 +99,12 @@ const initCheckout = async () => {
                     }
                 }
             },
+            applepay: {
+                configuration: {
+                    merchantName: 'Adyen Test merchant',
+                    merchantIdentifier: '000000000200001'
+                }
+            },
             paywithgoogle: {
                 countryCode: 'NL',
                 onAuthorized: console.info


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adds compatibility to the `onClick` event to the Apple Pay component.

```js
    checkout.create('applepay', {
      // ...
      onClick: (resolve, reject) => {
        resolve();
      }
    });
```

> Be aware that depending on what actions are performed in this event, an error could occur when creating the Apple Pay Session (`Must create a new ApplePaySession from a user gesture handler`, see [Creating an Apple Pay Session](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/creating_an_apple_pay_session)). This means, for example, starting the session after an asynchronous call will fail in most cases. Refer to the Apple Pay documentation for more information on this.

**Fixed issue**:  #589