### PR TITLE
Prevent the PayPal submit method to be called programatically in the Drop-in

### DIFF
--- a/packages/lib/src/components/PayPal/Paypal.test.ts
+++ b/packages/lib/src/components/PayPal/Paypal.test.ts
@@ -11,11 +11,11 @@ describe('Paypal', () => {
         expect(paypal.isValid).toBe(true);
     });
 
-    test('Prevents calling the submit method manually', () => {
-        console.error = jest.fn();
-        const paypal = new Paypal({});
-        paypal.submit();
-        expect(console.error).toHaveBeenCalled();
+    test('Prevents calling the submit method manually', async () => {
+        const onErrorMock = jest.fn();
+        const paypal = new Paypal({ onError: onErrorMock });
+        await paypal.submit();
+        expect(onErrorMock).toHaveBeenCalled();
     });
 });
 

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -95,6 +95,10 @@ class PaypalElement extends UIElement<PayPalElementProps> {
         this.props.onError(data, this.elementRef);
     }
 
+    startPayment() {
+        return Promise.reject('Calling submit() is not supported for this payment method');
+    }
+
     handleSubmit() {
         const { data, isValid } = this;
         if (this.props.onSubmit) this.props.onSubmit({ data, isValid }, this.elementRef);
@@ -106,7 +110,9 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     }
 
     submit() {
-        console.error('Calling submit() is not supported for this payment method');
+        this.startPayment().catch(e => {
+            this.props.onError(e, this.elementRef);
+        });
     }
 
     render() {


### PR DESCRIPTION
## Summary
Updated the PayPal component to prevent the `submit` method to be called when used in the component.
The `onError` will be triggered when trying to call the `submit` method in both the Drop-in and the component.

## Tested scenarios
Tested in the Drop-in and in the standalone component.
