### PR TITLE
Unify cvcRequired & hideCVCForBrand props under a single cvcPolicy prop

### DIFF
--- a/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.hidden.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.hidden.test.js
@@ -90,13 +90,6 @@ test('Test card has hidden cvc field ' + 'then complete date and see card is val
 
         // hidden cvc field
         .expect(cvcSpan.filterHidden().exists)
-        .ok()
-
-        // with "optional" text // TODO - currently passes but this should change once we pass cvcPolicy to the CVC component
-        .expect(cvcLabel.withExactText('CVC / CVV (optional)').exists)
-        .ok()
-        // and optional class
-        .expect(optionalCVCSpan.exists)
         .ok();
 
     // Fill date

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -61,7 +61,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                 }
             }),
             isValid: false,
-            hideCVCForBrand: false,
+            cvcPolicy: CVC_POLICY_REQUIRED,
             hideDateForBrand: false,
             focusedElement: '',
             additionalSelectElements: [],
@@ -98,7 +98,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
             prevState.storePaymentMethod !== this.state.storePaymentMethod ||
             !objectsDeepEqual(prevState.installments, this.state.installments) ||
             prevState.isSfpValid !== this.state.isSfpValid ||
-            prevState.hideCVCForBrand !== this.state.hideCVCForBrand ||
+            prevState.cvcPolicy !== this.state.cvcPolicy ||
             prevState.hideDateForBrand !== this.state.hideDateForBrand ||
             prevState.brand !== this.state.brand ||
             prevState.additionalSelectValue !== this.state.additionalSelectValue ||
