### PR TITLE
Fix/keep 3DS2 flows separate

### DIFF
--- a/packages/e2e/tests/cards/threeDS2/threeDS2.newFlow.redirect.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.newFlow.redirect.test.js
@@ -23,43 +23,51 @@ const logger = RequestLogger(
     }
 );
 
+const apiVersion = Number(process.env.API_VERSION.substr(1));
+
 const TEST_SPEED = 1;
 
 const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--card iframe');
 
 const cardUtils = cu(iframeSelector);
 
-fixture`Testing new (v67) hybrid 3DS2 Flow (redirect)`
+fixture`Testing new (v67) 3DS2 Flow (redirect)`
     .page(`${BASE_URL}?amount=12003`)
     .clientScripts('threeDS2.clientScripts.js')
     .requestHooks(logger);
 
-test('Fill in card number that will trigger redirect flow', async t => {
-    await start(t, 2000, TEST_SPEED);
+if (apiVersion >= 67) {
+    test('Fill in card number that will trigger redirect flow', async t => {
+        await start(t, 2000, TEST_SPEED);
 
-    // Set handler for the alert window
-    await t.setNativeDialogHandler(() => true);
+        // Set handler for the alert window
+        await t.setNativeDialogHandler(() => true);
 
-    // Fill card fields
-    await cardUtils.fillCardNumber(t, THREEDS2_FULL_FLOW_CARD);
-    await cardUtils.fillDateAndCVC(t);
+        // Fill card fields
+        await cardUtils.fillCardNumber(t, THREEDS2_FULL_FLOW_CARD);
+        await cardUtils.fillDateAndCVC(t);
 
-    // Expect card to now be valid
-    await t.expect(getIsValid('dropin')).eql(true);
+        // Expect card to now be valid
+        await t.expect(getIsValid('dropin')).eql(true);
 
-    // Click pay
-    await t
-        .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
-        // Expect no errors
-        .expect(Selector('.adyen-checkout__field--error').exists)
-        .notOk()
-        // Allow time for the ONLY /submitThreeDS2Fingerprint call, which we expect to be successful
-        .wait(2000)
-        .expect(logger.contains(r => r.response.statusCode === 200))
-        .ok()
-        // Allow time for redirect to occur
-        .wait(2000);
+        // Click pay
+        await t
+            .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
+            // Expect no errors
+            .expect(Selector('.adyen-checkout__field--error').exists)
+            .notOk()
+            // Allow time for the ONLY /submitThreeDS2Fingerprint call, which we expect to be successful
+            .wait(2000)
+            .expect(logger.contains(r => r.response.statusCode === 200))
+            .ok()
+            // Allow time for redirect to occur
+            .wait(2000);
 
-    // Inspect page for Redirect elements
-    await t.expect(Selector('title').innerText).eql('3D Authentication Host');
-});
+        // Inspect page for Redirect elements
+        await t.expect(Selector('title').innerText).eql('3D Authentication Host');
+    });
+} else {
+    test(`Skip testing new 3DS2 redirect flow since api version is too low (v${apiVersion})`, async t => {
+        await t.wait(250);
+    });
+}

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.newFlow.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.newFlow.test.js
@@ -1,5 +1,5 @@
 const path = require('path');
-require('dotenv').config({ path: path.resolve('../../', '.env') }); // 2 dirs up, apparently!
+require('dotenv').config({ path: path.resolve('../../', '.env') });
 
 import { Selector, RequestLogger } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
@@ -13,6 +13,7 @@ const detailsURL = `${BASE_URL}/details`;
 const loggerDetails = RequestLogger(
     { detailsURL, method: 'post' },
     {
+        //        logRequestBody: true,
         logResponseHeaders: true,
         logResponseBody: true
     }
@@ -28,128 +29,148 @@ const loggerSubmitThreeDS2 = RequestLogger(
     }
 );
 
+const apiVersion = Number(process.env.API_VERSION.substr(1));
+
 const TEST_SPEED = 1;
 
 const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--card iframe');
 
 const cardUtils = cu(iframeSelector);
 
-fixture`Testing new (v67) hybrid 3DS2 Flow`
+fixture`Testing new (v67) 3DS2 Flow`
     .page(BASE_URL)
     .clientScripts('threeDS2.clientScripts.js')
     .requestHooks([loggerDetails, loggerSubmitThreeDS2]);
 
