### PR TITLE
Brand (in PaymentMethod data) is reset after a failed binLookup

### DIFF
--- a/packages/e2e/tests/cards/Bancontact/bancontact.dualbranding.reset.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.dualbranding.reset.test.js
@@ -1,0 +1,245 @@
+import cu from '../utils/cardUtils';
+import { ClientFunction, Selector } from 'testcafe';
+import { start, getIframeSelector } from '../../utils/commonUtils';
+import { BASE_URL } from '../../pages';
+import { BCMC_CARD, UNKNOWN_VISA_CARD } from '../utils/constants';
+
+const cvcSpan = Selector('.adyen-checkout__dropin .adyen-checkout__field__cvc');
+
+const brandingIcon = Selector('.adyen-checkout__dropin .adyen-checkout__card__cardNumber__brandIcon');
+const dualBrandingIconHolderActive = Selector('.adyen-checkout__payment-method--bcmc .adyen-checkout__card__dual-branding__buttons--active');
+
+const getPropFromPMData = ClientFunction(prop => {
+    return window.dropin.dropinRef.state.activePaymentMethod.formatData().paymentMethod[prop];
+});
+
+const TEST_SPEED = 1;
+
+const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--bcmc iframe');
+
+const cardUtils = cu(iframeSelector);
+
+fixture`Testing Bancontact, with dual branded cards, in Dropin, resetting after failed binLookup`
+    .page(BASE_URL + '?countryCode=BE')
+    .clientScripts('bancontact.clientScripts.js');
+
+test(
+    'Fill in dual branded card then ' +
+        'check that brands have been sorted to place Bcmc first then ' +
+        'ensure only bcmc logo shows after deleting digits',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        // Bcmc first, Maestro second
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro');
+
+        await cardUtils.deleteCardNumber(t);
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('bcmc');
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'select bcmc, as first item (brand sorting has occurred), then' +
+        'ensure only bcmc logo shows after deleting digits and ' +
+        'that the brand has been reset on paymentMethod data',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro');
+
+        // Click BCMC brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(0));
+
+        // Should be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql('bcmc');
+
+        await cardUtils.deleteCardNumber(t);
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('bcmc');
+
+        // Should not be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql(undefined);
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'select maestro then' +
+        'ensure cvc field is hidden even though it is maestro (brand sorting has occurred)' +
+        'ensure only bcmc logo shows after deleting digits and ' +
+        'that the brand has been reset on paymentMethod data',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro');
+
+        // Click Maestro brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(1));
+
+        // Should be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql('maestro');
+
+        // Hidden cvc field
+        await t.expect(cvcSpan.filterHidden().exists).ok();
+
+        await cardUtils.deleteCardNumber(t);
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('bcmc');
+
+        // Should not be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql(undefined);
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'paste in number not recognised by binLookup (but that internally is recognised as Visa)' +
+        'ensure that bcmc logo shows',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro');
+
+        await cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste'); // number not recognised by binLookup
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('bcmc');
+
+        await t.wait(2000);
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'select maestro then' +
+        'paste in number not recognised by binLookup (but that internally is recognised as Visa)' +
+        'ensure that bcmc logo shows',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro');
+
+        // Click Maestro brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(1));
+
+        // Hidden cvc field
+        await t.expect(cvcSpan.filterHidden().exists).ok();
+
+        await cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste'); // number not recognised by binLookup
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('bcmc');
+
+        await t.wait(2000);
+    }
+);

--- a/packages/e2e/tests/cards/Bancontact/bancontact.dualbranding.reset.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.dualbranding.reset.test.js
@@ -193,8 +193,6 @@ test(
             // bcmc card icon
             .expect(brandingIcon.getAttribute('alt'))
             .contains('bcmc');
-
-        await t.wait(2000);
     }
 );
 

