### PR TITLE
Fix path to the PostCSS config file

### DIFF
--- a/packages/lib/config/rollup.config.js
+++ b/packages/lib/config/rollup.config.js
@@ -60,7 +60,9 @@ async function getPlugins({ compress, analyze, version, useTypescript = true }) 
             }),
         json({ namedExports: false, compact: true, preferConst: true }),
         postcss({
-            config: 'postcss.config.js',
+            config: {
+                path: 'config/postcss.config.js'
+            },
             sourceMap: true,
             inject: false,
             extract: 'adyen.css'


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The path to the PostCSS config file was not set correctly, which means the plugins were not running. For this reason the CSS files in our releases were not minified and auto-prefixed.

## Tested scenarios
Built the project and checked the generated CSS file.