-test('Fill in card number that will trigger frictionless flow', async t => {
-    await start(t, 2000, TEST_SPEED);
+if (apiVersion >= 67) {
+    test('Fill in card number that will trigger frictionless flow', async t => {
+        await start(t, 2000, TEST_SPEED);
 
-    // Set handler for the alert window
-    await t.setNativeDialogHandler(() => true);
+        // Set handler for the alert window
+        await t.setNativeDialogHandler(() => true);
 
-    // Fill card fields
-    await cardUtils.fillCardNumber(t, THREEDS2_FRICTIONLESS_CARD);
-    await cardUtils.fillDateAndCVC(t);
+        // Fill card fields
+        await cardUtils.fillCardNumber(t, THREEDS2_FRICTIONLESS_CARD);
+        await cardUtils.fillDateAndCVC(t);
 
-    // Expect card to now be valid
-    await t.expect(getIsValid('dropin')).eql(true);
+        // Expect card to now be valid
+        await t.expect(getIsValid('dropin')).eql(true);
 
-    // Click pay
-    await t
-        .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
-        // Expect no errors
-        .expect(Selector('.adyen-checkout__field--error').exists)
-        .notOk()
-        // Allow time for the ONLY details call, which we expect to be successful
-        .wait(2000)
-        .expect(loggerDetails.contains(r => r.response.statusCode === 200))
-        .ok()
-        // Allow time for the alert to manifest
-        .wait(2000);
+        // Click pay
+        await t
+            .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
+            // Expect no errors
+            .expect(Selector('.adyen-checkout__field--error').exists)
+            .notOk()
+            // Allow time for the ONLY details call, which we expect to be successful
+            .wait(2000)
+            .expect(loggerDetails.contains(r => r.response.statusCode === 200))
+            .ok()
+            // Allow time for the alert to manifest
+            .wait(2000);
 
-    // Check the value of the alert text
-    const history = await t.getNativeDialogHistory();
-    await t.expect(history[0].text).eql('Authorised');
-});
+        // Check the value of the alert text
+        const history = await t.getNativeDialogHistory();
+        await t.expect(history[0].text).eql('Authorised');
+    });
 
-test('Fill in card number that will trigger full flow (fingerprint & challenge)', async t => {
-    loggerDetails.clear();
+    test('Fill in card number that will trigger full flow (fingerprint & challenge)', async t => {
+        loggerDetails.clear();
 
-    await start(t, 2000, TEST_SPEED);
+        await start(t, 2000, TEST_SPEED);
 
-    // Set handler for the alert window
-    await t.setNativeDialogHandler(() => true);
+        // Set handler for the alert window
+        await t.setNativeDialogHandler(() => true);
 
-    // Fill card fields
-    await cardUtils.fillCardNumber(t, THREEDS2_FULL_FLOW_CARD);
-    await cardUtils.fillDateAndCVC(t);
+        // Fill card fields
+        await cardUtils.fillCardNumber(t, THREEDS2_FULL_FLOW_CARD);
+        await cardUtils.fillDateAndCVC(t);
 
-    // Expect card to now be valid
-    await t.expect(getIsValid('dropin')).eql(true);
+        // Expect card to now be valid
+        await t.expect(getIsValid('dropin')).eql(true);
 
-    // Click pay
-    await t
-        .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
-        // Expect no errors
-        .expect(Selector('.adyen-checkout__field--error').exists)
-        .notOk()
-        // Allow time for the /submitThreeDS2Fingerprint call, which we expect to be successful
-        .wait(2000)
-        .expect(loggerSubmitThreeDS2.contains(r => r.response.statusCode === 200))
-        .ok();
+        // Click pay
+        await t
+            .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
+            // Expect no errors
+            .expect(Selector('.adyen-checkout__field--error').exists)
+            .notOk()
+            // Allow time for the /submitThreeDS2Fingerprint call, which we expect to be successful
+            .wait(2000)
+            .expect(loggerSubmitThreeDS2.contains(r => r.response.statusCode === 200))
+            .ok();
 
-    // console.log(logger.requests[0].response.headers);
+        // console.log(logger.requests[0].response.headers);
 
-    // Complete challenge
-    await fillChallengeField(t);
-    await submitChallenge(t);
+        // Complete challenge
+        await fillChallengeField(t);
+        await submitChallenge(t);
 
-    await t
-        // Allow time for the /details call, which we expect to be successful
-        .wait(2000)
-        .expect(loggerDetails.contains(r => r.response.statusCode === 200))
-        .ok()
-        .wait(1000);
+        await t
+            // Allow time for the /details call, which we expect to be successful
+            .wait(2000)
+            .expect(loggerDetails.contains(r => r.response.statusCode === 200))
+            .ok()
+            .wait(1000);
 
-    // console.log(logger.requests[1].response.headers);
+        // console.log(logger.requests[1].response.headers);
 
-    // Check the value of the alert text
-    const history = await t.getNativeDialogHistory();
-    await t.expect(history[0].text).eql('Authorised');
-});
+        // Check request body is in the expected form
+        //        const requestBodyBuffer = loggerDetails.requests[0].request.body;
+        //        const requestBody = JSON.parse(requestBodyBuffer);
+        //        console.log('### threeDS2.newFlow.test::loggerDetails.requests.length:: ', loggerDetails.requests.length);
+        //        console.log('### threeDS2.newFlow.test::requestBody:: ', requestBody);
+        //
+        //        await t
+        //            .expect(requestBody.details.threeDSResult)
+        //            .ok()
+        //            .expect(requestBody.paymentData)
+        //            .notOk();
 
-test('Fill in card number that will trigger challenge-only flow', async t => {
-    loggerDetails.clear();
+        // Check the value of the alert text
+        const history = await t.getNativeDialogHistory();
+        await t.expect(history[0].text).eql('Authorised');
+    });
 
-    await start(t, 2000, TEST_SPEED);
+    test('Fill in card number that will trigger challenge-only flow', async t => {
+        loggerDetails.clear();
 
-    // Set handler for the alert window
-    await t.setNativeDialogHandler(() => true);
+        await start(t, 2000, TEST_SPEED);
 
-    // Fill card fields
-    await cardUtils.fillCardNumber(t, THREEDS2_CHALLENGE_ONLY_CARD);
-    await cardUtils.fillDateAndCVC(t);
+        // Set handler for the alert window
+        await t.setNativeDialogHandler(() => true);
 
-    // Expect card to now be valid
-    await t.expect(getIsValid('dropin')).eql(true);
+        // Fill card fields
+        await cardUtils.fillCardNumber(t, THREEDS2_CHALLENGE_ONLY_CARD);
+        await cardUtils.fillDateAndCVC(t);
 
-    // Click pay
-    await t
-        .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
-        // Expect no errors
-        .expect(Selector('.adyen-checkout__field--error').exists)
-        .notOk();
+        // Expect card to now be valid
+        await t.expect(getIsValid('dropin')).eql(true);
 
-    // Complete challenge
-    await fillChallengeField(t);
-    await submitChallenge(t);
+        // Click pay
+        await t
+            .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
+            // Expect no errors
+            .expect(Selector('.adyen-checkout__field--error').exists)
+            .notOk();
 
-    await t
-        // Allow time for the ONLY details call, which we expect to be successful
-        .wait(2000)
-        .expect(loggerDetails.contains(r => r.response.statusCode === 200))
-        .ok()
-        .wait(2000);
+        // Complete challenge
+        await fillChallengeField(t);
+        await submitChallenge(t);
 
-    // Check the value of the alert text
-    const history = await t.getNativeDialogHistory();
-    await t.expect(history[0].text).eql('Authorised');
-});
+        await t
+            // Allow time for the ONLY details call, which we expect to be successful
+            .wait(2000)
+            .expect(loggerDetails.contains(r => r.response.statusCode === 200))
+            .ok()
+            .wait(2000);
+
+        // Check the value of the alert text
+        const history = await t.getNativeDialogHistory();
+        await t.expect(history[0].text).eql('Authorised');
+    });
+} else {
+    test(`Skip testing new 3DS2 flow since api version is too low (v${apiVersion})`, async t => {
+        await t.wait(250);
+    });
+}

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.oldFlow.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.oldFlow.test.js
@@ -14,8 +14,10 @@ const logger = RequestLogger(
     { url, method: 'post' },
     {
         logRequestBody: true,
+        //        stringifyRequestBody: true,
         logResponseHeaders: true,
         logResponseBody: true
+        //        stringifyResponseBody: true
     }
 );
 
