### PR TITLE
Fix double onSubmit call on Google Pay when using a custom button

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -44,7 +44,7 @@ class GooglePay extends UIElement<GooglePayProps> {
     }
 
     public loadPayment = () => {
-        const { onSubmit = () => {}, onAuthorized = () => {} } = this.props;
+        const { onAuthorized = () => {} } = this.props;
 
         return new Promise((resolve, reject) => this.props.onClick(resolve, reject))
             .then(() => this.googlePay.initiatePayment(this.props))
@@ -55,7 +55,6 @@ class GooglePay extends UIElement<GooglePayProps> {
                     googlePayCardNetwork: paymentData.paymentMethodData.info.cardNetwork
                 });
 
-                onSubmit({ data: this.data, isValid: this.isValid }, this);
                 return onAuthorized(paymentData);
             })
             .catch(error => {
@@ -65,7 +64,9 @@ class GooglePay extends UIElement<GooglePayProps> {
     };
 
     public submit = () => {
-        return this.loadPayment();
+        return this.loadPayment().then(() => {
+            if (this.props.onSubmit) this.props.onSubmit({ data: this.data, isValid: this.isValid }, this);
+        });
     };
 
     public startPayment = () => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When making a Google Pay payment on the Drop-in with a custom button, a double `onSubmit` event was triggered.

## Tested scenarios
- Calling `dropin.submit()` with Google Pay selected fires `onSubmit` once

**Fixed issue**:  #972
