### PR TITLE
Release 3.22.1

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -45,6 +45,6 @@
         "whatwg-fetch": "^3.5.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.22.0"
+        "@adyen/adyen-web": "3.22.1"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "umd:main": "dist/adyen.js",
     "types": "dist/types",
     "typings": "dist/types",
-    "version": "3.22.0",
+    "version": "3.22.1",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -47,6 +47,6 @@
         "whatwg-fetch": "^3.5.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.22.0"
+        "@adyen/adyen-web": "3.22.1"
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Fixes
- Fix loading status on QRCode components #753
- Prevent the PayPal submit method being called programmatically in the Drop-in #754
- Update RatePay to support NL. #755

## Changes
Upped SecuredFields version to 3.3.1

## Required API version
Adyen Web v3.22.1 requires API v66 or later.