### PR TITLE
Release 3.22.2

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -45,6 +45,6 @@
         "whatwg-fetch": "^3.5.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.22.1"
+        "@adyen/adyen-web": "3.22.2"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "umd:main": "dist/adyen.js",
     "types": "dist/types",
     "typings": "dist/types",
-    "version": "3.22.1",
+    "version": "3.22.2",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -47,6 +47,6 @@
         "whatwg-fetch": "^3.5.0"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.22.1"
+        "@adyen/adyen-web": "3.22.2"
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Fixes
The 3DS2 flows are kept separate #762
(This fixes the backwards compatibility issues with existing 3D Secure 2.0 integrations - see "Warning" on last 2 releases, `3.22.1` & `3.22.0`)

## Improvements
The phone input field labels have been improved for the Qiwi Wallet and MBWay components #756

## Required API version
Adyen Web v3.22.2 requires API v66 or later