### PR TITLE
Bancontact card component acts correctly when dual branded with Visa

### DIFF
--- a/packages/e2e/tests/cards/Bancontact/bancontact.clientScripts.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.clientScripts.js
@@ -1,0 +1,5 @@
+window.dropinConfig = {
+    showStoredPaymentMethods: false // hide stored PMs
+};
+
+window.mainConfiguration = { allowPaymentMethods: ['bcmc'] };

--- a/packages/e2e/tests/cards/Bancontact/bancontact.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.test.js
@@ -1,0 +1,258 @@
+import cu from '../utils/cardUtils';
+
+const path = require('path');
+require('dotenv').config({ path: path.resolve('../../', '.env') });
+
+import { RequestMock, Selector } from 'testcafe';
+import { start, getIsValid, getIframeSelector } from '../../utils/commonUtils';
+import { BASE_URL } from '../../pages';
+import { DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../utils/constants';
+
+const brandsHolder = Selector('.adyen-checkout__payment-method__brands');
+
+const numberSpan = Selector('.adyen-checkout__dropin .adyen-checkout__card__cardNumber__input');
+const cvcSpan = Selector('.adyen-checkout__dropin .adyen-checkout__field__cvc');
+
+const dualBrandingIconHolder = Selector('.adyen-checkout__payment-method--bcmc .adyen-checkout__card__dual-branding__buttons');
+const dualBrandingIconHolderActive = Selector('.adyen-checkout__payment-method--bcmc .adyen-checkout__card__dual-branding__buttons--active');
+
+const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+
+/**
+ * NOTE - we are mocking the response until such time as we have the correct BIN in the Test DB
+ */
+const mockedResponse = {
+    brands: [
+        {
+            brand: 'bcmc',
+            cvcPolicy: 'hidden',
+            enableLuhnCheck: true,
+            showExpiryDate: true,
+            supported: true
+        },
+        {
+            brand: 'visa',
+            cvcPolicy: 'required',
+            enableLuhnCheck: true,
+            showExpiryDate: true,
+            supported: true
+        }
+    ],
+    issuingCountryCode: 'BE',
+    requestId: null
+};
+
+const mock = RequestMock()
+    .onRequestTo(request => {
+        return request.url === requestURL && request.method === 'post';
+    })
+    .respond(
+        (req, res) => {
+            const body = JSON.parse(req.body);
+            mockedResponse.requestId = body.requestId;
+            res.setBody(mockedResponse);
+        },
+        200,
+        {
+            'Access-Control-Allow-Origin': BASE_URL
+        }
+    );
+
+const TEST_SPEED = 1;
+
+const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--bcmc iframe');
+
+const cardUtils = cu(iframeSelector);
+
+fixture`Testing Bancontact in Dropin`
+    .page(BASE_URL + '?countryCode=BE')
+    .clientScripts('bancontact.clientScripts.js')
+    .requestHooks(mock);
+
+test('Check Bancontact comp is correctly presented at startup', async t => {
+    // Start, allow time to load
+    await start(t, 2000, TEST_SPEED);
+
+    // Expect 3 card brand logos to be displayed
+    await t
+        .expect(brandsHolder.exists)
+        .ok()
+        .expect(
+            brandsHolder
+                .find('img')
+                .nth(0)
+                .getAttribute('alt')
+        )
+        .eql('bcmc')
+        .expect(
+            brandsHolder
+                .find('img')
+                .nth(1)
+                .getAttribute('alt')
+        )
+        .eql('maestro')
+        .expect(
+            brandsHolder
+                .find('img')
+                .nth(2)
+                .getAttribute('alt')
+        )
+        .eql('visa');
+
+    // Hidden cvc field
+    await t.expect(cvcSpan.filterHidden().exists).ok();
+
+    // BCMC logo in number field
+    await t
+        .expect(numberSpan.exists)
+        .ok()
+        .expect(
+            numberSpan
+                .find('img')
+                .nth(0)
+                .getAttribute('alt')
+        )
+        .eql('bcmc');
+});
+
+test('Entering digits that our local regEx will recognise as Visa does not affect the UI', async t => {
+    await start(t, 2000, TEST_SPEED);
+
+    await cardUtils.fillCardNumber(t, '41');
+
+    // BCMC logo still in number field
+    await t
+        .expect(
+            numberSpan
+                .find('img')
+                .nth(0)
+                .getAttribute('alt')
+        )
+        .eql('bcmc');
+
+    // Hidden cvc field
+    await t.expect(cvcSpan.filterHidden().exists).ok();
+});
+
+test('Enter card number, that we mock to co-branded bcmc/visa ' + 'then complete expiryDate and expect comp to be valid', async t => {
+    await start(t, 2000, TEST_SPEED);
+
+    await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+
+    await t
+        .expect(dualBrandingIconHolderActive.exists)
+        .ok()
+        .expect(
+            dualBrandingIconHolderActive
+                .find('img')
+                .nth(0)
+                .getAttribute('data-value')
+        )
+        .eql('bcmc')
+        .expect(
+            dualBrandingIconHolderActive
+                .find('img')
+                .nth(1)
+                .getAttribute('data-value')
+        )
+        .eql('visa');
+
+    await cardUtils.fillDate(t, TEST_DATE_VALUE);
+
+    // Expect comp to now be valid
+    await t.expect(getIsValid('dropin')).eql(true);
+});
+
+test(
+    'Enter card number, that we mock to co-branded bcmc/visa ' +
+        'then complete expiryDate and expect comp to be valid' +
+        'then click Visa logo and expect comp to not be valid' +
+        'then click BCMC logo and expect comp to be valid again',
+    async t => {
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('visa');
+
+        await cardUtils.fillDate(t, TEST_DATE_VALUE);
+
+        // Expect comp to now be valid
+        await t.expect(getIsValid('dropin')).eql(true);
+
+        // Click Visa brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(1));
+
+        // Expect comp not to be valid
+        await t.expect(getIsValid('dropin')).eql(false);
+
+        // Click BCMC brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(0));
+
+        // Expect comp to be valid
+        await t.expect(getIsValid('dropin')).eql(true);
+    }
+);
+
+test(
+    'Enter card number, that we mock to co-branded bcmc/visa ' +
+        'then complete expiryDate and expect comp to be valid' +
+        'then click Visa logo and expect comp to not be valid' +
+        'then enter CVC and expect comp to be valid',
+    async t => {
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('visa');
+
+        await cardUtils.fillDate(t, TEST_DATE_VALUE);
+
+        // Expect comp to now be valid
+        await t.expect(getIsValid('dropin')).eql(true);
+
+        // Click Visa brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(1));
+
+        // Expect comp not to be valid
+        await t.expect(getIsValid('dropin')).eql(false);
+
+        // fill CVC
+        await cardUtils.fillCVC(t, TEST_CVC_VALUE);
+
+        // Expect comp to now be valid
+        await t.expect(getIsValid('dropin')).eql(true);
+    }
+);

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -6,11 +6,18 @@ class BancontactElement extends CardElement {
         super(props);
     }
 
+    /**
+     * Now that the Bancontact (BCMC) Card component can accept a number dual branded with Visa (which requires a CVC) it has to handled differently
+     * at creation time (no automatic removing of the CVC securedField).
+     * At the same time we can't treat it as a regular 'card' component - because it needs to hide the CVC field at at startup,
+     * as well as show the BCMC logo in the number field and ignore any of the internal, regEx driven, brand detection.
+     */
     formatProps(props: CardElementProps) {
         return {
-            ...super.formatProps({ ...props, brand: 'bcmc' }), // Spread props and set brand before passing to super - ensures super.hasCVC gets set to false
-            // Override only display brands (groupTypes are decided earlier on super.formatProps)
-            brands: ['bcmc', 'maestro']
+            ...super.formatProps(props),
+            // Override display brands - these are also the brands that will be considered "supported" by /binLookup
+            brands: ['bcmc', 'maestro', 'visa'],
+            type: 'bcmc' // Force type (only for the Dropin is type automatically set to 'bcmc') - this will bypass the regEx brand detection
         };
     }
 

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -7,7 +7,7 @@ class BancontactElement extends CardElement {
     }
 
     /**
-     * Now that the Bancontact (BCMC) Card component can accept a number dual branded with Visa (which requires a CVC) it has to handled differently
+     * Now that the Bancontact (BCMC) Card component can accept a number dual branded with Visa (which requires a CVC) it has to be handled differently
      * at creation time (no automatic removing of the CVC securedField).
      * At the same time we can't treat it as a regular 'card' component - because it needs to hide the CVC field at at startup,
      * as well as show the BCMC logo in the number field and ignore any of the internal, regEx driven, brand detection.

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -15,7 +15,7 @@ export class CardElement extends UIElement<CardElementProps> {
             ...props,
             // Mismatch between hasHolderName & holderNameRequired which can mean card can never be valid
             holderNameRequired: !props.hasHolderName ? false : props.holderNameRequired,
-            // False for Bcmc cards & if merchant explicitly wants to hide the CVC field
+            // False for *stored* BCMC cards & if merchant explicitly wants to hide the CVC field
             hasCVC: !((props.brand && props.brand === 'bcmc') || props.hideCVC),
             // billingAddressRequired only available for non-stored cards
             billingAddressRequired: props.storedPaymentMethodId ? false : props.billingAddressRequired,

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -39,7 +39,8 @@ export interface CardElementProps extends UIElementProps {
 
     /**
      *  Decides whether CVC component will even be rendered.
-     *  Always true except when hideCVC set to false by merchant OR in the case of a bcmc card
+     *  Always true except when hideCVC set to false by merchant OR in the case of a *stored* BCMC card.
+     *  (For the Bancontact card comp this is set to true since dual-branding possibilities mean the BCMC card can now end up needing to show a CVC field)
      */
     hasCVC?: boolean;
 

--- a/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
@@ -2,7 +2,7 @@ import { Language } from '../../../language/Language';
 
 export interface SFPProps {
     /**
-     * CSF RELATED (23)
+     * CSF RELATED (±22)
      */
     allowedDOMAccess?: boolean;
     autoFocus?: boolean;
@@ -38,7 +38,7 @@ export interface SFPProps {
     render;
 
     /**
-     * RELATED TO COMPS HIGHER UP THE RENDER CHAIN - Card, CardInput etc (36)
+     * RELATED TO COMPS HIGHER UP THE RENDER CHAIN - Card, CardInput etc (±39)
      */
     amount: object;
     billingAddressAllowedCountries: string[];
@@ -46,6 +46,7 @@ export interface SFPProps {
     billingAddressRequiredFields: string[];
     brand: string;
     createFromAction: () => {};
+    cvcPolicy: string;
     data: object;
     details: object[];
     enableStoreDetails: boolean;

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
@@ -1,5 +1,5 @@
 import { select, getAttribute } from '../utilities/dom';
-import { ENCRYPTED_SECURITY_CODE, ENCRYPTED_EXPIRY_YEAR, DATE_POLICY_REQUIRED } from '../configuration/constants';
+import { ENCRYPTED_EXPIRY_YEAR, DATE_POLICY_REQUIRED } from '../configuration/constants';
 import { existy, getCVCPolicy } from '../utilities/commonUtils';
 import cardType from '../utilities/cardType';
 import { SFSetupObject } from './AbstractSecuredField';
@@ -48,9 +48,6 @@ export function createSecuredFields(): number {
 
     // CONTINUE AS CREDIT-CARD TYPE...
     this.isSingleBrandedCard = false;
-
-    // re. BCMC - boolean to indicate whether the markup contains a CVC field that shouldn't be there
-    this.hasRedundantCVCField = false;
 
     this.securityCode = '';
 
@@ -108,7 +105,6 @@ export function createCardSecuredFields(securedFields: HTMLElement[]): number {
             brand: type,
             cvcPolicy: getCVCPolicy(cvcPolicyObj),
             cvcText: this.securityCode
-            //                maxLength: (type === 'amex')? 4 : 3,
         };
 
         setTimeout(() => {
@@ -117,8 +113,7 @@ export function createCardSecuredFields(securedFields: HTMLElement[]): number {
     }
 
     // Return the number of iframes we've created
-    // - taking into account whether we initially tried to create one for an unnecessary CVC field
-    return this.hasRedundantCVCField ? securedFields.length - 1 : securedFields.length;
+    return securedFields.length;
 }
 
 // forEach detected holder for a securedField...
@@ -143,15 +138,6 @@ export function setupSecuredField(pItem: HTMLElement): void {
     }
 
     const extraFieldData: string = getAttribute(pItem, 'data-info');
-
-    // CVC FIELD CHECKS
-    // If we have a fieldType for CVC field AND it's a single branded card AND hideCVC is true...
-    // ...then we are showing a CVC field when we shouldn't e.g. for a BCMC card - so don't make an iframe
-    if (fieldType === ENCRYPTED_SECURITY_CODE && this.isSingleBrandedCard && cvcPolicyObj.hideCVC) {
-        // We have an unnecessary CVC field
-        this.hasRedundantCVCField = true;
-        return;
-    } // -- end CVC FIELD CHECKS
 
     // ////// CREATE SecuredField passing in configObject of props that will be set on the SecuredField instance
     const setupObj: SFSetupObject = {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/handleValidation.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/handleValidation.ts
@@ -9,6 +9,7 @@ export function handleValidation(pFeedbackObj: SFFeedbackObj): void {
     // --
     let callbackObjectsArr: CbObjOnFieldValid[];
     const fieldType: string = pFeedbackObj.fieldType;
+    const isGenericCard: boolean = this.state.type === 'card';
 
     /**
      * CHECK IF CVC IS OPTIONAL
@@ -18,7 +19,7 @@ export function handleValidation(pFeedbackObj: SFFeedbackObj): void {
     // If it is optional, and we're dealing with the generic card type,
     // (re)set the property that indicates this (in the CVC SecuredField instance)
     if (
-        this.state.type === 'card' &&
+        isGenericCard &&
         Object.prototype.hasOwnProperty.call(pFeedbackObj, 'cvcRequired') &&
         existy(pFeedbackObj.cvcRequired) &&
         Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_SECURITY_CODE)

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/handleBrandFromBinLookup.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/handleBrandFromBinLookup.ts
@@ -57,24 +57,22 @@ export function handleBrandFromBinLookup(binLookupResponse: BinLookupResponse): 
     });
 
     /**
-     * CHECK IF BRAND CHANGE MEANS FORM IS NOW VALID e.g maestro/bcmc (which don't require cvc)
+     * CHECK IF BRAND CHANGE MEANS FORM IS NOW VALID e.g maestro/bcmc (which don't require cvc) OR bcmc/visa (one of which doesn't require cvc, one of which does)
      */
-    // NOTE: We currently don't reset the cvcPolicy or datePolicy on single branded card components since we don't expect these policies to change based on typed BIN
-    if (this.state.type === 'card') {
-        /**
-         * Set the cvcPolicy value on the relevant SecuredFields instance (which will reflect in the cvc field being considered valid,
-         *  as long as it is not in error)...
-         */
-        if (Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_SECURITY_CODE)) {
-            this.state.securedFields[ENCRYPTED_SECURITY_CODE].cvcPolicy = binBrandObj.cvcPolicy;
-        }
 
-        /**
-         * ...and set the datePolicy...
-         */
-        if (Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_EXPIRY_DATE)) {
-            this.state.securedFields[ENCRYPTED_EXPIRY_DATE].datePolicy = datePolicy;
-        }
+    /**
+     * Set the cvcPolicy value on the relevant SecuredFields instance (which will reflect in the cvc field being considered valid,
+     *  as long as it is not in error)...
+     */
+    if (Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_SECURITY_CODE)) {
+        this.state.securedFields[ENCRYPTED_SECURITY_CODE].cvcPolicy = binBrandObj.cvcPolicy;
+    }
+
+    /**
+     * ...and set the datePolicy...
+     */
+    if (Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_EXPIRY_DATE)) {
+        this.state.securedFields[ENCRYPTED_EXPIRY_DATE].datePolicy = datePolicy;
     }
 
     /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/handleBrandFromBinLookup.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/handleBrandFromBinLookup.ts
@@ -22,10 +22,14 @@ export function sendBrandToCardSF(brandObj: SendBrandObject): void {
 }
 
 export function handleBrandFromBinLookup(binLookupResponse: BinLookupResponse): void {
+    const isGenericCard: boolean = this.state.type === 'card';
+
     // The number of digits in number field has dropped below threshold for BIN lookup - so tell SF to reset & republish the brand it detects
     if (!binLookupResponse) {
-        // This will be sent to CardNumber SF which will trigger the brand to be re-evaluated and broadcast (which will reset cvcPolicy)
-        this.sendBrandToCardSF({ brand: 'reset' });
+        if (isGenericCard) {
+            // This will be sent to CardNumber SF which will trigger the brand to be re-evaluated and broadcast (which will reset cvcPolicy)
+            this.sendBrandToCardSF({ brand: 'reset' });
+        }
 
         // Reset datePolicy - which never comes from SF
         if (this.state.type === 'card' && Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_EXPIRY_DATE)) {
@@ -50,11 +54,13 @@ export function handleBrandFromBinLookup(binLookupResponse: BinLookupResponse): 
 
     this.processBrand(brandObj as SFFeedbackObj);
 
-    // Pass brand to CardNumber SF
-    this.sendBrandToCardSF({
-        brand: passedBrand,
-        enableLuhnCheck: binLookupResponse.supportedBrands[0].enableLuhnCheck !== false
-    });
+    if (isGenericCard) {
+        // Pass brand to CardNumber SF
+        this.sendBrandToCardSF({
+            brand: passedBrand,
+            enableLuhnCheck: binLookupResponse.supportedBrands[0].enableLuhnCheck !== false
+        });
+    }
 
     /**
      * CHECK IF BRAND CHANGE MEANS FORM IS NOW VALID e.g maestro/bcmc (which don't require cvc) OR bcmc/visa (one of which doesn't require cvc, one of which does)

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processBrand.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processBrand.ts
@@ -32,10 +32,11 @@ export function handleProcessBrand(pFeedbackObj: SFFeedbackObj): BrandInfoObject
             return null;
         }
 
-        const isGenericCard: boolean = this.state.type === 'card';
+        // Now BCMC can dual brand with Visa it must also be treated as a generic card so we can show/hide the CVC field
+        const treatAsGenericCard: boolean = this.state.type === 'card' || this.state.type === 'bcmc';
 
         // ...if also a generic card - tell cvc field...
-        if (isGenericCard && newBrand) {
+        if (treatAsGenericCard && newBrand) {
             this.state.brand = newBrandObj;
             // console.log('### processBrand::handleProcessBrand:: this.state.brand', this.state.brand);
 
@@ -60,7 +61,7 @@ export function handleProcessBrand(pFeedbackObj: SFFeedbackObj): BrandInfoObject
         }
 
         // ...then check for & spread brand related properties...
-        const brandInfoObj: BrandInfoObject = isGenericCard
+        const brandInfoObj: BrandInfoObject = treatAsGenericCard
             ? {
                   ...(pFeedbackObj.brand && { brand: pFeedbackObj.brand }),
                   ...(pFeedbackObj.cvcText && { cvcText: pFeedbackObj.cvcText }),

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processBrand.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processBrand.ts
@@ -34,22 +34,19 @@ export function handleProcessBrand(pFeedbackObj: SFFeedbackObj): BrandInfoObject
 
         // Now BCMC can dual brand with Visa it must also be treated as a generic card so we can show/hide the CVC field
         const treatAsGenericCard: boolean = this.state.type === 'card' || this.state.type === 'bcmc';
+        const isGenericCard: boolean = this.state.type === 'card';
 
         // ...if also a generic card - tell cvc field...
         if (treatAsGenericCard && newBrand) {
             this.state.brand = newBrandObj;
             // console.log('### processBrand::handleProcessBrand:: this.state.brand', this.state.brand);
 
-            const baseDataObj: object = {
-                txVariant: this.state.type,
-                brand: newBrandObj.brand
-            };
-
-            // Perform postMessage to send brand on specified (CVC) field
-            if (Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_SECURITY_CODE)) {
+            // Perform postMessage to send brand on specified (CVC) field - IF we are dealing with a generic card
+            if (isGenericCard && Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_SECURITY_CODE)) {
                 const dataObj: object = {
-                    ...baseDataObj,
                     ...{
+                        txVariant: this.state.type,
+                        brand: newBrandObj.brand,
                         fieldType: ENCRYPTED_SECURITY_CODE,
                         hideCVC: pFeedbackObj.cvcPolicy === CVC_POLICY_HIDDEN,
                         cvcRequired: pFeedbackObj.cvcPolicy === CVC_POLICY_REQUIRED,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Now that the Bancontact (BCMC) Card component can accept a number dual branded with Visa (which requires a CVC) it has to be handled differently at creation time (no automatic removing of the CVC securedField).
At the same time we can't treat it as a regular 'card' component - because it needs to hide the CVC field at at startup,
as well as show the BCMC logo in the number field and ignore any of the internal, regEx driven, brand detection.

## Tested scenarios
Tested manually and also added e2e test for the expected scenarios/UI changes

**Fixed issue**:  Continuation of issue COWEB-869