--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.reset.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.reset.test.js
@@ -1,0 +1,189 @@
+import cu from '../utils/cardUtils';
+
+const path = require('path');
+require('dotenv').config({ path: path.resolve('../../', '.env') });
+
+import { RequestMock, Selector } from 'testcafe';
+import { start, getIsValid, getIframeSelector } from '../../utils/commonUtils';
+import { BASE_URL } from '../../pages';
+import { DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE, UNKNOWN_VISA_CARD } from '../utils/constants';
+
+const cvcSpan = Selector('.adyen-checkout__dropin .adyen-checkout__field__cvc');
+
+const brandingIcon = Selector('.adyen-checkout__dropin .adyen-checkout__card__cardNumber__brandIcon');
+
+const dualBrandingIconHolderActive = Selector('.adyen-checkout__payment-method--bcmc .adyen-checkout__card__dual-branding__buttons--active');
+
+const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+
+/**
+ * NOTE - we are mocking the response until such time as we have the correct BIN in the Test DB
+ */
+const mockedResponse = {
+    brands: [
+        {
+            brand: 'bcmc',
+            cvcPolicy: 'hidden',
+            enableLuhnCheck: true,
+            showExpiryDate: true,
+            supported: true
+        },
+        {
+            brand: 'visa',
+            cvcPolicy: 'required',
+            enableLuhnCheck: true,
+            showExpiryDate: true,
+            supported: true
+        }
+    ],
+    issuingCountryCode: 'BE',
+    requestId: null
+};
+
+const mockedNullResponse = {
+    requestId: null
+};
+
+let sendNullResponse = false;
+
+const mock = RequestMock()
+    .onRequestTo(request => {
+        return request.url === requestURL && request.method === 'post';
+    })
+    .respond(
+        (req, res) => {
+            const body = JSON.parse(req.body);
+
+            if (sendNullResponse === false) {
+                mockedResponse.requestId = body.requestId;
+                res.setBody(mockedResponse);
+                sendNullResponse = true;
+            } else {
+                mockedNullResponse.requestId = body.requestId;
+                res.setBody(mockedNullResponse);
+                sendNullResponse = false;
+            }
+        },
+        200,
+        {
+            'Access-Control-Allow-Origin': BASE_URL
+        }
+    );
+
+const TEST_SPEED = 0.5;
+
+const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--bcmc iframe');
+
+const cardUtils = cu(iframeSelector);
+
+fixture`Testing Bancontact in Dropin`
+    .page(BASE_URL + '?countryCode=BE')
+    .clientScripts('bancontact.clientScripts.js')
+    .requestHooks(mock);
+
+test(
+    'Enter card number, that we mock to co-branded bcmc/visa ' +
+        'then click Visa logo and expect CVC field to show, then' +
+        'paste in number not recognised by binLookup (but that internally is recognised as Visa)' +
+        'ensure that bcmc logo shows & CVC field is hidden',
+    async t => {
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('visa');
+
+        // Click Visa brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(1));
+
+        // Visible CVC field
+        await t.expect(cvcSpan.filterVisible().exists).ok();
+
+        // Expect iframe to exist in CVC field and with aria-required set to true
+        // TODO comment in once sf 3.4.1 is on Test
+        //        await t
+        //            .switchToIframe(iframeSelector.nth(2))
+        //            .expect(Selector('#encryptedSecurityCode').getAttribute('aria-required'))
+        //            .eql('true')
+        //            .switchToMainWindow();
+
+        await cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste'); // number not recognised by binLookup
+
+        // Hidden CVC field
+        await t.expect(cvcSpan.filterHidden().exists).ok();
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('bcmc');
+    }
+);
+test(
+    'Enter card number, that we mock to co-branded bcmc/visa ' +
+        'then click Visa logo and expect CVC field to show, then' +
+        'delete card number and ' +
+        'ensure that bcmc logo shows & CVC field is hidden',
+    async t => {
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('visa');
+
+        // Click Visa brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(1));
+
+        // Visible CVC field
+        await t.expect(cvcSpan.filterVisible().exists).ok();
+
+        // Expect iframe to exist in CVC field and with aria-required set to true
+        // TODO comment in once sf 3.4.1 is on Test
+        //        await t
+        //            .switchToIframe(iframeSelector.nth(2))
+        //            .expect(Selector('#encryptedSecurityCode').getAttribute('aria-required'))
+        //            .eql('true')
+        //            .switchToMainWindow();
+
+        await cardUtils.deleteCardNumber(t);
+
+        // Hidden CVC field
+        await t.expect(cvcSpan.filterHidden().exists).ok();
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('bcmc');
+    }
+);

