### PR TITLE
Ensure the Card prop hasCVC is set to false for all Bcmc/Bancontact instance

### DIFF
--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -8,8 +8,7 @@ class BancontactElement extends CardElement {
 
     formatProps(props: CardElementProps) {
         return {
-            brand: 'bcmc',
-            ...super.formatProps(props),
+            ...super.formatProps({ ...props, brand: 'bcmc' }), // Spread props and set brand before passing to super - ensures super.hasCVC gets set to false
             // Override only display brands (groupTypes are decided earlier on super.formatProps)
             brands: ['bcmc', 'maestro']
         };

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -15,7 +15,7 @@ export class CardElement extends UIElement<CardElementProps> {
             ...props,
             // Mismatch between hasHolderName & holderNameRequired which can mean card can never be valid
             holderNameRequired: !props.hasHolderName ? false : props.holderNameRequired,
-            // Special catch for recurring bcmc (i.e. card with no cvc field). Scenario?? - Dropin - One click with no details
+            // False for Bcmc cards & if merchant explicitly wants to hide the CVC field
             hasCVC: !((props.brand && props.brand === 'bcmc') || props.hideCVC),
             // billingAddressRequired only available for non-stored cards
             billingAddressRequired: props.storedPaymentMethodId ? false : props.billingAddressRequired,

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -34,8 +34,14 @@ export interface CardElementProps extends UIElementProps {
     /** Show/hide the "store details" checkbox */
     enableStoreDetails?: boolean;
 
-    /** Show/hide the CVC field */
+    /** Show/hide the CVC field - merchant set config option */
     hideCVC?: boolean;
+
+    /**
+     *  Decides whether CVC component will even be rendered.
+     *  Always true except when hideCVC set to false by merchant OR in the case of a bcmc card
+     */
+    hasCVC?: boolean;
 
     /** Show/hide the card holder name field */
     hasHolderName?: boolean;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently the Card component's property `hasCVC` is only set to `false` for stored (recurring) BCMC cards _not_ for a regular BCMC/Bancontact card.
It is this property that is supposed to decide whether to even render a CVC field.
The fact that the CVC field is being hidden for a regular, single-branded BCMC/Bancontact card is currently based on the fact that for a single-branded card the SecuredFields fires off a _single_ brand callback. This single callback call was designed for the Custom Card component as a way to provide extra brand information e.g. URL at which to find the logo; and it is entirely coincidental that it happens to cause the CVC field to be hidden for the regular BCMC/Bancontact card.
This PR fixes that.

## Tested scenarios
All unit & e2e tests pass
