### PR TITLE
Feature/dropped support for aria labels config prop

### DIFF
--- a/packages/lib/src/components/Ach/components/AchInput/defaultProps.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/defaultProps.ts
@@ -29,6 +29,5 @@ export default {
 
     // Customization
     styles: {},
-    placeholders: {},
-    ariaLabels: {}
+    placeholders: {}
 };

--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -37,6 +37,5 @@ export default {
 
     // Customization
     styles: {},
-    placeholders: {},
-    ariaLabels: {}
+    placeholders: {}
 };

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -154,8 +154,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             showWarnings: this.props.showWarnings,
             iframeUIConfig: {
                 sfStyles: this.props.styles,
-                placeholders: this.props.placeholders,
-                ariaConfig: this.props.ariaLabels
+                placeholders: this.props.placeholders
             },
             i18n: this.props.i18n,
             callbacks: {
@@ -171,8 +170,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
                 onAdditionalSFConfig: this.props.onAdditionalSFConfig,
                 onAdditionalSFRemoved: this.props.onAdditionalSFRemoved
             },
-            isKCP: this.state.hasKoreanFields,
-            locale: this.props.locale
+            isKCP: this.state.hasKoreanFields
         };
 
         this.csf = initCSF(csfSetupObj);

--- a/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
@@ -5,7 +5,6 @@ export interface SFPProps {
      * CSF RELATED (23)
      */
     allowedDOMAccess?: boolean;
-    ariaLabels?: object;
     autoFocus?: boolean;
     brands?: string[];
     groupTypes?: string[];
@@ -107,6 +106,5 @@ export default {
 
     // Customization
     placeholders: {},
-    ariaLabels: {},
     styles: {}
 };

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
@@ -28,8 +28,6 @@ export function handleConfig(): void {
     // Ensure passed loadingContext has trailing slash
     this.config.loadingContext = lastChar(loadingContext) === '/' ? loadingContext : `${loadingContext}/`;
 
-    this.config.locale = this.props.i18n.locale;
-
     this.config.isCreditCardType = NON_CREDIT_CARD_TYPE_SECURED_FIELDS.includes(this.props.type) === false;
 
     // Configuration object for individual txVariants

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
@@ -28,7 +28,7 @@ export function handleConfig(): void {
     // Ensure passed loadingContext has trailing slash
     this.config.loadingContext = lastChar(loadingContext) === '/' ? loadingContext : `${loadingContext}/`;
 
-    this.config.locale = this.props.locale;
+    this.config.locale = this.props.i18n.locale;
 
     this.config.isCreditCardType = NON_CREDIT_CARD_TYPE_SECURED_FIELDS.includes(this.props.type) === false;
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
@@ -15,7 +15,6 @@ export interface SFInternalConfig {
     trimTrailingSeparator: boolean;
     isCreditCardType: boolean;
     showWarnings: boolean;
-    locale?: string;
 }
 
 export interface SFSetupObject extends SFInternalConfig {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
@@ -11,12 +11,19 @@ const ENCRYPTED_EXPIRY_DATE = 'encryptedExpiryDate';
 const ENCRYPTED_SECURITY_CODE = 'encryptedSecurityCode';
 
 const TRANSLATED_NUMBER_IFRAME_TITLE = LANG['creditCard.encryptedCardNumber.aria.iframeTitle'];
+const TRANSLATED_NUMBER_IFRAME_LABEL = LANG['creditCard.encryptedCardNumber.aria.label'];
+
 const TRANSLATED_DATE_IFRAME_TITLE = LANG['creditCard.encryptedExpiryDate.aria.iframeTitle'];
+const TRANSLATED_DATE_IFRAME_LABEL = LANG['creditCard.encryptedExpiryDate.aria.label'];
+
 const TRANSLATED_CVC_IFRAME_TITLE = LANG['creditCard.encryptedSecurityCode.aria.iframeTitle'];
+const TRANSLATED_CVC_IFRAME_LABEL = LANG['creditCard.encryptedSecurityCode.aria.label'];
 
 const GENERAL_ERROR_CODE = ERROR_CODES[ERROR_MSG_INCOMPLETE_FIELD];
+const CARD_TOO_OLD_ERROR_CODE = ERROR_CODES[ERROR_MSG_CARD_TOO_OLD];
 
 const TRANSLATED_INCOMPLETE_FIELD_ERROR = LANG[GENERAL_ERROR_CODE];
+const TRANSLATED_CARD_TOO_OLD_ERROR = LANG[CARD_TOO_OLD_ERROR_CODE];
 
 const TRANSLATED_NUMBER_PLACEHOLDER = LANG['creditCard.numberField.placeholder'];
 const TRANSLATED_DATE_PLACEHOLDER = LANG['creditCard.expiryDateField.placeholder'];
@@ -25,21 +32,6 @@ const TRANSLATED_CVC_PLACEHOLDER = LANG['creditCard.cvcField.placeholder'];
 const nodeHolder = document.createElement('div');
 
 const i18n = new Language('en-US', {});
-
-const mockAriaConfig = {
-    lang: 'en-GB',
-    encryptedCardNumber: {
-        label: 'Credit or debit card number field',
-        iframeTitle: 'Iframe for credit card number field'
-    },
-    encryptedExpiryDate: {
-        label: 'Credit or debit card expiration date field',
-        error: { [GENERAL_ERROR_CODE]: 'Field is not filled out' }
-    },
-    encryptedSecurityCode: {
-        label: 'Credit or debit card 3 or 4 digit security code field'
-    }
-} as AriaConfig;
 
 const mockPlaceholders = {
     encryptedCardNumber: '9999 9999 9999 9999',
@@ -75,62 +67,32 @@ const setupObj = {
  */
 describe('SecuredField handling ariaConfig object - should set defaults', () => {
     //
-    test('Card number field with no defined ariaConfig should get default title & translated error props', () => {
+    test('Card number field should get translated title, label & error props plus a lang prop that equals the i18n.locale', () => {
         const card = new SecuredField(setupObj, i18n);
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].iframeTitle).toEqual(TRANSLATED_NUMBER_IFRAME_TITLE);
+        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].label).toEqual(TRANSLATED_NUMBER_IFRAME_LABEL);
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
+        expect(card.config.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale); // = 'en-US'
     });
 
-    test('Date field with no defined ariaConfig should get default title & translated error props', () => {
+    test('Date field should get translated title, label & error props plus a lang prop that equals the i18n.locale', () => {
         setupObj.fieldType = ENCRYPTED_EXPIRY_DATE;
 
         const card = new SecuredField(setupObj, i18n);
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].iframeTitle).toEqual(TRANSLATED_DATE_IFRAME_TITLE);
+        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].label).toEqual(TRANSLATED_DATE_IFRAME_LABEL);
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
+        expect(card.config.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale);
     });
 
-    test('CVC field with no defined ariaConfig should get default title & translated error props', () => {
+    test('CVC field should get translated title, label & error props plus a lang prop that equals the i18n.locale', () => {
         setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
 
         const card = new SecuredField(setupObj, i18n);
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].iframeTitle).toEqual(TRANSLATED_CVC_IFRAME_TITLE);
+        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].label).toEqual(TRANSLATED_CVC_IFRAME_LABEL);
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
-    });
-});
-
-describe('SecuredField handling ariaConfig object - should set defaults only where they are not already defined', () => {
-    //
-    test('Card number field with ariaConfig with label & iframeTitle should preserve these props and also get a translated error prop', () => {
-        setupObj.iframeUIConfig.ariaConfig = mockAriaConfig;
-        setupObj.fieldType = ENCRYPTED_CARD_NUMBER;
-
-        const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].label).toEqual(mockAriaConfig[ENCRYPTED_CARD_NUMBER].label);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].iframeTitle).toEqual(mockAriaConfig[ENCRYPTED_CARD_NUMBER].iframeTitle);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
-
-        // Also check that configured language is preserved
-        expect(card.config.iframeUIConfig.ariaConfig.lang).toEqual(mockAriaConfig.lang);
-    });
-
-    test('Date field with ariaConfig with label & error should preserve these props and also get a iframeTitle prop', () => {
-        setupObj.fieldType = ENCRYPTED_EXPIRY_DATE;
-
-        const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].label).toEqual(mockAriaConfig[ENCRYPTED_EXPIRY_DATE].label);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].iframeTitle).toEqual(TRANSLATED_DATE_IFRAME_TITLE);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual(
-            mockAriaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]
-        );
-    });
-
-    test('CVC field with ariaConfig with label should preserve this prop and also get default title & translated error props', () => {
-        setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
-
-        const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].label).toEqual(mockAriaConfig[ENCRYPTED_SECURITY_CODE].label);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].iframeTitle).toEqual(TRANSLATED_CVC_IFRAME_TITLE);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
+        expect(card.config.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale);
     });
 });
 
