### PR TITLE
Cleanup - pass an object to destructure rather than separate arguments

### DIFF
--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -10,7 +10,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
     constructor(props) {
         super(props);
 
-        const { token, notificationURL } = this.props;
+        const { token, notificationURL } = this.props; // See comments on prepareFingerPrintData regarding notificationURL
 
         if (token) {
             const fingerPrintData = prepareFingerPrintData({ token, notificationURL });

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/handleEncryption.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/handleEncryption.ts
@@ -4,13 +4,8 @@ import { ENCRYPTED_EXPIRY_MONTH, ENCRYPTED_EXPIRY_YEAR, ENCRYPTED_SECURITY_CODE,
 import { processErrors } from './utils/processErrors';
 import { truthy } from '../utilities/commonUtils';
 import { SFFeedbackObj, CbObjOnFieldValid, EncryptionObj } from '../types';
-import * as logger from '../utilities/logger';
 
 export function handleEncryption(pFeedbackObj: SFFeedbackObj): void {
-    if (process.env.NODE_ENV === 'development' && window._b$dl) {
-        logger.log('\n### HandleEncryption:: pFeedbackObj=', pFeedbackObj);
-    }
-
     // EXTRACT VARS
     const fieldType: string = pFeedbackObj.fieldType;
 
@@ -50,7 +45,12 @@ export function handleEncryption(pFeedbackObj: SFFeedbackObj): void {
     // MAKE ENCRYPTION OBJECTS FOR EACH OF THE INDIVIDUAL INPUTS
     // N.B. when considering "individual inputs" we are concerned with the 4 fields that the checkoutAPI expects to receive for a credit card payment:
     // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
-    const callbackObjectsArr: CbObjOnFieldValid[] = makeCallbackObjectsEncryption(fieldType, this.state.type, this.props.rootNode, encryptedObjArr);
+    const callbackObjectsArr: CbObjOnFieldValid[] = makeCallbackObjectsEncryption({
+        fieldType,
+        txVariant: this.state.type,
+        rootNode: this.props.rootNode,
+        encryptedObjArr
+    });
 
     // For number field - add the endDigits to the encryption object
     if (fieldType === ENCRYPTED_CARD_NUMBER && truthy(pFeedbackObj.endDigits)) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/handleValidation.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/handleValidation.ts
@@ -38,7 +38,7 @@ export function handleValidation(pFeedbackObj: SFFeedbackObj): void {
     // If the field was previously encrypted...
     if (this.state.securedFields[fieldType].isEncrypted) {
         // callbackObjectsArr will be an array containing 1 or 2 objects that need to be broadcast
-        callbackObjectsArr = makeCallbackObjectsValidation(fieldType, this.state.type, this.props.rootNode);
+        callbackObjectsArr = makeCallbackObjectsValidation({ fieldType, txVariant: this.state.type, rootNode: this.props.rootNode });
 
         // Add the endDigits to the object we send to the onFieldValid callback
         // NOTE: in this case (validation) this will be an empty string

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/callbackUtils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/callbackUtils.ts
@@ -1,26 +1,27 @@
 import { ENCRYPTED_EXPIRY_DATE } from '../../configuration/constants';
 import { CbObjOnFieldValid, EncryptionObj } from '../../types';
-// import * as logger from '../../utilities/logger';
 
-const makeCallbackObj = (
-    pFieldType: string,
-    pEncryptedFieldName: string,
-    uuid: string,
-    pIsValid: boolean,
-    pTxVariant: string,
-    pRootNode: HTMLElement
-): CbObjOnFieldValid => ({
-    fieldType: pFieldType, // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryDate
-    encryptedFieldName: pEncryptedFieldName, // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
+interface CallbackObjectProps {
+    fieldType: string;
+    encryptedFieldName: string;
+    uuid: string;
+    isValid: boolean;
+    txVariant: string;
+    rootNode: HTMLElement;
+}
+
+const makeCallbackObj = ({ fieldType, encryptedFieldName, uuid, isValid, txVariant, rootNode }: CallbackObjectProps): CbObjOnFieldValid => ({
+    fieldType, // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryDate
+    encryptedFieldName, // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
     uid: uuid, // card-encrypted-encryptedCardNumber, card-encrypted-encryptedSecurityCode, card-encrypted-month, card-encrypted-year, card-encrypted-encryptedExpiryMonth, card-encrypted-encryptedExpiryYear
-    valid: pIsValid,
-    type: pTxVariant,
-    rootNode: pRootNode // A ref to the 'form' element holding the securedFields
+    valid: isValid,
+    type: txVariant,
+    rootNode // A ref to the 'form' element holding the securedFields
 });
 
-export const makeCallbackObjectsValidation = (pFieldType: string, pTxVariant: string, pRootNode: HTMLElement): CbObjOnFieldValid[] => {
+export const makeCallbackObjectsValidation = ({ fieldType, txVariant, rootNode }): CbObjOnFieldValid[] => {
     // - create callback objects to report the changed valid state of the field
-    const isExpiryDateField: boolean = pFieldType === ENCRYPTED_EXPIRY_DATE;
+    const isExpiryDateField: boolean = fieldType === ENCRYPTED_EXPIRY_DATE;
 
     const callbackObjectsArr: CbObjOnFieldValid[] = [];
 
@@ -36,14 +37,22 @@ export const makeCallbackObjectsValidation = (pFieldType: string, pTxVariant: st
     const totalFields: number = isExpiryDateField ? 2 : 1;
 
     for (i = 0; i < totalFields; i += 1) {
-        encryptedType = isExpiryDateField ? sepExpiryDateNames[i] : pFieldType; // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
+        encryptedType = isExpiryDateField ? sepExpiryDateNames[i] : fieldType; // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
 
-        uuid = `${pTxVariant}-encrypted-${encryptedType}`; // card-encrypted-encryptedCardNumber, card-encrypted-encryptedSecurityCode, card-encrypted-encryptedExpiryMonth, card-encrypted-encryptedExpiryYear
+        uuid = `${txVariant}-encrypted-${encryptedType}`; // card-encrypted-encryptedCardNumber, card-encrypted-encryptedSecurityCode, card-encrypted-encryptedExpiryMonth, card-encrypted-encryptedExpiryYear
 
-        encryptedFieldName = isExpiryDateField ? encryptedType : pFieldType; // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
+        encryptedFieldName = isExpiryDateField ? encryptedType : fieldType; // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
 
         // Create objects to broadcast valid state
-        const callbackObj: CbObjOnFieldValid = makeCallbackObj(pFieldType, encryptedFieldName, uuid, false, pTxVariant, pRootNode);
+        // const callbackObj: CbObjOnFieldValid = makeCallbackObj(pFieldType, encryptedFieldName, uuid, false, pTxVariant, pRootNode, null);
+        const callbackObj: CbObjOnFieldValid = makeCallbackObj({
+            fieldType,
+            encryptedFieldName,
+            uuid,
+            isValid: false,
+            txVariant,
+            rootNode
+        } as CallbackObjectProps);
 
         callbackObjectsArr.push(callbackObj);
     }
@@ -51,12 +60,7 @@ export const makeCallbackObjectsValidation = (pFieldType: string, pTxVariant: st
     return callbackObjectsArr;
 };
 
-export const makeCallbackObjectsEncryption = (
-    pFieldType: string,
-    pTxVariant: string,
-    pRootNode: HTMLElement,
-    pEncryptedObjArr: EncryptionObj[]
-): CbObjOnFieldValid[] => {
+export const makeCallbackObjectsEncryption = ({ fieldType, txVariant, rootNode, encryptedObjArr }): CbObjOnFieldValid[] => {
     let i: number;
     let uuid: string;
     let encryptedObj: EncryptionObj;
@@ -65,14 +69,22 @@ export const makeCallbackObjectsEncryption = (
 
     const callbackObjectsArr: CbObjOnFieldValid[] = [];
 
-    for (i = 0; i < pEncryptedObjArr.length; i += 1) {
-        encryptedObj = pEncryptedObjArr[i];
+    for (i = 0; i < encryptedObjArr.length; i += 1) {
+        encryptedObj = encryptedObjArr[i];
         encryptedFieldName = encryptedObj.encryptedFieldName;
-        uuid = `${pTxVariant}-encrypted-${encryptedFieldName}`;
+        uuid = `${txVariant}-encrypted-${encryptedFieldName}`;
         encryptedBlob = encryptedObj.blob;
 
         // Create objects to broadcast valid state
-        const callbackObj: CbObjOnFieldValid = makeCallbackObj(pFieldType, encryptedFieldName, uuid, true, pTxVariant, pRootNode);
+        // const callbackObj: CbObjOnFieldValid = makeCallbackObj(fieldType, encryptedFieldName, uuid, true, txVariant, rootNode, code);
+        const callbackObj: CbObjOnFieldValid = makeCallbackObj({
+            fieldType,
+            encryptedFieldName,
+            uuid,
+            isValid: true,
+            txVariant,
+            rootNode
+        } as CallbackObjectProps);
         callbackObj.blob = encryptedBlob;
 
         callbackObjectsArr.push(callbackObj);

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processBrand.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processBrand.ts
@@ -39,13 +39,11 @@ export function handleProcessBrand(pFeedbackObj: SFFeedbackObj): boolean {
             // because it needs to know the cvcPolicy (to set the aria-required attribute & to show the iframe)
             if (Object.prototype.hasOwnProperty.call(this.state.securedFields, ENCRYPTED_SECURITY_CODE)) {
                 const dataObj: object = {
-                    ...{
-                        txVariant: this.state.type,
-                        brand: newBrandObj.brand,
-                        fieldType: ENCRYPTED_SECURITY_CODE,
-                        cvcPolicy: pFeedbackObj.cvcPolicy,
-                        numKey: this.state.securedFields[ENCRYPTED_SECURITY_CODE].numKey
-                    }
+                    txVariant: this.state.type,
+                    brand: newBrandObj.brand,
+                    fieldType: ENCRYPTED_SECURITY_CODE,
+                    cvcPolicy: pFeedbackObj.cvcPolicy,
+                    numKey: this.state.securedFields[ENCRYPTED_SECURITY_CODE].numKey
                 };
                 postMessageToIframe(dataObj, this.getIframeContentWin(ENCRYPTED_SECURITY_CODE), this.config.loadingContext);
             }


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Cleanup:
 - pass an object to destructure, rather than separate arguments, when handling securedFields encryption & validation.
 - removed unnecessary spread operator in ProcessBrand
 - added comment

## Tested scenarios
All tests pass
