### PR TITLE
Feature/pass new props to sf

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -5,7 +5,7 @@ import handlers from './SecuredFieldsProviderHandlers';
 import defaultProps, { SFPProps } from './defaultProps';
 import {
     CSFReturnObject,
-    SetupObject,
+    CSFSetupObject,
     StylesObject,
     CbObjOnError,
     CbObjOnFocus,
@@ -146,7 +146,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             loadingContext = process.env.__SF_ENV__;
         }
 
-        const csfSetupObj: SetupObject = {
+        const csfSetupObj: CSFSetupObject = {
             rootNode: root,
             type: this.props.type,
             clientKey: this.props.clientKey,
@@ -174,7 +174,9 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
                 onAdditionalSFConfig: this.props.onAdditionalSFConfig,
                 onAdditionalSFRemoved: this.props.onAdditionalSFRemoved
             },
-            isKCP: this.state.hasKoreanFields
+            isKCP: this.state.hasKoreanFields,
+            legacyInputMode: this.props.legacyInputMode,
+            maxExpiryDate: this.props.maxExpiryDate
         };
 
         this.csf = initCSF(csfSetupObj);

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -176,7 +176,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             },
             isKCP: this.state.hasKoreanFields,
             legacyInputMode: this.props.legacyInputMode,
-            maxExpiryDate: this.props.maxExpiryDate
+            minimumExpiryDate: this.props.minimumExpiryDate
         };
 
         this.csf = initCSF(csfSetupObj);

