### PR TITLE
Fix IssuerList components data attribute when state is empty

### DIFF
--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -59,7 +59,7 @@ class IssuerListContainer extends UIElement<IssuerListProps> {
         return {
             paymentMethod: {
                 type: this.constructor['type'],
-                issuer: this.state?.data.issuer
+                issuer: this.state?.data?.issuer
             }
         };
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Fix an issue where the `data` attribute could fail if called too early on Issuer List components (iDeal, Dotpay, etc...)

## Tested scenarios
- Calling `component.data` on init does not fail anymore.
