### PR TITLE
onBinLookup callback

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -27,7 +27,8 @@ export class CardElement extends UIElement<CardElementProps> {
             configuration: {
                 ...props.configuration,
                 ...(props.koreanAuthenticationRequired !== undefined && { koreanAuthenticationRequired: props.koreanAuthenticationRequired })
-            }
+            },
+            onBinLookup: props.onBinLookup ??= () => {}
         };
     }
 

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -7,7 +7,8 @@ import {
     CbObjOnError,
     CbObjOnFieldValid,
     CbObjOnFocus,
-    CbObjOnLoad
+    CbObjOnLoad,
+    CbObjOnBinLookup
 } from '../internal/SecuredFields/lib/types';
 
 export interface CardElementProps extends UIElementProps {
@@ -78,6 +79,11 @@ export interface CardElementProps extends UIElementProps {
      * Provides the BIN Number of the card (up to 6 digits), called as the user types in the PAN.
      */
     onBinValue?: (event: CbObjOnBinValue) => void;
+
+    /**
+     * After binLookup call - provides the brand(s) we detect the user is entering, and if we support the brand(s)
+     */
+    onBinLookup?: (event: CbObjOnBinLookup) => void;
 
     [key: string]: any;
 }

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -175,6 +175,12 @@ export interface CbObjOnBinValue {
     encryptedBin?: string;
 }
 
+export interface CbObjOnBinLookup {
+    type: string;
+    detectedBrands: string[];
+    supportedBrands: string[];
+}
+
 export interface CbObjOnError {
     fieldType: string;
     error: string;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A merchant wants to know when a shopper is entering their merchant-branded card into in a card component that is not configured for it - and specifically what brands are supported and what type of card is being entered.
This boils down to exposing the `supportedBrands` and `detectedBrands` from the `/binLookup` API.
So there is now a possibility for the merchant to add a new callback `onBinLookup` which will receive an object that looks like this:
```
{
  type: 'card', // could be specific brand if component is dedicated to a single brand e.g. 'bcmc'
  detectedBrands: ["mc"],
  supportedBrands: ["visa", "amex", ]
}
```

## Tested scenarios
`onBinLookup` is called if defined by the merchant. If not defined there is a default set which catches the callback and prevents an error being thrown


**Fixed issue**:  COWEB-889
