### PR TITLE
Fix/issue with dual branding opacity

### DIFF
--- a/packages/e2e/tests/cards/dualBranding/dualBranding.clientScripts.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.clientScripts.js
@@ -10,13 +10,6 @@ window.dropinConfig = {
     showStoredPaymentMethods: false // hide stored PMs so credit card is first on list
 };
 
-/**
- * Seems to be an error with TestCafe
- * Throws:
- *  JavaScript error details:
- *  ReferenceError: PaymentRequest is not defined
- *    at https://pay.google.com/gp/p/js/pay.js:237:404
- */
 window.mainConfiguration = {
     paymentMethodsConfiguration: {
         card: { brands: ['mc', 'amex', 'visa', 'cartebancaire'] }

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
@@ -193,7 +193,7 @@ test(
         await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
 
         // Paste dual branded card (visa/cb) into card field
-        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true, true); // true, true = {replace: true, paste: true} which will mimic select and paste action
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, 'paste');
 
         // Check buttons are active
         await t.expect(dualBrandingIconHolderActive.exists).ok();
@@ -275,7 +275,7 @@ test(
         const lastDigits = DUAL_BRANDED_CARD.substring(11, 16);
 
         // Paste partial dual branded card (visa/cb) into card field
-        await cardUtils.fillCardNumber(t, firstDigits, true, true);
+        await cardUtils.fillCardNumber(t, firstDigits, 'paste');
 
         // Check buttons are present but NOT active (which will mean the holding element is at 25% opacity)
         await t

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
@@ -258,7 +258,7 @@ test(
     }
 );
 
-test.only(
+test(
     'Fill in card number that will get single branding result from binLookup, ' +
         'then enter a partial dual branded card number,' +
         'check both brand icons are at reduced alpha,' +

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
@@ -1,7 +1,7 @@
 import { Selector, ClientFunction } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
 import cu from '../utils/cardUtils';
-import { DUAL_BRANDED_CARD } from '../utils/constants';
+import { DUAL_BRANDED_CARD, REGULAR_TEST_CARD } from '../utils/constants';
 import { BASE_URL } from '../../pages';
 
 const dualBrandingIconHolder = Selector('.adyen-checkout__payment-method--card .adyen-checkout__card__dual-branding__buttons');
@@ -171,6 +171,175 @@ test(
             )
             .eql(false)
             // first icon should have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true);
+    }
+);
+
+test(
+    'Fill in card number that will get single branding result from binLookup, ' +
+        'then enter a dual branded card number,' +
+        'check both brand icons are at full alpha,' +
+        'then click icons and make sure they go to the expected alpha',
+    async t => {
+        // Start, allow time for iframes to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+
+        // Fill card field with dual branded card (visa/cb)
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true);
+
+        // Check buttons are active
+        await t.expect(dualBrandingIconHolderActive.exists).ok();
+
+        // Check icon opacities (should be 100%)
+        await t
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false);
+
+        // Click brand icons
+        await t
+            // click first icon
+            .click(dualBrandingIconHolderActive.find('img').nth(0))
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULD have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true)
+            // click second icon
+            .click(dualBrandingIconHolderActive.find('img').nth(1))
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // first icon SHOULD have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true);
+    }
+);
+
+test.only(
+    'Fill in card number that will get single branding result from binLookup, ' +
+        'then enter a partial dual branded card number,' +
+        'check both brand icons are at reduced alpha,' +
+        'complete card number,' +
+        'check both brand icons are at full alpha,' +
+        'then click icons and make sure they go to the expected alpha',
+    async t => {
+        // Start, allow time for iframes to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+
+        const firstDigits = DUAL_BRANDED_CARD.substring(0, 11);
+        const lastDigits = DUAL_BRANDED_CARD.substring(11, 16);
+
+        // Partially fill card field with dual branded card (visa/cb)
+        await cardUtils.fillCardNumber(t, firstDigits, true);
+
+        // Check buttons are present but NOT active (which will mean the holding element is at 25% opacity)
+        await t
+            .expect(dualBrandingIconHolder.exists)
+            .ok()
+            .expect(dualBrandingIconHolderActive.exists)
+            .notOk();
+
+        // Complete field
+        await cardUtils.fillCardNumber(t, lastDigits);
+
+        // Check buttons are active
+        await t.expect(dualBrandingIconHolderActive.exists).ok();
+
+        // Check icon opacities (should be 100%)
+        await t
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false);
+
+        // Click brand icons
+        await t
+            // click first icon
+            .click(dualBrandingIconHolderActive.find('img').nth(0))
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULD have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true)
+            // click second icon
+            .click(dualBrandingIconHolderActive.find('img').nth(1))
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // first icon SHOULD have the "not selected" class
             .expect(
                 dualBrandingIconHolderActive
                     .find('img')

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.dropin.test.js
@@ -192,8 +192,8 @@ test(
 
         await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
 
-        // Fill card field with dual branded card (visa/cb)
-        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true);
+        // Paste dual branded card (visa/cb) into card field
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true, true); // true, true = {replace: true, paste: true} which will mimic select and paste action
 
         // Check buttons are active
         await t.expect(dualBrandingIconHolderActive.exists).ok();