@@ -147,8 +109,7 @@ describe('SecuredField handling ariaConfig object - should trim the config objec
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE]).toBe(undefined);
     });
 
-    test('cvc field, with defined ariaConfig, should only have a property related to the cvc and nothing for date or cvc', () => {
-        setupObj.iframeUIConfig.ariaConfig = mockAriaConfig;
+    test('cvc field, with default ariaConfig, should only have a property related to the cvc and nothing for date or number', () => {
         setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
 
         const card = new SecuredField(setupObj, i18n);
@@ -171,15 +132,16 @@ describe('SecuredField handling ariaConfig object - should trim the config objec
         expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[ERROR_CODES[ERROR_MSG_INVALID_FIELD]]).toBe(undefined);
     });
 
-    test('date field, with defined ariaConfig, should have its own defined error object', () => {
-        setupObj.iframeUIConfig.ariaConfig = mockAriaConfig;
+    test('date field, with default ariaConfig, should have expected, translated, error strings', () => {
         setupObj.fieldType = ENCRYPTED_EXPIRY_DATE;
 
         const card = new SecuredField(setupObj, i18n);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual('Field is not filled out');
+        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[ERROR_CODES[ERROR_MSG_CARD_TOO_OLD]]).toBe(undefined);
+        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[ERROR_CODES[ERROR_MSG_CARD_TOO_OLD]]).toEqual(
+            TRANSLATED_CARD_TOO_OLD_ERROR
+        );
     });
 
     test('Card number field with default ariaConfig should have an error object containing certain keys whose values are the correct translations', () => {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
@@ -176,8 +176,7 @@ export function setupSecuredField(pItem: HTMLElement): void {
         iframeSrc: this.config.iframeSrc,
         loadingContext: this.config.loadingContext,
         showWarnings: this.config.showWarnings,
-        holderEl: pItem,
-        locale: this.config.locale
+        holderEl: pItem
     };
 
     const sf: SecuredField = new SecuredField(setupObj, this.props.i18n)

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/init/processAriaConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/init/processAriaConfig.ts
@@ -1,4 +1,3 @@
-import getProp from '../../../../../../../utils/getProp';
 import { addErrorTranslationsToObject } from '../../../../../../../core/Errors/utils';
 import { AriaConfigObject, AriaConfig, SFInternalConfig } from '../../AbstractSecuredField';
 import Language from '../../../../../../../language/Language';

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/init/processAriaConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/init/processAriaConfig.ts
@@ -21,27 +21,14 @@ export function processAriaConfig(configObj: SFInternalConfig, fieldType: string
     // Get translation for aria label
     const label: string = i18n.get(`${type}.${fieldType}.aria.label`);
 
-    let newAriaFieldConfigObj: AriaConfigObject;
+    // Get lang property
+    const lang = configObj.locale;
 
-    // Check for a pre-existing, merchant defined ariaConfig object and extract lang property
-    const lang = getProp(configObj, `iframeUIConfig.ariaConfig.lang`) || configObj.locale;
-
-    // Get config object for this specific field, if it exists...
-    const ariaFieldConfig: AriaConfigObject = getProp(configObj, `iframeUIConfig.ariaConfig.${fieldType}`);
-    if (ariaFieldConfig) {
-        newAriaFieldConfigObj = {
-            ...ariaFieldConfig,
-            // If object already has a title & label - use them; otherwise use values from translation file
-            iframeTitle: ariaFieldConfig.iframeTitle || iframeTitle,
-            label: ariaFieldConfig.label || label
-        };
-    } else {
-        // ... else, create a new object with the iframeTitle & label values from translation file
-        newAriaFieldConfigObj = { iframeTitle, label };
-    }
+    // Ceate a new object with the iframeTitle & label values from translation file
+    const ariaFieldConfigObj: AriaConfigObject = { iframeTitle, label };
 
     // Add error translations object
-    const ariaFieldConfigWithTranslatedErrors = addErrorTranslationsToObject(newAriaFieldConfigObj, i18n);
+    const ariaFieldConfigWithTranslatedErrors = addErrorTranslationsToObject(ariaFieldConfigObj, i18n);
 
     // Create a new aria config object keeping the old entries and adding a new one for this field
     // N.B. need to do this deconstruction of the original aria config object to break existing refs & avoid getting an "accumulated" object

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/init/processAriaConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/init/processAriaConfig.ts
@@ -22,7 +22,7 @@ export function processAriaConfig(configObj: SFInternalConfig, fieldType: string
     const label: string = i18n.get(`${type}.${fieldType}.aria.label`);
 
     // Get lang property
-    const lang = configObj.locale;
+    const lang = i18n.locale;
 
     // Ceate a new object with the iframeTitle & label values from translation file
     const ariaFieldConfigObj: AriaConfigObject = { iframeTitle, label };

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -39,7 +39,6 @@ interface CSFCommonProps {
     keypadFix?: boolean;
     isKCP?: boolean;
     iframeUIConfig?: object;
-    locale?: string;
 }
 
 export interface SetupObject extends CSFCommonProps {

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -44,17 +44,6 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
                 }
             },
             showInstallmentAmounts: true,
-            ariaLabels: {
-                lang: 'en-GB',
-                encryptedCardNumber: {
-                    label: 'Credit or debit card number field',
-                    iframeTitle: 'cc number field iframe'
-                },
-                encryptedExpiryDate: {
-                    label: 'put your date in here',
-                    iframeTitle: 'date iframe'
-                }
-            },
             onError: obj => {
                 console.log('### Cards::onError:: obj=', obj);
             },

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -37,15 +37,6 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
         })
         .mount('.donation-field');
 
-    const ariaLabels = {
-        lang: 'en-GB',
-        encryptedBankAccountNumber: {
-            label: 'Custom aria bank accnt label',
-            iframeTitle: 'Iframe for bank accnt number',
-            error: 'Ongeldig kaartnummer'
-        }
-    };
-
     // SEPA Bank Transfer
     window.bankTransfer = checkout.create('bankTransfer_IBAN').mount('.bankTransfer-field');
     window.bankTransferResult = checkout
@@ -72,7 +63,6 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
         .create('ach', {
             // holderNameRequired: false,
             // hasHolderName: false,
-            ariaLabels,
             onConfigSuccess: obj => {
                 console.log('### Components::onConfigSuccess:: obj', obj);
             },

--- a/packages/playground/src/pages/SecuredFields/SecuredFields.js
+++ b/packages/playground/src/pages/SecuredFields/SecuredFields.js
@@ -1,7 +1,7 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
 import { makePayment, makeDetailsCall } from '../../services';
-import { styles, placeholders, ariaLabels, setCCErrors, setFocus, onBrand, onConfigSuccess } from './securedFields.config';
+import { styles, placeholders, setCCErrors, setFocus, onBrand, onConfigSuccess } from './securedFields.config';
 import { styles_si, onConfigSuccess_si, onFieldValid_si, onBrand_si, onError_si, onFocus_si } from './securedFields-si.config';
 import { fancyStyles, fancyChangeBrand, fancyErrors, fancyFieldValid, fancyFocus } from './securedFields-fancy.config';
 import { materialStyles, materialFocus, handleMaterialError, onMaterialFieldValid } from './securedFields-material.config';
@@ -52,7 +52,6 @@ window.securedFields = checkout
         brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
         styles,
         placeholders,
-        ariaLabels,
         onConfigSuccess,
         onBrand,
         onBinValue: cbObj => {
@@ -95,7 +94,6 @@ window.fancySecuredFields = checkout
         type: 'card',
         brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
         styles: fancyStyles,
-        ariaLabels,
         autoFocus: false,
         onFieldValid: fancyFieldValid,
         onBrand: fancyChangeBrand,

--- a/packages/playground/src/pages/SecuredFields/securedFields.config.js
+++ b/packages/playground/src/pages/SecuredFields/securedFields.config.js
@@ -24,21 +24,6 @@ export const placeholders = {
     encryptedSecurityCode: '8888'
 };
 
-export const ariaLabels = {
-    lang: 'en-GB',
-    encryptedCardNumber: {
-        label: 'Credit or debit card number field',
-        iframeTitle: 'Iframe for credit card number field'
-        //        error: 'credit card number is in error'
-    },
-    encryptedExpiryDate: {
-        label: 'Credit or debit card expiration date field'
-    },
-    encryptedSecurityCode: {
-        label: 'Credit or debit card 3 or 4 digit security code field'
-    }
-};
-
 export function onConfigSuccess(pCallbackObj) {
     document.querySelector('.secured-fields').style.display = 'block';
     document.querySelector('.card-input__spinner__holder').style.display = 'none';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Dropped support for a merchant defined `ariaLabels` config property.
(The aria config values which are read from the translations files can be customised when configuring the Checkout instance via a translations object).
- Removed the internal config prop `locale` from the SecuredFields flow (the `i18n` prop contains the necessary locale info)

## Tested scenarios
All tests, e2e & unit, pass

**Fixed issue**:  COWEB-830
