### PR TITLE
Allow custom icons and custom brand icons

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -28,8 +28,8 @@ export class CardElement extends UIElement<CardElementProps> {
                 ...props.configuration,
                 socialSecurityNumberMode: props.configuration?.socialSecurityNumberMode ?? 'auto',
             },
-            brandsConfiguration: props.brandsConfiguration ?? props?.configuration?.brandsConfiguration ?? {},
-            icon: props.icon ?? props?.configuration?.icon,
+            brandsConfiguration: props.brandsConfiguration || props.configuration?.brandsConfiguration || {},
+            icon: props.icon || props.configuration?.icon,
             onBinLookup: props.onBinLookup ??= () => {}
         };
     }

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -28,6 +28,8 @@ export class CardElement extends UIElement<CardElementProps> {
                 ...props.configuration,
                 socialSecurityNumberMode: props.configuration?.socialSecurityNumberMode ?? 'auto',
             },
+            brandsConfiguration: props.brandsConfiguration ?? props?.configuration?.brandsConfiguration ?? {},
+            icon: props.icon ?? props?.configuration?.icon,
             onBinLookup: props.onBinLookup ??= () => {}
         };
     }
@@ -92,17 +94,18 @@ export class CardElement extends UIElement<CardElementProps> {
     }
 
     get icon() {
-        return getImage({ loadingContext: this.props.loadingContext })(this.brand);
+        return this.props.icon ?? getImage({ loadingContext: this.props.loadingContext })(this.brand);
     }
 
     get brands(): { icon: any; name: string }[] {
-        const { brands, loadingContext } = this.props;
+        const { brands, loadingContext, brandsConfiguration } = this.props;
         if (brands) {
-            return brands.map(brand => ({
-                icon: getImage({ loadingContext })(brand),
-                name: brand
-            }));
+            return brands.map(brand => {
+                const brandIcon = brandsConfiguration[brand]?.icon ?? getImage({ loadingContext })(brand);
+                return { icon: brandIcon, name: brand };
+            })
         }
+
         return [];
     }
 

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -20,6 +20,11 @@ export interface CardElementProps extends UIElementProps {
     brand?: string;
 
     /**
+     * Configuration specific to brands
+     */
+    brandsConfiguration?: CardBrandsConfiguration;
+
+    /**
      * type will always be "card" (generic card, stored card)
      * except for a single branded card when it will be the same as the brand prop
      */
@@ -101,6 +106,14 @@ export type SocialSecurityMode = 'show' | 'hide' | 'auto';
 export interface CardConfiguration {
     koreanAuthenticationRequired?: boolean;
     socialSecurityNumberMode?: SocialSecurityMode;
+    icon?: string;
+    brandsConfiguration?: CardBrandsConfiguration;
+}
+
+export interface CardBrandsConfiguration {
+    [key: string]: {
+        icon?: string;
+    };
 }
 
 interface CardPaymentMethodData {

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -9,7 +9,10 @@ export class GiftcardElement extends UIElement {
     public static type = 'giftcard';
 
     formatProps(props) {
-        return props;
+        return {
+            ...props?.configuration,
+            ...props
+        };
     }
 
     /**
@@ -31,7 +34,7 @@ export class GiftcardElement extends UIElement {
     }
 
     get icon() {
-        return getImage({ loadingContext: this.props.loadingContext })(this.props.brand);
+        return this.props.icon ?? getImage({ loadingContext: this.props.loadingContext })(this.props.brand);
     }
 
     get displayName() {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -14,6 +14,7 @@ export interface UIElementProps extends BaseElementProps {
     onError?: (error, element?: UIElement) => void;
 
     name?: string;
+    icon?: string;
     amount?: PaymentAmount;
 
     /**
@@ -134,7 +135,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> {
      * Get the element icon URL for the current environment
      */
     get icon(): string {
-        return getImage({ loadingContext: this.props.loadingContext })(this.constructor['type']);
+        return this.props.icon ?? getImage({ loadingContext: this.props.loadingContext })(this.constructor['type']);
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Allow customizing icons of each payment method.
- Allow customizing brand icons on the card component.

All components accept an `icon` prop. In the Drop-in this will be displayed next to the name, in Components, this will be returned by `component.icon`.

```js
checkout.create('paywithgoogle', {
  someConfig: {},
  icon: 'htttps://...`
});
```

The Card component brand icons can also be customized through the `brandsConfiguration` property.

```js
{
  paymentMethodsConfiguration: {
   card: {
      brandsConfiguration: { 
        visa: {
          icon: 'https://...'
        }
      }
   }
}
```