@@ -274,8 +274,8 @@ test(
         const firstDigits = DUAL_BRANDED_CARD.substring(0, 11);
         const lastDigits = DUAL_BRANDED_CARD.substring(11, 16);
 
-        // Partially fill card field with dual branded card (visa/cb)
-        await cardUtils.fillCardNumber(t, firstDigits, true);
+        // Paste partial dual branded card (visa/cb) into card field
+        await cardUtils.fillCardNumber(t, firstDigits, true, true);
 
         // Check buttons are present but NOT active (which will mean the holding element is at 25% opacity)
         await t

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
@@ -1,7 +1,7 @@
 import { Selector, ClientFunction } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
 import cu from '../utils/cardUtils';
-import { DUAL_BRANDED_CARD } from '../utils/constants';
+import { DUAL_BRANDED_CARD, REGULAR_TEST_CARD } from '../utils/constants';
 import { CARDS_URL } from '../../pages';
 
 const dualBrandingIconHolder = Selector('.card-field .adyen-checkout__card__dual-branding__buttons');
@@ -144,7 +144,7 @@ test(
         await t
             // click first icon
             .click(dualBrandingIconHolderActive.find('img').nth(0))
-            // first icon shouldn't have the "not selected" class
+            // first icon SHOULDN'T have the "not selected" class
             .expect(
                 dualBrandingIconHolderActive
                     .find('img')
@@ -152,7 +152,7 @@ test(
                     .hasClass(NOT_SELECTED_CLASS)
             )
             .eql(false)
-            // second icon should have the "not selected" class
+            // second icon SHOULD have the "not selected" class
             .expect(
                 dualBrandingIconHolderActive
                     .find('img')
@@ -162,7 +162,7 @@ test(
             .eql(true)
             // click second icon
             .click(dualBrandingIconHolderActive.find('img').nth(1))
-            // second icon shouldn't have the "not selected" class
+            // second icon SHOULDN'T have the "not selected" class
             .expect(
                 dualBrandingIconHolderActive
                     .find('img')
@@ -170,7 +170,7 @@ test(
                     .hasClass(NOT_SELECTED_CLASS)
             )
             .eql(false)
-            // first icon should have the "not selected" class
+            // first icon SHOULD have the "not selected" class
             .expect(
                 dualBrandingIconHolderActive
                     .find('img')
@@ -180,4 +180,172 @@ test(
             .eql(true);
     }
 );
-//
+
+test(
+    'Fill in card number that will get single branding result from binLookup, ' +
+        'then enter a dual branded card number,' +
+        'check both brand icons are at full alpha,' +
+        'then click icons and make sure they go to the expected alpha',
+    async t => {
+        // Start, allow time for iframes to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+
+        // Fill card field with dual branded card (visa/cb)
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true);
+
+        // Check buttons are active
+        await t.expect(dualBrandingIconHolderActive.exists).ok();
+
+        // Check icon opacities (should be 100%)
+        await t
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false);
+
+        // Click brand icons
+        await t
+            // click first icon
+            .click(dualBrandingIconHolderActive.find('img').nth(0))
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULD have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true)
+            // click second icon
+            .click(dualBrandingIconHolderActive.find('img').nth(1))
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // first icon SHOULD have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true);
+    }
+);
+
+test(
+    'Fill in card number that will get single branding result from binLookup, ' +
+        'then enter a partial dual branded card number,' +
+        'check both brand icons are at reduced alpha,' +
+        'complete card number,' +
+        'check both brand icons are at full alpha,' +
+        'then click icons and make sure they go to the expected alpha',
+    async t => {
+        // Start, allow time for iframes to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+
+        const firstDigits = DUAL_BRANDED_CARD.substring(0, 11);
+        const lastDigits = DUAL_BRANDED_CARD.substring(11, 16);
+
+        // Partially fill card field with dual branded card (visa/cb)
+        await cardUtils.fillCardNumber(t, firstDigits, true);
+
+        // Check buttons are present but NOT active (which will mean the holding element is at 25% opacity)
+        await t
+            .expect(dualBrandingIconHolder.exists)
+            .ok()
+            .expect(dualBrandingIconHolderActive.exists)
+            .notOk();
+
+        // Complete field
+        await cardUtils.fillCardNumber(t, lastDigits);
+
+        // Check buttons are active
+        await t.expect(dualBrandingIconHolderActive.exists).ok();
+
+        // Check icon opacities (should be 100%)
+        await t
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false);
+
+        // Click brand icons
+        await t
+            // click first icon
+            .click(dualBrandingIconHolderActive.find('img').nth(0))
+            // first icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // second icon SHOULD have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true)
+            // click second icon
+            .click(dualBrandingIconHolderActive.find('img').nth(1))
+            // second icon SHOULDN'T have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(false)
+            // first icon SHOULD have the "not selected" class
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .hasClass(NOT_SELECTED_CLASS)
+            )
+            .eql(true);
+    }
+);

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
@@ -193,7 +193,7 @@ test(
         await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
 
         // Paste dual branded card (visa/cb) into card field
-        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true, true); // true, true = {replace: true, paste: true} which will mimic select and paste action
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, 'paste');
 
         // Check buttons are active
         await t.expect(dualBrandingIconHolderActive.exists).ok();
