### PR TITLE
Disable pay button while on loading state

### DIFF
--- a/packages/lib/src/components/internal/Button/Button.scss
+++ b/packages/lib/src/components/internal/Button/Button.scss
@@ -52,6 +52,9 @@
 
     &.adyen-checkout__button--pay {
         margin-top: 24px;
+        &:disabled {
+            opacity: 1;
+        }
     }
 
     &.adyen-checkout__button--standalone {

--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -11,6 +11,7 @@ interface PayButtonProps {
 
     label?: string;
     amount: PaymentAmount;
+    status?: string;
 }
 
 const PayButton = ({ amount, classNameModifiers = [], label, ...props }: PayButtonProps) => {
@@ -20,7 +21,9 @@ const PayButton = ({ amount, classNameModifiers = [], label, ...props }: PayButt
         ? i18n.get('confirmPreauthorization')
         : `${i18n.get('payButton')} ${!!amount?.value && !!amount?.currency ? i18n.amount(amount.value, amount.currency) : ''}`;
 
-    return <Button {...props} classNameModifiers={[...classNameModifiers, 'pay']} label={label || defaultLabel} />;
+    return (
+        <Button {...props} disabled={props.status === 'loading'} classNameModifiers={[...classNameModifiers, 'pay']} label={label || defaultLabel} />
+    );
 };
 
 export default PayButton;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This fixes an issue where the default Pay button could still be submitted through the keyboard while on `loading` state. With this, we should prevent any accidental double submission of the payment form.

## Tested scenarios
- Pay button can't be focused while on `loading` state.

