### PR TITLE
Release 3.22.0

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -45,6 +45,6 @@
         "whatwg-fetch": "^3.5.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.21.1"
+        "@adyen/adyen-web": "3.22.0"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "umd:main": "dist/adyen.js",
     "types": "dist/types",
     "typings": "dist/types",
-    "version": "3.21.1",
+    "version": "3.22.0",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -47,6 +47,6 @@
         "whatwg-fetch": "^3.5.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.21.1"
+        "@adyen/adyen-web": "3.22.0"
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Fixes
Filter payment methods which are not supported in the Drop-in (#722). 

## Changes
In preparation for a future release, we've made some updates to the 3D Secure flow. This should not have any effect on your integration (#729)

## Required API version
Adyen Web v3.22.0 requires API v66 or later.