@@ -275,7 +275,7 @@ test(
         const lastDigits = DUAL_BRANDED_CARD.substring(11, 16);
 
         // Paste partial dual branded card (visa/cb) into card field
-        await cardUtils.fillCardNumber(t, firstDigits, true, true);
+        await cardUtils.fillCardNumber(t, firstDigits, 'paste');
 
         // Check buttons are present but NOT active (which will mean the holding element is at 25% opacity)
         await t

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.test.js
@@ -192,8 +192,8 @@ test(
 
         await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
 
-        // Fill card field with dual branded card (visa/cb)
-        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true);
+        // Paste dual branded card (visa/cb) into card field
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD, true, true); // true, true = {replace: true, paste: true} which will mimic select and paste action
 
         // Check buttons are active
         await t.expect(dualBrandingIconHolderActive.exists).ok();
@@ -274,8 +274,8 @@ test(
         const firstDigits = DUAL_BRANDED_CARD.substring(0, 11);
         const lastDigits = DUAL_BRANDED_CARD.substring(11, 16);
 
-        // Partially fill card field with dual branded card (visa/cb)
-        await cardUtils.fillCardNumber(t, firstDigits, true);
+        // Paste partial dual branded card (visa/cb) into card field
+        await cardUtils.fillCardNumber(t, firstDigits, true, true);
 
         // Check buttons are present but NOT active (which will mean the holding element is at 25% opacity)
         await t

--- a/packages/e2e/tests/cards/kcp/startWithKCP/startWithKCP.test.js
+++ b/packages/e2e/tests/cards/kcp/startWithKCP/startWithKCP.test.js
@@ -69,7 +69,7 @@ test(
         await t.expect(getCardState('valid', 'encryptedPassword')).eql(true);
 
         // Replace number
-        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, true);
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, 'replace');
 
         // (Does the password securedField get removed)
         await t.expect(passwordHolder.exists).notOk();
@@ -112,7 +112,7 @@ test(
             .notOk();
 
         // Replace number with non-korean card
-        await cardUtils.fillCardNumber(t, KOREAN_TEST_CARD, true);
+        await cardUtils.fillCardNumber(t, KOREAN_TEST_CARD, 'replace');
 
         // Complete form
         await kcpUtils.fillTaxNumber(t);

--- a/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
+++ b/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
@@ -137,7 +137,7 @@ test(
             .notOk();
 
         // Replace number with non-korean card
-        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, true);
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, 'replace');
 
         // Expect card to now be valid
         await t.expect(getIsValid()).eql(true);

--- a/packages/e2e/tests/cards/utils/cardUtils.js
+++ b/packages/e2e/tests/cards/utils/cardUtils.js
@@ -1,6 +1,5 @@
 import { fillIFrame, deleteFromIFrame } from '../../utils/commonUtils';
 import { REGULAR_TEST_CARD, TEST_DATE_VALUE, TEST_CVC_VALUE } from './constants';
