### PR TITLE
e2e tests for brand detection

### DIFF
--- a/packages/e2e/tests/cards/branding/branding.clientScripts.js
+++ b/packages/e2e/tests/cards/branding/branding.clientScripts.js
@@ -1,0 +1,7 @@
+/**
+ * Set cartebancaire as a brand since the test dual brand card is visa/cb
+ */
+window.cardConfig = {
+    type: 'scheme',
+    brands: ['mc', 'visa', 'amex', 'maestro', 'bcmc']
+};

--- a/packages/e2e/tests/cards/branding/branding.test.js
+++ b/packages/e2e/tests/cards/branding/branding.test.js
@@ -1,0 +1,95 @@
+import { Selector } from 'testcafe';
+import { start, getIframeSelector } from '../../utils/commonUtils';
+import cu from '../utils/cardUtils';
+import { CARDS_URL } from '../../pages';
+
+const cvcSpan = Selector('.card-field .adyen-checkout__field__cvc');
+const optionalCVCSpan = Selector('.card-field .adyen-checkout__field__cvc--optional');
+const cvcLabel = Selector('.card-field .adyen-checkout__label__text');
+const brandingIcon = Selector('.card-field .adyen-checkout__card__cardNumber__brandIcon');
+
+//const getPropFromPMData = ClientFunction(prop => {
+//    return window.card.formatData().paymentMethod[prop];
+//});
+
+const TEST_SPEED = 1;
+
+const iframeSelector = getIframeSelector('.card-field iframe');
+
+const cardUtils = cu(iframeSelector);
+
+fixture`Testing dual branding`.page(CARDS_URL).clientScripts('branding.clientScripts.js');
+
+test('Test for generic card icon, ' + 'then enter number recognised as maestro, ' + 'then add digit so it will be seen as a bcmc card', async t => {
+    // Start, allow time for iframes to load
+    await start(t, 2000, TEST_SPEED);
+
+    await t
+        // generic card icon
+        .expect(brandingIcon.getAttribute('src'))
+        .contains('nocard.svg')
+
+        // visible cvc field
+        .expect(cvcSpan.filterVisible().exists)
+        .ok()
+
+        // with regular text
+        .expect(cvcLabel.withExactText('CVC / CVV').exists)
+        .ok()
+
+        // and not optional
+        .expect(optionalCVCSpan.exists)
+        .notOk();
+
+    // Partially fill card field with digits that will be recognised as maestro
+    await cardUtils.fillCardNumber(t, '670');
+
+    await t
+        // maestro card icon
+        .expect(brandingIcon.getAttribute('src'))
+        .contains('maestro.svg')
+
+        // with "optional" text
+        .expect(cvcLabel.withExactText('CVC / CVV (optional)').exists)
+        .ok()
+        // and optional class
+        .expect(optionalCVCSpan.exists)
+        .ok();
+
+    await t.wait(500);
+
+    // Add digit so card is recognised as bcmc
+    await cardUtils.fillCardNumber(t, '3');
+
+    await t
+        // bcmc icon
+        .expect(brandingIcon.getAttribute('src'))
+        .contains('bcmc.svg')
+
+        // hidden cvc field
+        .expect(cvcSpan.filterHidden().exists)
+        .ok();
+
+    await t.wait(500);
+
+    // Delete number
+    await cardUtils.deleteCardNumber(t);
+
+    // Card is reset
+    await t
+        // generic card icon
+        .expect(brandingIcon.getAttribute('src'))
+        .contains('nocard.svg')
+
+        // visible cvc field
+        .expect(cvcSpan.filterVisible().exists)
+        .ok()
+
+        // with regular text
+        .expect(cvcLabel.withExactText('CVC / CVV').exists)
+        .ok()
+
+        // and not optional
+        .expect(optionalCVCSpan.exists)
+        .notOk();
+});

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.test.tsx
@@ -18,7 +18,7 @@ let wrapper = mount(
     />
 );
 
-describe('CardInput', () => {
+describe('CardNumber', () => {
     test('Renders a CardNumber field, with standard brand image, and no dual branding', () => {
         expect(wrapper.find('[data-cse="encryptedCardNumber"]')).toHaveLength(1);
         expect(wrapper.find('.adyen-checkout__card__cardNumber__input .adyen-checkout__card__cardNumber__brandIcon')).toHaveLength(1);

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -11,8 +11,17 @@ import {
 } from '../internal/SecuredFields/lib/types';
 
 export interface CardElementProps extends UIElementProps {
-    type?: string;
+    /**
+     * this.props.brand is never set for a generic card
+     * It is only set for a single-branded card or a stored card
+     */
     brand?: string;
+
+    /**
+     * this.props.type will always be "card" (generic card, stored card)
+     * except for a single branded card when it will be the same as the brand prop
+     */
+    type?: string;
 
     /** @deprecated use brands instead */
     groupTypes?: string[];


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added e2e tests for card brand detection
Tests especially focus on the state of the CVC field as brands are entered that see this field as optional or not required