### PR TITLE
Ensure iDeal selected bank icon has a height for IE11

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Select/Select.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.scss
@@ -30,7 +30,7 @@
     margin-right: 8px;
     margin-left: auto;
     max-width: 40px;
-    max-height: 26px;
+    height: 26px;
     border-radius: 3px;
 }
 


### PR DESCRIPTION
## Summary
Enforcing a height and width of auto on this icon causes the icon to not have a body on IE11. Setting the fixed height ensures the icon is always visible.

It solves the iDeal selected bank icon not appearing on IE11.

## Tested scenarios
- Tested in IE11.
- Tested in a modern browser.


**Fixed issue**:  #674
