### PR TITLE
Accept socialSecurityNumberMode outside configuration on Card component

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -26,7 +26,7 @@ export class CardElement extends UIElement<CardElementProps> {
             // - if merchant has defined value directly in props, use this instead
             configuration: {
                 ...props.configuration,
-                socialSecurityNumberMode: props.configuration?.socialSecurityNumberMode ?? 'auto',
+                socialSecurityNumberMode: props.socialSecurityNumberMode || props.configuration?.socialSecurityNumberMode || 'auto',
             },
             brandsConfiguration: props.brandsConfiguration || props.configuration?.brandsConfiguration || {},
             icon: props.icon || props.configuration?.icon,

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -55,6 +55,8 @@ export interface CardElementProps extends UIElementProps {
     /** Whether the card holder name field will be required */
     holderNameRequired?: boolean;
 
+    socialSecurityNumberMode?: SocialSecurityMode;
+
     configuration?: CardConfiguration;
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Allows setting `socialSecurityNumberMode` on the root of the Card component configuration as well as in the `configuration` object.