### PR TITLE
Add adyen-web package.json to exports

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -19,7 +19,8 @@
             "import": "./dist/es/index.js",
             "require": "./dist/cjs/index.js"
         },
-        "./dist/adyen.css": "./dist/adyen.css"
+        "./dist/adyen.css": "./dist/adyen.css",
+        "./package.json": "./package.json"
     },
     "version": "4.4.0",
     "license": "MIT",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
It's not an uncommon pattern for bundlers/tools to do `require.resolve(path.join('@adyen/adyen-web', 'package.json'))` in order to find the location of a package's `package.json` file. However, for packages that have adopted the `exports` field in their `package.json`, this pattern won't work unless `package.json` itself is listed as an 'exported'/accessible file for the module. Here are some related discussions around this pattern: https://github.com/nodejs/node/issues/33460 and https://github.com/nodejs/modules/issues/516

A similar issue arose and was fixed by #837 for the CSS bundle in `adyen-web`.

This change allows the above pattern using `require.resolve` to work for `@adyen/adyen-web`.

@marcperez since you fixed the exports issue for the CSS bundle previously.
