### PR TITLE
Ensure the class name reflecting the fundingSource always has a value…

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -173,9 +173,8 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                 render={({ setRootNode, setFocusOn }, sfpState) => (
                     <div
                         ref={setRootNode}
-                        className={`adyen-checkout__card-input ${styles['card-input__wrapper']} adyen-checkout__card-input--${
-                            this.props.fundingSource??='credit'
-                        }`}
+                        className={`adyen-checkout__card-input ${styles['card-input__wrapper']} adyen-checkout__card-input--${this.props
+                            .fundingSource ?? 'credit'}`}
                     >
                         {this.props.storedPaymentMethodId ? (
                             <LoadingWrapper status={sfpState.status}>

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -173,7 +173,9 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                 render={({ setRootNode, setFocusOn }, sfpState) => (
                     <div
                         ref={setRootNode}
-                        className={`adyen-checkout__card-input ${styles['card-input__wrapper']} adyen-checkout__card-input--${this.props.fundingSource}`}
+                        className={`adyen-checkout__card-input ${styles['card-input__wrapper']} adyen-checkout__card-input--${
+                            this.props.fundingSource??='credit'
+                        }`}
                     >
                         {this.props.storedPaymentMethodId ? (
                             <LoadingWrapper status={sfpState.status}>

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -84,7 +84,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
             'adyen-checkout__payment-method': true,
             [styles['adyen-checkout__payment-method']]: true,
             [`adyen-checkout__payment-method--${paymentMethod.props.type}`]: true,
-            [`adyen-checkout__payment-method--${paymentMethod.props.fundingSource}`]: true,
+            [`adyen-checkout__payment-method--${paymentMethod.props.fundingSource}`]: paymentMethod.props.fundingSource??='credit',
             'adyen-checkout__payment-method--selected': isSelected,
             [styles['adyen-checkout__payment-method--selected']]: isSelected,
             'adyen-checkout__payment-method--loading': isLoading,

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -84,7 +84,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
             'adyen-checkout__payment-method': true,
             [styles['adyen-checkout__payment-method']]: true,
             [`adyen-checkout__payment-method--${paymentMethod.props.type}`]: true,
-            [`adyen-checkout__payment-method--${paymentMethod.props.fundingSource}`]: paymentMethod.props.fundingSource??='credit',
+            [`adyen-checkout__payment-method--${paymentMethod.props.fundingSource ?? 'credit'}`]: true,
             'adyen-checkout__payment-method--selected': isSelected,
             [styles['adyen-checkout__payment-method--selected']]: isSelected,
             'adyen-checkout__payment-method--loading': isLoading,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Ensure the class name reflecting the fundingSource always has a value even when 'splitCardFundingSources' has not been set

## Tested scenarios
If `splitCardFundingSources` is not set then the class name reflecting the `fundingSource` will always have the value: 
`"credit"` e.g. `adyen-checkout__card-input--credit`
Otherwise it reflects the value from the `/paymentMethods` response
