### PR TITLE
Fix Boleto not showing the state field

### DIFF
--- a/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.tsx
+++ b/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.tsx
@@ -102,10 +102,11 @@ function BoletoInput(props) {
 
             {props.billingAddressRequired && (
                 <Address
+                    allowedCountries={['BR']}
                     label="billingAddress"
                     data={{ ...props.data.billingAddress, country: 'BR' }}
                     onChange={handleAddress}
-                    requiredFields={['street', 'houseNumberOrName', 'postalCode', 'city', 'stateOrProvince']}
+                    requiredFields={['country', 'street', 'houseNumberOrName', 'postalCode', 'city', 'stateOrProvince']}
                     ref={addressRef}
                 />
             )}


### PR DESCRIPTION
## Summary
- Fix Boleto not showing the state field
- Align UI with other compoents by showing the country field as read only.

