### PR TITLE
Adding to e2e branding tests

### DIFF
--- a/packages/e2e/tests/cards/branding/branding.test.js
+++ b/packages/e2e/tests/cards/branding/branding.test.js
@@ -1,7 +1,8 @@
 import { Selector } from 'testcafe';
-import { start, getIframeSelector } from '../../utils/commonUtils';
+import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
 import cu from '../utils/cardUtils';
 import { CARDS_URL } from '../../pages';
+import { MAESTRO_CARD, TEST_DATE_VALUE, TEST_CVC_VALUE, BCMC_CARD } from '../utils/constants';
 
 const cvcSpan = Selector('.card-field .adyen-checkout__field__cvc');
 const optionalCVCSpan = Selector('.card-field .adyen-checkout__field__cvc--optional');
@@ -18,59 +19,110 @@ const iframeSelector = getIframeSelector('.card-field iframe');
 
 const cardUtils = cu(iframeSelector);
 
-fixture`Testing dual branding`.page(CARDS_URL).clientScripts('branding.clientScripts.js');
+fixture`Testing branding - especially regarding optional and hidden cvc fields`.page(CARDS_URL).clientScripts('branding.clientScripts.js');
 
-test('Test for generic card icon, ' + 'then enter number recognised as maestro, ' + 'then add digit so it will be seen as a bcmc card', async t => {
+test(
+    'Test for generic card icon, ' +
+        'then enter number recognised as maestro, ' +
+        'then add digit so it will be seen as a bcmc card ,' +
+        'then delete number (back to generic card)',
+    async t => {
+        // Start, allow time for iframes to load
+        await start(t, 2000, TEST_SPEED);
+
+        await t
+            // generic card icon
+            .expect(brandingIcon.getAttribute('src'))
+            .contains('nocard.svg')
+
+            // visible cvc field
+            .expect(cvcSpan.filterVisible().exists)
+            .ok()
+
+            // with regular text
+            .expect(cvcLabel.withExactText('CVC / CVV').exists)
+            .ok()
+
+            // and not optional
+            .expect(optionalCVCSpan.exists)
+            .notOk();
+
+        // Partially fill card field with digits that will be recognised as maestro
+        await cardUtils.fillCardNumber(t, '670');
+
+        await t
+            // maestro card icon
+            .expect(brandingIcon.getAttribute('src'))
+            .contains('maestro.svg')
+
+            // with "optional" text
+            .expect(cvcLabel.withExactText('CVC / CVV (optional)').exists)
+            .ok()
+            // and optional class
+            .expect(optionalCVCSpan.exists)
+            .ok();
+
+        await t.wait(500);
+
+        // Add digit so card is recognised as bcmc
+        await cardUtils.fillCardNumber(t, '3');
+
+        await t
+            // bcmc icon
+            .expect(brandingIcon.getAttribute('src'))
+            .contains('bcmc.svg')
+
+            // hidden cvc field
+            .expect(cvcSpan.filterHidden().exists)
+            .ok();
+
+        await t.wait(500);
+
+        // Delete number
+        await cardUtils.deleteCardNumber(t);
+
+        // Card is reset
+        await t
+            // generic card icon
+            .expect(brandingIcon.getAttribute('src'))
+            .contains('nocard.svg')
+
+            // visible cvc field
+            .expect(cvcSpan.filterVisible().exists)
+            .ok()
+
+            // with regular text
+            .expect(cvcLabel.withExactText('CVC / CVV').exists)
+            .ok()
+
+            // and not optional
+            .expect(optionalCVCSpan.exists)
+            .notOk();
+    }
+);
+
+test('Test card is valid with maestro details (cvc optional) ' + 'then test it is invalid (& brand reset) when number deleted', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
-    await t
-        // generic card icon
-        .expect(brandingIcon.getAttribute('src'))
-        .contains('nocard.svg')
+    // generic card
+    await t.expect(brandingIcon.getAttribute('src')).contains('nocard.svg');
 
-        // visible cvc field
-        .expect(cvcSpan.filterVisible().exists)
-        .ok()
-
-        // with regular text
-        .expect(cvcLabel.withExactText('CVC / CVV').exists)
-        .ok()
-
-        // and not optional
-        .expect(optionalCVCSpan.exists)
-        .notOk();
-
-    // Partially fill card field with digits that will be recognised as maestro
-    await cardUtils.fillCardNumber(t, '670');
+    // Maestro
+    await cardUtils.fillCardNumber(t, MAESTRO_CARD);
+    await cardUtils.fillDate(t, TEST_DATE_VALUE);
 
     await t
         // maestro card icon
         .expect(brandingIcon.getAttribute('src'))
-        .contains('maestro.svg')
+        .contains('maestro.svg');
 
-        // with "optional" text
-        .expect(cvcLabel.withExactText('CVC / CVV (optional)').exists)
-        .ok()
-        // and optional class
-        .expect(optionalCVCSpan.exists)
-        .ok();
+    await t.expect(getIsValid('card')).eql(true);
 
-    await t.wait(500);
+    // add cvc
+    await cardUtils.fillCVC(t, TEST_CVC_VALUE);
 
-    // Add digit so card is recognised as bcmc
-    await cardUtils.fillCardNumber(t, '3');
-
-    await t
-        // bcmc icon
-        .expect(brandingIcon.getAttribute('src'))
-        .contains('bcmc.svg')
-
-        // hidden cvc field
-        .expect(cvcSpan.filterHidden().exists)
-        .ok();
-
-    await t.wait(500);
+    await t.expect(getIsValid('card')).eql(true);
 
     // Delete number
     await cardUtils.deleteCardNumber(t);
@@ -79,17 +131,37 @@ test('Test for generic card icon, ' + 'then enter number recognised as maestro, 
     await t
         // generic card icon
         .expect(brandingIcon.getAttribute('src'))
-        .contains('nocard.svg')
+        .contains('nocard.svg');
 
-        // visible cvc field
-        .expect(cvcSpan.filterVisible().exists)
-        .ok()
+    await t.expect(getIsValid('card')).eql(false);
+});
 
-        // with regular text
-        .expect(cvcLabel.withExactText('CVC / CVV').exists)
-        .ok()
+test('Test card is valid with bcmc details (no cvc) ' + 'then test it is invalid (& brand reset) when number deleted', async t => {
+    // Start, allow time for iframes to load
+    await start(t, 2000, TEST_SPEED);
 
-        // and not optional
-        .expect(optionalCVCSpan.exists)
-        .notOk();
+    // generic card
+    await t.expect(brandingIcon.getAttribute('src')).contains('nocard.svg');
+
+    // Maestro
+    await cardUtils.fillCardNumber(t, BCMC_CARD);
+    await cardUtils.fillDate(t, TEST_DATE_VALUE);
+
+    await t
+        // maestro card icon
+        .expect(brandingIcon.getAttribute('src'))
+        .contains('bcmc.svg');
+
+    await t.expect(getIsValid('card')).eql(true);
+
+    // Delete number
+    await cardUtils.deleteCardNumber(t);
+
+    // Card is reset
+    await t
+        // generic card icon
+        .expect(brandingIcon.getAttribute('src'))
+        .contains('nocard.svg');
+
+    await t.expect(getIsValid('card')).eql(false);
 });

--- a/packages/e2e/tests/cards/utils/constants.js
+++ b/packages/e2e/tests/cards/utils/constants.js
@@ -1,11 +1,14 @@
 export const KOREAN_TEST_CARD = '9490220006611406'; // 9490220006611406 works against Test. For localhost:8080 use: 5067589608564358 + hack in triggerBinLookup
 export const REGULAR_TEST_CARD = '5500000000000004';
 export const DUAL_BRANDED_CARD = '4035501000000008'; // dual branded visa & cartebancaire
+export const MAESTRO_CARD = '5000550000000029';
+export const BCMC_CARD = '6703444444444449'; // actually dual branded bcmc & maestro
+
 export const THREEDS2_FRICTIONLESS_CARD = '5201281505129736';
 export const THREEDS2_FULL_FLOW_CARD = '5000550000000029';
 export const THREEDS2_CHALLENGE_ONLY_CARD = '4212345678910006';
 
-export const TEST_DATE_VALUE = '10/20';
+export const TEST_DATE_VALUE = '03/30';
 export const TEST_CVC_VALUE = '737';
 export const TEST_PWD_VALUE = '12';
 export const TEST_TAX_NUMBER_VALUE = '123456';

--- a/packages/e2e/tests/giftcards/enoughBalance/enoughBalance.test.js
+++ b/packages/e2e/tests/giftcards/enoughBalance/enoughBalance.test.js
@@ -18,7 +18,7 @@ const iframeSelector = getIframeSelector('.card-field iframe');
 
 fixture`Testing gift cards`
     .page(GIFTCARDS_URL)
-    .clientScripts('enoughBalance.clientScripts.js')
+    //    .clientScripts('enoughBalance.clientScripts.js')
     .requestHooks(mock);
 
 test('Should prompt a confirmation when using a gift card with enough balance', async t => {


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adding to e2e branding tests. 
Fixing warning about empty clientScripts file (giftcards > enoughBalance test)
Updated constant for expiry date

## Tested scenarios
All tests run and pass

