### PR TITLE
Release 3.23.0

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -45,6 +45,6 @@
         "whatwg-fetch": "^3.6.1"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.22.2"
+        "@adyen/adyen-web": "3.23.0"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "umd:main": "dist/adyen.js",
     "types": "dist/types",
     "typings": "dist/types",
-    "version": "3.22.2",
+    "version": "3.23.0",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -47,6 +47,6 @@
         "whatwg-fetch": "^3.6.1"
     },
     "dependencies": {
-        "@adyen/adyen-web": "3.22.2"
+        "@adyen/adyen-web": "3.23.0"
     }
 }


### PR DESCRIPTION
## Improvements
* Amazon Pay now supports the `cancelUrl` configuration property and the `submit()` method (#778)
* Improved support for Gift cards with a transaction limit (#561)

## Required API version
Adyen Web 3.23.0 requires API v66 or later.

