### PR TITLE
Add support for Girocard to ApplePay component

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -10,7 +10,7 @@ import { preparePaymentRequest } from './payment-request';
 import { resolveSupportedVersion, mapBrands } from './utils';
 import { ApplePayElementProps, ApplePayElementData, ApplePaySessionRequest } from './types';
 
-const latestSupportedVersion = 10;
+const latestSupportedVersion = 11;
 
 class ApplePayElement extends UIElement<ApplePayElementProps> {
     protected static type = 'applepay';

--- a/packages/lib/src/components/ApplePay/utils.ts
+++ b/packages/lib/src/components/ApplePay/utils.ts
@@ -18,8 +18,10 @@ export function mapBrands(brands) {
         discover: 'discover',
         jcb: 'jcb',
         electron: 'electron',
-        maestro: 'maestro'
+        maestro: 'maestro',
+        girocard: 'girocard'
     };
+
     return brands.reduce((accumulator, item) => {
         if (!!brandMapping[item] && !accumulator.includes(brandMapping[item])) {
             accumulator.push(brandMapping[item]);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Add `girocard` support to ApplePay
- Bump maximum supported ApplePay version to `11`