### PR TITLE
Prevent calling the submit method for PayPal

### DIFF
--- a/packages/lib/src/components/PayPal/Paypal.test.ts
+++ b/packages/lib/src/components/PayPal/Paypal.test.ts
@@ -10,6 +10,13 @@ describe('Paypal', () => {
         const paypal = new Paypal({});
         expect(paypal.isValid).toBe(true);
     });
+
+    test('Prevents calling the submit method manually', () => {
+        console.error = jest.fn();
+        const paypal = new Paypal({});
+        paypal.submit();
+        expect(console.error).toHaveBeenCalled();
+    });
 });
 
 describe('Paypal configuration prop configures correctly', () => {

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -106,7 +106,7 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     }
 
     submit() {
-        console.warn('Calling submit() is not supported for this payment method');
+        console.error('Calling submit() is not supported for this payment method');
     }
 
     render() {

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -23,6 +23,7 @@ class PaypalElement extends UIElement<PayPalElementProps> {
         this.handleComplete = this.handleComplete.bind(this);
         this.handleError = this.handleError.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
+        this.submit = this.submit.bind(this);
     }
 
     // Required for transition period (until configuration object becomes the norm)
@@ -95,12 +96,17 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     }
 
     handleSubmit() {
-        this.submit();
+        const { data, isValid } = this;
+        if (this.props.onSubmit) this.props.onSubmit({ data, isValid }, this.elementRef);
 
         return new Promise((resolve, reject) => {
             this.resolve = resolve;
             this.reject = reject;
         });
+    }
+
+    submit() {
+        console.warn('Calling submit() is not supported for this payment method');
     }
 
     render() {


### PR DESCRIPTION
## Summary
As triggering the PayPal buttons programatically is not possible (as discussed in paypal/paypal-checkout-components#1264 and in paypal/paypal-checkout-components#522), we should show a console error if the `submit` method is called.