### PR TITLE
Add union types for SecuredFields fieldType and encryptedFieldName

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/core/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/CSF.ts
@@ -18,7 +18,7 @@ import handleAdditionalFields from './utils/registerAdditionalField';
 import tabHandlers from './utils/tabbing/handleTab';
 import postMessageToIframe from './utils/iframes/postMessageToIframe';
 import AbstractCSF from './AbstractCSF';
-import { CSFReturnObject, CSFSetupObject, StylesObject, CbObjOnAdditionalSF, CSFStateObject } from '../types';
+import { CSFReturnObject, CSFSetupObject, StylesObject, CbObjOnAdditionalSF, CSFStateObject, SFFieldType } from '../types';
 import * as logger from '../utilities/logger';
 import { selectOne } from '../utilities/dom';
 import { BinLookupResponse } from '../../../../Card/types';
@@ -131,7 +131,7 @@ class CSF extends AbstractCSF {
                     );
                 }
             },
-            setFocusOnFrame: (pFieldType: string): void => {
+            setFocusOnFrame: (pFieldType: SFFieldType): void => {
                 if (this.state.isConfigured) {
                     this.setFocusOnFrame(pFieldType);
                 } else {
@@ -140,7 +140,7 @@ class CSF extends AbstractCSF {
             },
             // For component based implementation - if showValidation function is called on the component use this
             // function as a way to notify the CSF that a field is in error
-            isValidated: (pFieldType: string, code: string): void => {
+            isValidated: (pFieldType: SFFieldType, code: string): void => {
                 if (this.state.isConfigured) {
                     if (Object.prototype.hasOwnProperty.call(this.state.securedFields, pFieldType)) {
                         this.state.securedFields[pFieldType].hasError = true;
@@ -166,7 +166,7 @@ class CSF extends AbstractCSF {
                     notConfiguredWarning('You cannot set validated on any secured field');
                 }
             },
-            hasUnsupportedCard: (pFieldType: string, code: string): void => {
+            hasUnsupportedCard: (pFieldType: SFFieldType, code: string): void => {
                 if (this.state.isConfigured) {
                     if (Object.prototype.hasOwnProperty.call(this.state.securedFields, pFieldType)) {
                         //
@@ -203,14 +203,14 @@ class CSF extends AbstractCSF {
                     notConfiguredWarning('You cannot set pass brands to secured fields');
                 }
             },
-            addSecuredField: (pFieldType: string): void => {
+            addSecuredField: (pFieldType: SFFieldType): void => {
                 const securedField: HTMLElement = selectOne(this.props.rootNode, `[data-cse="${pFieldType}"]`);
                 if (securedField) {
                     this.state.numIframes += 1;
                     this.setupSecuredField(securedField);
                 }
             },
-            removeSecuredField: (pFieldType: string): void => {
+            removeSecuredField: (pFieldType: SFFieldType): void => {
                 if (this.state.securedFields[pFieldType]) {
                     this.state.securedFields[pFieldType].destroy();
                     delete this.state.securedFields[pFieldType];

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/handleEncryption.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/handleEncryption.ts
@@ -7,7 +7,7 @@ import { SFFeedbackObj, CbObjOnFieldValid, EncryptionObj } from '../types';
 
 export function handleEncryption(pFeedbackObj: SFFeedbackObj): void {
     // EXTRACT VARS
-    const fieldType: string = pFeedbackObj.fieldType;
+    const fieldType = pFeedbackObj.fieldType;
 
     // SET FOCUS ON OTHER INPUT - If user has just typed a correct expiryDate - set focus on the cvc field OR typed a correct expiryMonth - focus on year field
     if (this.config.autoFocus) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/callbackUtils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/callbackUtils.ts
@@ -1,9 +1,9 @@
 import { ENCRYPTED_EXPIRY_DATE } from '../../configuration/constants';
-import { CbObjOnFieldValid, EncryptionObj } from '../../types';
+import { CbObjOnFieldValid, EncryptionObj, SFEncryptedFieldName, SFFieldType } from '../../types';
 
 interface CallbackObjectProps {
-    fieldType: string;
-    encryptedFieldName: string;
+    fieldType: SFFieldType;
+    encryptedFieldName: SFEncryptedFieldName;
     uuid: string;
     isValid: boolean;
     txVariant: string;
@@ -25,23 +25,27 @@ export const makeCallbackObjectsValidation = ({ fieldType, txVariant, rootNode }
 
     const callbackObjectsArr: CbObjOnFieldValid[] = [];
 
-    const sepExpiryDateNames: string[] = ['encryptedExpiryMonth', 'encryptedExpiryYear'];
+    const sepExpiryDateNames = ['encryptedExpiryMonth', 'encryptedExpiryYear'] as const;
 
     let i: number;
     let uuid: string;
-    let encryptedType: string;
-    let encryptedFieldName: string;
+    let encryptedType: SFEncryptedFieldName;
+    let encryptedFieldName: SFEncryptedFieldName;
 
     // For expiryDate field we need to remove 2 DOM elements & create 2 objects (relating to month & year)
     // - for everything else we just need to remove 1 element & create 1 callback object
     const totalFields: number = isExpiryDateField ? 2 : 1;
 
     for (i = 0; i < totalFields; i += 1) {
-        encryptedType = isExpiryDateField ? sepExpiryDateNames[i] : fieldType; // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
+        if (fieldType === ENCRYPTED_EXPIRY_DATE) {
+            encryptedType = sepExpiryDateNames[i];
+        } else {
+            encryptedType = fieldType;
+        }
 
         uuid = `${txVariant}-encrypted-${encryptedType}`; // card-encrypted-encryptedCardNumber, card-encrypted-encryptedSecurityCode, card-encrypted-encryptedExpiryMonth, card-encrypted-encryptedExpiryYear
 
-        encryptedFieldName = isExpiryDateField ? encryptedType : fieldType; // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
+        encryptedFieldName = encryptedType; // encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear
 
         // Create objects to broadcast valid state
         // const callbackObj: CbObjOnFieldValid = makeCallbackObj(pFieldType, encryptedFieldName, uuid, false, pTxVariant, pRootNode, null);
@@ -64,7 +68,7 @@ export const makeCallbackObjectsEncryption = ({ fieldType, txVariant, rootNode, 
     let i: number;
     let uuid: string;
     let encryptedObj: EncryptionObj;
-    let encryptedFieldName: string;
+    let encryptedFieldName: SFEncryptedFieldName;
     let encryptedBlob: string;
 
     const callbackObjectsArr: CbObjOnFieldValid[] = [];

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processErrors.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processErrors.test.ts
@@ -26,21 +26,21 @@ const errorObj_dateTooOld = {
     action: 'dateKeyPressed',
     fieldType: 'encryptedExpiryDate',
     numKey: 3522473789
-};
+} as const;
 
 const erroObj_dateTooFar = {
     error: ERROR_MSG_CARD_TOO_FAR_IN_FUTURE,
     action: 'dateKeyPressed',
     fieldType: 'encryptedExpiryDate',
     numKey: 3522473789
-};
+} as const;
 
 const errorObj_incompleteField = {
     error: ERROR_MSG_INCOMPLETE_FIELD,
     action: 'blur',
     fieldType: 'encryptedCardNumber',
     numKey: 3522473789
-};
+} as const;
 
 // const errorObj_luhnCheck = {
 //    "action": "luhnCheck",
@@ -61,14 +61,14 @@ const noErrorObj = {
     action: 'dateKeyPressed',
     fieldType: 'encryptedCardNumber',
     numKey: 3522473789
-};
+} as const;
 
 const noErrorObj_date = {
     error: '',
     action: 'dateKeyPressed',
     fieldType: 'encryptedExpiryDate',
     numKey: 3522473789
-};
+} as const;
 
 beforeEach(() => {
     console.error = jest.fn(error => {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processErrors.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/utils/processErrors.ts
@@ -13,7 +13,7 @@ export const processErrors = (
 ): CbObjOnError => {
     if (!Object.prototype.hasOwnProperty.call(pFeedbackObj, 'error')) return null;
 
-    const fieldType: string = pFeedbackObj.fieldType;
+    const fieldType = pFeedbackObj.fieldType;
 
     const field: SecuredField = securedField;
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -167,9 +167,11 @@ export interface CbObjOnAllValid {
     rootNode: HTMLElement;
 }
 
+export type SFFieldType = 'encryptedCardNumber' | 'encryptedSecurityCode' | 'encryptedExpiryDate';
+export type SFEncryptedFieldName = Exclude<SFFieldType, 'encryptedExpiryDate'> | 'encryptedExpiryMonth' | 'encryptedExpiryYear';
 export interface CbObjOnFieldValid {
-    fieldType: string;
-    encryptedFieldName: string;
+    fieldType: SFFieldType;
+    encryptedFieldName: SFEncryptedFieldName;
     uid: string;
     valid: boolean;
     type: string;
@@ -179,7 +181,7 @@ export interface CbObjOnFieldValid {
 }
 
 export interface CbObjOnAutoComplete {
-    fieldType: string;
+    fieldType: SFFieldType;
     name: string;
     value: string;
     action: string;
@@ -200,7 +202,7 @@ export interface CbObjOnBinLookup {
 }
 
 export interface CbObjOnError {
-    fieldType: string;
+    fieldType: SFFieldType;
     error: string;
     type: string;
     rootNode?: HTMLElement;
@@ -213,7 +215,7 @@ export interface CbObjOnFocus {
     action: string;
     focus: boolean;
     numChars: number;
-    fieldType: string;
+    fieldType: SFFieldType;
     rootNode: HTMLElement;
     type: string;
     currentFocusObject: string;
@@ -231,13 +233,13 @@ export interface CbObjOnConfigSuccess {
 export interface CbObjOnAdditionalSF {
     additionalIframeConfigured?: boolean;
     additionalIframeRemoved?: boolean;
-    fieldType: string;
+    fieldType: SFFieldType;
     type: string;
 }
 
 export interface SFFeedbackObj {
     action: string;
-    fieldType: string;
+    fieldType: SFFieldType;
     numKey: number;
     brand?: string;
     code?: string;
@@ -267,7 +269,7 @@ export interface SFFeedbackObj {
 
 export interface EncryptionObj {
     type: string;
-    encryptedFieldName: string;
+    encryptedFieldName: SFEncryptedFieldName;
     blob: string;
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Adding additional typing to SecuredField types in the form of union types `SFFieldType` and `SFEncryptedFieldName` for the common `fieldType` and `encryptedFieldName` used in event payloads for event handlers in Adyen web components. 

We are in the process of upgrading to v4 of `adyen-web`, and had previously been using some hand-rolled types, including unions for these specific fields. This allowed us to (among other things) make use of exhaustive switch statements when handling events, which are a useful construct to ensure thorough handling of all possible field types in an event handler.
The current typings for these properties in the event payloads are generic strings, meaning our existing code would no longer work (you cannot exhaustively check a `string` type).

It seemed like the best first approach would be to see how difficult converting these fields to union types would be and try to contribute that change back upstream if you folks were interested, so here we are.

