### PR TITLE
Fix for new bcmc bins

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -10,11 +10,9 @@ export const ENCRYPTED_PIN_FIELD = 'encryptedPin';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.2.7';
+export const SF_VERSION = '3.2.8';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
-
-export const IFRAME_TITLE = 'Iframe for secured card data input field';
 
 export const NON_CREDIT_CARD_TYPE_SECURED_FIELDS = ['sepa', 'sepadirectdebit', 'ach', 'giftcard'];
 

--- a/packages/lib/src/core/Errors/constants.ts
+++ b/packages/lib/src/core/Errors/constants.ts
@@ -1,6 +1,5 @@
 export const ERROR_MSG_CARD_TOO_OLD = 'Card too old';
 export const ERROR_MSG_CARD_TOO_FAR_IN_FUTURE = 'Date too far in future';
-export const ERROR_MSG_CARD_NUMBER_MISMATCH = "Typed card number doesn't match card brand";
 export const ERROR_MSG_INCOMPLETE_FIELD = 'incomplete field';
 export const ERROR_MSG_LUHN_CHECK_FAILED = 'luhn check failed';
 export const ERROR_MSG_UNSUPPORTED_CARD_ENTERED = 'Unsupported card entered';
@@ -21,7 +20,6 @@ export const ERROR_CODES = {
     [ERROR_MSG_INCOMPLETE_FIELD]: 'error.va.gen.01',
     [ERROR_MSG_INVALID_FIELD]: 'error.va.gen.02',
     [ERROR_MSG_LUHN_CHECK_FAILED]: 'error.va.sf-cc-num.01',
-    [ERROR_MSG_CARD_NUMBER_MISMATCH]: 'error.va.sf-cc-num.02',
     [ERROR_MSG_CARD_TOO_OLD]: 'error.va.sf-cc-dat.01',
     [ERROR_MSG_CARD_TOO_FAR_IN_FUTURE]: 'error.va.sf-cc-dat.02',
     [ERROR_MSG_UNSUPPORTED_CARD_ENTERED]: 'error.va.sf-cc-num.03' // Triggered in Components

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -177,7 +177,6 @@
     "error.va.gen.01": "Incomplete field",
     "error.va.gen.02": "Field not valid",
     "error.va.sf-cc-num.01": "Invalid card number",
-    "error.va.sf-cc-num.02": "Typed card number doesn't match card brand",
     "error.va.sf-cc-num.03": "Unsupported card entered",
     "error.va.sf-cc-dat.01": "Card too old",
     "error.va.sf-cc-dat.02": "Date too far in the future",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Upped SF version to 3.2.8 - where, inbuilt check for wrong number in single-branded card, is removed.
This check was failing to recognise new BCMC bins and throwing an error which then prevented `/binLookup` from working.
So in the case of single-branded card components i.e. a card component hard typed to only accept a single brand e.g. 'bcmc' - securedFields now no longer try to detect what brand the shopper is _actually_ typing to see if it is correct or not; instead relying on binLookup to do this

## Tested scenarios
All test still pass.
sf v3.2.8 is available on Test & Live
New bcmc bins are recognised
Typin a non-bcmc card into a bcmc card component gives the expected "unsupported card" error

**Fixed issue**:  COWEB-869
