### PR TITLE
Feature/more e2e tests

### DIFF
--- a/packages/e2e/app/src/services/commonConfig.js
+++ b/packages/e2e/app/src/services/commonConfig.js
@@ -6,7 +6,7 @@ const DEFAULT_COUNTRY = 'US';
 
 const urlParams = getSearchParameters(window.location.search);
 export const shopperLocale = DEFAULT_LOCALE;
-export const countryCode = DEFAULT_COUNTRY;
+export const countryCode = urlParams.countryCode || DEFAULT_COUNTRY;
 export const currency = getCurrency(countryCode);
 export const amountValue = urlParams.amount ?? 25900;
 export const amount = {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -45,6 +45,6 @@
         "whatwg-fetch": "^3.5.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.18.1"
+        "@adyen/adyen-web": "3.18.2"
     }
 }

--- a/packages/e2e/tests/bacsDD/bacs.clientScripts.js
+++ b/packages/e2e/tests/bacsDD/bacs.clientScripts.js
@@ -1,0 +1,5 @@
+window.dropinConfig = {
+    showStoredPaymentMethods: false // hide stored PMs
+};
+
+//window.mainConfiguration = {};

--- a/packages/e2e/tests/bacsDD/bacs.test.js
+++ b/packages/e2e/tests/bacsDD/bacs.test.js
@@ -1,0 +1,114 @@
+import { Selector } from 'testcafe';
+import { start, getIsValid } from '../utils/commonUtils';
+import { BASE_URL } from '../pages';
+
+const checkboxLabel = Selector('.adyen-checkout__bacs .adyen-checkout__checkbox');
+//const checkboxAmount = Selector('.adyen-checkout__input--amountConsentCheckbox');
+//const checkboxAccount = Selector('.adyen-checkout__input--accountConsentCheckbox');
+
+const holderName = Selector('.adyen-checkout__bacs-input--holder-name');
+const nonEditableHolderName = holderName.withAttribute('readonly');
+const editButton = Selector('.adyen-checkout__bacs--edit-button');
+const payButton = Selector('.adyen-checkout__bacs .adyen-checkout__button--pay');
+const validTicks = Selector('.adyen-checkout-input__inline-validation--valid');
+
+const voucher = Selector('.adyen-checkout__voucher-result--directdebit_GB');
+const voucherButton = Selector('.adyen-checkout__voucher-result--directdebit_GB .adyen-checkout__button--secondary');
+
+const TEST_SPEED = 1;
+
+fixture`Testing BacsDD in dropin`.page(BASE_URL + '?countryCode=GB').clientScripts('bacs.clientScripts.js');
+
+test('Fill in Bacs details, check "Edit" phase and then complete payment', async t => {
+    // Start, allow time to load
+    await start(t, 2000, TEST_SPEED);
+
+    await t
+        // Select Bacs PM
+        .click('.adyen-checkout__payment-method--directdebit_GB')
+
+        /**
+         * Fill phase 1 form
+         */
+        // Check holderName doesn't have a readonly attribute
+        .expect(nonEditableHolderName.exists)
+        .notOk()
+
+        // Fill fields
+        .typeText(holderName, 'g stacey')
+        .typeText('.adyen-checkout__bacs--bank-account-number', '12345678')
+        .typeText('.adyen-checkout__bacs--bank-location-id', '987654')
+        .typeText('.adyen-checkout__bacs-input--shopper-email', 'gs@smiffy.nl')
+
+        // Expect to see green "valid" ticks
+        .expect(validTicks.filterVisible().exists)
+        .ok()
+
+        // Click Pay
+        .click(payButton)
+        // Expect errors
+        .expect(Selector('.adyen-checkout__field--error').exists)
+        .ok()
+
+        // Click checkboxes (in reality click their labels - for some reason clicking the actual checkboxes takes ages)
+        .click(checkboxLabel.nth(0))
+        //                .expect(checkboxAmount.checked).ok()
+        .click(checkboxLabel.nth(1))
+        //        .expect(checkboxAccount.checked).ok()
+
+        // Click Pay
+        .click(payButton)
+        // Expect no errors
+        .expect(Selector('.adyen-checkout__field--error').exists)
+        .notOk()
+
+        // Expect dropin to be valid
+        .expect(getIsValid('dropin'))
+        .eql(true)
+
+        /**
+         * Form in phase 2
+         */
+        // Check holderName is now readonly
+        .expect(nonEditableHolderName.exists)
+        .ok()
+
+        // Expect not to see green "valid" ticks (should be display:none)
+        .expect(validTicks.filterHidden().exists)
+        .ok()
+
+        // Check we now have an Edit button
+        .expect(editButton.exists)
+        .ok()
+
+        // Click Edit
+        .click(editButton)
+
+        /**
+         * Form in phase 1 again
+         */
+        // Check holderName doesn't have a readonly attribute
+        .expect(nonEditableHolderName.exists)
+        .notOk()
+
+        // Change holder name
+        .typeText(holderName, 's dooley', { replace: true })
+
+        // Click Pay
+        .click(payButton)
+
+        /**
+         * Form in phase 2 again
+         */
+        // Click Pay
+        .click(payButton)
+
+        /**
+         * Final phase: voucher action has been handled
+         */
+        .wait(3000)
+        .expect(voucher.exists)
+        .ok()
+        .expect(voucherButton.exists)
+        .ok();
+});

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
@@ -1,5 +1,5 @@
 import { Selector, ClientFunction } from 'testcafe';
