### PR TITLE
Amazon APB flow

### DIFF
--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -15,8 +15,10 @@ export class AmazonPayElement extends UIElement<AmazonPayElementProps> {
     formatProps(props) {
         return {
             ...props,
+            checkoutMode: props.isDropin ? 'ProcessOrder' : props.checkoutMode,
             environment: props.environment.toUpperCase(),
             locale: props.locale.replace('-', '_'),
+            productType: props.isDropin && !props.addressDetails ? 'PayOnly' : props.productType,
             region: props.region.toUpperCase()
         };
     }

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
@@ -1,25 +1,16 @@
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { getAmazonSignature } from '../services';
-import { getCheckoutLocale, getPayloadJSON } from '../utils';
-import { AmazonPayButtonProps, AmazonPayButtonSettings, CheckoutSessionConfig, PayloadJSON } from '../types';
+import { getAmazonPaySettings, getPayloadJSON } from '../utils';
+import { AmazonPayButtonProps, CheckoutSessionConfig, PayloadJSON } from '../types';
 import useCoreContext from '../../../core/Context/useCoreContext';
 
 export default function AmazonPayButton(props: AmazonPayButtonProps) {
     const { loadingContext } = useCoreContext();
-    const { amazonRef, buttonColor, configuration = {} } = props;
+    const { amazonRef, configuration = {} } = props;
     const [signature, setSignature] = useState<string>(null);
-    const payloadJSON: PayloadJSON = getPayloadJSON(configuration.storeId, props.returnUrl, props.cancelUrl, props.deliverySpecifications);
-
-    const settings: AmazonPayButtonSettings = {
-        ...(buttonColor && { buttonColor }),
-        checkoutLanguage: getCheckoutLocale(props.locale, props.region),
-        ledgerCurrency: props.currency,
-        merchantId: configuration.merchantId,
-        productType: props.productType,
-        placement: props.placement,
-        sandbox: props.environment === 'TEST'
-    };
+    const payloadJSON: PayloadJSON = getPayloadJSON(props);
+    const settings = getAmazonPaySettings(props);
 
     const handleOnClick = () => {
         new Promise(props.onClick).then(this.initCheckout).catch(error => {

--- a/packages/lib/src/components/AmazonPay/defaultProps.ts
+++ b/packages/lib/src/components/AmazonPay/defaultProps.ts
@@ -1,10 +1,12 @@
 export default {
+    cancelUrl: window.location.href,
     configuration: {},
     environment: 'TEST',
     locale: 'en_GB',
     placement: 'Cart',
     productType: 'PayAndShip',
     region: 'EU',
+    returnUrl: window.location.href,
     showOrderButton: true,
     showChangePaymentDetailsButton: false,
     showSignOutButton: false,

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -12,7 +12,7 @@ declare global {
 type ButtonColor = 'Gold' | 'LightGray' | 'DarkGray';
 type Placement = 'Home' | 'Product' | 'Cart' | 'Checkout' | 'Other';
 type ProductType = 'PayOnly' | 'PayAndShip';
-type Currency = 'USD' | 'EUR' | 'GBP';
+export type Currency = 'USD' | 'EUR' | 'GBP';
 export type Region = 'US' | 'EU' | 'UK';
 export type SupportedLocale = typeof SUPPORTED_LOCALES_EU[number] | typeof SUPPORTED_LOCALES_US[number];
 
@@ -23,9 +23,10 @@ export interface AmazonPayConfiguration {
 }
 
 export interface AmazonPayElementProps {
+    addressDetails?: AddressDetails;
     amazonPayToken?: string;
     amazonCheckoutSessionId?: string;
-    amount: PaymentAmount;
+    amount?: PaymentAmount;
     buttonColor?: ButtonColor;
     cancelUrl?: string;
     clientKey?: string;
@@ -36,6 +37,7 @@ export interface AmazonPayElementProps {
     i18n: Language;
     loadingContext?: string;
     locale?: string;
+    merchantMetadata?: MerchantMetadata;
     onSubmit?: (state: any, element: UIElement) => void;
     payButton?: any;
     placement?: Placement;
@@ -57,6 +59,7 @@ export interface AmazonPayComponentProps extends AmazonPayElementProps {
 }
 
 export interface AmazonPayButtonProps {
+    amount?: PaymentAmount;
     amazonRef: any;
     buttonColor?: ButtonColor;
     cancelUrl?: string;
@@ -141,13 +144,46 @@ export interface AmazonPayButtonSettings {
     ledgerCurrency: Currency;
 }
 
+interface MerchantMetadata {
+    customInformation?: string;
+    merchantReferenceId?: string;
+    merchantStoreName?: string;
+    noteToBuyer?: string;
+}
+
+interface AddressDetails {
+    name?: string;
+    addressLine1?: string;
+    addressLine2?: string;
+    addressLine3?: string;
+    city?: string;
+    districtOrCounty?: string;
+    stateOrRegion?: string;
+    postalCode?: string;
+    countryCode?: string;
+    phoneNumber?: string;
+}
+
+export interface ChargeAmount {
+    amount: string;
+    currencyCode: string;
+}
+
 export interface PayloadJSON {
+    addressDetails?: AddressDetails;
+    deliverySpecifications?: DeliverySpecifications;
+    merchantMetadata?: MerchantMetadata;
+    paymentDetails?: {
+        paymentIntent: 'Confirm';
+        chargeAmount: ChargeAmount;
+    };
     storeId: string;
     webCheckoutDetails: {
         checkoutCancelUrl?: string;
-        checkoutReviewReturnUrl: string;
+        checkoutMode?: 'ProcessOrder';
+        checkoutResultReturnUrl?: string;
+        checkoutReviewReturnUrl?: string;
     };
-    deliverySpecifications?: DeliverySpecifications;
 }
 
 export interface CheckoutDetailsRequest {
@@ -158,6 +194,7 @@ export interface CheckoutDetailsRequest {
 
 export interface UpdateAmazonCheckoutSessionRequest {
     amount: PaymentAmount;
+    checkoutCancelUrl?: string;
     checkoutResultReturnUrl: string;
     checkoutSessionId: string;
 }

--- a/packages/lib/src/components/Dropin/elements/filters.ts
+++ b/packages/lib/src/components/Dropin/elements/filters.ts
@@ -1,4 +1,4 @@
-export const UNSUPPORTED_PAYMENT_METHODS = ['amazonpay', 'androidpay', 'samsungpay'];
+export const UNSUPPORTED_PAYMENT_METHODS = ['androidpay', 'samsungpay'];
 
 // filter payment methods that we don't support in the Drop-in
 export const filterUnsupported = paymentMethod => !UNSUPPORTED_PAYMENT_METHODS.includes(paymentMethod.constructor['type']);

--- a/packages/playground/src/config/paymentsConfig.js
+++ b/packages/playground/src/config/paymentsConfig.js
@@ -10,6 +10,8 @@ const paymentsConfig = {
     returnUrl,
     reference: `${identifier}-checkout-components-ref`,
     additionalData: {
+        // Force response code. See https://docs.adyen.com/development-resources/test-cards/result-code-testing/adyen-response-codes
+        // RequestedTestAcquirerResponseCode: 2,
         allow3DS2: true
     },
     shopperEmail: 'test-shopper@storytel.com',

--- a/packages/playground/src/pages/Wallets/Wallets.js
+++ b/packages/playground/src/pages/Wallets/Wallets.js
@@ -29,32 +29,31 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
     const step = urlSearchParams.get('step');
 
     // Initial state
-    if (!amazonCheckoutSessionId || step === 'cancel') {
+    if (!step) {
         window.amazonpay = checkout
             .create('amazonpay', {
-                currency: 'GBP',
-                environment: 'test',
-                configuration: {
-                    merchantId: 'A3SKIS53IXYBBU',
-                    publicKeyId: 'AG77NIXPURMDUC3DOC5WQPPH',
-                    storeId: 'amzn1.application-oa2-client.4cedd73b56134e5ea57aaf487bf5c77e'
-                },
+                amount,
                 productType: 'PayOnly',
-                cancelUrl: 'http://localhost:3020/wallets?step=cancel',
+
+                // Regular checkout:
+                // returnUrl: 'http://localhost:3020/wallets?step=result',
+                // checkoutMode: 'ProcessOrder'
+
+                // Express Checkout flow:
                 returnUrl: 'http://localhost:3020/wallets?step=review'
             })
             .mount('.amazonpay-field');
     }
 
     // Review and confirm order
-    if (amazonCheckoutSessionId && step === 'review') {
+    if (step === 'review') {
         window.amazonpay = checkout
             .create('amazonpay', {
                 /**
                  * The merchant will receive the amazonCheckoutSessionId attached in the return URL.
                  */
                 amazonCheckoutSessionId,
-                cancelUrl: 'http://localhost:3020/wallets?step=cancel',
+                cancelUrl: 'http://localhost:3020/wallets',
                 returnUrl: 'http://localhost:3020/wallets?step=result',
                 amount: {
                     currency: 'GBP',
@@ -65,7 +64,7 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
     }
 
     // Make payment
-    if (amazonCheckoutSessionId && step === 'result') {
+    if (step === 'result') {
         window.amazonpay = checkout
             .create('amazonpay', {
                 /**


### PR DESCRIPTION
## Summary
- Add support to the Additional Payment Button flow.
- Make Amazon Pay available in the Drop-in.
- Update Wallets and Drop-in playground pages to support this supported.
