### PR TITLE
Allow customizing the CardNumber field icon on the Card Component

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -323,6 +323,7 @@ function CardInput(props: CardInputProps) {
                             <CardFields
                                 {...props}
                                 brand={sfpState.brand}
+                                brandsConfiguration={this.props.brandsConfiguration}
                                 focusedElement={focusedElement}
                                 onFocusField={setFocusOn}
                                 hasCVC={props.hasCVC}

--- a/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
@@ -4,7 +4,7 @@ import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { BrandIconProps } from './types';
 import styles from '../CardInput.module.scss';
 
-export default function BrandIcon({ brand, brandsConfiguration }: BrandIconProps) {
+export default function BrandIcon({ brand, brandsConfiguration = {} }: BrandIconProps) {
     const { loadingContext } = useCoreContext();
     const imageName = brand === 'card' ? 'nocard' : brand;
     const imageUrl = brandsConfiguration[brand]?.icon ?? getCardImageUrl(imageName, loadingContext);

--- a/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
@@ -4,9 +4,10 @@ import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { BrandIconProps } from './types';
 import styles from '../CardInput.module.scss';
 
-export default function BrandIcon({ brand }: BrandIconProps) {
+export default function BrandIcon({ brand, brandsConfiguration }: BrandIconProps) {
     const { loadingContext } = useCoreContext();
     const imageName = brand === 'card' ? 'nocard' : brand;
+    const imageUrl = brandsConfiguration[brand]?.icon ?? getCardImageUrl(imageName, loadingContext);
     const handleError = e => {
         e.target.style.cssText = 'display: none';
     };
@@ -16,7 +17,7 @@ export default function BrandIcon({ brand }: BrandIconProps) {
             className={`${styles['card-input__icon']} adyen-checkout__card__cardNumber__brandIcon`}
             onError={handleError}
             alt={brand}
-            src={getCardImageUrl(imageName, loadingContext)}
+            src={imageUrl}
         />
     );
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
@@ -9,6 +9,7 @@ import styles from '../CardInput.module.scss';
 
 export default function CardFields({
     brand,
+    brandsConfiguration,
     dualBrandingElements,
     dualBrandingChangeHandler,
     dualBrandingSelected,
@@ -27,6 +28,7 @@ export default function CardFields({
         <div className="adyen-checkout__card__form">
             <CardNumber
                 brand={brand}
+                brandsConfiguration={brandsConfiguration}
                 error={errors.encryptedCardNumber}
                 focused={focusedElement === 'encryptedCardNumber'}
                 isValid={!!valid.encryptedCardNumber}

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -36,7 +36,7 @@ export default function CardNumber(props: CardNumberProps) {
                     'adyen-checkout__card__cardNumber__input--noBrand': !props.showBrandIcon
                 })}
             >
-                {props.showBrandIcon && !dualBrandingElements && <BrandIcon brand={props.brand} />}
+                {props.showBrandIcon && !dualBrandingElements && <BrandIcon brandsConfiguration={props.brandsConfiguration} brand={props.brand} />}
             </span>
 
             {dualBrandingElements && !error && (
@@ -50,6 +50,7 @@ export default function CardNumber(props: CardNumberProps) {
                         <DualBrandingIcon
                             key={element.id}
                             brand={element.id}
+                            brandsConfiguration={props.brandsConfiguration}
                             onClick={dualBrandingChangeHandler}
                             dataValue={element.id}
                             notSelected={dualBrandingSelected !== '' && dualBrandingSelected !== element.id}

--- a/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
@@ -5,7 +5,7 @@ import { getCardImageUrl } from '../../utils';
 import { DualBrandingIconProps } from '../types';
 import './DualBrandingIcon.scss';
 
-const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected, brandsConfiguration }: DualBrandingIconProps) => {
+const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected, brandsConfiguration = {} }: DualBrandingIconProps) => {
     const { loadingContext } = useCoreContext();
     const imageName = brand === 'card' ? 'nocard' : brand;
     const imageUrl = brandsConfiguration[brand]?.icon ?? getCardImageUrl(imageName, loadingContext);

--- a/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
@@ -5,9 +5,10 @@ import { getCardImageUrl } from '../../utils';
 import { DualBrandingIconProps } from '../types';
 import './DualBrandingIcon.scss';
 
-const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected }: DualBrandingIconProps) => {
+const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected, brandsConfiguration }: DualBrandingIconProps) => {
     const { loadingContext } = useCoreContext();
     const imageName = brand === 'card' ? 'nocard' : brand;
+    const imageUrl = brandsConfiguration[brand]?.icon ?? getCardImageUrl(imageName, loadingContext);
     const handleError = e => {
         e.target.style.cssText = 'display: none';
     };
@@ -19,7 +20,7 @@ const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected }: DualBrandi
             } adyen-checkout__card__cardNumber__brandIcon`}
             onError={handleError}
             alt={brand}
-            src={getCardImageUrl(imageName, loadingContext)}
+            src={imageUrl}
             onClick={onClick}
             data-value={dataValue}
         />

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -34,7 +34,7 @@ export interface CardHolderNameProps {
 
 export interface CardNumberProps {
     brand: string;
-    brandsConfiguration: CardBrandsConfiguration;
+    brandsConfiguration?: CardBrandsConfiguration;
     dualBrandingChangeHandler?: any;
     dualBrandingElements?: any;
     dualBrandingSelected?: string;

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -1,11 +1,14 @@
 import { PaymentAmount } from '../../../../../types';
+import { CardBrandsConfiguration } from '../../../types';
 
 export interface BrandIconProps {
     brand: string;
+    brandsConfiguration: CardBrandsConfiguration;
 }
 
 export interface CardFieldsProps {
     brand?: string;
+    brandsConfiguration?: CardBrandsConfiguration;
     dualBrandingChangeHandler?: any;
     dualBrandingElements?: any;
     dualBrandingSelected?: string;
@@ -31,6 +34,7 @@ export interface CardHolderNameProps {
 
 export interface CardNumberProps {
     brand: string;
+    brandsConfiguration: CardBrandsConfiguration;
     dualBrandingChangeHandler?: any;
     dualBrandingElements?: any;
     dualBrandingSelected?: string;
@@ -62,6 +66,7 @@ export interface CVCHintProps {
 
 export interface DualBrandingIconProps {
     brand: string;
+    brandsConfiguration: CardBrandsConfiguration;
     onClick?: any;
     dataValue?: string;
     notSelected?: boolean;

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -1,5 +1,5 @@
 import Language from '../../../../language/Language';
-import { CardConfiguration, DualBrandSelectElement, SocialSecurityMode } from '../../types';
+import { CardBrandsConfiguration, CardConfiguration, DualBrandSelectElement, SocialSecurityMode } from '../../types';
 import { PaymentAmount } from '../../../../types';
 import { InstallmentOptions } from './components/types';
 import { ValidationResult } from '../../../internal/PersonalDetails/types';
@@ -44,6 +44,7 @@ export interface CardInputProps {
     billingAddressRequired?: boolean;
     billingAddressRequiredFields?: string[];
     brand?: string;
+    brandsConfiguration?: CardBrandsConfiguration;
     configuration?: CardConfiguration;
     countryCode?: string;
     cvcPolicy?: string;

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -8,6 +8,10 @@ import PayButton from '../internal/PayButton';
 export class GiftcardElement extends UIElement {
     public static type = 'giftcard';
 
+    protected static defaultProps = {
+        brandsConfiguration: {}
+    };
+
     formatProps(props) {
         return {
             ...props?.configuration,
@@ -34,7 +38,11 @@ export class GiftcardElement extends UIElement {
     }
 
     get icon() {
-        return this.props.icon ?? getImage({ loadingContext: this.props.loadingContext })(this.props.brand);
+        return (
+            this.props.brandsConfiguration[this.props.brand]?.icon ||
+            this.props.icon ||
+            getImage({ loadingContext: this.props.loadingContext })(this.props.brand)
+        );
     }
 
     get displayName() {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Relates to #1039.

* The icon shown in the Card number field will also display the custom logo when a Card brand has a customized logo.
* Gift card brands can be customized through `brandsConfiguration` as well.

## Tested scenarios
- Custom Card brand icons are used everywhere