### PR TITLE
Add positionHolderNameOnTop for the Card component

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.scss
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.scss
@@ -1,3 +1,5 @@
+@import '../../../../style/index';
+
 .adyen-checkout__card-input__form {
     transition: opacity 0.25s ease-out;
 }
@@ -29,7 +31,11 @@
 .adyen-checkout__card__kcp-authentication,
 .adyen-checkout__installments,
 .adyen-checkout__card-input .adyen-checkout__fieldset--billingAddress {
-    margin-top: 16px;
+    margin-top: $spacing-medium;
+}
+
+.adyen-checkout__card__holderName:first-child {
+    margin: 0 0 $spacing-medium;
 }
 
 /* Hide card brand icon when cardNumber is in an error state */
@@ -120,11 +126,11 @@
     }
 
     .adyen-checkout__radio_group__input-wrapper {
-        margin-top: 20px
+        margin-top: 20px;
     }
 }
 
-.adyen-checkout__field--revolving-plan-installments{
+.adyen-checkout__field--revolving-plan-installments {
     position: relative;
     top: 42px;
     width: 30%;

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -53,9 +53,15 @@ describe('CardInput', () => {
         expect(wrapper.state('valid').holderName).toBe(undefined);
     });
 
-    test('shows holderName first', () => {
+    test.only('does not show the holder name first by default', () => {
+        const wrapper = mount(<CardInput hasHolderName={true} i18n={i18n} />);
+        expect(wrapper.find('CardHolderNameWrapper')).toHaveLength(1);
+        expect(wrapper.find('CardHolderNameWrapper:first-child')).toHaveLength(0);
+    });
+
+    test.only('shows holder name first', () => {
         const wrapper = mount(<CardInput hasHolderName={true} positionHolderNameOnTop={true} i18n={i18n} />);
-        expect(wrapper.find('CardHolderName:first-child')).toHaveLength(1);
+        expect(wrapper.find('CardHolderNameWrapper:first-child')).toHaveLength(1);
     });
 
     test('issuingCountryCode state var is converted to lowerCase', () => {

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -53,6 +53,11 @@ describe('CardInput', () => {
         expect(wrapper.state('valid').holderName).toBe(undefined);
     });
 
+    test('shows holderName first', () => {
+        const wrapper = mount(<CardInput hasHolderName={true} positionHolderNameOnTop={true} i18n={i18n} />);
+        expect(wrapper.find('CardHolderName:first-child')).toHaveLength(1);
+    });
+
     test('issuingCountryCode state var is converted to lowerCase', () => {
         const wrapper = mount(<CardInput i18n={i18n} />);
         wrapper.instance().processBinLookupResponse({ issuingCountryCode: 'KR' });

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -172,6 +172,17 @@ class CardInput extends Component<CardInputProps, CardInputState> {
 
         const showAmountsInInstallments = showInstallmentAmounts ?? true;
 
+        const CardHolderNameWrapper = () => (
+            <CardHolderName
+                required={this.props.holderNameRequired}
+                placeholder={this.props.placeholders.holderName}
+                value={this.state.data.holderName}
+                error={!!this.state.errors.holderName}
+                isValid={!!this.state.valid.holderName}
+                onChange={this.handleHolderName}
+            />
+        );
+
         return (
             <SecuredFieldsProvider
                 ref={this.sfp}
@@ -216,16 +227,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                             </LoadingWrapper>
                         ) : (
                             <LoadingWrapper status={sfpState.status}>
-                                {hasHolderName && positionHolderNameOnTop && (
-                                    <CardHolderName
-                                        required={this.props.holderNameRequired}
-                                        placeholder={this.props.placeholders.holderName}
-                                        value={this.state.data.holderName}
-                                        error={!!this.state.errors.holderName}
-                                        isValid={!!this.state.valid.holderName}
-                                        onChange={this.handleHolderName}
-                                    />
-                                )}
+                                {hasHolderName && positionHolderNameOnTop && <CardHolderNameWrapper />}
 
                                 <CardFields
                                     {...this.props}
@@ -242,16 +244,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                                     dualBrandingSelected={this.state.additionalSelectValue}
                                 />
 
-                                {hasHolderName && !positionHolderNameOnTop && (
-                                    <CardHolderName
-                                        required={this.props.holderNameRequired}
-                                        placeholder={this.props.placeholders.holderName}
-                                        value={this.state.data.holderName}
-                                        error={!!this.state.errors.holderName}
-                                        isValid={!!this.state.valid.holderName}
-                                        onChange={this.handleHolderName}
-                                    />
-                                )}
+                                {hasHolderName && !positionHolderNameOnTop && <CardHolderNameWrapper />}
 
                                 {this.props.configuration.koreanAuthenticationRequired && isKorea && (
                                     <KCPAuthentication

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -159,7 +159,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
     }
 
     render(
-        { countryCode, loadingContext, hasHolderName, hasCVC, installmentOptions, enableStoreDetails, showInstallmentAmounts },
+        { loadingContext, hasHolderName, hasCVC, installmentOptions, positionHolderNameOnTop, showInstallmentAmounts },
         { status, cvcPolicy, hideDateForBrand, focusedElement, issuingCountryCode }
     ) {
         const hasInstallments = !!Object.keys(installmentOptions).length;
@@ -168,7 +168,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
         const isOneClick = this.props.oneClick || !!this.props.storedPaymentMethodId;
 
         // If issuingCountryCode is set or the merchant defined countryCode is 'KR'
-        const isKorea = issuingCountryCode ? issuingCountryCode === 'kr' : countryCode === 'kr';
+        const isKorea = issuingCountryCode ? issuingCountryCode === 'kr' : this.props.countryCode === 'kr';
 
         const showAmountsInInstallments = showInstallmentAmounts ?? true;
 
@@ -216,6 +216,17 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                             </LoadingWrapper>
                         ) : (
                             <LoadingWrapper status={sfpState.status}>
+                                {hasHolderName && positionHolderNameOnTop && (
+                                    <CardHolderName
+                                        required={this.props.holderNameRequired}
+                                        placeholder={this.props.placeholders.holderName}
+                                        value={this.state.data.holderName}
+                                        error={!!this.state.errors.holderName}
+                                        isValid={!!this.state.valid.holderName}
+                                        onChange={this.handleHolderName}
+                                    />
+                                )}
+
                                 <CardFields
                                     {...this.props}
                                     brand={sfpState.brand}
@@ -231,7 +242,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                                     dualBrandingSelected={this.state.additionalSelectValue}
                                 />
 
-                                {hasHolderName && (
+                                {hasHolderName && !positionHolderNameOnTop && (
                                     <CardHolderName
                                         required={this.props.holderNameRequired}
                                         placeholder={this.props.placeholders.holderName}
@@ -256,7 +267,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                                     />
                                 )}
 
-                                {enableStoreDetails && <StoreDetails onChange={this.handleOnStoreDetails} />}
+                                {this.props.enableStoreDetails && <StoreDetails onChange={this.handleOnStoreDetails} />}
 
                                 {hasInstallments && (
                                     <Installments

--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -11,6 +11,7 @@ export default {
     hasStoreDetails: false,
     storedDetails: false,
     showBrandIcon: true,
+    positionHolderNameOnTop: false,
     billingAddressRequired: false,
     billingAddressRequiredFields: ['street', 'houseNumberOrName', 'postalCode', 'city', 'stateOrProvince', 'country'],
     installmentOptions: {},

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -20,6 +20,8 @@ export interface CardInputProps {
     loadingContext: string;
     payButton?: () => {};
     placeholders?: object;
+    positionHolderNameOnTop: boolean;
+    showInstallmentAmounts: boolean;
     showPayButton?: boolean;
     storedPaymentMethodId?: string;
     styles?: object;

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -67,6 +67,7 @@ getPaymentMethods({ amount, shopperLocale }).then(paymentMethodsResponse => {
             hasHolderName: true,
             holderNameRequired: true,
             holderName: 'J. Smith',
+            positionHolderNameOnTop: true,
 
             // billingAddress config:
             billingAddressRequired: true,


### PR DESCRIPTION
Add option to position the holder name field on top of the Card component.

## Summary
Users have been recurrently asking for the possibility of placing the holder name field at the top of the Card component. After discussing it with the some of the Frontend team and with some of our designers, we've decided to allow this.
Therefore we're adding a `positionHolderNameOnTop` option which accepts a boolean and it's `false` by default.

## Tested scenarios
Added test to check if the positioning is working


**Fixed issue**:  Adyen/adyen-web#882
