### PR TITLE
Remove "unrecognised card" warning 

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
@@ -93,15 +93,6 @@ export function createCardSecuredFields(securedFields: HTMLElement[]): number {
 
             this.securityCode = card.securityCode;
         }
-    } else {
-        // Check passed cardGroupTypes
-        this.config.cardGroupTypes.forEach(pItem => {
-            if (!existy(cardType.getCardByBrand(pItem))) {
-                logger.warn(
-                    `WARNING: The passed cardGroupType item "${pItem}" is not recognised by SecuredFields. This may affect whether it will be possible to process this payment.`
-                );
-            }
-        });
     }
 
     // Create a new SecuredField for each detected holding element


### PR DESCRIPTION
…t recognised by our regEx

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Remove "unrecognised card" warning (`console.warn`) when brands array contains type not recognised by our regEx.
In the light of `/binLookup` this warning is no longer relevant