### PR TITLE
Removing displayName from CardType objects

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -63,7 +63,6 @@ class CardInput extends Component<CardInputProps, CardInputState> {
             focusedElement: '',
             additionalSelectElements: [],
             additionalSelectValue: '',
-            additionalSelectType: '',
             issuingCountryCode: null
         };
 
@@ -113,8 +112,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
     public resetAdditionalSelectState() {
         this.setState({
             additionalSelectElements: [],
-            additionalSelectValue: '',
-            additionalSelectType: ''
+            additionalSelectValue: ''
         });
     }
 

--- a/packages/lib/src/components/Card/components/CardInput/handlers.ts
+++ b/packages/lib/src/components/Card/components/CardInput/handlers.ts
@@ -131,9 +131,7 @@ function handleAdditionalDataSelection(e: Event): void {
     this.setState({ additionalSelectValue: value }, this.validateCardInput);
 
     // Pass brand into SecuredFields
-    if (this.state.additionalSelectType === 'brandSwitcher') {
-        this.sfp.current.processBinLookupResponse({ issuingCountryCode: this.state.issuingCountryCode, supportedBrands: [value] });
-    }
+    this.sfp.current.processBinLookupResponse({ issuingCountryCode: this.state.issuingCountryCode, supportedBrands: [value] });
 }
 
 export default {

--- a/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
+++ b/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
@@ -16,7 +16,7 @@ export default function processBinLookupResponse(binValueObject: BinValueObject)
         // 1) Multiple options found - add to the UI & inform SFP
         if (binValueObject.supportedBrands.length > 1) {
             // --
-            const switchObj = createCardVariantSwitcher(binValueObject.supportedBrands, 'brandSwitcher');
+            const switchObj = createCardVariantSwitcher(binValueObject.supportedBrands);
 
             // Set properties on state to trigger a Select element in the UI
             this.setState(switchObj.stateObject); // Don't need to call validateCardInput - this will be called by the brandChange from SFP

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -31,7 +31,6 @@ export interface CardInputProps {
 
 export interface CardInputState {
     additionalSelectElements: any[];
-    additionalSelectType: string;
     additionalSelectValue: string;
     billingAddress: object;
     data?: object;

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -1,5 +1,4 @@
 import { getImageUrl } from '../../../../utils/get-image';
-import cardType from '../../../internal/SecuredFields/lib/utilities/cardType';
 
 export const getCardImageUrl = (brand: string, loadingContext: string): string => {
     const imageOptions = {
@@ -16,23 +15,14 @@ export const getCardImageUrl = (brand: string, loadingContext: string): string =
  * @param types - array containing 2 card brands or types
  * @param switcherType - type of switcher ('brandSwitcher' or 'cardTypeSwitcher' - the latter would switch between 'debit' & 'credit' varieties)
  */
-export const createCardVariantSwitcher = (types: string[], switcherType: string) => {
+export const createCardVariantSwitcher = (types: string[]) => {
     const leadType = types[0];
-    let displayName = cardType.getDisplayName(leadType); // Works for when types are card brands e.g. 'visa', 'mc' NOT when types are 'credit'/'debit'
-    const leadDisplayName = displayName || leadType;
-
     const subType = types[1];
-    displayName = cardType.getDisplayName(subType);
-    const subDisplayName = displayName || subType;
 
     return {
         stateObject: {
-            additionalSelectElements: [
-                { id: leadType, name: leadDisplayName },
-                { id: subType, name: subDisplayName }
-            ],
+            additionalSelectElements: [{ id: leadType }, { id: subType }]
             // additionalSelectValue: leadType, // comment out line if no initial selection is to be made
-            additionalSelectType: switcherType
         },
         leadType
     };

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/cardType.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/cardType.ts
@@ -14,7 +14,6 @@ CardType.cards = [];
 
 CardType.cards.push({
     cardType: 'mc',
-    displayName: 'Mastercard',
     startingRules: [51, 52, 53, 54, 55, 22, 23, 24, 25, 26, 27],
     permittedLengths: [16],
     pattern: /^(5[1-5][0-9]{0,14}|2[2-7][0-9]{0,14})$/,
@@ -25,7 +24,6 @@ CardType.cards.push({ cardType: 'visadankort', startingRules: [4571], permittedL
 
 CardType.cards.push({
     cardType: 'visa',
-    displayName: 'Visa',
     startingRules: [4],
     permittedLengths: [13, 16, 19],
     pattern: /^4[0-9]{0,18}$/,
@@ -151,7 +149,6 @@ CardType.cards.push({ cardType: 'uatp', startingRules: [1], permittedLengths: [1
 
 CardType.cards.push({
     cardType: 'cartebancaire',
-    displayName: 'Cartes Bancaires',
     startingRules: [4, 5, 6],
     permittedLengths: [16],
     pattern: /^[4-6][0-9]{0,15}$/
@@ -325,11 +322,6 @@ const getCardByBrand = pBrand => {
     return cardType[0];
 };
 
-const getDisplayName = pBrand => {
-    const card = getCardByBrand(pBrand);
-    return card ? card.displayName : null;
-};
-
 const isGenericCardType = (type = 'card') => type === 'card' || type === 'scheme';
 
 export default {
@@ -337,7 +329,6 @@ export default {
     detectCardLength,
     getShortestPermittedCardLength,
     getCardByBrand,
-    getDisplayName,
     isGenericCardType,
     __NO_BRAND: CardType.__NO_BRAND,
     allCards: CardType.cards


### PR DESCRIPTION
## Summary
Removed `displayName` from `CardType` objects - it was never put into use.
Also removed `switcherType` param from dual-branding functionality - again it was never put into use.

## Tested scenarios
All tests, including e2e ones (which include specific dual-branding testing) still pass