-import { start, getIframeSelector } from '../../utils/commonUtils';
+import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
 import cu from '../utils/cardUtils';
 import { DUAL_BRANDED_CARD } from '../utils/constants';
 import { BASE_URL } from '../../pages';
@@ -8,10 +8,6 @@ const dualBrandingIconHolder = Selector('.adyen-checkout__payment-method--card .
 const dualBrandingIconHolderActive = Selector('.adyen-checkout__payment-method--card .adyen-checkout__card__dual-branding__buttons--active');
 
 const NOT_SELECTED_CLASS = 'adyen-checkout__card__cardNumber__brandIcon--not-selected';
-
-const getCardIsValid = ClientFunction(() => {
-    return window.dropin.isValid;
-});
 
 const getPropFromPMData = ClientFunction(prop => {
     return window.dropin.state.data.paymentMethod[prop];
@@ -30,7 +26,6 @@ test('Fill in card number that will get dual branding result from binLookup, ' +
     await start(t, 2000, TEST_SPEED);
 
     // Fill card field with dual branded card (visa/cb)
-    // await fillCardNumber(t, DUAL_BRANDED_CARD);
     await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
 
     await t
@@ -67,7 +62,7 @@ test(
         await cardUtils.fillDateAndCVC(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid('dropin')).eql(true);
 
         // Should not be a brand property in the PM data
         await t.expect(getPropFromPMData('brand')).eql(undefined);
@@ -90,7 +85,7 @@ test(
         await cardUtils.fillDateAndCVC(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid('dropin')).eql(true);
 
         // Click brand icons
         await t

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
-import { start, getIframeSelector } from '../../utils/commonUtils';
-import cu, { getCardIsValid } from '../utils/cardUtils';
+import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
+import cu from '../utils/cardUtils';
 import { DUAL_BRANDED_CARD } from '../utils/constants';
 import { CARDS_URL } from '../../pages';
 
@@ -62,7 +62,7 @@ test(
         await cardUtils.fillDateAndCVC(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // Should not be a brand property in the PM data
         await t.expect(getPropFromPMData('brand')).eql(undefined);
@@ -85,7 +85,7 @@ test(
         await cardUtils.fillDateAndCVC(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // Click brand icons
         await t

--- a/packages/e2e/tests/cards/kcp/startWithKCP/startWithKCP.test.js
+++ b/packages/e2e/tests/cards/kcp/startWithKCP/startWithKCP.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
-import { start, getIframeSelector } from '../../../utils/commonUtils';
-import cu, { getCardIsValid } from '../../utils/cardUtils';
+import { start, getIframeSelector, getIsValid } from '../../../utils/commonUtils';
+import cu from '../../utils/cardUtils';
 import kcp from '../../utils/kcpUtils';
 import { KOREAN_TEST_CARD, REGULAR_TEST_CARD, TEST_TAX_NUMBER_VALUE } from '../../utils/constants';
 import { CARDS_URL } from '../../../pages';
@@ -39,7 +39,7 @@ test(
         await cardUtils.fillDateAndCVC(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
     }
 );
 
@@ -59,7 +59,7 @@ test(
         await kcpUtils.fillPwd(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // Expect card state to have tax and pwd elements
         await t.expect(getCardState('data', 'taxNumber')).eql(TEST_TAX_NUMBER_VALUE);
@@ -82,7 +82,7 @@ test(
         await t.expect(getCardState('valid', 'encryptedPassword')).eql(false);
 
         // Expect card to still be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
     }
 );
 
@@ -102,7 +102,7 @@ test(
         await cardUtils.fillDateAndCVC(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // click pay
         await t
@@ -119,7 +119,7 @@ test(
         await kcpUtils.fillPwd(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // click pay
         await t

--- a/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
+++ b/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
-import { start, getIframeSelector } from '../../../utils/commonUtils';
-import cu, { getCardIsValid } from '../../utils/cardUtils';
+import { start, getIframeSelector, getIsValid } from '../../../utils/commonUtils';
+import cu from '../../utils/cardUtils';
 import kcp from '../../utils/kcpUtils';
 import { KOREAN_TEST_CARD, REGULAR_TEST_CARD, TEST_PWD_VALUE, TEST_TAX_NUMBER_VALUE } from '../../utils/constants';
 import { CARDS_URL } from '../../../pages';
@@ -54,7 +54,7 @@ test(
         // // Expect card to now be valid
         await t
             .wait(1000)
-            .expect(getCardIsValid())
+            .expect(getIsValid())
             .eql(true);
     }
 );
@@ -75,7 +75,7 @@ test(
         await kcpUtils.fillPwd(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // Expect card state to have tax and pwd elements
         await t.expect(getCardState('data', 'taxNumber')).eql(TEST_TAX_NUMBER_VALUE);
@@ -95,7 +95,7 @@ test(
         await t.expect(getCardState('valid', 'encryptedPassword')).eql(false);
 
         // Expect card to no longer be valid
-        await t.expect(getCardIsValid()).eql(false);
+        await t.expect(getIsValid()).eql(false);
     }
 );
 
@@ -127,7 +127,7 @@ test(
         await kcpUtils.fillPwd(t);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // click pay
         await t
@@ -140,7 +140,7 @@ test(
         await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, true);
 
         // Expect card to now be valid
-        await t.expect(getCardIsValid()).eql(true);
+        await t.expect(getIsValid()).eql(true);
 
         // click pay
         await t
@@ -166,7 +166,7 @@ test(
         await kcpUtils.fillTaxNumber(t);
 
         // Expect card to not be valid
-        await t.expect(getCardIsValid()).eql(false);
+        await t.expect(getIsValid()).eql(false);
 
         // click pay
         await t

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.oldFlow.redirect.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.oldFlow.redirect.test.js
@@ -1,6 +1,6 @@
 import { Selector, RequestLogger } from 'testcafe';
-import { start, getIframeSelector } from '../../utils/commonUtils';
-import cu, { getCardIsValid } from '../utils/cardUtils';
+import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
+import cu from '../utils/cardUtils';
 import { THREEDS2_FULL_FLOW_CARD } from '../utils/constants';
 import { BASE_URL } from '../../pages';
 
@@ -36,7 +36,7 @@ test('Fill in card number that will trigger redirect flow', async t => {
     await cardUtils.fillDateAndCVC(t);
 
     // Expect card to now be valid
-    await t.expect(getCardIsValid('dropin')).eql(true);
+    await t.expect(getIsValid('dropin')).eql(true);
 
     // Click pay
     await t

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.oldFlow.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.oldFlow.test.js
@@ -1,6 +1,6 @@
 import { Selector, RequestLogger } from 'testcafe';
-import { start, getIframeSelector } from '../../utils/commonUtils';
-import cu, { getCardIsValid } from '../utils/cardUtils';
+import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
+import cu from '../utils/cardUtils';
 import { fillChallengeField, submitChallenge } from '../utils/threeDS2Utils';
 import { THREEDS2_CHALLENGE_ONLY_CARD, THREEDS2_FRICTIONLESS_CARD, THREEDS2_FULL_FLOW_CARD } from '../utils/constants';
 import { BASE_URL } from '../../pages';
@@ -37,7 +37,7 @@ test('Fill in card number that will trigger frictionless flow', async t => {
     await cardUtils.fillDateAndCVC(t);
 
     // Expect card to now be valid
-    await t.expect(getCardIsValid('dropin')).eql(true);
+    await t.expect(getIsValid('dropin')).eql(true);
 
     // Click pay
     await t
@@ -70,7 +70,7 @@ test('Fill in card number that will trigger challenge flow', async t => {
     await cardUtils.fillDateAndCVC(t);
 
     // Expect card to now be valid
-    await t.expect(getCardIsValid('dropin')).eql(true);
+    await t.expect(getIsValid('dropin')).eql(true);
 
     // Click pay
     await t
@@ -116,7 +116,7 @@ test('Fill in card number that will trigger challenge-only flow', async t => {
     await cardUtils.fillDateAndCVC(t);
 
     // Expect card to now be valid
-    await t.expect(getCardIsValid('dropin')).eql(true);
+    await t.expect(getIsValid('dropin')).eql(true);
 
     // Click pay
     await t

--- a/packages/e2e/tests/cards/utils/cardUtils.js
+++ b/packages/e2e/tests/cards/utils/cardUtils.js
@@ -64,7 +64,3 @@ const fillDateAndCVC = iframeSelector => {
         return fc(t, cvcValue);
     };
 };
-
-export const getCardIsValid = ClientFunction((who = 'card') => {
-    return window[who].isValid;
-});

--- a/packages/e2e/tests/utils/commonUtils.js
+++ b/packages/e2e/tests/utils/commonUtils.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { ClientFunction, Selector } from 'testcafe';
 
 export const getIframeSelector = (selectorStr, timeout = 20000) => {
     return Selector(selectorStr, { timeout });
@@ -32,3 +32,7 @@ export const checkIframeContainsValue = async (t, iframeSelector, iFrameNum, iFr
         .expect(Selector(iFrameInputSelector).value)
         .contains(valueToCheck);
 };
+
+export const getIsValid = ClientFunction((who = 'card') => {
+    return window[who].isValid;
+});

--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -237,6 +237,7 @@ function BacsInput(props: BacsInputProps) {
             {status === ENTER_STATE && (
                 <ConsentCheckbox
                     data={data}
+                    classNameModifiers={['amountConsentCheckbox']}
                     errorMessage={!!errors.amountConsentCheckbox}
                     label={i18n.get('bacs.consent.amount')}
                     onChange={handleConsentCheckbox('amountConsentCheckbox')}
@@ -247,6 +248,7 @@ function BacsInput(props: BacsInputProps) {
             {status === ENTER_STATE && (
                 <ConsentCheckbox
                     data={data}
+                    classNameModifiers={['accountConsentCheckbox']}
                     errorMessage={!!errors.accountConsentCheckbox}
                     label={i18n.get('bacs.consent.account')}
                     onChange={handleConsentCheckbox('accountConsentCheckbox')}

--- a/packages/lib/src/components/BacsDD/components/validate.ts
+++ b/packages/lib/src/components/BacsDD/components/validate.ts
@@ -23,9 +23,9 @@ export const bacsValidationRules: object = {
             return { isValid, value: formattedVal, showError: false };
         },
         shopperEmail: value => {
-            return { isValid: email.test(value), value, errorMessage: true };
+            return { isValid: email.test(value), value, showError: false };
         },
-        default: value => ({ isValid: value && value.length > 0, value })
+        default: value => ({ isValid: value && value.length > 0, value, showError: false })
     },
     blur: {
         bankAccountNumber: (num): object => {
@@ -37,8 +37,8 @@ export const bacsValidationRules: object = {
             return { isValid: bankLocationIdRegEx.test(num), value: num, showError: true };
         },
         shopperEmail: value => {
-            return { isValid: email.test(value), value, errorMessage: true };
+            return { isValid: email.test(value), value, showError: true };
         },
-        default: value => ({ isValid: value && value.length > 0, value })
+        default: value => ({ isValid: value && value.length > 0, value, showError: true })
     }
 };

--- a/packages/lib/src/components/internal/FormFields/ConsentCheckbox/ConsentCheckbox.tsx
+++ b/packages/lib/src/components/internal/FormFields/ConsentCheckbox/ConsentCheckbox.tsx
@@ -7,7 +7,7 @@ export default function ConsentCheckbox({ data, errorMessage, label, onChange, .
         <Field classNameModifiers={['consentCheckbox']} errorMessage={errorMessage}>
             <Checkbox
                 name="consentCheckbox"
-                classNameModifiers={['consentCheckbox']}
+                classNameModifiers={[...props.classNameModifiers??=[], 'consentCheckbox']}
                 onInput={onChange}
                 value={data.consentCheckbox}
                 label={label}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added e2e tests for Bacs Direct Debit
- Use of common `getIsValid` util function
- Correct `adyen-web` version in `package.json`
- `ConsentCheckbox` accepts `classNameModifiers` prop (needed for Bacs tests)

## Tested scenarios
All tests run and pass
ConsentCheckbox still works in both OpenInvoice and Bacs utilisations

