### PR TITLE
Fix/payment methods configuration dropin props precedence

### DIFF
--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -9,7 +9,7 @@ import { PaymentMethod } from '../../../types';
  */
 const createElements = (components: PaymentMethod[] = [], props, create) => {
     const elements = components
-        .map(c => create(c.type, { ...c, ...props }))
+        .map(c => create(c, props))
         .filter(filterPresent)
         .filter(filterUnsupported);
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -178,6 +178,16 @@ class Core {
             });
         }
 
+        /**
+         * PaymentMethod is defined as a paymentMethods object (Used internally on Drop-in).
+         */
+        if (typeof PaymentMethod === 'object' && typeof PaymentMethod.type === 'string') {
+            // paymentMethodsConfiguration object will take precedence here
+            const paymentMethodsConfiguration = getComponentConfiguration(PaymentMethod.type, this.options.paymentMethodsConfiguration);
+            // handle rest of the flow normally (creating by string)
+            return this.handleCreate(PaymentMethod.type, { ...PaymentMethod, ...options, ...paymentMethodsConfiguration });
+        }
+
         return this.handleCreateError(PaymentMethod);
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix `paymentMethodsConfiguration` on Drop-in for properties on the `paymentMethodsResponse`.

## Tested scenarios
- `brands` can be correctly set on the `paymentMethodsConfiguration`.


