### PR TITLE
Delay conversion id creation

### DIFF
--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -17,28 +17,20 @@ class Analytics {
     private readonly logEvent;
     private readonly logTelemetry;
     private readonly queue = new EventsQueue();
+    public readonly collectId;
 
     constructor({ loadingContext, locale, clientKey, analytics }: CoreOptions) {
         this.props = { ...Analytics.defaultProps, ...analytics };
         this.logEvent = logEvent({ loadingContext, locale });
         this.logTelemetry = postTelemetry({ loadingContext, locale, clientKey });
+        this.collectId = collectId({ loadingContext, clientKey });
 
         const { conversion, enabled } = this.props;
-
-        if (conversion && enabled) {
+        if (conversion === true && enabled === true) {
             if (this.props.conversionId) {
+                // handle prefilled conversionId
                 this.conversionId = this.props.conversionId;
                 this.queue.run(this.conversionId);
-            } else {
-                // If no conversionId is provided, fetch a new one
-                collectId({ loadingContext, clientKey })
-                    .then(conversionId => {
-                        this.conversionId = conversionId;
-                        this.queue.run(this.conversionId);
-                    })
-                    .catch(() => {
-                        this.queue.run();
-                    });
             }
         }
     }
@@ -47,6 +39,14 @@ class Analytics {
         const { conversion, enabled, telemetry } = this.props;
 
         if (enabled === true) {
+            if (conversion === true && !this.conversionId) {
+                // fetch a new conversionId if none is already available
+                this.collectId().then(conversionId => {
+                    this.conversionId = conversionId;
+                    this.queue.run(this.conversionId);
+                });
+            }
+
             if (telemetry === true) {
                 const telemetryTask = conversionId => this.logTelemetry({ ...event, conversionId }).catch(() => {});
                 this.queue.add(telemetryTask);

--- a/packages/lib/src/core/Services/collect-id.ts
+++ b/packages/lib/src/core/Services/collect-id.ts
@@ -3,18 +3,27 @@ import { httpPost } from './http';
 /**
  * Log event to Adyen
  * @param config - ready to be serialized and included in the body of request
- * @returns a promise containing the response of the call
+ * @returns a function returning a promise containing the response of the call
  */
-const collectId = config => {
-    if (!config.clientKey) return Promise.reject();
+const collectId = ({ loadingContext, clientKey }) => {
+    let promise;
 
     const options = {
         errorLevel: 'silent' as const,
-        loadingContext: config.loadingContext,
-        path: `v1/analytics/id?clientKey=${config.clientKey}`
+        loadingContext: loadingContext,
+        path: `v1/analytics/id?clientKey=${clientKey}`
     };
 
-    return httpPost(options).then(conversion => conversion.id);
+    return () => {
+        if (promise) return promise;
+        if (!clientKey) return Promise.reject();
+
+        promise = httpPost(options)
+            .then(conversion => conversion?.id)
+            .catch(() => {});
+
+        return promise;
+    };
 };
 
 export default collectId;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Delays fetching the `conversionId` on the Analytics module until the first telemetry call.

## Tested scenarios
- Creating a new `AdyenCheckout` instance does not call the `conversionId` endpoint
- Mounting a component prompts a `conversionId` call.
- If called multiple times, conversionId is only fetched once.
