### PR TITLE
e2e test for "exotic" brand in card comp dedicated to single txVariant

### DIFF
--- a/packages/e2e/tests/cards/branding/branding.exotic.clientScripts.js
+++ b/packages/e2e/tests/cards/branding/branding.exotic.clientScripts.js
@@ -1,0 +1,4 @@
+window.cardConfig = {
+    type: 'scheme',
+    brands: ['korean_local_card']
+};

--- a/packages/e2e/tests/cards/branding/branding.exotic.test.js
+++ b/packages/e2e/tests/cards/branding/branding.exotic.test.js
@@ -1,0 +1,41 @@
+import { ClientFunction, Selector } from 'testcafe';
+import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
+import cu from '../utils/cardUtils';
+import { CARDS_URL } from '../../pages';
+import { TEST_DATE_VALUE, TEST_CVC_VALUE, KOREAN_TEST_CARD } from '../utils/constants';
+
+const setForceClick = ClientFunction(val => {
+    window.testCafeForceClick = val;
+});
+
+const TEST_SPEED = 1;
+
+const iframeSelector = getIframeSelector('.card-field iframe');
+
+const cardUtils = cu(iframeSelector);
+
+fixture`Testing card component dedicated to a single, "exotic", txVariant that we don't recognise internally but that is recognised by /binLookup`
+    .page(CARDS_URL)
+    .clientScripts('branding.exotic.clientScripts.js');
+
+/**
+ * Relies on sf v3.3.1
+ */
+test('Input details for "exotic" brand - card should still become valid, with no errors', async t => {
+    // Start, allow time for iframes to load
+    await start(t, 2000, TEST_SPEED);
+
+    // Exotic brand
+    await cardUtils.fillCardNumber(t, KOREAN_TEST_CARD);
+
+    await setForceClick(true); // to force error, or rather lack of it
+
+    // Expect no errors
+    await t.expect(Selector('.adyen-checkout__field--error').exists).notOk();
+
+    await cardUtils.fillDate(t, TEST_DATE_VALUE);
+    await cardUtils.fillCVC(t, TEST_CVC_VALUE);
+
+    // Is valid
+    await t.expect(getIsValid('card')).eql(true);
+});

--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -4,7 +4,7 @@ import { PaymentMethod } from '../../../types';
 /**
  * Returns a filtered (available) list of component Elements
  * @param components - Array of PaymentMethod objects from the /paymentMethods response
- * @param props - High level props to be passed through to every component (as defined in utils/getCommonsProps)
+ * @param props - High level props to be passed through to every component (as defined in utils/getCommonProps)
  * @param create - Reference to the main instance `create` method
  */
 const createElements = (components: PaymentMethod[] = [], props, create) => {

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -175,9 +175,9 @@ const fingerprintFlowPropsDropin = ['elementRef'];
  *  Must contain all props needed for the challenge stage since, in the new 3DS2 flow, the fingerprint component will be the "component" reference
  *  if the /submitThreeDS2Fingerprint response dictates we "handleAction" to create a challenge
  */
-const fingerprintFlowProps = ['createFromAction', 'onAdditionalDetails', 'challengeWindowSize', 'size'];
+const fingerprintFlowProps = ['createFromAction', 'onAdditionalDetails', 'challengeWindowSize'];
 
-const challengeFlowProps = ['challengeWindowSize', 'size']; // support "size" for legacy purposes
+const challengeFlowProps = ['challengeWindowSize'];
 
 /**
  * Add props specifically needed for the type of 3DS2 flow: fingerprint or challenge

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -10,7 +10,7 @@ export const ENCRYPTED_PIN_FIELD = 'encryptedPin';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.3.0';
+export const SF_VERSION = '3.3.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -146,7 +146,7 @@ class Core {
             // 1. global props
             // 2. props defined on the PaymentMethod in the response object (will not have a value for the 'dropin' component)
             // 3. a paymentMethodsConfiguration object, if defined at top level
-            // 4. the combined props of checkout & the configuration object defined on this particular component
+            // 4. the configuration object defined on this particular component (after it has passed through getPropsForComponent)
             const component = new PaymentMethod({ ...globalOptions, ...paymentMethodsDetails, ...paymentMethodsConfiguration, ...options });
 
             if (!options.isDropin) {
@@ -165,7 +165,7 @@ class Core {
         }
 
         /**
-         * If we are trying to create a payment method that is in the paymentMethodsResponse & does not explicitily
+         * If we are trying to create a payment method that is in the paymentMethodsResponse & does not explicitly
          * implement a component, it will default to a redirect component
          */
         if (typeof PaymentMethod === 'string' && this.paymentMethodsResponse.has(PaymentMethod)) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added test for card comp dedicated to single "exotic" txVariant that we don't recognise internally in our regExs - shopper should still be able to enter card details and have the card become valid
- Relies on new version of securedFields: `3.3.1`
- Dropped support for `size` config prop for 3DS2
- Fixed some typos and comments

## Tested scenarios
All e2e tests run and pass

**Fixed issue**:  FOC-42352