@@ -89,10 +91,8 @@ if (apiVersion <= 66) {
              * Allow time for the FIRST details call, which we expect to be successful
              */
             .wait(1000)
-            .expect(logger.contains(r => r.response.statusCode === 200))
+            .expect(logger.contains(r => JSON.parse(r.request.body).details['threeds2.fingerprint'] && r.response.statusCode === 200))
             .ok();
-
-        // console.log(logger.requests[0].response.headers);
 
         // Complete challenge
         await fillChallengeField(t);
@@ -103,11 +103,9 @@ if (apiVersion <= 66) {
              * Allow time for the SECOND details call, which we expect to be successful
              */
             .wait(1000)
-            .expect(logger.contains(r => r.response.statusCode === 200))
+            .expect(logger.contains(r => JSON.parse(r.request.body).details['threeds2.challengeResult'] && r.response.statusCode === 200))
             .ok()
             .wait(2000);
-
-        //        console.log(logger.requests[1].request.body);
 
         // Check request body is in the expected form
         const requestBodyBuffer = logger.requests[1].request.body;

--- a/packages/e2e/tests/index.js
+++ b/packages/e2e/tests/index.js
@@ -16,8 +16,7 @@ const remote = process.argv.indexOf('--remote') > -1 || process.argv.indexOf('-r
             browser = remoteConnection;
         }
         const failedCount = await runner
-            //            .src(`${PATH}**/*.test.js`)
-            .src(`${PATH}**/threeDS2.**.test.js`)
+            .src(`${PATH}**/*.test.js`)
             .browsers(browser)
             .run();
 

--- a/packages/e2e/tests/index.js
+++ b/packages/e2e/tests/index.js
@@ -16,7 +16,8 @@ const remote = process.argv.indexOf('--remote') > -1 || process.argv.indexOf('-r
             browser = remoteConnection;
         }
         const failedCount = await runner
-            .src(`${PATH}**/*.test.js`)
+            //            .src(`${PATH}**/*.test.js`)
+            .src(`${PATH}**/threeDS2.**.test.js`)
             .browsers(browser)
             .run();
 

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -14,7 +14,7 @@ export interface ThreeDS2ChallengeProps {
     size?: string;
     challengeWindowSize?: '01' | '02' | '03' | '04' | '05';
     type?: string;
-    goesDirectToChallenge?: boolean;
+    useOriginalFlow?: boolean;
 }
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -12,7 +12,7 @@ export interface ThreeDS2DeviceFingerprintProps {
     paymentData: string;
     showSpinner: boolean;
     type: string;
-
+    useOriginalFlow?: boolean;
     loadingContext?: string;
     clientKey?: string;
     elementRef?: UIElement;
@@ -37,7 +37,12 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
             return null;
         }
 
-        return <DeviceFingerprint {...this.props} onComplete={this.callSubmit3DS2Fingerprint} />;
+        /**
+         * this.props.useOriginalFlow indicates the old 3DS2 flow.
+         * It means the call to create this component came from the old 'threeDS2Fingerprint' action and upon completion should call the /details endpoint
+         * instead of the new /submitThreeDS2Fingerprint endpoint
+         */
+        return <DeviceFingerprint {...this.props} onComplete={this.props.useOriginalFlow ? this.onComplete : this.callSubmit3DS2Fingerprint} />;
     }
 }
 

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -33,13 +33,11 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
     setStatusComplete(resultObj) {
         this.setState({ status: 'complete' }, () => {
             /**
-             * As we transition to switching to the new 3DS2 Flow and we are in a "hybrid" mode of old /payments response working with
-             * new /submitThreeDS2Fingerprint endpoint - the challenge-only flow skips the /submitThreeDS2Fingerprint call - so the resolveData needs
-             * to be prepared in the "old" way
-             *
-             * This situation will also apply to the threeds2InMDFlow TODO once fully switched to new flow - rename goesDirectToChallenge to threeds2InMDFlow
+             * Create the data in the way that the /details endpoint expects.
+             *  This is different for the 'old',v66, flow triggered by a 'threeDS2Challenge' action (which includes the threeds2InMDFlow)
+             *  than for the the new, v67, 'threeDS2' action
              */
-            const resolveDataFunction = this.props.goesDirectToChallenge ? createOldChallengeResolveData : createChallengeResolveData;
+            const resolveDataFunction = this.props.useOriginalFlow ? createOldChallengeResolveData : createChallengeResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj.transStatus, this.props.paymentData);
             this.props.onComplete(data);
         });

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -1,6 +1,6 @@
 import { Component, h } from 'preact';
 import DoFingerprint3DS2 from './DoFingerprint3DS2';
