### PR TITLE
Fix/issuer lists were not populating

### DIFF
--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -48,7 +48,7 @@ class IssuerListContainer extends UIElement<IssuerListProps> {
     };
 
     formatProps(props) {
-        const issuers = props.issuers || (props.details && props.details.length && (props.details.find(d => d.key === 'issuer') || {}).items) || [];
+        const issuers = (props.details && props.details.length && (props.details.find(d => d.key === 'issuer') || {}).items) || props.issuers || [];
         return { ...props, issuers };
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`IssuerListContainer` was always reading the default prop `issuers` which was set to an empty array & therefore truthy. So it was never going on to inspect the actual `props.details` array where the issuer information exists

## Tested scenarios
iDEAL issuer list populates again.
ideal e2e test passes

