### PR TITLE
Filter payment methods not supported in the Drop-in

### DIFF
--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -1,5 +1,5 @@
 import { getComponent, getComponentConfiguration } from '../..';
-import { filterPresent, filterAvailable } from './filters';
+import { filterUnsupported, filterPresent, filterAvailable } from './filters';
 import { PaymentMethod } from '../../../types';
 
 const FALLBACK_COMPONENT = 'redirect';
@@ -28,7 +28,11 @@ const createElements = (components: PaymentMethod[] = [], props, componentsConfi
         return componentInstance;
     };
 
-    const elements = components.map(createElement).filter(filterPresent);
+    const elements = components
+        .filter(filterUnsupported)
+        .map(createElement)
+        .filter(filterPresent);
+
     const elementPromises = elements.map(filterAvailable).map(p => p.catch(e => e));
 
     return Promise.all(elementPromises).then(values => elements.filter((el, i) => values[i] === true));

--- a/packages/lib/src/components/Dropin/elements/filters.test.ts
+++ b/packages/lib/src/components/Dropin/elements/filters.test.ts
@@ -1,6 +1,17 @@
-import { filterPresent, filterAvailable } from './filters';
+import { UNSUPPORTED_PAYMENT_METHODS, filterUnsupported, filterPresent, filterAvailable } from './filters';
 
 describe('elements filters', () => {
+    describe('filterUnsupported', () => {
+        test('should return true if the paymentMethod is not supported', () => {
+            expect(filterUnsupported(UNSUPPORTED_PAYMENT_METHODS[0])).toBe(true);
+        });
+
+        test('should return false if the paymentMethod is supported', () => {
+            expect(filterUnsupported('test')).toBe(false);
+            expect(filterUnsupported(null)).toBe(false);
+        });
+    });
+
     describe('filterPresent', () => {
         test('should return true if the paymentMethod is truthy', () => {
             expect(filterPresent({})).toBe(true);

--- a/packages/lib/src/components/Dropin/elements/filters.ts
+++ b/packages/lib/src/components/Dropin/elements/filters.ts
@@ -1,3 +1,8 @@
+const UNSUPPORTED_PAYMENT_METHODS = ['amazonpay', 'androidpay', 'samsungpay'];
+
+// filter payment methods that we don't support in the Drop-in
+export const filterUnsupported = paymentMethod => UNSUPPORTED_PAYMENT_METHODS.includes(paymentMethod);
+
 // filter payment methods that we support (that are in the paymentMethods/index dictionary)
 export const filterPresent = paymentMethod => !!paymentMethod;
 

--- a/packages/lib/src/components/Dropin/elements/filters.ts
+++ b/packages/lib/src/components/Dropin/elements/filters.ts
@@ -1,7 +1,10 @@
-const UNSUPPORTED_PAYMENT_METHODS = ['amazonpay', 'androidpay', 'samsungpay'];
+export const UNSUPPORTED_PAYMENT_METHODS = ['amazonpay', 'androidpay', 'samsungpay'];
 
 // filter payment methods that we don't support in the Drop-in
-export const filterUnsupported = paymentMethod => UNSUPPORTED_PAYMENT_METHODS.includes(paymentMethod);
+export const filterUnsupported = paymentMethod => {
+    console.log(paymentMethod);
+    return !UNSUPPORTED_PAYMENT_METHODS.includes(paymentMethod.type);
+};
 
 // filter payment methods that we support (that are in the paymentMethods/index dictionary)
 export const filterPresent = paymentMethod => !!paymentMethod;


### PR DESCRIPTION
## Summary
We need to filter payment methods which are not supported in the Drop-in wether we support them as components or not.

## Tested scenarios
Added tests.