-import { createFingerprintResolveData, handleErrorCode, prepareFingerPrintData } from '../utils';
+import { createFingerprintResolveData, createOldFingerprintResolveData, handleErrorCode, prepareFingerPrintData } from '../utils';
 import { PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State } from './types';
 import { ResultObject } from '../../types';
 
@@ -45,7 +45,13 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
 
     setStatusComplete(resultObj: ResultObject) {
         this.setState({ status: 'complete' }, () => {
-            const data = createFingerprintResolveData(this.props.dataKey, resultObj, this.props.paymentData);
+            /**
+             * Create the data in the way that the endpoint expects:
+             *  - this will be the /details endpoint for the 'old', v66, flow triggered by a 'threeDS2Fingerprint' action
+             *  - and will be the /submitThreeDS2Fingerprint endpoint for the new, v67, 'threeDS2' action
+             */
+            const resolveDataFunction = this.props.useOriginalFlow ? createOldFingerprintResolveData : createFingerprintResolveData;
+            const data = resolveDataFunction(this.props.dataKey, resultObj, this.props.paymentData);
             this.props.onComplete(data);
         });
     }

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -123,13 +123,21 @@ export const createFingerprintResolveData = (dataKey: string, resultObj: ResultO
     }
 });
 
+// Old 3DS2 flow
+export const createOldFingerprintResolveData = (dataKey: string, resultObj: ResultObject, paymentData: string): any => ({
+    data: {
+        details: { 'threeds2.fingerprint': encodeObject(resultObj) },
+        paymentData
+    }
+});
+
 export const createChallengeResolveData = (dataKey: string, transStatus: string, authorisationToken: string): ChallengeResolveData => ({
     data: {
         details: { [dataKey]: encodeObject({ transStatus, authorisationToken }) }
     }
 });
 
