### PR TITLE
Default playground to module dependencies entry

### DIFF
--- a/packages/playground/config/webpack.config.js
+++ b/packages/playground/config/webpack.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     resolve: {
+        mainFields: ['module', 'main'],
         extensions: ['.js', '.jsx', '.ts', '.tsx', '.scss']
     },
     stats: { children: false },

--- a/packages/playground/src/pages/Dropin/Dropin.js
+++ b/packages/playground/src/pages/Dropin/Dropin.js
@@ -1,4 +1,4 @@
-import AdyenCheckout from '@adyen/adyen-web/dist/es';
+import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/adyen.css';
 import { makeDetailsCall, makePayment, getPaymentMethods, checkBalance, createOrder, cancelOrder } from '../../services';
 import { amount, shopperLocale, countryCode } from '../../config/commonConfig';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Load the `module` entry on the `package.json` for dependencies (skipping the default `browser`) on the Playground. See https://webpack.js.org/configuration/resolve/#resolvemainfields.