--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
@@ -202,7 +202,7 @@ test(
         await t.expect(cvcSpan.filterVisible().exists).ok();
 
         // Expect iframe to exist in CVC field and with aria-required set to true
-        return t
+        await t
             .switchToIframe(iframeSelector.nth(2))
             .expect(Selector('#encryptedSecurityCode').getAttribute('aria-required'))
             .eql('true')

--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
@@ -13,7 +13,6 @@ const brandsHolder = Selector('.adyen-checkout__payment-method__brands');
 const numberSpan = Selector('.adyen-checkout__dropin .adyen-checkout__card__cardNumber__input');
 const cvcSpan = Selector('.adyen-checkout__dropin .adyen-checkout__field__cvc');
 
-const dualBrandingIconHolder = Selector('.adyen-checkout__payment-method--bcmc .adyen-checkout__card__dual-branding__buttons');
 const dualBrandingIconHolderActive = Selector('.adyen-checkout__payment-method--bcmc .adyen-checkout__card__dual-branding__buttons--active');
 
 const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
@@ -199,11 +198,24 @@ test(
         // Click Visa brand icon
         await t.click(dualBrandingIconHolderActive.find('img').nth(1));
 
+        // Visible CVC field
+        await t.expect(cvcSpan.filterVisible().exists).ok();
+
+        // Expect iframe to exist in CVC field and with aria-required set to true
+        return t
+            .switchToIframe(iframeSelector.nth(2))
+            .expect(Selector('#encryptedSecurityCode').getAttribute('aria-required'))
+            .eql('true')
+            .switchToMainWindow();
+
         // Expect comp not to be valid
         await t.expect(getIsValid('dropin')).eql(false);
 
         // Click BCMC brand icon
         await t.click(dualBrandingIconHolderActive.find('img').nth(0));
+
+        // Hidden CVC field
+        await t.expect(cvcSpan.filterHidden().exists).ok();
 
         // Expect comp to be valid
         await t.expect(getIsValid('dropin')).eql(true);

--- a/packages/e2e/tests/cards/dualBranding/binLookup.branding.reset.clientScripts.js
+++ b/packages/e2e/tests/cards/dualBranding/binLookup.branding.reset.clientScripts.js
@@ -1,0 +1,17 @@
+/**
+ * Set cartebancaire as a brand since the test dual brand card is visa/cb
+ */
+window.cardConfig = {
+    type: 'scheme',
+    brands: ['mc', 'visa', 'amex', 'cartebancaire']
+};
+
+window.dropinConfig = {
+    showStoredPaymentMethods: false // hide stored PMs so credit card is first on list
+};
+
+window.mainConfiguration = {
+    paymentMethodsConfiguration: {
+        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire', 'bcmc', 'maestro'] }
+    }
+};

--- a/packages/e2e/tests/cards/dualBranding/binLookup.branding.reset.test.js
+++ b/packages/e2e/tests/cards/dualBranding/binLookup.branding.reset.test.js
@@ -1,0 +1,304 @@
+import cu from '../utils/cardUtils';
+import { ClientFunction, Selector } from 'testcafe';
+import { start, getIsValid, getIframeSelector } from '../../utils/commonUtils';
+import { BASE_URL } from '../../pages';
+import { BCMC_CARD, UNKNOWN_VISA_CARD, REGULAR_TEST_CARD } from '../utils/constants';
+
+const cvcSpan = Selector('.adyen-checkout__dropin .adyen-checkout__field__cvc');
+
+const brandingIcon = Selector('.adyen-checkout__dropin .adyen-checkout__card__cardNumber__brandIcon');
+const dualBrandingIconHolderActive = Selector('.adyen-checkout__payment-method--card .adyen-checkout__card__dual-branding__buttons--active');
+
+const getPropFromPMData = ClientFunction(prop => {
+    return window.dropin.dropinRef.state.activePaymentMethod.formatData().paymentMethod[prop];
+});
+
+const TEST_SPEED = 1;
+
+const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--card iframe');
+
+const cardUtils = cu(iframeSelector);
+
+fixture`Testing Card component, in Dropin, resetting brand after failed binLookup`
+    .page(BASE_URL)
+    .clientScripts('binLookup.branding.reset.clientScripts.js');
+
+/**
+ * SINGLE BRANDING RESETS
+ */
+test(
+    'Fill in regular MC card then ' +
+        'check that a brand has been set on PM data, then' +
+        'paste in a card unrecognised by binLookup, ' +
+        'check that the brand has been reset on paymentMethod data and ' +
+        'that the internal regex have recognised the unrecognised card as Visa',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD); // mc
+
+        // Should be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql('mc');
+
+        // Paste number not recognised by binLookup
+        await cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste');
+
+        // Brand property in the PM data should be reset
+        await t.expect(getPropFromPMData('brand')).eql(undefined);
+
+        await t
+            // visa card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('visa');
+    }
+);
+
+test(
+    'Fill in regular MC card then ' +
+        'check that a brand has been set on PM data, then' +
+        'delete digits and , ' +
+        'check that the brand has been reset on paymentMethod data ',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, REGULAR_TEST_CARD); // mc
+
+        // Should be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql('mc');
+
+        // Paste number not recognised by binLookup
+        await cardUtils.deleteCardNumber(t);
+
+        // Brand property in the PM data should be reset
+        await t.expect(getPropFromPMData('brand')).eql(undefined);
+
+        await t
+            // generic card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('card');
+    }
+);
+
+/**
+ * DUAL BRANDING RESETS (similar to those done in bancontact.dualbranding.reset.test, but applied to the regular card component, in Dropin)
+ */
+test(
+    'Fill in dual branded card then ' +
+        'check no sorting has occurred to place bcmc first, then' +
+        'ensure only generic card logo shows after deleting digits',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        // Maestro first, Bcmc second
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc');
+
+        await cardUtils.deleteCardNumber(t);
+
+        await t
+            // generic card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('card');
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'select bcmc then' +
+        'ensure only generic card logo shows after deleting digits and ' +
+        'that the brand has been reset on paymentMethod data',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc');
+
+        // Click BCMC brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(1));
+
+        // Should be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql('bcmc');
+
+        await cardUtils.deleteCardNumber(t);
+
+        await t
+            // generic card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('card');
+
+        // Should not be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql(undefined);
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'select maestro then' +
+        'ensure cvc field is shown' +
+        'ensure only bcmc logo shows after deleting digits and ' +
+        'that the brand has been reset on paymentMethod data',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc');
+
+        // Click Maestro brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(0));
+
+        // Should be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql('maestro');
+
+        // Hidden cvc field
+        await t.expect(cvcSpan.filterVisible().exists).ok();
+
+        await cardUtils.deleteCardNumber(t);
+
+        await t
+            // generic card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('card');
+
+        // Should not be a brand property in the PM data
+        await t.expect(getPropFromPMData('brand')).eql(undefined);
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'paste in number not recognised by binLookup (but that internally is recognised as Visa)' +
+        'ensure that Visa logo shows',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc');
+
+        await cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste'); // number not recognised by binLookup
+
+        await t
+            // generic card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('visa');
+
+        await t.wait(2000);
+    }
+);
+
+test(
+    'Fill in dual branded card then ' +
+        'select maestro then ' +
+        'paste in number not recognised by binLookup (but that internally is recognised as Visa)' +
+        'ensure that visa logo shows',
+    async t => {
+        // Start, allow time to load
+        await start(t, 2000, TEST_SPEED);
+
+        await cardUtils.fillCardNumber(t, BCMC_CARD); // dual branded with maestro
+
+        await t
+            .expect(dualBrandingIconHolderActive.exists)
+            .ok()
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(0)
+                    .getAttribute('data-value')
+            )
+            .eql('maestro')
+            .expect(
+                dualBrandingIconHolderActive
+                    .find('img')
+                    .nth(1)
+                    .getAttribute('data-value')
+            )
+            .eql('bcmc');
+
+        // Click Maestro brand icon
+        await t.click(dualBrandingIconHolderActive.find('img').nth(0));
+
+        // Hidden cvc field
+        await t.expect(cvcSpan.filterVisible().exists).ok();
+
+        await cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste'); // number not recognised by binLookup
+
+        await t
+            // bcmc card icon
+            .expect(brandingIcon.getAttribute('alt'))
+            .contains('visa');
+    }
+);

