### PR TITLE
Update PayPal component to add the onShippingChange event.

### DIFF
--- a/packages/lib/src/components/PayPal/components/PaypalButtons.tsx
+++ b/packages/lib/src/components/PayPal/components/PaypalButtons.tsx
@@ -4,7 +4,7 @@ import { PayPalButtonsProps, FundingSource } from '../types';
 import { getStyle } from '../utils';
 
 export default function PaypalButtons(props: PayPalButtonsProps) {
-    const { onInit, onComplete, onClick, onCancel, onError, onSubmit, paypalRef, style } = props;
+    const { onInit, onComplete, onClick, onCancel, onError, onShippingChange, onSubmit, paypalRef, style } = props;
     const paypalButtonRef = useRef(null);
     const creditButtonRef = useRef(null);
 
@@ -16,6 +16,7 @@ export default function PaypalButtons(props: PayPalButtonsProps) {
             onClick,
             onCancel,
             onError,
+            onShippingChange,
             createOrder: onSubmit,
             onApprove: onComplete
         });

--- a/packages/lib/src/components/PayPal/defaultProps.ts
+++ b/packages/lib/src/components/PayPal/defaultProps.ts
@@ -53,7 +53,8 @@ const defaultProps: PayPalElementProps = {
     onInit: () => {},
     onClick: () => {},
     onCancel: () => {},
-    onError: () => {}
+    onError: () => {},
+    onShippingChange: () => {}
 };
 
 export default defaultProps;

--- a/packages/lib/src/components/PayPal/types.ts
+++ b/packages/lib/src/components/PayPal/types.ts
@@ -103,8 +103,21 @@ interface PayPalCommonProps {
      * @see {@link https://developer.paypal.com/docs/checkout/integration-features/customize-button/}
      */
     style?: PayPalStyles;
+
+    /**
+     * @see {@link https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#oninitonclick}
+     */
     onInit?: (data?: object, actions?: object) => void;
+
+    /**
+     * @see {@link https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#oninitonclick}
+     */
     onClick?: () => void;
+
+    /**
+     * @see {@link https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#onshippingchange}
+     */
+    onShippingChange?: (data, actions) => void;
 }
 
 export interface PayPalConfig {


### PR DESCRIPTION
## Summary
Update PayPal component to add the `onShippingChange` event. This lets merchants listen to shipping changes and accept or reject the selected address.

More information on PayPal's [docs](https://developer.paypal.com/docs/checkout/integration-features/shipping-callback/) and (JavaScript SDK references](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#onshippingchange).

```js
const paypalComponent = checkout.create('paypal', {
    // ...
    onShippingChange: (data, actions) => {
        if (data.shipping_address.country_code !== 'US') {
            return actions.reject();
        }

        return actions.resolve();
    }
}
```

Keep in mind that updating the order is not supported in our implementation, so it's not possible to patch the amount according to the selected address.

**Fixed issue**:  adyen/adyen-web#700
