### PR TITLE
Remove "edge case" code

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
@@ -123,13 +123,6 @@ function handleOnBrand(cardInfo: CbObjOnBrand): void {
             this.props.onBrand({ ...cardInfo, brandImageUrl: getCardImageUrl(cardInfo.brand, this.props.loadingContext) });
         }
     );
-
-    /**
-     * Edge case: one-click PMs where CVC is hidden or optional
-     */
-    if ((this.props.hideCVC || cardInfo.cvcPolicy === CVC_POLICY_HIDDEN || cardInfo.cvcPolicy === CVC_POLICY_OPTIONAL) && this.props.oneClick) {
-        this.handleOnNoDataRequired();
-    }
 }
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
@@ -30,7 +30,6 @@ export interface SFPProps {
     /**
      * SFP RELATED (6)
      */
-    hideCVC: boolean;
     i18n: Language;
     koreanAuthenticationRequired: boolean;
     hasKoreanFields: boolean;
@@ -55,6 +54,7 @@ export interface SFPProps {
     expiryYear: string; // one-click card
     hasCVC: boolean;
     hasHolderName: boolean;
+    hideCVC: boolean;
     holderName: string;
     holderNameRequired: boolean;
     hasStoreDetails: boolean;

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
@@ -118,8 +118,7 @@ class SecuredField extends AbstractSecuredField {
 
     iframeOnLoadListenerFn(): void {
         if (process.env.NODE_ENV === 'development' && window._b$dl) {
-            logger.log('\n############################');
-            logger.log('### SecuredField:::: onIframeLoaded:: this type=', this.config.txVariant);
+            logger.log('\n### SecuredField:::: onIframeLoaded:: this type=', this.config.txVariant);
         }
 
         off(window, 'load', this.iframeOnLoadListener, false);

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/iframes/postMessageValidation.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/iframes/postMessageValidation.ts
@@ -14,7 +14,6 @@ export const originCheckPassed = (event: MessageEvent, pLoadingContext: string, 
 
     if (origin !== adyenDomain) {
         if (pShowWarnings) {
-            logger.warn('####################################################################################');
             logger.warn(
                 'WARNING postMessageValidation: postMessage listener for iframe::origin mismatch!\n Received message with origin:',
                 origin,
@@ -22,7 +21,6 @@ export const originCheckPassed = (event: MessageEvent, pLoadingContext: string, 
                 adyenDomain
             );
             logger.warn('### event.data=', event.data);
-            logger.warn('####################################################################################');
         }
         return false;
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Since changes in `v3.21.0` to how we validate the `CardInput` - the edge case in `SecuredFieldsProviderHandlers.handleOnBrand` is no longer necessary. This ensured that for one click cards with an optional CVC field the Card component was marked as valid (and 'ready').
However recent changes means this now happens through the `handleOnAllValid` handler & this edge case code is redundant.

## Tested scenarios
All unit & e2e tests pass