@@ -160,7 +160,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
 
     render(
         { countryCode, loadingContext, hasHolderName, hasCVC, installmentOptions, enableStoreDetails, showInstallmentAmounts },
-        { status, hideCVCForBrand, hideDateForBrand, focusedElement, issuingCountryCode }
+        { status, cvcPolicy, hideDateForBrand, focusedElement, issuingCountryCode }
     ) {
         const hasInstallments = !!Object.keys(installmentOptions).length;
 
@@ -194,11 +194,10 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                             <LoadingWrapper status={sfpState.status}>
                                 <StoredCardFields
                                     {...this.props}
-                                    cvcRequired={sfpState.cvcPolicy === CVC_POLICY_REQUIRED}
                                     errors={sfpState.errors}
                                     brand={sfpState.brand}
                                     hasCVC={hasCVC}
-                                    hideCVCForBrand={hideCVCForBrand}
+                                    cvcPolicy={cvcPolicy}
                                     onFocusField={setFocusOn}
                                     focusedElement={focusedElement}
                                     status={sfpState.status}
@@ -223,11 +222,10 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                                     focusedElement={focusedElement}
                                     onFocusField={setFocusOn}
                                     hasCVC={hasCVC}
-                                    hideCVCForBrand={hideCVCForBrand}
+                                    cvcPolicy={cvcPolicy}
                                     hideDateForBrand={hideDateForBrand}
                                     errors={sfpState.errors}
                                     valid={sfpState.valid}
-                                    cvcRequired={sfpState.cvcPolicy === CVC_POLICY_REQUIRED}
                                     dualBrandingElements={this.state.additionalSelectElements.length > 0 && this.state.additionalSelectElements}
                                     dualBrandingChangeHandler={this.handleAdditionalDataSelection}
                                     dualBrandingSelected={this.state.additionalSelectValue}

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -5,6 +5,7 @@ import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { CVCProps } from './types';
 import styles from '../CardInput.module.scss';
+import { CVC_POLICY_HIDDEN, CVC_POLICY_OPTIONAL, CVC_POLICY_REQUIRED } from '../../../../internal/SecuredFields/lib/configuration/constants';
 
 export default function CVC(props: CVCProps) {
     const {
@@ -17,15 +18,14 @@ export default function CVC(props: CVCProps) {
         filled,
         isValid,
         frontCVC = false,
-        hideCVCForBrand = false,
-        cvcRequired = true
+        cvcPolicy = CVC_POLICY_REQUIRED
     } = props;
     const { i18n } = useCoreContext();
 
     const fieldClassnames = classNames(className, {
         'adyen-checkout__field__cvc': true,
-        [styles['adyen-checkout__card__cvc__input--hidden']]: hideCVCForBrand,
-        'adyen-checkout__field__cvc--optional': !cvcRequired
+        [styles['adyen-checkout__card__cvc__input--hidden']]: cvcPolicy === CVC_POLICY_HIDDEN,
+        'adyen-checkout__field__cvc--optional': cvcPolicy === CVC_POLICY_OPTIONAL
     });
 
     const cvcClassnames = classNames({
@@ -38,7 +38,7 @@ export default function CVC(props: CVCProps) {
         [styles['adyen-checkout__input']]: true
     });
 
-    const fieldLabel = cvcRequired ? label : i18n.get('creditCard.cvcField.title.optional');
+    const fieldLabel = cvcPolicy !== CVC_POLICY_OPTIONAL ? label : i18n.get('creditCard.cvcField.title.optional');
 
     return (
         <Field

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
@@ -9,14 +9,13 @@ import styles from '../CardInput.module.scss';
 
 export default function CardFields({
     brand,
-    cvcRequired,
     dualBrandingElements,
     dualBrandingChangeHandler,
     dualBrandingSelected,
     errors,
     focusedElement,
     hasCVC,
-    hideCVCForBrand,
+    cvcPolicy,
     hideDateForBrand,
     onFocusField,
     showBrandIcon,
@@ -58,10 +57,9 @@ export default function CardFields({
 
                 {hasCVC && (
                     <CVC
-                        cvcRequired={cvcRequired}
                         error={errors.encryptedSecurityCode}
                         focused={focusedElement === 'encryptedSecurityCode'}
-                        hideCVCForBrand={hideCVCForBrand}
+                        cvcPolicy={cvcPolicy}
                         isValid={!!valid.encryptedSecurityCode}
                         filled={!!errors.encryptedSecurityCode || !!valid.encryptedSecurityCode}
                         label={i18n.get('creditCard.cvcField.title')}

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
@@ -25,11 +25,10 @@ export default function StoredCardFields({ brand, hasCVC, onFocusField, errors, 
 
                 {hasCVC && (
                     <CVC
-                        cvcRequired={props.cvcRequired}
+                        cvcPolicy={props.cvcPolicy}
                         error={errors.encryptedSecurityCode}
                         focused={props.focusedElement === 'encryptedSecurityCode'}
                         filled={!!valid.encryptedSecurityCode || !!errors.encryptedSecurityCode}
-                        hideCVCForBrand={props.hideCVCForBrand}
                         isValid={!!valid.encryptedSecurityCode}
                         label={i18n.get('creditCard.cvcField.title')}
                         onFocusField={onFocusField}

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -6,14 +6,13 @@ export interface BrandIconProps {
 
 export interface CardFieldsProps {
     brand?: string;
-    cvcRequired?: any;
     dualBrandingChangeHandler?: any;
     dualBrandingElements?: any;
     dualBrandingSelected?: string;
     errors?: any;
     focusedElement?: any;
     hasCVC?: any;
-    hideCVCForBrand?: any;
+    cvcPolicy?: string;
     hideDateForBrand?: any;
     onFocusField?: any;
     showBrandIcon?: boolean;
@@ -46,12 +45,11 @@ export interface CardNumberProps {
 export interface CVCProps {
     className?: string;
     classNameModifiers?: string[];
-    cvcRequired: boolean;
     error?: string;
     filled?: any;
     focused?: any;
     frontCVC?: boolean;
-    hideCVCForBrand?: boolean;
+    cvcPolicy?: string;
     isValid?: any;
     label?: any;
     onFocusField: (field: string) => void;
@@ -124,13 +122,12 @@ export type RtnType_ParamVoidFn = (e) => void;
 
 export interface StoredCardFieldsProps {
     brand: string;
-    cvcRequired: boolean;
     errors: any;
     expiryMonth: string;
     expiryYear: string;
     focusedElement: string;
     hasCVC: boolean;
-    hideCVCForBrand: any;
+    cvcPolicy: string;
     lastFour: string;
     onFocusField: any;
     valid: any;

--- a/packages/lib/src/components/Card/components/CardInput/handlers.ts
+++ b/packages/lib/src/components/Card/components/CardInput/handlers.ts
@@ -93,7 +93,7 @@ function handleSecuredFieldsChange(newState: SFPState): void {
             holderName: this.props.holderNameRequired ? validateHolderName(tempHolderName, this.props.holderNameRequired) : true
         },
         isSfpValid: sfState.isSfpValid,
-        hideCVCForBrand: sfState.hideCVCForBrand,
+        cvcPolicy: sfState.cvcPolicy,
         hideDateForBrand: sfState.hideDateForBrand,
         brand: sfState.brand
     });

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -36,7 +36,7 @@ export interface CardInputState {
     data?: object;
     errors?: object;
     focusedElement: string;
-    hideCVCForBrand: boolean;
+    cvcPolicy: string;
     hideDateForBrand: boolean;
     isValid: boolean;
     status: string;

--- a/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
+++ b/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
@@ -22,7 +22,7 @@ export default function callSubmit3DS2Fingerprint({ data }) {
         }
 
         /**
-         * Frictionless (no challenge) flow
+         * Frictionless (no challenge) flow OR "refused" flow
          */
         if (resData.type === 'completed') {
             const { details } = resData;

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -33,7 +33,6 @@ export interface SFPState {
     billingAddress?: AddressSchema;
     hasUnsupportedCard?: boolean;
     hasKoreanFields?: boolean;
-    hideCVCForBrand?: boolean;
     hideDateForBrand?: boolean;
 }
 

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
@@ -114,7 +114,6 @@ function handleOnBrand(cardInfo: CbObjOnBrand): void {
                         ? false
                         : prevState.errors[ENCRYPTED_SECURITY_CODE]
             },
-            hideCVCForBrand: cardInfo.cvcPolicy === CVC_POLICY_HIDDEN,
             hideDateForBrand: cardInfo.datePolicy === DATE_POLICY_HIDDEN
         }),
         () => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In keeping with the changes to `/binLookup` and `SecuredFields` that see all options for the CVC field described under a single `cvcPolicy` property - propagate this change further up the chain to the `CardInput` component and unify its separate `cvcRequired` and `hideCVCForBrand` under a property of the same name, `cvcPolicy`, that is passed down into it's child components 

## Tested scenarios
All unit & e2e tests pass
