### PR TITLE
Remove browser field, add exports

### DIFF
--- a/packages/lib/config/rollup.config.js
+++ b/packages/lib/config/rollup.config.js
@@ -65,7 +65,7 @@ export default async () => [
             },
             {
                 name: 'AdyenCheckout',
-                file: pkg.browser,
+                file: pkg['umd:main'],
                 format: 'umd',
                 inlineDynamicImports: true,
                 sourcemap: true

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -10,6 +10,7 @@
     ],
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",
+    "umd:main": "dist/adyen.js",
     "types": "dist/types",
     "typings": "dist/types",
     "exports": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -10,10 +10,14 @@
     ],
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",
-    "umd:main": "dist/adyen.js",
-    "browser": "dist/adyen.js",
     "types": "dist/types",
     "typings": "dist/types",
+    "exports": {
+        ".": {
+            "import": "./dist/es/index.js",
+            "require": "./dist/cjs/index.js"
+        }
+    },
     "version": "3.20.0",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",

--- a/packages/playground/src/pages/Dropin/Dropin.js
+++ b/packages/playground/src/pages/Dropin/Dropin.js
@@ -1,4 +1,4 @@
-import AdyenCheckout from '@adyen/adyen-web/dist/es';
+import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
 import { makeDetailsCall, makePayment, getPaymentMethods, checkBalance, createOrder, cancelOrder } from '../../services';
 import { amount, shopperLocale, countryCode } from '../../config/commonConfig';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In order for some bundlers to default to the `module` version, we need to remove the `browser` field. Also adding new standard [`exports` field](https://nodejs.org/api/packages.html#packages_package_entry_points). 
