### PR TITLE
Increase max gift card length from 22 to 32 digits

### DIFF
--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -118,7 +118,7 @@ class Giftcard extends Component<GiftcardComponentProps> {
                             >
                                 <span
                                     data-cse="encryptedCardNumber"
-                                    data-info='{"length":"15-22", "maskInterval":4}'
+                                    data-info='{"length":"15-32", "maskInterval":4}'
                                     className={classNames({
                                         'adyen-checkout__input': true,
                                         'adyen-checkout__input--large': true,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Increase the maximum allowed gift card length from 22 to 32 digits.