-// Needed for old 3DS2 flow, new flow (challenge-only) & threeds2InMDFlow
+// Needed for old 3DS2 flow & threeds2InMDFlow
 export const createOldChallengeResolveData = (dataKey: string, transStatus: string, authorisationToken: string): any => ({
     data: {
         details: { 'threeds2.challengeResult': encodeObject({ transStatus }) },

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
@@ -11,7 +11,7 @@ export default function createIframe({ src, title = 'iframe element', policy = '
     // Commenting out stops the "The devicemotion events are blocked by feature policy" warning in Chrome >=66 that some merchant experienced
     // Commenting in stops the same warnings in development (??)
     if (process.env.NODE_ENV === 'development') {
-        iframeEl.setAttribute('allow', 'accelerometer, gyroscope');
+        iframeEl.setAttribute('allow', 'accelerometer; gyroscope');
     }
 
     const noIframeElContent = document.createTextNode('<p>Your browser does not support iframes.</p>');

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -21,7 +21,8 @@ const actionTypes = {
             ...props,
             type: 'IdentifyShopper',
             onComplete: props.onAdditionalDetails,
-            statusType: 'loading'
+            statusType: 'loading',
+            useOriginalFlow: true
         }),
 
     threeDS2Challenge: (action: PaymentAction, props) => {
@@ -35,7 +36,7 @@ const actionTypes = {
             isDropin: !!props.isDropin,
             type: 'ChallengeShopper',
             statusType: 'custom',
-            goesDirectToChallenge: true
+            useOriginalFlow: true
         });
     },
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Ensure that 3DS2 flows remain separate:
- if the initial `/payments` response returns a `threeDS2Fingerprint` action then we will stay in the "old" flow of making a `/details` call after the fingerprinting (which in the "full flow" scenario will lead to a `threeDS2Challenge` action and a second `/details` call)
- if the initial `/payments` response returns a `threeDS2` action then we will move into the new flow of making a `/submitThreeDS2Fingerprint ` call after the fingerprinting (which in the "full flow" scenario will lead to another `threeDS2` action culminating in a single `/details` call)

## Tested scenarios
Both scenarios work.
All unit tests pass.
All e2e tests for both scenarios pass.
The relevant 3DS2 e2e tests will run based on the API version
