### PR TITLE
Remove fallback to old error keys

### DIFF
--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -76,7 +76,7 @@ class Giftcard extends Component<GiftcardComponentProps> {
         }
 
         const getCardErrorMessage = sfpState => {
-            if (sfpState.errors.encryptedCardNumber) return i18n.get('creditCard.numberField.invalid');
+            if (sfpState.errors.encryptedCardNumber) return i18n.get('error.va.sf-cc-num.01');
 
             switch (this.state.status) {
                 case 'no-balance':

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.test.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 import SecuredFieldsProvider from './SecuredFieldsProvider';
 import Language from '../../../language/Language';
 import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD, ERROR_MSG_UNSUPPORTED_CARD_ENTERED, ERROR_MSG_CLEARED } from '../../../core/Errors/constants';
-import { getError, getDefaultErrorCode } from '../../../core/Errors/utils';
+import { getError } from '../../../core/Errors/utils';
 
 jest.mock('./lib', () => {
     return () => true;
@@ -245,20 +245,6 @@ describe('<SecuredFieldsProvider /> handling error codes', () => {
         expect(errorObj.error).toEqual(errorCode);
         expect(errorObj.errorText).toEqual(getError(errorCode));
         expect(errorObj.errorI18n).toEqual(i18n.get(errorCode));
-    });
-
-    it("should handle an error with a code it doesn't recognise and set the relevant state and props based on a default code", () => {
-        regularErrObj.error = 'some.strange.code';
-
-        wrapper.instance().handleOnError(regularErrObj);
-
-        expect(errorObj.error).toEqual('some.strange.code');
-
-        const defaultErrorCode = getDefaultErrorCode(regularErrObj.fieldType);
-        expect(wrapper.instance().state.errors.encryptedCardNumber).toEqual(defaultErrorCode);
-
-        expect(errorObj.errorText).toEqual(defaultErrorCode);
-        expect(errorObj.errorI18n).toEqual(i18n.get(defaultErrorCode));
     });
 
     it('should clear the previous error', () => {

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
@@ -1,6 +1,6 @@
 import { getCardImageUrl } from './utils';
 import { ENCRYPTED_SECURITY_CODE, ENCRYPTED_CARD_NUMBER } from './lib/configuration/constants';
-import { getError, getVerifiedErrorCode } from '../../../core/Errors/utils';
+import { getError } from '../../../core/Errors/utils';
 import { ERROR_MSG_CLEARED } from '../../../core/Errors/constants';
 import {
     CbObjOnError,
@@ -127,16 +127,16 @@ function handleOnError(cbObj: CbObjOnError, hasUnsupportedCard: boolean = null):
         }
     }
 
-    const verifiedErrorCode = getVerifiedErrorCode(cbObj.fieldType, cbObj.error, this.props.i18n);
+    const errorCode = cbObj.error;
 
     this.setState(prevState => ({
-        errors: { ...prevState.errors, [cbObj.fieldType]: verifiedErrorCode || false },
+        errors: { ...prevState.errors, [cbObj.fieldType]: errorCode || false },
         hasUnsupportedCard: hasUnsupportedCard !== null ? hasUnsupportedCard : false
     }));
 
-    cbObj.errorI18n = this.props.i18n.get(verifiedErrorCode); // Add translation
+    cbObj.errorI18n = this.props.i18n.get(errorCode); // Add translation
 
-    const errorExplained = getError(verifiedErrorCode);
+    const errorExplained = getError(errorCode);
     cbObj.errorText = errorExplained !== '' ? errorExplained : ERROR_MSG_CLEARED; // Add internal explanation
 
     this.props.onError(cbObj);

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -1,12 +1,4 @@
-import { ERROR_CODES, ERROR_MSG_INVALID_FIELD } from './constants';
-import Language from '../../language/Language';
-import {
-    ENCRYPTED_CARD_NUMBER,
-    ENCRYPTED_EXPIRY_DATE,
-    ENCRYPTED_EXPIRY_MONTH,
-    ENCRYPTED_EXPIRY_YEAR,
-    ENCRYPTED_SECURITY_CODE
-} from '../../components/internal/SecuredFields/lib/configuration/constants';
+import { ERROR_CODES } from './constants';
 
 /**
  * Access items stored in the ERROR_CODES object by either sending in the key - in which case you get the value

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -26,36 +26,6 @@ export const getError = (keyOrValue: string): string => {
     return keyOrValue;
 };
 
-export const getDefaultErrorCode = fieldType => {
-    switch (fieldType) {
-        case ENCRYPTED_CARD_NUMBER:
-            return 'creditCard.numberField.invalid';
-        case ENCRYPTED_EXPIRY_DATE:
-            return 'creditCard.expiryDateField.invalid';
-        case ENCRYPTED_EXPIRY_MONTH:
-            return 'creditCard.expiryDateField.invalid';
-        case ENCRYPTED_EXPIRY_YEAR:
-            return 'creditCard.expiryDateField.invalid';
-        case ENCRYPTED_SECURITY_CODE:
-            return 'creditCard.oneClickVerification.invalidInput.title';
-        default:
-            return getError(ERROR_MSG_INVALID_FIELD);
-    }
-};
-
-/**
- * If error translation exists then error (code) is usable, else return a default error code
- * @param error -
- * @param i18n -
- */
-export const getVerifiedErrorCode = (fieldType: string, error: string, i18n: Language): string => {
-    // Empty string is a error being cleared - so do nothing;
-    if (error === '') return error;
-    const translatedError = i18n.get(error);
-    // If translatedError still equals error then i18n didn't find a translation - so get a default code
-    return translatedError === error ? getDefaultErrorCode(fieldType) : error;
-};
-
 export const addAriaErrorTranslationsObject = i18n => {
     const errorKeys = Object.keys(ERROR_CODES);
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Previously, if the new securedFields error keys (example: `error.va.sf-cc-num.01`) weren't in the translation files
then we would fallback to using the old error keys (example: `creditCard.numberField.invalid`).
Now however these keys are included in all the translation files - so the "fallback" functionality can be removed

## Tested scenarios
All test still work

**Fixed issue**:  COWEB-884
