### PR TITLE
Fix onSubmit component reference on Google Pay component

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -65,7 +65,7 @@ class GooglePay extends UIElement<GooglePayProps> {
 
     public submit = () => {
         return this.loadPayment().then(() => {
-            if (this.props.onSubmit) this.props.onSubmit({ data: this.data, isValid: this.isValid }, this);
+            if (this.props.onSubmit) this.props.onSubmit({ data: this.data, isValid: this.isValid }, this.elementRef);
         });
     };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix the `component` reference on the second parameter of the `onSubmit` event to correctly point to the right instance (component or drop-in).

