### PR TITLE
Move promise dependency from devDependencies to dependencies

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -70,7 +70,6 @@
         "postcss": "^8.2.6",
         "postcss-reporter": "^7.0.2",
         "prettier": "^1.19.1",
-        "promise": "^8.1.0",
         "rollup": "^2.40.0",
         "rollup-plugin-postcss": "^4.0.0",
         "rollup-plugin-terser": "^7.0.2",
@@ -87,7 +86,8 @@
         "@types/applepayjs": "^3.0.1",
         "@types/googlepay": "^0.5.2",
         "classnames": "^2.2.6",
-        "preact": "^10.5.12"
+        "preact": "^10.5.12",
+        "promise": "^8.1.0"
     },
     "files": [
         "dist",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Move promise dependency from devDependencies to dependencies

## Tested scenarios
- Should fix an issue where the `promise` dependency could be missing when using the ES bundle.

**Fixed issue**:  #807 
