### PR TITLE
fixed failing e2e tests that used RequestMock

### DIFF
--- a/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.hidden.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.hidden.test.js
@@ -33,7 +33,9 @@ const mockedResponse = {
 };
 
 const mock = RequestMock()
-    .onRequestTo(requestURL)
+    .onRequestTo(request => {
+        return request.url === requestURL && request.method === 'post';
+    })
     .respond(
         (req, res) => {
             const body = JSON.parse(req.body);

--- a/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.optional.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.optional.test.js
@@ -33,7 +33,9 @@ const mockedResponse = {
 };
 
 const mock = RequestMock()
-    .onRequestTo(requestURL)
+    .onRequestTo(request => {
+        return request.url === requestURL && request.method === 'post';
+    })
     .respond(
         (req, res) => {
             const body = JSON.parse(req.body);

--- a/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.expiryDate.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.expiryDate.test.js
@@ -32,7 +32,9 @@ const mockedResponse = {
 };
 
 const mock = RequestMock()
-    .onRequestTo(requestURL)
+    .onRequestTo(request => {
+        return request.url === requestURL && request.method === 'post';
+    })
     .respond(
         (req, res) => {
             const body = JSON.parse(req.body);
@@ -56,7 +58,7 @@ fixture`Testing a PLCC, as detected by a mock/binLookup, for a response that sho
     .clientScripts('plcc.clientScripts.js')
     .requestHooks(mock);
 
-test('Test plcc card hides date field ', async t => {
+test('Test plcc card hides date field ' + 'then complete date and see card is valid ' + ' then delete card number and see card reset', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 

--- a/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.luhn.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.luhn.test.js
@@ -30,7 +30,9 @@ const mockedResponse = {
 };
 
 const mock = RequestMock()
-    .onRequestTo(requestURL)
+    .onRequestTo(request => {
+        return request.url === requestURL && request.method === 'post';
+    })
     .respond(
         (req, res) => {
             const body = JSON.parse(req.body);

--- a/packages/e2e/tests/cards/utils/constants.js
+++ b/packages/e2e/tests/cards/utils/constants.js
@@ -3,7 +3,7 @@ export const REGULAR_TEST_CARD = '5500000000000004';
 export const DUAL_BRANDED_CARD = '4035501000000008'; // dual branded visa & cartebancaire
 export const MAESTRO_CARD = '5000550000000029';
 export const BCMC_CARD = '6703444444444449'; // actually dual branded bcmc & maestro
-export const UNKNOWN_BIN_CARD = '1354 1001 4004 955'; // card that is not in the test DBs (uatp)
+export const UNKNOWN_BIN_CARD = '135410014004955'; // card that is not in the test DBs (uatp)
 
 export const FAILS_LUHN_CARD = '4111111111111112';
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The tests that used `RequestMock` started to fail - so added a predicate function on the `onRequestTo` method

## Tested scenarios
All tests pass
