### PR TITLE
Differentiate card from custom-card

### DIFF
--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -101,7 +101,7 @@ class BaseElement<P extends BaseElementProps> {
         if (this.props.modules && this.props.modules.analytics && !this.props.isDropin) {
             this.props.modules.analytics.send({
                 containerWidth: this._node && this._node.offsetWidth,
-                component: this.constructor['type'],
+                component: this.constructor['analyticsType'] ?? this.constructor['type'],
                 flavor: 'components'
             });
         }

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -6,7 +6,8 @@ import collectBrowserInfo from '../../utils/browserInfo';
 import getImage from '../../utils/get-image';
 
 export class SecuredFieldsElement extends UIElement {
-    public static type = 'custom-scheme';
+    public static type = 'scheme';
+    public static analyticsType = 'custom-scheme';
 
     formatProps(props) {
         return {
@@ -22,7 +23,7 @@ export class SecuredFieldsElement extends UIElement {
     formatData() {
         return {
             paymentMethod: {
-                type: 'scheme',
+                type: SecuredFieldsElement.type,
                 ...this.state.data
             },
             browserInfo: this.browserInfo

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -22,7 +22,7 @@ export class SecuredFieldsElement extends UIElement {
     formatData() {
         return {
             paymentMethod: {
-                type: SecuredFieldsElement.type,
+                type: 'scheme',
                 ...this.state.data
             },
             browserInfo: this.browserInfo

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -6,7 +6,7 @@ import collectBrowserInfo from '../../utils/browserInfo';
 import getImage from '../../utils/get-image';
 
 export class SecuredFieldsElement extends UIElement {
-    public static type = 'scheme';
+    public static type = 'custom-scheme';
 
     formatProps(props) {
         return {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Card component and custom card component now use a different static `type` property.
This will allow any analytics to differentiate between the two.

## Tested scenarios
Checked with relevant people in the analytics team that this will not affect existing dashboards and made sure they are aware of this change.
Reply:
> "There’s currently no logic taking this value explicitly into account, so it would just show up as another group by value in any of the dashboards"
