### PR TITLE
Fix order-status call on partial payments flow

### DIFF
--- a/packages/lib/src/core/Services/order-status.ts
+++ b/packages/lib/src/core/Services/order-status.ts
@@ -1,12 +1,12 @@
-import { httpGet } from './http';
+import { httpPost } from './http';
 import { OrderStatus } from '../../types';
 
 /**
  */
 function orderStatus(config, order): Promise<OrderStatus> {
-    const options = { path: `/v1/order/status?clientKey=${config.clientKey}`, loadingContext: config.loadingContext };
+    const options = { path: `v1/order/status?clientKey=${config.clientKey}`, loadingContext: config.loadingContext };
 
-    return httpGet(options, { orderData: order.orderData });
+    return httpPost(options, { orderData: order.orderData });
 }
 
 export default orderStatus;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix order-status call on partial payments flow.

## Tested scenarios
On a partial payments flow, the order status call works as expected.
The order status call uses a POST method.