### PR TITLE
Add new Apple Pay button types

### DIFF
--- a/packages/lib/src/components/ApplePay/components/ApplePayButton.module.scss
+++ b/packages/lib/src/components/ApplePay/components/ApplePayButton.module.scss
@@ -33,6 +33,30 @@
     .apple-pay-button--type-subscribe {
         -apple-pay-button-type: subscribe;
     }
+    .apple-pay-button--type-add-money {
+        -apple-pay-button-type: add-money;
+    }
+    .apple-pay-button--type-contribute {
+        -apple-pay-button-type: contribute;
+    }
+    .apple-pay-button--type-order {
+        -apple-pay-button-type: order;
+    }
+    .apple-pay-button--type-reload {
+        -apple-pay-button-type: reload;
+    }
+    .apple-pay-button--type-rent {
+        -apple-pay-button-type: rent;
+    }
+    .apple-pay-button--type-support {
+        -apple-pay-button-type: support;
+    }
+    .apple-pay-button--type-tip {
+        -apple-pay-button-type: tip;
+    }
+    .apple-pay-button--type-top-up {
+        -apple-pay-button-type: top-up;
+    }
 }
 
 @supports not (-webkit-appearance: -apple-pay-button) {

--- a/packages/lib/src/components/ApplePay/components/ApplePayButton.tsx
+++ b/packages/lib/src/components/ApplePay/components/ApplePayButton.tsx
@@ -3,11 +3,12 @@ import cx from 'classnames';
 import styles from './ApplePayButton.module.scss';
 import './ApplePayButton.scss';
 import Language from '../../../language/Language';
+import { ApplePayButtonType } from '../types';
 
 interface ApplePayButtonProps {
     i18n: Language;
     buttonColor: 'black' | 'white' | 'white-with-line';
-    buttonType: 'plain' | 'buy' | 'donate' | 'check-out' | 'book' | 'subscribe';
+    buttonType: ApplePayButtonType;
     onClick: (event) => void;
 }
 

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -10,6 +10,22 @@ declare global {
 
 type Initiative = 'web' | 'messaging';
 
+export type ApplePayButtonType =
+    | 'plain'
+    | 'buy'
+    | 'donate'
+    | 'check-out'
+    | 'book'
+    | 'subscribe'
+    | 'add-money'
+    | 'contribute'
+    | 'order'
+    | 'reload'
+    | 'rent'
+    | 'support'
+    | 'tip'
+    | 'top-up';
+
 export interface ApplePayElementProps extends UIElementProps {
     /**
      * The Apple Pay version number your website supports.
@@ -134,7 +150,7 @@ export interface ApplePayElementProps extends UIElementProps {
 
     // ButtonOptions
     buttonColor?: 'black' | 'white' | 'white-with-line';
-    buttonType?: 'plain' | 'buy' | 'donate' | 'check-out' | 'book' | 'subscribe';
+    buttonType?: ApplePayButtonType;
 
     /**
      * Show or hide the Apple Pay button

--- a/packages/playground/src/pages/Wallets/Wallets.js
+++ b/packages/playground/src/pages/Wallets/Wallets.js
@@ -184,10 +184,7 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
             merchantName: 'Adyen Test merchant', // Name to be displayed
             merchantIdentifier: '000000000200001' // Required. https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951611-merchantidentifier
         },
-
-        // Button config (optional)
-        buttonType: 'long', // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
-        buttonColor: 'default' // https://developers.google.com/pay/api/web/reference/object#ButtonOptions
+        buttonType: 'buy'
     });
 
     applepay


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Add new Apple Pay button types. The full list of supported types can be seen at `ApplePayButtonType`.