--- a/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
@@ -36,6 +36,8 @@ export interface SFPProps {
     onChange;
     oneClick: boolean;
     render;
+    legacyInputMode: boolean;
+    maxExpiryDate: string;
 
     /**
      * RELATED TO COMPS HIGHER UP THE RENDER CHAIN - Card, CardInput etc (±39)

--- a/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/defaultProps.ts
@@ -37,7 +37,7 @@ export interface SFPProps {
     oneClick: boolean;
     render;
     legacyInputMode: boolean;
-    maxExpiryDate: string;
+    minimumExpiryDate: string;
 
     /**
      * RELATED TO COMPS HIGHER UP THE RENDER CHAIN - Card, CardInput etc (±39)

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/configureCallbacks.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/configureCallbacks.ts
@@ -1,8 +1,8 @@
-import { CallbacksConfig } from '../types';
+import { CSFCallbacksConfig } from '../types';
 
 const noop = () => {};
 
-export function configureCallbacks(callbacksObj: CallbacksConfig = ({} as any) as CallbacksConfig): void {
+export function configureCallbacks(callbacksObj: CSFCallbacksConfig = ({} as any) as CSFCallbacksConfig): void {
     // --
     this.callbacks.onLoad = callbacksObj.onLoad ? callbacksObj.onLoad : noop;
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -14,7 +14,7 @@ export const GIFT_CARD = 'giftcard';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.4.0';
+export const SF_VERSION = '3.4.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
@@ -50,6 +50,12 @@ export function handleConfig(): void {
     // By default CSF is allowed to add a fix for iOS to force the keypad to retract - user of CSF must explicitly 'opt-out' to prevent this happening
     this.config.keypadFix = !(this.props.keypadFix === false || this.props.keypadFix === 'false');
 
+    // To set the type on the iframe input fields to 'tel' c.f. the default 'text' (with inputmode='numeric')
+    this.config.legacyInputMode = this.props.legacyInputMode || null;
+
+    // To configure the maximum expiry date to a merchant defined value
+    this.config.maxExpiryDate = this.props.maxExpiryDate || null;
+
     this.config.sfLogAtStart = this.props._b$dl === true;
 
     let sfBundleType: string = this.config.isCreditCardType ? 'card' : this.props.type;

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
@@ -54,7 +54,7 @@ export function handleConfig(): void {
     this.config.legacyInputMode = this.props.legacyInputMode || null;
 
     // To configure the maximum expiry date to a merchant defined value
-    this.config.maxExpiryDate = this.props.maxExpiryDate || null;
+    this.config.minimumExpiryDate = this.props.minimumExpiryDate || null;
 
     this.config.sfLogAtStart = this.props._b$dl === true;
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractCSF.ts
@@ -1,13 +1,13 @@
-import { SetupObject, ConfigObject, CallbacksConfig, CSFStateObject, SFFeedbackObj, SendBrandObject } from '../types';
+import { CSFSetupObject, CSFConfigObject, CSFCallbacksConfig, CSFStateObject, SFFeedbackObj, SendBrandObject } from '../types';
 import { createSecuredFields } from './createSecuredFields';
 import { handleProcessBrand } from './utils/processBrand';
 import { handleBrandFromBinLookup } from './utils/handleBrandFromBinLookup';
 
 abstract class AbstractCSF {
     // Set in CSF
-    protected callbacks: CallbacksConfig;
-    protected config: ConfigObject;
-    protected props: SetupObject;
+    protected callbacks: CSFCallbacksConfig;
+    protected config: CSFConfigObject;
+    protected props: CSFSetupObject;
     protected state: CSFStateObject;
     protected assessFormValidity: () => void;
     protected brandsFromBinLookup: typeof handleBrandFromBinLookup;
@@ -40,13 +40,13 @@ abstract class AbstractCSF {
     protected isSingleBrandedCard: boolean;
     protected securityCode: string;
     // --
-    protected constructor(setupObj: SetupObject) {
+    protected constructor(setupObj: CSFSetupObject) {
         this.props = setupObj;
         this.state = ({} as any) as CSFStateObject;
 
         // Initialise storage objects
-        this.config = ({} as any) as ConfigObject; // {} as ConfigObject fails in linting
-        this.callbacks = ({} as any) as CallbacksConfig;
+        this.config = ({} as any) as CSFConfigObject; // {} as ConfigObject fails in linting
+        this.callbacks = ({} as any) as CSFCallbacksConfig;
     }
 }
 export default AbstractCSF;

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
@@ -7,8 +7,12 @@ export type RtnType_callbackFn = (feedbackObj: SFFeedbackObj) => void;
 export type CVCPolicyType = 'required' | 'optional' | 'hidden';
 export type DatePolicyType = 'required' | 'hidden';
 
+/**
+ * Base interface, props common to both SFSetupObject & IframeConfigObject
+ */
 export interface SFInternalConfig {
-    extraFieldData: string;
+    fieldType: string; // extracted in createSecuredFields
+    extraFieldData: string; // extracted in createSecuredFields
     txVariant: string;
     cardGroupTypes: string[];
     iframeUIConfig: IframeUIConfigObject;
@@ -16,10 +20,14 @@ export interface SFInternalConfig {
     trimTrailingSeparator: boolean;
     isCreditCardType: boolean;
     showWarnings: boolean;
+    legacyInputMode: boolean;
+    maxExpiryDate: string;
 }
 
+/**
+ * The object passed from createSecuredFields to a new instance of SecuredField.ts
+ */
 export interface SFSetupObject extends SFInternalConfig {
-    fieldType: string;
     cvcPolicy: CVCPolicyType;
     datePolicy: DatePolicyType;
     iframeSrc: string;
@@ -27,11 +35,12 @@ export interface SFSetupObject extends SFInternalConfig {
     holderEl: HTMLElement;
 }
 
-// Config object sent to SecuredField iframe
+/**
+ * Object sent via postMessage to a SecuredField iframe
+ */
 export interface IframeConfigObject extends SFInternalConfig {
-    fieldType: string;
     cvcRequired: boolean;
-    numKey: number;
+    numKey: number; // generated in SecuredField.ts
 }
 
 interface IframeUIConfigObject {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
@@ -20,6 +20,7 @@ export interface SFInternalConfig {
     trimTrailingSeparator: boolean;
     isCreditCardType: boolean;
     showWarnings: boolean;
+    cvcPolicy: CVCPolicyType;
     legacyInputMode: boolean;
     maxExpiryDate: string;
 }
@@ -28,7 +29,6 @@ export interface SFInternalConfig {
  * The object passed from createSecuredFields to a new instance of SecuredField.ts
  */
 export interface SFSetupObject extends SFInternalConfig {
-    cvcPolicy: CVCPolicyType;
     datePolicy: DatePolicyType;
     iframeSrc: string;
     loadingContext: string;
@@ -39,7 +39,6 @@ export interface SFSetupObject extends SFInternalConfig {
  * Object sent via postMessage to a SecuredField iframe
  */
 export interface IframeConfigObject extends SFInternalConfig {
-    cvcPolicy: CVCPolicyType;
     numKey: number;
 }
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
@@ -22,7 +22,7 @@ export interface SFInternalConfig {
     showWarnings: boolean;
     cvcPolicy: CVCPolicyType;
     legacyInputMode: boolean;
-    maxExpiryDate: string;
+    minimumExpiryDate: string;
 }
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/CSF.ts
@@ -18,7 +18,7 @@ import handleAdditionalFields from './utils/registerAdditionalField';
 import tabHandlers from './utils/tabbing/handleTab';
 import postMessageToIframe from './utils/iframes/postMessageToIframe';
 import AbstractCSF from './AbstractCSF';
-import { CSFReturnObject, SetupObject, StylesObject, CbObjOnAdditionalSF } from '../types';
+import { CSFReturnObject, CSFSetupObject, StylesObject, CbObjOnAdditionalSF, CSFStateObject } from '../types';
 import * as logger from '../utilities/logger';
 import { selectOne } from '../utilities/dom';
 import { BinLookupResponse } from '../../../../Card/types';
@@ -29,7 +29,7 @@ const notConfiguredWarning = (str = 'You cannot use secured fields') => {
 
 class CSF extends AbstractCSF {
     // --
-    constructor(setupObj: SetupObject) {
+    constructor(setupObj: CSFSetupObject) {
         super(setupObj);
 
         this.state = {
@@ -55,7 +55,7 @@ class CSF extends AbstractCSF {
             registerFieldForIos: false,
             securedFields: {},
             isKCP: false
-        };
+        } as CSFStateObject;
 
         // Setup 'this' references
         this.configHandler = handleConfig;

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
@@ -57,7 +57,9 @@ const setupObj = {
     datePolicy: DATE_POLICY_REQUIRED as DatePolicyType,
     iframeSrc: null,
     loadingContext: null,
-    holderEl: nodeHolder
+    holderEl: nodeHolder,
+    legacyInputMode: null,
+    minimumExpiryDate: null
 };
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
@@ -22,7 +22,8 @@ import AbstractSecuredField, {
     AriaConfig,
     PlaceholdersObject,
     CVCPolicyType,
-    DatePolicyType
+    DatePolicyType,
+    SFInternalConfig
 } from '../core/AbstractSecuredField';
 import { pick, reject } from '../../utils';
 import { processAriaConfig } from './utils/init/processAriaConfig';
@@ -37,14 +38,14 @@ class SecuredField extends AbstractSecuredField {
     constructor(pSetupObj: SFSetupObject, i18n: Language) {
         super();
 
-        // List of props from setup object not required in the config object
+        // List of props from setup object not required, or not directly required (e.g. cvcPolicy), in the iframe config object
         const deltaPropsArr: string[] = ['fieldType', 'iframeSrc', 'cvcPolicy', 'datePolicy', 'loadingContext', 'holderEl'];
 
         // Copy passed setup object values to this.config...
         const configVarsFromSetUpObj = reject(deltaPropsArr).from(pSetupObj);
 
         // ...breaking references on iframeUIConfig object so we can overwrite its properties in each securedField instance
-        this.config = { ...this.config, ...configVarsFromSetUpObj, iframeUIConfig: { ...configVarsFromSetUpObj.iframeUIConfig } };
+        this.config = { ...this.config, ...configVarsFromSetUpObj, iframeUIConfig: { ...configVarsFromSetUpObj.iframeUIConfig } } as SFInternalConfig;
 
         // Copy passed setup object values to this
         const thisVarsFromSetupObj = pick(deltaPropsArr).from(pSetupObj);
@@ -141,7 +142,9 @@ class SecuredField extends AbstractSecuredField {
             sfLogAtStart: this.config.sfLogAtStart,
             showWarnings: this.config.showWarnings,
             trimTrailingSeparator: this.config.trimTrailingSeparator,
-            isCreditCardType: this.config.isCreditCardType
+            isCreditCardType: this.config.isCreditCardType,
+            legacyInputMode: this.config.legacyInputMode,
+            maxExpiryDate: this.config.maxExpiryDate
         };
 
         if (process.env.NODE_ENV === 'development' && window._b$dl) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
@@ -143,7 +143,7 @@ class SecuredField extends AbstractSecuredField {
             trimTrailingSeparator: this.config.trimTrailingSeparator,
             isCreditCardType: this.config.isCreditCardType,
             legacyInputMode: this.config.legacyInputMode,
-            maxExpiryDate: this.config.maxExpiryDate
+            minimumExpiryDate: this.config.minimumExpiryDate
         };
 
         if (process.env.NODE_ENV === 'development' && window._b$dl) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
@@ -154,7 +154,7 @@ export function setupSecuredField(pItem: HTMLElement): void {
         showWarnings: this.config.showWarnings,
         holderEl: pItem,
         legacyInputMode: this.config.legacyInputMode,
-        maxExpiryDate: this.config.maxExpiryDate
+        minimumExpiryDate: this.config.minimumExpiryDate
     };
 
     const sf: SecuredField = new SecuredField(setupObj, this.props.i18n)

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
@@ -154,7 +154,9 @@ export function setupSecuredField(pItem: HTMLElement): void {
         iframeSrc: this.config.iframeSrc,
         loadingContext: this.config.loadingContext,
         showWarnings: this.config.showWarnings,
-        holderEl: pItem
+        holderEl: pItem,
+        legacyInputMode: this.config.legacyInputMode,
+        maxExpiryDate: this.config.maxExpiryDate
     };
 
     const sf: SecuredField = new SecuredField(setupObj, this.props.i18n)

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/initCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/initCSF.ts
@@ -3,14 +3,14 @@ import cardType from '../utilities/cardType';
 import * as logger from '../utilities/logger';
 import { falsy } from '../utilities/commonUtils';
 import { findRootNode } from '../ui/domUtils';
-import { CSFReturnObject, SetupObject } from '../types';
+import { CSFReturnObject, CSFSetupObject } from '../types';
 
-const initCSF = (pSetupObj: SetupObject): CSFReturnObject => {
+const initCSF = (pSetupObj: CSFSetupObject): CSFReturnObject => {
     if (!pSetupObj) {
         throw new Error('No securedFields configuration object defined');
     }
 
-    const setupObj: SetupObject = { ...pSetupObj };
+    const setupObj: CSFSetupObject = { ...pSetupObj };
 
     // Ensure there is always a default type & map the generic types (e.g. 'card', 'scheme') to 'card'
     const isGenericCardType: boolean = cardType.isGenericCardType(setupObj.type);

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -29,6 +29,9 @@ export interface CSFReturnObject {
     sendValueToFrame?: any;
 }
 
+/**
+ * Base interface for SetupObject & ConfigObject
+ */
 interface CSFCommonProps {
     loadingContext: string;
     cardGroupTypes?: string[];
@@ -39,9 +42,15 @@ interface CSFCommonProps {
     keypadFix?: boolean;
     isKCP?: boolean;
     iframeUIConfig?: object;
+    legacyInputMode?: boolean;
+    maxExpiryDate?: string;
 }
 
-export interface SetupObject extends CSFCommonProps {
+// TODO rename to CSFSetupObject
+/**
+ * Object sent when SecuredFieldsProvider initialises CSF
+ */
+export interface CSFSetupObject extends CSFCommonProps {
     type: string;
     clientKey: string;
     rootNode: string | HTMLElement;
@@ -49,13 +58,19 @@ export interface SetupObject extends CSFCommonProps {
     i18n?: Language;
 }
 
-export interface ConfigObject extends CSFCommonProps {
+// TODO rename to CSFConfigObject
+/**
+ * The type for the config object created by CSF: properties that just need to be set once, at startup, and then don't change
+ * This object provides the source for many of the properties that are written into the SFSetupObject used to initialise a new SecuredField.ts
+ */
+export interface CSFConfigObject extends CSFCommonProps {
     iframeSrc: string;
     isCreditCardType: boolean;
     sfLogAtStart: boolean;
 }
 
-export interface CallbacksConfig {
+// TODO rename to CSFCallbacksObject
+export interface CSFCallbacksConfig {
     onLoad?: (callbackObj: object) => void;
     onConfigSuccess?: (callbackObj: object) => void;
     onFieldValid?: (callbackObj: object) => void;

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -46,7 +46,6 @@ interface CSFCommonProps {
     maxExpiryDate?: string;
 }
 
-// TODO rename to CSFSetupObject
 /**
  * Object sent when SecuredFieldsProvider initialises CSF
  */
@@ -58,7 +57,6 @@ export interface CSFSetupObject extends CSFCommonProps {
     i18n?: Language;
 }
 
-// TODO rename to CSFConfigObject
 /**
  * The type for the config object created by CSF: properties that just need to be set once, at startup, and then don't change
  * This object provides the source for many of the properties that are written into the SFSetupObject used to initialise a new SecuredField.ts
@@ -69,7 +67,6 @@ export interface CSFConfigObject extends CSFCommonProps {
     sfLogAtStart: boolean;
 }
 
-// TODO rename to CSFCallbacksObject
 export interface CSFCallbacksConfig {
     onLoad?: (callbackObj: object) => void;
     onConfigSuccess?: (callbackObj: object) => void;

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -43,7 +43,7 @@ interface CSFCommonProps {
     isKCP?: boolean;
     iframeUIConfig?: object;
     legacyInputMode?: boolean;
-    maxExpiryDate?: string;
+    minimumExpiryDate?: string;
 }
 
 /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
 In preparation for new SF functionality - pass config props `legacyInputMode` & `minimumExpiryDate` to SF

## Tested scenarios
Properties go directly to SecuredFieldsProvider and are then set in the config object used to intialise a new SecuredField


**Relates to issues:** COWEB-932 & COWEB-843