--- a/packages/e2e/tests/cards/utils/constants.js
+++ b/packages/e2e/tests/cards/utils/constants.js
@@ -4,6 +4,7 @@ export const DUAL_BRANDED_CARD = '4035501000000008'; // dual branded visa & cart
 export const MAESTRO_CARD = '5000550000000029';
 export const BCMC_CARD = '6703444444444449'; // actually dual branded bcmc & maestro
 export const UNKNOWN_BIN_CARD = '135410014004955'; // card that is not in the test DBs (uatp)
+export const UNKNOWN_VISA_CARD = '4111111111111111'; // card that is not in the test DBs (visa)
 
 export const FAILS_LUHN_CARD = '4111111111111112';
 

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -1,5 +1,6 @@
 import { CardElement } from './Card';
 import { CardElementProps } from './types';
+import { CVC_POLICY_HIDDEN } from '../internal/SecuredFields/lib/configuration/constants';
 
 class BancontactElement extends CardElement {
     constructor(props: CardElementProps) {
@@ -17,7 +18,8 @@ class BancontactElement extends CardElement {
             ...super.formatProps(props),
             // Override display brands - these are also the brands that will be considered "supported" by /binLookup
             brands: ['bcmc', 'maestro', 'visa'],
-            type: 'bcmc' // Force type (only for the Dropin is type automatically set to 'bcmc') - this will bypass the regEx brand detection
+            type: 'bcmc', // Force type (only for the Dropin is type automatically set to 'bcmc') - this will bypass the regEx brand detection
+            cvcPolicy: CVC_POLICY_HIDDEN
         };
     }
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -74,8 +74,8 @@ export class CardElement extends UIElement<CardElementProps> {
         if (this.props.onBrand) this.props.onBrand(event);
     };
 
-    processBinLookupResponse(binLookupResponse: BinLookupResponse) {
-        if (this.componentRef?.processBinLookupResponse) this.componentRef.processBinLookupResponse(binLookupResponse);
+    processBinLookupResponse(binLookupResponse: BinLookupResponse, isReset = false) {
+        if (this.componentRef?.processBinLookupResponse) this.componentRef.processBinLookupResponse(binLookupResponse, isReset);
         return this;
     }
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -150,11 +150,11 @@ class CardInput extends Component<CardInputProps, CardInputState> {
         if (this.kcpAuthenticationRef?.current) this.kcpAuthenticationRef.current.showValidation();
     }
 
-    public processBinLookupResponse(data: BinLookupResponse) {
+    public processBinLookupResponse(data: BinLookupResponse, isReset: boolean) {
         const issuingCountryCode = data?.issuingCountryCode ? data.issuingCountryCode.toLowerCase() : null;
 
         this.setState({ issuingCountryCode }, () => {
-            this.processBinLookup(data);
+            this.processBinLookup(data, isReset);
         });
     }
 

--- a/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.scss
@@ -1,6 +1,6 @@
 .adyen-checkout__card__dual-branding__buttons{
   display: flex;
-  opacity: 0.25;
+  opacity: 0.40;
   pointer-events: none;
 
   &--active{
@@ -17,7 +17,7 @@
     }
 
     &--not-selected{
-      opacity: 0.25;
+      opacity: 0.50;
     }
   }
 }

--- a/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
+++ b/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
@@ -3,11 +3,16 @@ import { BinLookupResponse } from '../../types';
 
 // Based on values in binValueObject we might need to trigger additional markup
 // e.g. a selector for brands or to choose between credit/debit card variations
-export default function processBinLookupResponse(binLookupResponse: BinLookupResponse): void {
+export default function processBinLookup(binLookupResponse: BinLookupResponse, isReset: boolean): void {
     // RESET: The number of digits in number field has dropped below threshold for BIN lookup - so reset the UI & inform SFP
     if (!binLookupResponse) {
         this.resetAdditionalSelectState();
-        this.sfp.current.processBinLookupResponse(binLookupResponse);
+
+        // If /binLookup has 'reset' then for a generic card the internal regex will kick in to show the right brand icon
+        // However for a single-branded card we need to pass the "base" type so the brand logo is reset
+        const brandToReset = isReset && this.props.type !== 'card' ? this.props.type : null;
+
+        this.sfp.current.processBinLookupResponse(binLookupResponse, brandToReset);
         return;
     }
 

--- a/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
+++ b/packages/lib/src/components/Card/components/CardInput/processBinLookup.ts
@@ -1,5 +1,6 @@
 import { createCardVariantSwitcher } from './utils';
 import { BinLookupResponse } from '../../types';
+import { SingleBrandResetObject } from '../../../internal/SecuredFields/SecuredFieldsProvider';
 
 // Based on values in binValueObject we might need to trigger additional markup
 // e.g. a selector for brands or to choose between credit/debit card variations
@@ -12,7 +13,10 @@ export default function processBinLookup(binLookupResponse: BinLookupResponse, i
         // However for a single-branded card we need to pass the "base" type so the brand logo is reset
         const brandToReset = isReset && this.props.type !== 'card' ? this.props.type : null;
 
-        this.sfp.current.processBinLookupResponse(binLookupResponse, brandToReset);
+        this.sfp.current.processBinLookupResponse(binLookupResponse, {
+            brand: brandToReset,
+            cvcPolicy: this.props.cvcPolicy
+        } as SingleBrandResetObject);
         return;
     }
 

--- a/packages/lib/src/components/Card/triggerBinLookUp.ts
+++ b/packages/lib/src/components/Card/triggerBinLookUp.ts
@@ -107,6 +107,10 @@ export default function triggerBinLookUp(callbackObj: CbObjOnBinValue) {
                         supportedBrands: null,
                         brands: this.props.brands || DEFAULT_CARD_GROUP_TYPES
                     } as CbObjOnBinLookup);
+
+                    // Reset the UI and let the native, regex branding happen (for the generic card)
+                    // For a single-branded card we need to pass a boolean to prompt resetting the brand logo to the 'base' type
+                    this.processBinLookupResponse(null, true);
                 }
             } else {
                 if (!data?.requestId) {
@@ -119,7 +123,7 @@ export default function triggerBinLookUp(callbackObj: CbObjOnBinValue) {
     } else if (this.currentRequestId) {
         // If onBinValue callback is called AND we have been doing binLookup BUT passed object doesn't have an encryptedBin property
         // - then the number of digits in number field has dropped below threshold for BIN lookup - so reset the UI
-        this.processBinLookupResponse(null);
+        this.processBinLookupResponse(null, true);
 
         this.currentRequestId = null; // Ignore any pending responses
 

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -256,7 +256,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             });
     }
 
-    public processBinLookupResponse(binLookupResponse: BinLookupResponse): void {
+    public processBinLookupResponse(binLookupResponse: BinLookupResponse, brandToReset: string): void {
         // If we were dealing with an unsupported card and now we have a valid /binLookup response - reset state and inform CSF
         // (Scenario: from an unsupportedCard state the shopper has pasted another number long enough to trigger a /binLookup)
         if (this.state.hasUnsupportedCard) {
@@ -268,6 +268,11 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
         }
 
         this.issuingCountryCode = binLookupResponse?.issuingCountryCode?.toLowerCase();
+
+        // If "resetting" /binLookup for a single-branded card, brandToReset will be the value of the brand whose logo we want to reshow
+        if (brandToReset) {
+            this.setState({ brand: brandToReset });
+        }
 
         // Scenarios:
         // RESET (binLookupResponse === null): The number of digits in number field has dropped below threshold for BIN lookup

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -36,6 +36,11 @@ export interface SFPState {
     hideDateForBrand?: boolean;
 }
 
+export interface SingleBrandResetObject {
+    brand: string;
+    cvcPolicy: CVCPolicyType;
+}
+
 /**
  * SecuredFieldsProvider:
  * Initialises & handles the client-side part of SecuredFields
@@ -256,7 +261,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             });
     }
 
-    public processBinLookupResponse(binLookupResponse: BinLookupResponse, brandToReset: string): void {
+    public processBinLookupResponse(binLookupResponse: BinLookupResponse, resetObject: SingleBrandResetObject): void {
         // If we were dealing with an unsupported card and now we have a valid /binLookup response - reset state and inform CSF
         // (Scenario: from an unsupportedCard state the shopper has pasted another number long enough to trigger a /binLookup)
         if (this.state.hasUnsupportedCard) {
@@ -269,9 +274,11 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
 
         this.issuingCountryCode = binLookupResponse?.issuingCountryCode?.toLowerCase();
 
-        // If "resetting" /binLookup for a single-branded card, brandToReset will be the value of the brand whose logo we want to reshow
-        if (brandToReset) {
-            this.setState({ brand: brandToReset });
+        // If "resetting" /binLookup for a single-branded card, resetObject.brand will be the value of the brand whose logo we want to reshow
+        if (resetObject?.brand) {
+            this.setState(resetObject, () => {
+                this.props.onChange(this.state);
+            });
         }
 
         // Scenarios:


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When card information is entered, and recognised by `/binLookup`, a `brand` property is set which will ultimately end up in the `paymentMethod` data submitted to the `/payments` endpoint.
However if the shopper then _pastes_ a second card number directly into the field - the `paymentMethod.brand` will remain set to the previous card brand.
This PR ensures that if `/binLookup` fails to recognize the BIN for a second card then this `brand` property is reset.

## Tested scenarios
Various e2e tests included to test the above scenario.
Also testing:
- that for the Bancontact card component - a "reset" for an unrecognised card means the BCMC logo is once again displayed
- for the generic Card component this "reset" ensures that the internal regex brand detection takes place on the card number

**Fixed issue**:  COWEB-937
