### PR TITLE
Accept new Google Pay payment method type

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -37,7 +37,7 @@ class GooglePay extends UIElement<GooglePayProps> {
     formatData() {
         return {
             paymentMethod: {
-                type: GooglePay.type,
+                type: this.props.type ?? GooglePay.type,
                 ...this.state
             }
         };

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -22,6 +22,8 @@ export interface GooglePayPropsConfiguration {
 }
 
 export interface GooglePayProps extends UIElementProps {
+    type?: 'googlepay' | 'paywithgoogle';
+
     environment?: google.payments.api.Environment | string;
     configuration?: GooglePayPropsConfiguration;
 

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -118,6 +118,7 @@ const componentsMap = {
     payu_IN_cashcard: PayuCashcard,
     payu_IN_nb: PayuNetBanking,
     paywithgoogle: GooglePay,
+    googlepay: GooglePay,
     pix: Pix,
     qiwiwallet: QiwiWallet,
     ratepay: RatePay,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Accept the new Google Pay payment method type (`googlepay`) while maintaining compatibility with the current one (`paywithgoogle`).
