### PR TITLE
Increasing securedFields version to 3.2.7

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -10,7 +10,7 @@ export const ENCRYPTED_PIN_FIELD = 'encryptedPin';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.2.6';
+export const SF_VERSION = '3.2.7';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Increase securedFields version to 3.2.7
Minor changes:
-  Fixed issue in Safari: when securedFields are cross-origin, tabbing into that field takes 2 presses of the Tab key when the field has not yet had focus (COWEB-852) 
- Made autoComplete fix (no tabIndex) for iOS/Chrome more specific - before it was applied if system was iOS, now it's only applied if system is iOS & Chrome
- removed `devicemotion` listener from cse file (prevents warnings in console)
- securedField, if it fails to configure, detects if it was loaded with a 
clientKey and changes console message accordingly

## Tested scenarios
Everything still works! 
All tests still pass.
