### PR TITLE
fix(BankTransfer): showEmailAdress flag

### DIFF
--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -42,6 +42,10 @@ export class BankTransferElement extends UIElement<BankTransferProps> {
     };
 
     render() {
+        if(this.props.showEmailAddress === undefined || this.props.showEmailAddress === null){
+            this.props.showEmailAddress = BankTransferElement.defaultProps.showEmailAddress;
+        }
+
         if (this.props.reference) {
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
@@ -53,10 +57,12 @@ export class BankTransferElement extends UIElement<BankTransferProps> {
         if (this.props.showPayButton) {
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
-                    <BankTransferInput ref={this.handleRef} {...this.props} onChange={this.setState} />
+                    {this.props.showEmailAddress && (
+                        <BankTransferInput ref={this.handleRef} {...this.props} onChange={this.setState} />
+                    )}
                     <RedirectButton {...this.props} name={this.displayName} onSubmit={this.submit} payButton={this.payButton} />
                 </CoreProvider>
-            );
+            )
         }
 
         return null;

--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -42,10 +42,6 @@ export class BankTransferElement extends UIElement<BankTransferProps> {
     };
 
     render() {
-        if(this.props.showEmailAddress === undefined || this.props.showEmailAddress === null){
-            this.props.showEmailAddress = BankTransferElement.defaultProps.showEmailAddress;
-        }
-
         if (this.props.reference) {
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
@@ -62,7 +58,7 @@ export class BankTransferElement extends UIElement<BankTransferProps> {
                     )}
                     <RedirectButton {...this.props} name={this.displayName} onSubmit={this.submit} payButton={this.payButton} />
                 </CoreProvider>
-            )
+            );
         }
 
         return null;


### PR DESCRIPTION
## Summary
We have noticed that you have implemented the feature to send a copy to the email when there is a payment with Bank Transfer. Which is a very good feature but in our case we do not need it and we noticed that the **showEmailAddress** flag was not working. 
