### PR TITLE
Add buttonSizeMode and buttonLocale to Google Pay component

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -4,7 +4,7 @@ import GooglePayService from './GooglePayService';
 import GooglePayButton from './components/GooglePayButton';
 import defaultProps from './defaultProps';
 import { GooglePayProps } from './types';
-import { mapBrands } from './utils';
+import { mapBrands, getGooglePayLocale } from './utils';
 
 class GooglePay extends UIElement<GooglePayProps> {
     public static type = 'paywithgoogle';
@@ -17,12 +17,15 @@ class GooglePay extends UIElement<GooglePayProps> {
      */
     formatProps(props) {
         const allowedCardNetworks = props.brands?.length ? mapBrands(props.brands) : props.allowedCardNetworks;
-
+        const buttonSizeMode = props.buttonSizeMode ?? (props.isDropin ? 'fill' : 'static');
+        const buttonLocale = getGooglePayLocale(props.buttonLocale ?? props.i18n.locale);
         return {
             ...props,
             showButton: props.showPayButton === true,
             configuration: props.configuration,
-            allowedCardNetworks
+            allowedCardNetworks,
+            buttonSizeMode,
+            buttonLocale
         };
     }
 
@@ -115,6 +118,8 @@ class GooglePay extends UIElement<GooglePayProps> {
                 <GooglePayButton
                     buttonColor={this.props.buttonColor}
                     buttonType={this.props.buttonType}
+                    buttonSizeMode={this.props.buttonSizeMode}
+                    buttonLocale={this.props.buttonLocale}
                     paymentsClient={this.googlePay.paymentsClient}
                     onClick={this.submit}
                 />

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -18,7 +18,7 @@ class GooglePay extends UIElement<GooglePayProps> {
     formatProps(props) {
         const allowedCardNetworks = props.brands?.length ? mapBrands(props.brands) : props.allowedCardNetworks;
         const buttonSizeMode = props.buttonSizeMode ?? (props.isDropin ? 'fill' : 'static');
-        const buttonLocale = getGooglePayLocale(props.buttonLocale ?? props.i18n.locale);
+        const buttonLocale = getGooglePayLocale(props.buttonLocale ?? props.i18n?.locale);
         return {
             ...props,
             showButton: props.showPayButton === true,

--- a/packages/lib/src/components/GooglePay/components/GooglePayButton.scss
+++ b/packages/lib/src/components/GooglePay/components/GooglePayButton.scss
@@ -15,8 +15,4 @@
     &.gpay-button {
         padding: 15px 24px 13px;
     }
-
-    &.long {
-        width: 100%;
-    }
 }

--- a/packages/lib/src/components/GooglePay/components/GooglePayButton.tsx
+++ b/packages/lib/src/components/GooglePay/components/GooglePayButton.tsx
@@ -4,6 +4,8 @@ import './GooglePayButton.scss';
 interface GooglePayButtonProps {
     buttonColor: google.payments.api.ButtonColor;
     buttonType: google.payments.api.ButtonType;
+    buttonSizeMode: google.payments.api.ButtonSizeMode;
+    buttonLocale: string;
     paymentsClient: Promise<google.payments.api.PaymentsClient>;
     onClick: (e: Event) => void;
 }
@@ -13,7 +15,8 @@ class GooglePayButton extends Component<GooglePayButtonProps> {
 
     public static defaultProps = {
         buttonColor: 'default', // default (black), black, white
-        buttonType: 'long' // long, short
+        buttonType: 'long', // long, short
+        buttonSizeMode: 'static' // long, short
     };
     private clicked = false;
 
@@ -32,10 +35,10 @@ class GooglePayButton extends Component<GooglePayButtonProps> {
     };
 
     componentDidMount() {
-        const { buttonColor, buttonType, paymentsClient } = this.props;
+        const { buttonColor, buttonType, buttonLocale, buttonSizeMode, paymentsClient } = this.props;
 
         paymentsClient
-            .then(client => client.createButton({ onClick: this.handleClick, buttonType, buttonColor }))
+            .then(client => client.createButton({ onClick: this.handleClick, buttonType, buttonColor, buttonLocale, buttonSizeMode }))
             .then(googlePayButton => {
                 this.paywithgoogleWrapper.appendChild(googlePayButton);
             });

--- a/packages/lib/src/components/GooglePay/defaultProps.ts
+++ b/packages/lib/src/components/GooglePay/defaultProps.ts
@@ -8,6 +8,7 @@ export default {
     // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
     buttonColor: 'default' as google.payments.api.ButtonColor, // default/black/white
     buttonType: 'long' as google.payments.api.ButtonType, // long/short
+    buttonSizeMode: undefined,
     showPayButton: true, // show or hide the Google Pay button
 
     // PaymentDataRequest

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -117,6 +117,8 @@ export interface GooglePayProps extends UIElementProps {
     // Button
     buttonColor?: google.payments.api.ButtonColor;
     buttonType?: google.payments.api.ButtonType;
+    buttonSizeMode?: google.payments.api.ButtonSizeMode;
+    buttonLocale?: string;
 
     // Events
     onClick?: (resolve, reject) => void;

--- a/packages/lib/src/components/GooglePay/utils.ts
+++ b/packages/lib/src/components/GooglePay/utils.ts
@@ -62,7 +62,7 @@ const supportedLocales = [
     'zh'
 ];
 
-export function getGooglePayLocale(locale) {
+export function getGooglePayLocale(locale = '') {
     const twoLetterLocale = locale.toLowerCase().substring(0, 2);
     return supportedLocales.includes(twoLetterLocale) ? twoLetterLocale : null;
 }

--- a/packages/lib/src/components/GooglePay/utils.ts
+++ b/packages/lib/src/components/GooglePay/utils.ts
@@ -27,3 +27,42 @@ export function mapBrands(brands) {
         return accumulator;
     }, []);
 }
+
+const supportedLocales = [
+    'en',
+    'ar',
+    'bg',
+    'ca',
+    'cs',
+    'da',
+    'de',
+    'el',
+    'es',
+    'et',
+    'fi',
+    'fr',
+    'hr',
+    'id',
+    'it',
+    'ja',
+    'ko',
+    'ms',
+    'nl',
+    'no',
+    'pl',
+    'pt',
+    'ru',
+    'sk',
+    'sl',
+    'sr',
+    'sv',
+    'th',
+    'tr',
+    'uk',
+    'zh'
+];
+
+export function getGooglePayLocale(locale) {
+    const twoLetterLocale = locale.toLowerCase().substring(0, 2);
+    return supportedLocales.includes(twoLetterLocale) ? twoLetterLocale : null;
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Adds the `buttonSizeMode` configuration property
- Adds the `buttonLocale` configuration property

See https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions for more information on these properties.

## Tested scenarios
- `buttonSizeMode` defaults to `fill` on the Drop-in
- `buttonLocale` defaults to the current locale set on the AdyenCheckout instance


**Fixed issue**:  <!-- #-prefixed issue number -->
