### PR TITLE
Fetch ponyfill

### DIFF
--- a/packages/lib/src/core/Services/fetch.ts
+++ b/packages/lib/src/core/Services/fetch.ts
@@ -1,0 +1,5 @@
+import { fetch as fetchPolyfill } from 'whatwg-fetch';
+
+const fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response> = 'fetch' in window ? window.fetch : fetchPolyfill;
+
+export default fetch;

--- a/packages/lib/src/core/Services/http.ts
+++ b/packages/lib/src/core/Services/http.ts
@@ -1,3 +1,4 @@
+import fetch from './fetch';
 import { FALLBACK_CONTEXT } from '../config';
 
 interface HttpOptions {

--- a/packages/lib/src/polyfills.ts
+++ b/packages/lib/src/polyfills.ts
@@ -3,7 +3,6 @@ import 'core-js/es/object/keys';
 import 'core-js/es/array/includes';
 import 'core-js/es/array/find';
 import 'core-js/es/array/find-index';
-import 'whatwg-fetch';
 
 // ChildNode.remove()
 (function(arr) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Move the `fetch` polyfill to the `services/` folder to prevent it from polluting the global namespace.
