### PR TITLE
Add CSS file exports in package.json

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -18,7 +18,8 @@
         ".": {
             "import": "./dist/es/index.js",
             "require": "./dist/cjs/index.js"
-        }
+        },
+        "./dist/adyen.css": "./dist/adyen.css"
     },
     "version": "4.0.0",
     "license": "MIT",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Add missing CSS file export in `package.json`.

## Tested scenarios
Webpack 5 can correctly load the CSS assets.


**Fixed issue**:  #832
