### PR TITLE
Fix Card holder name focus lost when typing on the field

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -53,17 +53,6 @@ describe('CardInput', () => {
         expect(wrapper.state('valid').holderName).toBe(undefined);
     });
 
-    test('does not show the holder name first by default', () => {
-        const wrapper = mount(<CardInput hasHolderName={true} i18n={i18n} />);
-        expect(wrapper.find('CardHolderNameWrapper')).toHaveLength(1);
-        expect(wrapper.find('CardHolderNameWrapper:first-child')).toHaveLength(0);
-    });
-
-    test('shows holder name first', () => {
-        const wrapper = mount(<CardInput hasHolderName={true} positionHolderNameOnTop={true} i18n={i18n} />);
-        expect(wrapper.find('CardHolderNameWrapper:first-child')).toHaveLength(1);
-    });
-
     test('issuingCountryCode state var is converted to lowerCase', () => {
         const wrapper = mount(<CardInput i18n={i18n} />);
         wrapper.instance().processBinLookupResponse({ issuingCountryCode: 'KR' });

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -193,7 +193,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
             (this.state.showSocialSecurityNumber && configuration.socialSecurityNumberMode === 'auto') ||
             configuration.socialSecurityNumberMode === 'show';
 
-        const CardHolderNameWrapper = () => (
+        const cardHolderField = (
             <CardHolderName
                 required={this.props.holderNameRequired}
                 placeholder={this.props.placeholders.holderName}
@@ -248,7 +248,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                             </LoadingWrapper>
                         ) : (
                             <LoadingWrapper status={sfpState.status}>
-                                {hasHolderName && positionHolderNameOnTop && <CardHolderNameWrapper />}
+                                {hasHolderName && positionHolderNameOnTop && cardHolderField}
 
                                 <CardFields
                                     {...this.props}
@@ -265,7 +265,7 @@ class CardInput extends Component<CardInputProps, CardInputState> {
                                     dualBrandingSelected={this.state.additionalSelectValue}
                                 />
 
-                                {hasHolderName && !positionHolderNameOnTop && <CardHolderNameWrapper />}
+                                {hasHolderName && !positionHolderNameOnTop && cardHolderField}
 
                                 {configuration.koreanAuthenticationRequired && isKorea && (
                                     <KCPAuthentication


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes an issue where the card holder name field would lose focus when typing on the field.


## Tested scenarios
- Card holder name field does not lose focus


**Fixed issue**:  #917
