### PR TITLE
remove 'only' from e2e test

### DIFF
--- a/packages/e2e/tests/cards/general/general.test.js
+++ b/packages/e2e/tests/cards/general/general.test.js
@@ -14,7 +14,7 @@ const cardUtils = cu(iframeSelector);
 fixture`Testing regular card completion and payment`.page(CARDS_URL);
 //    .clientScripts('general.clientScripts.js');
 
-test.only('Can fill out the fields in the regular custom card and make a successful payment', async t => {
+test('Can fill out the fields in the regular custom card and make a successful payment', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Removed a `test.only`

