### PR TITLE
Fix test script not running on Windows environments

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,7 +24,7 @@
         "dev-server": "cross-env NODE_ENV=development webpack --watch --config config/webpack.dev.js",
         "docs:generate": "typedoc --out docs src --exclude \"**/*+(index|.test).ts\"",
         "build": "rm -rf dist/ && webpack --config config/webpack.prod.js",
-        "test": "BABEL_ENV=test jest --config config/jest.config.js",
+        "test": "cross-env BABEL_ENV=test jest --config config/jest.config.js",
         "test:watch": "npm run test -- --watchAll",
         "test:coverage": "npm run test -- --coverage",
         "stats": "webpack --config config/webpack.prod.js --profile --progress --json > stats.json",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,7 +24,7 @@
         "dev-server": "cross-env NODE_ENV=development webpack --watch --config config/webpack.dev.js",
         "docs:generate": "typedoc --out docs src --exclude \"**/*+(index|.test).ts\"",
         "build": "rm -rf dist/ && webpack --config config/webpack.prod.js",
-        "test": "cross-env BABEL_ENV=test jest --config config/jest.config.js",
+        "test": "jest --config config/jest.config.js",
         "test:watch": "npm run test -- --watchAll",
         "test:coverage": "npm run test -- --coverage",
         "stats": "webpack --config config/webpack.prod.js --profile --progress --json > stats.json",


### PR DESCRIPTION
## Summary
Trying to run our tests on a Windows environment returns the error `'BABEL_ENV' is not recognized as an internal or external command`. Using `cross-env` should fix it.

Image as reference by @emidev98:

![image](https://user-images.githubusercontent.com/7926613/105472257-fed52580-5c9b-11eb-9cae-45ea5168cad5.png)
