### PR TITLE
Select component updates

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
@@ -93,6 +93,7 @@ function Installments(props: InstallmentsProps) {
                         classNameModifiers={['revolving-plan-installments']}
                     >
                         {renderFormField('select', {
+                            filterable: false,
                             items: installmentOptions.values.map(installmentItemsMapper),
                             selected: installmentAmount,
                             onChange: onSelectInstallment,
@@ -108,6 +109,7 @@ function Installments(props: InstallmentsProps) {
         <div className="adyen-checkout__installments">
             <Field label={i18n.get('installments')} classNameModifiers={['installments']}>
                 {renderFormField('select', {
+                    filterable: false,
                     items: installmentOptions.values.map(installmentItemsMapper),
                     selected: installmentAmount,
                     onChange: onSelectInstallment,

--- a/packages/lib/src/components/internal/FormFields/Select/Select.module.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.module.scss
@@ -26,6 +26,28 @@
     transform: rotate(180deg);
 }
 
+.adyen-checkout__filter-input {
+    background: $color-white;
+    border: 0;
+    caret-color: $color-blue;
+    color: $color-black;
+    font-family: inherit;
+    font-size: $font-size-medium;
+    height: 100%;
+    padding: 0;
+    width: 100%;
+
+    &::placeholder {
+        color: $color-gray-dark;
+        font-weight: 200;
+    }
+
+    &:focus,
+    &:active {
+        outline: 0;
+    }
+}
+
 .adyen-checkout__dropdown__list {
     position: absolute;
     width: 100%;

--- a/packages/lib/src/components/internal/FormFields/Select/Select.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.scss
@@ -63,9 +63,10 @@
 }
 
 .adyen-checkout__dropdown__button__text {
-    white-space: nowrap;
     overflow: hidden;
+    pointer-events: none;
     text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .adyen-checkout__dropdown__list {

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import SelectButton from './components/SelectButton';
 import SelectList from './components/SelectList';
 import uuid from '../../../../utils/uuid';
+import { keys } from './constants';
 import { SelectItem, SelectProps } from './types';
 import styles from './Select.module.scss';
 import './Select.scss';
@@ -13,20 +14,11 @@ function Select(props: SelectProps) {
     const selectContainerRef = useRef(null);
     const toggleButtonRef = useRef(null);
     const selectListRef = useRef(null);
-    const firstUpdate = useRef(true);
     const [textFilter, setTextFilter] = useState<string>(null);
     const [showList, setShowList] = useState<boolean>(false);
     const selectListId: string = useMemo(() => `select-${uuid()}`, []);
 
     const active: SelectItem = props.items.find(i => i.id === props.selected) || ({} as SelectItem);
-
-    const keys = {
-        arrowDown: 'ArrowDown',
-        arrowUp: 'ArrowUp',
-        enter: 'Enter',
-        escape: 'Escape',
-        space: ' '
-    };
 
     /**
      * Closes the selectList, empties the text filter and focuses the button element
@@ -34,7 +26,7 @@ function Select(props: SelectProps) {
     const closeList = () => {
         setTextFilter(null);
         setShowList(false);
-        toggleButtonRef.current.focus();
+        if (toggleButtonRef.current) toggleButtonRef.current.focus();
     };
 
     /**
@@ -133,17 +125,12 @@ function Select(props: SelectProps) {
     };
 
     useEffect(() => {
-        if (firstUpdate.current) return;
-
-        if (showList && props.filterable) {
-            if (filterInputRef.current) filterInputRef.current.focus();
-        } else {
-            if (toggleButtonRef.current) toggleButtonRef.current.focus();
+        if (showList && props.filterable && filterInputRef.current) {
+            filterInputRef.current.focus();
         }
     }, [showList]);
 
     useEffect(() => {
-        firstUpdate.current = false;
         document.addEventListener('click', handleClickOutside, false);
 
         return () => {

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -1,217 +1,197 @@
-import { Component, h } from 'preact';
+import { h } from 'preact';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import cx from 'classnames';
+import SelectButton from './components/SelectButton';
+import SelectList from './components/SelectList';
+import uuid from '../../../../utils/uuid';
+import { SelectItem, SelectProps } from './types';
 import styles from './Select.module.scss';
 import './Select.scss';
-import { SelectProps, SelectState } from './types';
 
-class Select extends Component<SelectProps, SelectState> {
-    private selectContainer;
-    private toggleButton;
-    private dropdownList;
+function Select(props: SelectProps) {
+    const filterInputRef = useRef(null);
+    const selectContainerRef = useRef(null);
+    const toggleButtonRef = useRef(null);
+    const selectListRef = useRef(null);
+    const firstUpdate = useRef(true);
+    const [textFilter, setTextFilter] = useState<string>(null);
+    const [showList, setShowList] = useState<boolean>(false);
+    const selectListId: string = useMemo(() => `select-${uuid()}`, []);
 
-    public static defaultProps = {
-        items: [],
-        readonly: false,
-        onChange: () => {}
+    const active: SelectItem = props.items.find(i => i.id === props.selected) || ({} as SelectItem);
+
+    const keys = {
+        arrowDown: 'ArrowDown',
+        arrowUp: 'ArrowUp',
+        enter: 'Enter',
+        escape: 'Escape',
+        space: ' '
     };
 
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            toggleDropdown: false
-        };
-
-        this.toggle = this.toggle.bind(this);
-        this.select = this.select.bind(this);
-        this.closeDropdown = this.closeDropdown.bind(this);
-        this.handleButtonKeyDown = this.handleButtonKeyDown.bind(this);
-        this.handleClickOutside = this.handleClickOutside.bind(this);
-        this.handleKeyDown = this.handleKeyDown.bind(this);
-        this.handleOnError = this.handleOnError.bind(this);
-    }
-
-    componentDidMount() {
-        document.addEventListener('click', this.handleClickOutside, false);
-    }
-
-    componentWillUnmount() {
-        document.removeEventListener('click', this.handleClickOutside, false);
-    }
-
-    handleClickOutside(e) {
-        if (!this.selectContainer.contains(e.target)) {
-            this.setState({ toggleDropdown: false });
-        }
-    }
-
-    toggle(e) {
-        e.preventDefault();
-        this.setState({ toggleDropdown: !this.state.toggleDropdown });
-    }
-
-    select(e) {
-        e.preventDefault();
-
-        if (!e.currentTarget.getAttribute('data-disabled')) {
-            this.closeDropdown();
-            const value = e.currentTarget.getAttribute('data-value');
-            const name = this.props.name;
-            this.props.onChange({ target: { value, name } });
-        }
-    }
-
     /**
-     * Closes the dropdown and focuses the button element
+     * Closes the selectList, empties the text filter and focuses the button element
      */
-    closeDropdown() {
-        this.setState({ toggleDropdown: false }, () => this.toggleButton.focus());
-    }
+    const closeList = () => {
+        setTextFilter(null);
+        setShowList(false);
+        toggleButtonRef.current.focus();
+    };
 
     /**
-     * Handle keyDown events on the adyen-checkout__dropdown__element
-     * Navigates through the list, or select an element, or close the menu.
+     * Handle keyDown events on the selectList button
+     * Opens the selectList and focuses the first element if available
+     * @param e - KeyboardEvent
+     */
+    const handleButtonKeyDown = (e: KeyboardEvent) => {
+        if ([keys.arrowUp, keys.arrowDown, keys.enter].includes(e.key) || (e.key === keys.space && (!props.filterable || !showList))) {
+            e.preventDefault();
+            setShowList(true);
+            if (selectListRef.current?.firstElementChild) {
+                selectListRef.current.firstElementChild.focus();
+            }
+        }
+    };
+
+    /**
+     * Close the select list when clicking outside the list
+     * @param e - MouseEvent
+     */
+    const handleClickOutside = (e: MouseEvent) => {
+        if (!selectContainerRef.current.contains(e.target)) {
+            setShowList(false);
+        }
+    };
+
+    /**
+     * Handle keyDown events on the select button
+     * Navigates through the list, or select an element, or focus the filter intput, or close the menu.
      * @param e - KeyDownEvent
      */
-    handleKeyDown(e) {
-        switch (e.key) {
-            case 'Escape':
-                e.preventDefault();
-                this.setState({ toggleDropdown: false });
-                break;
-            case ' ': // space
-            case 'Enter':
-                this.select(e);
-                break;
-            case 'ArrowDown':
-                e.preventDefault();
-                if (e.target.nextElementSibling) e.target.nextElementSibling.focus();
-                break;
-            case 'ArrowUp':
-                e.preventDefault();
-                if (e.target.previousElementSibling) e.target.previousElementSibling.focus();
-                break;
-            default:
-        }
-    }
+    const handleListKeyDown = (e: KeyboardEvent) => {
+        const target = e.target as HTMLInputElement;
 
-    /**
-     * Handle keyDown events on the adyen-checkout__dropdown__button
-     * Opens the dropdownList and focuses the first element if available
-     * @param e - KeyDownEvent
-     */
-    handleButtonKeyDown(e) {
         switch (e.key) {
-            case 'ArrowUp':
-            case 'ArrowDown':
-            case ' ': // space
-            case 'Enter':
+            case keys.escape:
                 e.preventDefault();
-                this.setState({ toggleDropdown: true });
-                if (this.dropdownList?.firstElementChild) {
-                    this.dropdownList.firstElementChild.focus();
+                setShowList(false);
+                break;
+            case keys.space:
+            case keys.enter:
+                handleSelect(e);
+                break;
+            case keys.arrowDown:
+                e.preventDefault();
+                if (target.nextElementSibling) (target.nextElementSibling as HTMLElement).focus();
+                break;
+            case keys.arrowUp:
+                e.preventDefault();
+                if (target.previousElementSibling) {
+                    (target.previousElementSibling as HTMLElement).focus();
+                } else if (props.filterable && filterInputRef.current) {
+                    filterInputRef.current.focus();
                 }
                 break;
             default:
         }
-    }
+    };
 
-    handleOnError(e) {
-        e.target.style.cssText = 'display: none';
-    }
+    /**
+     * Closes the select list and fires an onChange
+     * @param e - Event
+     */
+    const handleSelect = (e: Event) => {
+        e.preventDefault();
+        const target = e.currentTarget as HTMLInputElement;
 
-    render({ className = '', classNameModifiers = [], isInvalid, items = [], placeholder, readonly, selected }, { toggleDropdown }) {
-        const active = items.find(i => i.id === selected) || {};
+        if (!target.getAttribute('data-disabled')) {
+            closeList();
+            const value = target.getAttribute('data-value');
+            props.onChange({ target: { value, name: props.name } });
+        }
+    };
 
-        return (
-            <div
-                className={cx([
-                    'adyen-checkout__dropdown',
-                    styles['adyen-checkout__dropdown'],
-                    className,
-                    ...classNameModifiers.map(m => `adyen-checkout__dropdown--${m}`)
-                ])}
-                ref={ref => {
-                    this.selectContainer = ref;
-                }}
-            >
-                <button
-                    type="button"
-                    className={cx([
-                        'adyen-checkout__dropdown__button',
-                        styles['adyen-checkout__dropdown__button'],
-                        {
-                            'adyen-checkout__dropdown__button--readonly': readonly,
-                            'adyen-checkout__dropdown__button--active': toggleDropdown,
-                            [styles['adyen-checkout__dropdown__button--active']]: toggleDropdown,
-                            'adyen-checkout__dropdown__button--invalid': isInvalid
-                        }
-                    ])}
-                    onClick={!readonly ? this.toggle : undefined}
-                    onKeyDown={!readonly ? this.handleButtonKeyDown : undefined}
-                    tabIndex={0}
-                    title={active.name || placeholder}
-                    aria-haspopup="listbox"
-                    aria-expanded={toggleDropdown}
-                    aria-disabled={readonly}
-                    ref={ref => {
-                        this.toggleButton = ref;
-                    }}
-                >
-                    <span className="adyen-checkout__dropdown__button__text">{active.selectedOptionName || active.name || placeholder}</span>
-                    {active.icon && (
-                        <img className="adyen-checkout__dropdown__button__icon" src={active.icon} alt={active.name} onError={this.handleOnError} />
-                    )}
-                </button>
+    /**
+     * Updates the state with the current text filter value
+     * @param e - KeyboardEvent
+     */
+    const handleTextFilter = (e: KeyboardEvent) => {
+        const value: string = (e.target as HTMLInputElement).value;
+        setTextFilter(value.toLowerCase());
+    };
 
-                <ul
-                    role="listbox"
-                    className={cx({
-                        'adyen-checkout__dropdown__list': true,
-                        [styles['adyen-checkout__dropdown__list']]: true,
-                        'adyen-checkout__dropdown__list--active': toggleDropdown,
-                        [styles['adyen-checkout__dropdown__list--active']]: toggleDropdown
-                    })}
-                    ref={ref => {
-                        this.dropdownList = ref;
-                    }}
-                >
-                    {items.map(item => (
-                        <li
-                            key={item.id}
-                            role="option"
-                            tabIndex={-1}
-                            aria-selected={item.id === active.id}
-                            aria-disabled={!!item.disabled}
-                            className={cx([
-                                'adyen-checkout__dropdown__element',
-                                styles['adyen-checkout__dropdown__element'],
-                                {
-                                    'adyen-checkout__dropdown__element--active': item.id === active.id,
-                                    'adyen-checkout__dropdown__element--disabled': !!item.disabled
-                                }
-                            ])}
-                            data-value={item.id}
-                            data-disabled={!!item.disabled}
-                            onClick={this.select}
-                            onKeyDown={this.handleKeyDown}
-                        >
-                            <span>{item.name}</span>
+    /**
+     * Toggles the selectList and focuses in either the filter input or in the selectList button
+     * @param e - Event
+     */
+    const toggleList = (e: Event) => {
+        e.preventDefault();
+        setShowList(!showList);
+    };
 
-                            {item.icon && (
-                                <img
-                                    className="adyen-checkout__dropdown__element__icon"
-                                    alt={item.name}
-                                    src={item.icon}
-                                    onError={this.handleOnError}
-                                />
-                            )}
-                        </li>
-                    ))}
-                </ul>
-            </div>
-        );
-    }
+    useEffect(() => {
+        if (firstUpdate.current) return;
+
+        if (showList && props.filterable) {
+            if (filterInputRef.current) filterInputRef.current.focus();
+        } else {
+            if (toggleButtonRef.current) toggleButtonRef.current.focus();
+        }
+    }, [showList]);
+
+    useEffect(() => {
+        firstUpdate.current = false;
+        document.addEventListener('click', handleClickOutside, false);
+
+        return () => {
+            document.removeEventListener('click', handleClickOutside, false);
+        };
+    }, []);
+
+    return (
+        <div
+            className={cx([
+                'adyen-checkout__dropdown',
+                styles['adyen-checkout__dropdown'],
+                props.className,
+                ...props.classNameModifiers.map(m => `adyen-checkout__dropdown--${m}`)
+            ])}
+            ref={selectContainerRef}
+        >
+            <SelectButton
+                active={active}
+                filterInputRef={filterInputRef}
+                filterable={props.filterable}
+                isInvalid={props.isInvalid}
+                onButtonKeyDown={handleButtonKeyDown}
+                onInput={handleTextFilter}
+                placeholder={props.placeholder}
+                readonly={props.readonly}
+                selectListId={selectListId}
+                showList={showList}
+                toggleButtonRef={toggleButtonRef}
+                toggleList={toggleList}
+            />
+            <SelectList
+                active={active}
+                items={props.items}
+                onKeyDown={handleListKeyDown}
+                onSelect={handleSelect}
+                selectListId={selectListId}
+                selectListRef={selectListRef}
+                showList={showList}
+                textFilter={textFilter}
+            />
+        </div>
+    );
 }
+
+Select.defaultProps = {
+    className: '',
+    classNameModifiers: [],
+    filterable: true,
+    items: [],
+    readonly: false,
+    onChange: () => {}
+};
 
 export default Select;

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -43,7 +43,9 @@ function Select(props: SelectProps) {
      * @param e - KeyboardEvent
      */
     const handleButtonKeyDown = (e: KeyboardEvent) => {
-        if ([keys.arrowUp, keys.arrowDown, keys.enter].includes(e.key) || (e.key === keys.space && (!props.filterable || !showList))) {
+        if (e.key === keys.enter && props.filterable && showList && textFilter) {
+            handleSelect(e);
+        } else if ([keys.arrowUp, keys.arrowDown, keys.enter].includes(e.key) || (e.key === keys.space && (!props.filterable || !showList))) {
             e.preventDefault();
             setShowList(true);
             if (selectListRef.current?.firstElementChild) {
@@ -101,7 +103,9 @@ function Select(props: SelectProps) {
      */
     const handleSelect = (e: Event) => {
         e.preventDefault();
-        const target = e.currentTarget as HTMLInputElement;
+
+        // If the target is not one of the list items, select the first list item
+        const target: HTMLInputElement = selectListRef.current.contains(e.currentTarget) ? e.currentTarget : selectListRef.current.firstElementChild;
 
         if (!target.getAttribute('data-disabled')) {
             closeList();

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -4,50 +4,18 @@ import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { SelectButtonProps } from '../types';
 import styles from '../Select.module.scss';
 
+function SelectButtonElement({ filterable, ...props }) {
+    if (filterable) return <div {...props} />;
+
+    return <button {...props} />;
+}
+
 function SelectButton(props: SelectButtonProps) {
     const { i18n } = useCoreContext();
     const { active, readonly, showList } = props;
 
-    if (props.filterable) {
-        return (
-            <div
-                aria-autocomplete="list"
-                aria-controls={props.selectListId}
-                aria-disabled={readonly}
-                aria-expanded={showList}
-                aria-haspopup="listbox"
-                className={cx({
-                    'adyen-checkout__dropdown__button': true,
-                    [styles['adyen-checkout__dropdown__button']]: true,
-                    'adyen-checkout__dropdown__button--readonly': readonly,
-                    'adyen-checkout__dropdown__button--active': showList,
-                    [styles['adyen-checkout__dropdown__button--active']]: showList,
-                    'adyen-checkout__dropdown__button--invalid': props.isInvalid
-                })}
-                onClick={!readonly ? props.toggleList : null}
-                onKeyDown={!readonly ? props.onButtonKeyDown : null}
-                ref={props.toggleButtonRef}
-                role="combobox"
-                tabIndex={0}
-                title={active.name || props.placeholder}
-            >
-                {!showList ? (
-                    <Fragment>{active.name || props.placeholder}</Fragment>
-                ) : (
-                    <input
-                        className={cx('adyen-checkout__filter-input', [styles['adyen-checkout__filter-input']])}
-                        onInput={props.onInput}
-                        placeholder={i18n.get('select.filter.placeholder')}
-                        ref={props.filterInputRef}
-                        type="text"
-                    />
-                )}
-            </div>
-        );
-    }
-
     return (
-        <button
+        <SelectButtonElement
             aria-disabled={readonly}
             aria-expanded={showList}
             aria-haspopup="listbox"
@@ -59,15 +27,36 @@ function SelectButton(props: SelectButtonProps) {
                 [styles['adyen-checkout__dropdown__button--active']]: showList,
                 'adyen-checkout__dropdown__button--invalid': props.isInvalid
             })}
+            filterable={props.filterable}
             onClick={!readonly ? props.toggleList : null}
             onKeyDown={!readonly ? props.onButtonKeyDown : null}
             ref={props.toggleButtonRef}
+            role={props.filterable ? 'button' : null}
             tabIndex={0}
             title={active.name || props.placeholder}
+            type={!props.filterable ? 'button' : null}
         >
-            <span className="adyen-checkout__dropdown__button__text">{active.selectedOptionName || active.name || props.placeholder}</span>
-            {active.icon && <img className="adyen-checkout__dropdown__button__icon" src={active.icon} alt={active.name} />}
-        </button>
+            {!showList || !props.filterable ? (
+                <Fragment>
+                    <span className="adyen-checkout__dropdown__button__text">{active.selectedOptionName || active.name || props.placeholder}</span>
+                    {active.icon && <img className="adyen-checkout__dropdown__button__icon" src={active.icon} alt={active.name} />}
+                </Fragment>
+            ) : (
+                <input
+                    aria-autocomplete="list"
+                    aria-controls={props.selectListId}
+                    aria-expanded={showList}
+                    aria-owns={props.selectListId}
+                    autoComplete="off"
+                    className={cx('adyen-checkout__filter-input', [styles['adyen-checkout__filter-input']])}
+                    onInput={props.onInput}
+                    placeholder={i18n.get('select.filter.placeholder')}
+                    ref={props.filterInputRef}
+                    role="combobox"
+                    type="text"
+                />
+            )}
+        </SelectButtonElement>
     );
 }
 export default SelectButton;

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -1,0 +1,74 @@
+import { h } from 'preact';
+import { Fragment } from 'preact';
+import cx from 'classnames';
+import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { SelectButtonProps } from '../types';
+import styles from '../Select.module.scss';
+
+function SelectButton(props: SelectButtonProps) {
+    const { i18n } = useCoreContext();
+    const { active, readonly, showList } = props;
+
+    if (props.filterable) {
+        return (
+            <div
+                aria-autocomplete="list"
+                aria-controls={props.selectListId}
+                aria-disabled={readonly}
+                aria-expanded={showList}
+                aria-haspopup="listbox"
+                className={cx({
+                    'adyen-checkout__dropdown__button': true,
+                    [styles['adyen-checkout__dropdown__button']]: true,
+                    'adyen-checkout__dropdown__button--readonly': readonly,
+                    'adyen-checkout__dropdown__button--active': showList,
+                    [styles['adyen-checkout__dropdown__button--active']]: showList,
+                    'adyen-checkout__dropdown__button--invalid': props.isInvalid
+                })}
+                onClick={!readonly ? props.toggleList : null}
+                onKeyDown={!readonly ? props.onButtonKeyDown : null}
+                ref={props.toggleButtonRef}
+                role="combobox"
+                tabIndex={0}
+                title={active.name || props.placeholder}
+            >
+                {!showList ? (
+                    <Fragment>{active.name || props.placeholder}</Fragment>
+                ) : (
+                    <input
+                        className={cx('adyen-checkout__filter-input', [styles['adyen-checkout__filter-input']])}
+                        onInput={props.onInput}
+                        placeholder={i18n.get('select.filter.placeholder')}
+                        ref={props.filterInputRef}
+                        type="text"
+                    />
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <button
+            aria-disabled={readonly}
+            aria-expanded={showList}
+            aria-haspopup="listbox"
+            className={cx({
+                'adyen-checkout__dropdown__button': true,
+                [styles['adyen-checkout__dropdown__button']]: true,
+                'adyen-checkout__dropdown__button--readonly': readonly,
+                'adyen-checkout__dropdown__button--active': showList,
+                [styles['adyen-checkout__dropdown__button--active']]: showList,
+                'adyen-checkout__dropdown__button--invalid': props.isInvalid
+            })}
+            onClick={!readonly ? props.toggleList : null}
+            onKeyDown={!readonly ? props.onButtonKeyDown : null}
+            ref={props.toggleButtonRef}
+            tabIndex={0}
+            title={active.name || props.placeholder}
+        >
+            <span className="adyen-checkout__dropdown__button__text">{active.selectedOptionName || active.name || props.placeholder}</span>
+            {active.icon && <img className="adyen-checkout__dropdown__button__icon" src={active.icon} alt={active.name} />}
+        </button>
+    );
+}
+export default SelectButton;

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -1,5 +1,4 @@
-import { h } from 'preact';
-import { Fragment } from 'preact';
+import { h, Fragment } from 'preact';
 import cx from 'classnames';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { SelectButtonProps } from '../types';

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
@@ -1,0 +1,44 @@
+import { h } from 'preact';
+import cx from 'classnames';
+import SelectListItem from './SelectListItem';
+import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { SelectListProps } from '../types';
+import styles from '../Select.module.scss';
+
+function SelectList({ active, items, showList, textFilter, ...props }: SelectListProps) {
+    const { i18n } = useCoreContext();
+    const filteredItems = items.filter(item => !textFilter || item.name.toLowerCase().includes(textFilter));
+
+    return (
+        <ul
+            className={cx({
+                test: true,
+                'adyen-checkout__dropdown__list': true,
+                [styles['adyen-checkout__dropdown__list']]: true,
+                'adyen-checkout__dropdown__list--active': showList,
+                [styles['adyen-checkout__dropdown__list--active']]: showList
+            })}
+            id={props.selectListId}
+            ref={props.selectListRef}
+            role="listbox"
+        >
+            {filteredItems.length ? (
+                filteredItems.map(item => (
+                    <SelectListItem
+                        item={item}
+                        key={item.id}
+                        onKeyDown={props.onKeyDown}
+                        onSelect={props.onSelect}
+                        selected={item.id === active.id}
+                    />
+                ))
+            ) : (
+                <div className="adyen-checkout__dropdown__element adyen-checkout__dropdown__element--no-options">
+                    {i18n.get('select.noOptionsFound')}
+                </div>
+            )}
+        </ul>
+    );
+}
+
+export default SelectList;

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectListItem.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectListItem.tsx
@@ -1,0 +1,30 @@
+import { h } from 'preact';
+import cx from 'classnames';
+import { SelectItemProps } from '../types';
+import styles from '../Select.module.scss';
+
+const SelectListItem = ({ item, selected, ...props }: SelectItemProps) => (
+    <li
+        aria-disabled={!!item.disabled}
+        aria-selected={selected}
+        className={cx([
+            'adyen-checkout__dropdown__element',
+            styles['adyen-checkout__dropdown__element'],
+            {
+                'adyen-checkout__dropdown__element--active': selected,
+                'adyen-checkout__dropdown__element--disabled': !!item.disabled
+            }
+        ])}
+        data-disabled={!!item.disabled}
+        data-value={item.id}
+        onClick={props.onSelect}
+        onKeyDown={props.onKeyDown}
+        role="option"
+        tabIndex={-1}
+    >
+        <span>{item.name}</span>
+        {item.icon && <img className="adyen-checkout__dropdown__element__icon" alt={item.name} src={item.icon} />}
+    </li>
+);
+
+export default SelectListItem;

--- a/packages/lib/src/components/internal/FormFields/Select/constants.ts
+++ b/packages/lib/src/components/internal/FormFields/Select/constants.ts
@@ -1,0 +1,7 @@
+export const keys = {
+    arrowDown: 'ArrowDown',
+    arrowUp: 'ArrowUp',
+    enter: 'Enter',
+    escape: 'Escape',
+    space: ' '
+};

--- a/packages/lib/src/components/internal/FormFields/Select/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Select/types.ts
@@ -1,21 +1,53 @@
-interface SelectItem {
+export interface SelectItem {
+    disabled?: boolean;
+    icon?: string;
     id: string;
     name: string;
-    icon?: string;
+    selectedOptionName?: string;
 }
 
 export interface SelectProps {
     className: string;
     classNameModifiers: string[];
+    filterable: boolean;
     isInvalid: boolean;
     items: SelectItem[];
+    name?: string;
     onChange: (e) => void;
     placeholder: string;
     readonly: boolean;
     selected: string;
-    name?: string;
 }
 
-export interface SelectState {
-    toggleDropdown: boolean;
+export interface SelectButtonProps {
+    active: SelectItem;
+    filterInputRef;
+    filterable: boolean;
+    isInvalid: boolean;
+    onButtonKeyDown: (e: KeyboardEvent) => void;
+    onInput: (e: Event) => void;
+    placeholder: string;
+    readonly: boolean;
+    selectListId: string;
+    showList: boolean;
+    toggleButtonRef;
+    toggleList: (e: Event) => void;
+}
+
+export interface SelectListProps {
+    active: SelectItem;
+    items: SelectItem[];
+    onKeyDown: (e: KeyboardEvent) => void;
+    onSelect: (e: Event) => void;
+    selectListId: string;
+    selectListRef;
+    showList: boolean;
+    textFilter: string;
+}
+
+export interface SelectItemProps {
+    item: SelectItem;
+    selected: boolean;
+    onKeyDown: (e: KeyboardEvent) => void;
+    onSelect: (e: Event) => void;
 }

--- a/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
@@ -49,6 +49,7 @@ export function PhoneInput(props) {
                             <Field inputWrapperModifiers={['phoneInput']}>
                                 {renderFormField('select', {
                                     className: 'adyen-checkout__dropdown--small adyen-checkout__countryFlag',
+                                    filterable: false,
                                     items: props.items,
                                     name: props.prefixName,
                                     onChange: handleChangeFor('phonePrefix'),

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -135,6 +135,8 @@
     "select.stateOrProvince": "Select state or province",
     "select.provinceOrTerritory": "Select province or territory",
     "select.country": "Select country",
+    "select.noOptionsFound": "No options found",
+    "select.filter.placeholder": "Search...",
     "telephoneNumber.invalid": "Invalid telephone number",
     "qrCodeOrApp": "or",
     "paypal.processingPayment": "Processing payment...",


### PR DESCRIPTION
## Summary
- Make it possible to filter options in the Select component
- Update component to use hooks.
- Filterable lists will be the new default behaviour.
- Added strings:
```
"select.noOptionsFound": "No options found"
"select.filter.placeholder": "Search..."
```

## Tested scenarios
Both filterable and non filterable lists.

**Fixed issue**:  Adyen/adyen-web#725
