### PR TITLE
Support action props through paymentMethodsConfiguration

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -81,12 +81,11 @@ describe('Dropin', () => {
             expect(pa.componentFromAction instanceof ThreeDS2Challenge).toEqual(true);
             expect(pa.componentFromAction.props.statusType).toEqual('custom');
             expect(pa.componentFromAction.props.isDropin).toBe(true);
-
             expect(pa.componentFromAction.props.size).toEqual('02');
         });
 
         test('new challenge action gets challengeWindowSize from paymentMethodsConfiguration', () => {
-            const checkout = new AdyenCheckout({ paymentMethodsConfiguration: { card: { challengeWindowSize: '02' } } });
+            const checkout = new AdyenCheckout({ paymentMethodsConfiguration: { threeDS2: { challengeWindowSize: '02' } } });
 
             const dropin = checkout.create('dropin');
 

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -6,7 +6,7 @@ export interface DropinElementProps extends UIElementProps {
      * Configure each payment method displayed on the Drop-in
      */
     paymentMethodsConfiguration?: {
-        [key in keyof PaymentMethods]?: Partial<PaymentMethodOptions<key>>;
+        [key in keyof PaymentMethods | keyof ['threeDS2']]?: Partial<PaymentMethodOptions<key>>;
     };
 
     paymentMethods?: PaymentMethod[];

--- a/packages/lib/src/components/UIElement.test.ts
+++ b/packages/lib/src/components/UIElement.test.ts
@@ -128,7 +128,7 @@ describe('UIElement', () => {
         test('should handle new challenge action', () => {
             const checkout = new Core({
                 paymentMethodsConfiguration: {
-                    card: { challengeWindowSize: '02' }
+                    threeDS2: { challengeWindowSize: '02' }
                 }
             });
 

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -53,6 +53,8 @@ const actionTypes = {
             loadingContext: props.loadingContext,
             clientKey: props.clientKey,
             _parentInstance: props._parentInstance,
+            paymentMethodType: props.paymentMethodType,
+
             // Props unique to a particular flow
             ...get3DS2FlowProps(action.subtype, props)
         };
@@ -97,6 +99,6 @@ const actionTypes = {
             statusType: 'custom'
         });
     }
-};
+} as const;
 
 export default actionTypes;

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -75,7 +75,7 @@ describe('Core', () => {
         });
 
         test('should handle new fingerprint action', () => {
-            const checkout = new AdyenCheckout({ paymentMethodsConfiguration: { card: { challengeWindowSize: '04' } } });
+            const checkout = new AdyenCheckout({ paymentMethodsConfiguration: { threeDS2: { challengeWindowSize: '04' } } });
 
             const fingerprintAction = {
                 paymentData: 'Ab02b4c0!BQABAgCUeRP+3La4...',
@@ -100,7 +100,7 @@ describe('Core', () => {
         test('should handle new challenge action', () => {
             const checkout = new AdyenCheckout({
                 paymentMethodsConfiguration: {
-                    card: {
+                    threeDS2: {
                         challengeWindowSize: '03'
                     }
                 }
@@ -130,7 +130,7 @@ describe('Core', () => {
             const onAdditionalDetailsCreateFromAction = jest.fn().mockName('onSubmitMockComponent');
             const checkout = new AdyenCheckout({
                 onAdditionalDetails: onAdditionalDetailsGlobal,
-                paymentMethodsConfiguration: { bcmc_mobile_QR: { onAdditionalDetails: onAdditionalDetailsBCMC } }
+                paymentMethodsConfiguration: { qrCode: { onAdditionalDetails: onAdditionalDetailsBCMC } }
             });
 
             test('paymentMethodsConfiguration properties take precedence over global configuration', () => {
@@ -140,7 +140,7 @@ describe('Core', () => {
                     type: 'qrCode',
                     paymentData: 'test'
                 });
-                expect(paymentAction.props.onAdditionalDetails).toBe(onAdditionalDetailsBCMC);
+                expect(paymentAction.props.onAdditionalDetails).toEqual(onAdditionalDetailsBCMC);
             });
 
             test('createFromAction props take precedence over paymentMethodsConfiguration and global configuration', () => {

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -52,7 +52,7 @@ class Core {
      */
     public createFromAction(action: PaymentAction, options = {}): UIElement {
         if (action.type) {
-            const paymentMethodsConfiguration = getComponentConfiguration(action.paymentMethodType, this.options.paymentMethodsConfiguration);
+            const paymentMethodsConfiguration = getComponentConfiguration(action.type, this.options.paymentMethodsConfiguration);
             const props = { ...processGlobalOptions(this.options), ...paymentMethodsConfiguration, ...this.getPropsForComponent(options) };
             return getComponentForAction(action, props);
         }

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -1,5 +1,5 @@
 import { CustomTranslations, Locales } from '../language/types';
-import { PaymentAmount, PaymentMethods, PaymentMethodOptions } from '../types';
+import { PaymentAmount, PaymentMethods, PaymentMethodOptions, PaymentActionsType } from '../types';
 import { AnalyticsOptions } from './Analytics/types';
 import { PaymentMethodsResponseObject } from './ProcessResponse/PaymentMethodsResponse/types';
 import { RiskModuleOptions } from './RiskModule/RiskModule';
@@ -47,9 +47,7 @@ export interface CoreOptions {
     /**
      * Optional per payment method configuration
      */
-    paymentMethodsConfiguration?: {
-        [key in keyof PaymentMethods]?: Partial<PaymentMethodOptions<key>>;
-    };
+    paymentMethodsConfiguration?: PaymentMethodsConfiguration;
 
     /**
      * Display only these payment methods
@@ -72,3 +70,11 @@ export interface CoreOptions {
 
     [key: string]: any;
 }
+
+export type PaymentMethodsConfiguration =
+    | {
+          [key in keyof PaymentMethods]?: Partial<PaymentMethodOptions<key>>;
+      }
+    | {
+          [key in PaymentActionsType]?: any;
+      };

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -1,5 +1,8 @@
 import paymentMethods from '../components';
 import { ADDRESS_SCHEMA } from '../components/internal/Address/constants';
+import actionTypes from '../core/ProcessResponse/PaymentAction/actionTypes';
+
+export type PaymentActionsType = keyof typeof actionTypes;
 
 /**
  * {@link https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v51/payments__resParam_action API Explorer /payments action}
@@ -8,7 +11,7 @@ export interface PaymentAction {
     /**
      * General type of action that needs to be taken by the client
      */
-    type: string;
+    type: PaymentActionsType | string;
 
     /**
      * Refinement of type of action that needs to be taken by the client (currently only applies to the new 'threeDS2' type)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Allow passing props directly to action components through the `paymentMethodsConfiguration` property.

Example:
```js
    const checkout = new AdyenCheckout({
        // ...
        paymentMethodsConfiguration: {
            threeDS2: {
                challengeWindowSize: '05'
            }
        }
        // ...
    });
```