### PR TITLE
Apply sorting rules to brands returned by binLookup

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -1,5 +1,6 @@
 import { getImageUrl } from '../../../../utils/get-image';
 import { BrandObject, DualBrandSelectElement } from '../../types';
+import { CVC_POLICY_HIDDEN } from '../../../internal/SecuredFields/lib/configuration/constants';
 
 export const getCardImageUrl = (brand: string, loadingContext: string): string => {
     const imageOptions = {
@@ -30,4 +31,53 @@ export const createCardVariantSwitcher = (brandObj: BrandObject[]) => {
         },
         leadBrand
     };
+};
+
+/**
+ * At some time in the future hopefully the /binLookup will be able to sort the returned brands array according to the criteria below
+ * But until that happy day we must use the following Utils
+ */
+const objByBrand = brandStr => element => element.brand === brandStr;
+const objIsPLCC = element => element.brand.includes('plcc') || element.brand.includes('cbcc');
+
+export const sortBrandsAccordingToRules = (brandsArray: any, cardType: string): any => {
+    // Don't mutate the original
+    const clonedArr = brandsArray.map(item => ({ ...item }));
+
+    const hasBCMC = clonedArr.some(objByBrand('bcmc'));
+    const hasMaestro = clonedArr.some(objByBrand('maestro'));
+    const hasVisa = clonedArr.some(objByBrand('visa'));
+    const hasCarteBancaire = clonedArr.some(objByBrand('cartebancaire'));
+    const hasPLCC = clonedArr.some(objIsPLCC);
+
+    /**
+     * RULE 1: if BCMC card component then bcmc is always the first of the dual brands
+     */
+    if (cardType === 'bcmc' && hasBCMC) {
+        if (clonedArr[0].brand !== 'bcmc') clonedArr.reverse();
+    }
+
+    /**
+     * RULE 2: if BCMC card component & bcmc is dual branded with maestro
+     *  - maestro has cvcPolicy:'hidden'
+     */
+    if (cardType === 'bcmc' && hasBCMC && hasMaestro) {
+        clonedArr[1].cvcPolicy = CVC_POLICY_HIDDEN; // Maestro already placed into index 1 by Rule 1
+    }
+
+    /**
+     * RULE 3: if regular card and dual branding contains Visa & Cartebancaire - ensure Visa is first
+     */
+    if (cardType === 'card' && hasVisa && hasCarteBancaire) {
+        if (clonedArr[0].brand !== 'visa') clonedArr.reverse();
+    }
+
+    /**
+     * RULE 4: if regular card and dual branding contains a PLCC this should be shown first
+     */
+    if (cardType === 'card' && hasPLCC) {
+        if (!clonedArr[0].brand.includes('plcc') && !clonedArr[0].brand.includes('cbcc')) clonedArr.reverse();
+    }
+
+    return clonedArr;
 };

--- a/packages/lib/src/components/Card/triggerBinLookUp.ts
+++ b/packages/lib/src/components/Card/triggerBinLookUp.ts
@@ -4,6 +4,7 @@ import { DEFAULT_CARD_GROUP_TYPES } from '../internal/SecuredFields/lib/configur
 import { getError } from '../../core/Errors/utils';
 import { ERROR_MSG_UNSUPPORTED_CARD_ENTERED } from '../../core/Errors/constants';
 import { BinLookupResponse, BinLookupResponseRaw } from './types';
+import { sortBrandsAccordingToRules } from './components/CardInput/utils';
 
 export default function triggerBinLookUp(callbackObj: CbObjOnBinValue) {
     // Allow way for merchant to disallow binLookup by specifically setting the prop to false
@@ -32,20 +33,17 @@ export default function triggerBinLookUp(callbackObj: CbObjOnBinValue) {
             // If response is the one we were waiting for...
             if (data?.requestId === this.currentRequestId) {
                 if (data.brands?.length) {
-                    const mappedResponse = data.brands.reduce(
+                    // Sort brands according to rules
+                    const sortedBrands = data.brands.length === 2 ? sortBrandsAccordingToRules(data.brands, this.props.type) : data.brands;
+
+                    const mappedResponse = sortedBrands.reduce(
                         (acc, item) => {
                             // All brand strings end up in the detectedBrands array
                             acc.detectedBrands.push(item.brand);
 
                             // Add supported brand objects to the supportedBrands array
                             if (item.supported === true) {
-                                /**
-                                 * NOTE we are currently using item.enableLuhnCheck === false as an indicator of a PLCC - this could/should change in the future
-                                 */
-                                // Add PLCCs to the front of the array so their icons are displayed first
-                                const action = item.enableLuhnCheck === false ? 'unshift' : 'push';
-                                acc.supportedBrands[action](item);
-
+                                acc.supportedBrands.push(item);
                                 return acc;
                             }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added a frontend layer to sort the array of `brands` objects from the /binLookup response.
This is necessary because there are some inconsistencies in the /binLookup response: 
e.g. card brands not always returned in the same order
and the fact that some components force new rules:
e.g. standalone Bancontact/BCMC card component with a dual branded bcmc/maestro card should show the maestro brand with a hidden cvc field 
To correct these things we now apply some rules via a frontend sorting procedure.
In the future it may be that the /binLookup will be able to sort the returned brands array according to these criteria.

## Tested scenarios
Tested the rules are applied and the brands are sorted accordingly.

