### PR TITLE
Update RatePay to support NL.

### DIFF
--- a/packages/lib/src/components/RatePay/config.ts
+++ b/packages/lib/src/components/RatePay/config.ts
@@ -1,1 +1,1 @@
-export const ALLOWED_COUNTRIES = ['AT', 'CH', 'DE'];
+export const ALLOWED_COUNTRIES = ['AT', 'CH', 'DE', 'NL'];


### PR DESCRIPTION
## Summary
Add `NL` to the list of supported countries for RatePay.