-import { ClientFunction } from 'testcafe';
 
 /**
  * Unique to each component are where the iframes are to be found,
@@ -33,8 +32,8 @@ export default iframeSelector => {
  * @returns {Promise<*>}
  */
 const fillCardNumber = iframeSelector => {
-    return async (t, value = REGULAR_TEST_CARD, replace = false) => {
-        return fillIFrame(t, iframeSelector, 0, '#encryptedCardNumber', value, replace);
+    return async (t, value = REGULAR_TEST_CARD, replace = false, paste = false) => {
+        return fillIFrame(t, iframeSelector, 0, '#encryptedCardNumber', value, replace, paste);
     };
 };
 

--- a/packages/e2e/tests/cards/utils/cardUtils.js
+++ b/packages/e2e/tests/cards/utils/cardUtils.js
@@ -32,8 +32,8 @@ export default iframeSelector => {
  * @returns {Promise<*>}
  */
 const fillCardNumber = iframeSelector => {
-    return async (t, value = REGULAR_TEST_CARD, replace = false, paste = false) => {
-        return fillIFrame(t, iframeSelector, 0, '#encryptedCardNumber', value, replace, paste);
+    return async (t, value = REGULAR_TEST_CARD, action) => {
+        return fillIFrame(t, iframeSelector, 0, '#encryptedCardNumber', value, action);
     };
 };
 
@@ -50,14 +50,14 @@ const deleteCVC = iframeSelector => {
 };
 
 const fillDate = iframeSelector => {
-    return async (t, value = TEST_DATE_VALUE, replace = false) => {
-        return fillIFrame(t, iframeSelector, 1, '#encryptedExpiryDate', value, replace);
+    return async (t, value = TEST_DATE_VALUE, action) => {
+        return fillIFrame(t, iframeSelector, 1, '#encryptedExpiryDate', value, action);
     };
 };
 
 const fillCVC = iframeSelector => {
-    return async (t, value = TEST_CVC_VALUE, replace = false) => {
-        return fillIFrame(t, iframeSelector, 2, '#encryptedSecurityCode', value, replace);
+    return async (t, value = TEST_CVC_VALUE, action) => {
+        return fillIFrame(t, iframeSelector, 2, '#encryptedSecurityCode', value, action);
     };
 };
 

--- a/packages/e2e/tests/cards/utils/kcpUtils.js
+++ b/packages/e2e/tests/cards/utils/kcpUtils.js
@@ -30,8 +30,8 @@ export default iframeSelector => {
  * @returns {Promise<*>}
  */
 const fillPwd = iframeSelector => {
-    return async (t, value = TEST_PWD_VALUE, replace = false) => {
-        return fillIFrame(t, iframeSelector, 3, '#encryptedPassword', value, replace);
+    return async (t, value = TEST_PWD_VALUE, action) => {
+        return fillIFrame(t, iframeSelector, 3, '#encryptedPassword', value, action);
     };
 };
 

--- a/packages/e2e/tests/cards/utils/threeDS2Utils.js
+++ b/packages/e2e/tests/cards/utils/threeDS2Utils.js
@@ -2,8 +2,8 @@ import { fillIFrame, getIframeSelector } from '../../utils/commonUtils';
 
 const iframeSelector = getIframeSelector('.adyen-checkout__threeds2__challenge iframe');
 
-export const fillChallengeField = async (t, value = 'password', replace = false) => {
-    return fillIFrame(t, iframeSelector, 0, '.input-field', value, replace);
+export const fillChallengeField = async (t, value = 'password', action) => {
+    return fillIFrame(t, iframeSelector, 0, '.input-field', value, action);
 };
 
 export const submitChallenge = async t => {

--- a/packages/e2e/tests/openInvoices/afterpay/afterpay.test.js
+++ b/packages/e2e/tests/openInvoices/afterpay/afterpay.test.js
@@ -1,4 +1,4 @@
-import { ClientFunction } from 'testcafe';
+import { ClientFunction, Selector } from 'testcafe';
 import { OPENINVOICES_URL } from '../../pages';
 
 fixture`Testing AfterPay (OpenInvoices)`.page(`${OPENINVOICES_URL}?countryCode=NL`);
@@ -16,12 +16,16 @@ const mockAddress = {
     street: 'Street'
 };
 
+const checkboxLabelGender = Selector('.afterpay-field .adyen-checkout__field--gender .adyen-checkout__radio_group__label');
+const checkboxConsent = Selector('.afterpay-field input[name=consentCheckbox]', { timeout: 1000 });
+
 test('should make an AfterPay payment', async t => {
     // Opens dropdown
     await t
         .typeText('.afterpay-field .adyen-checkout__input--firstName', 'First')
         .typeText('.afterpay-field .adyen-checkout__input--lastName', 'Last')
-        .click('.afterpay-field .adyen-checkout__field--gender .adyen-checkout__radio_group__input:first-child')
+        // Click checkbox (in reality click its label - for some reason clicking the actual checkboxes takes ages)
+        .click(checkboxLabelGender.nth(0))
         .typeText('.afterpay-field .adyen-checkout__input--dateOfBirth', '01/01/1970')
         .typeText('.afterpay-field .adyen-checkout__input--shopperEmail', 'test@test.com')
         .typeText('.afterpay-field .adyen-checkout__input--telephoneNumber', '612345678')
@@ -29,7 +33,8 @@ test('should make an AfterPay payment', async t => {
         .typeText('.afterpay-field .adyen-checkout__input--houseNumberOrName', mockAddress.houseNumberOrName)
         .typeText('.afterpay-field .adyen-checkout__input--city', mockAddress.city)
         .typeText('.afterpay-field .adyen-checkout__input--postalCode', mockAddress.postalCode)
-        .click('.afterpay-field input[name=consentCheckbox]');
+        // Can't use the checkboxLabelGender trick to speed up the click 'cos this label contains a link - so use a Selector with a timeout
+        .click(checkboxConsent);
 
     const stateData = await getComponentData();
 

--- a/packages/e2e/tests/utils/commonUtils.js
+++ b/packages/e2e/tests/utils/commonUtils.js
@@ -8,7 +8,19 @@ export const start = async (t, wait = 1000, speed = 1) => {
     return t.wait(wait).setTestSpeed(speed);
 };
 
-export const fillIFrame = async (t, iframeSelector, iFrameNum, iFrameInputSelector, value, replace = false, paste = false) => {
+export const fillIFrame = async (t, iframeSelector, iFrameNum, iFrameInputSelector, value, action = 'add') => {
+    let replace = false;
+    let paste = false;
+    switch (action) {
+        case 'replace':
+            replace = true;
+            break;
+        case 'paste':
+            replace = paste = true;
+            break;
+        default: // 'add'
+    }
+
     return t
         .switchToMainWindow()
         .switchToIframe(iframeSelector.nth(iFrameNum))

--- a/packages/e2e/tests/utils/commonUtils.js
+++ b/packages/e2e/tests/utils/commonUtils.js
@@ -8,11 +8,11 @@ export const start = async (t, wait = 1000, speed = 1) => {
     return t.wait(wait).setTestSpeed(speed);
 };
 
-export const fillIFrame = async (t, iframeSelector, iFrameNum, iFrameInputSelector, value, replace = false) => {
+export const fillIFrame = async (t, iframeSelector, iFrameNum, iFrameInputSelector, value, replace = false, paste = false) => {
     return t
         .switchToMainWindow()
         .switchToIframe(iframeSelector.nth(iFrameNum))
-        .typeText(iFrameInputSelector, value, { replace })
+        .typeText(iFrameInputSelector, value, { replace, paste })
         .switchToMainWindow();
 };
 

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -25,8 +25,8 @@ export const createCardVariantSwitcher = (brandObj: BrandObject[]) => {
             additionalSelectElements: [
                 { id: leadBrand.brand, brandObject: leadBrand },
                 { id: subBrand.brand, brandObject: subBrand }
-            ] as DualBrandSelectElement[]
-            // additionalSelectValue: leadBrand.brand, // comment out line if no initial selection is to be made
+            ] as DualBrandSelectElement[],
+            additionalSelectValue: '' // set to leadBrand.brand if an initial selection is to be made
         },
         leadBrand
     };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- When pasting a dual branded card number over a single branded card number the icons were not showing up at full opacity.
- Likewise pasting a partial dual branded card number over a single branded card number: the icons are barely visible until the number is completed - and then they are not shown at full opacity.
- Also reduced time the Afterpay test took to run

## Tested scenarios
Written new e2e tests to cover the reduced opacity scenarios

**Fixed issue**:  COWEB -925
