### PR TITLE
handleAction accepts & propagates challengeWindowSize option

### DIFF
--- a/packages/e2e/app/src/handlers.js
+++ b/packages/e2e/app/src/handlers.js
@@ -2,7 +2,7 @@ import { makePayment, makeDetailsCall } from './services';
 
 export function handleResponse(response, component) {
     if (response.action) {
-        component.handleAction(response.action);
+        component.handleAction(response.action, window.actionConfigObject || {});
     } else if (response.resultCode) {
         alert(response.resultCode);
     }

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.default.size.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.default.size.test.js
@@ -67,7 +67,7 @@ test('Fill in card number that will trigger full flow (fingerprint & challenge)'
 
     // console.log(logger.requests[0].response.headers);
 
-    // Check challenge window size is read from config prop
+    // Check challenge window size is read from default config prop
     await t.expect(Selector('.adyen-checkout__threeds2__challenge--02').exists).ok();
 
     // Complete challenge

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.handleAction.clientScripts.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.handleAction.clientScripts.js
@@ -1,0 +1,21 @@
+window.dropinConfig = {
+    showStoredPaymentMethods: false // hide stored PMs so credit card is first on list
+};
+
+/**
+ * Seems to be an error with TestCafe
+ * Throws:
+ *  JavaScript error details:
+ *  ReferenceError: PaymentRequest is not defined
+ *    at https://pay.google.com/gp/p/js/pay.js:237:404
+ */
+window.mainConfiguration = {
+    removePaymentMethods: ['paywithgoogle', 'applepay'],
+    paymentMethodsConfiguration: {
+        threeDS2: {
+            challengeWindowSize: '04'
+        }
+    }
+};
+
+window.actionConfigObject = { challengeWindowSize: '01' };

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.handleAction.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.handleAction.test.js
@@ -5,7 +5,7 @@ import { Selector, RequestLogger } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../utils/commonUtils';
 import cu from '../utils/cardUtils';
 import { fillChallengeField, submitChallenge } from '../utils/threeDS2Utils';
-import { THREEDS2_CHALLENGE_ONLY_CARD, THREEDS2_FRICTIONLESS_CARD, THREEDS2_FULL_FLOW_CARD } from '../utils/constants';
+import { THREEDS2_CHALLENGE_ONLY_CARD, THREEDS2_FULL_FLOW_CARD } from '../utils/constants';
 import { BASE_URL } from '../../pages';
 
 const detailsURL = `${BASE_URL}/details`;
@@ -31,44 +31,13 @@ const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--card 
 
 const cardUtils = cu(iframeSelector);
 
-fixture`Testing new (v67) 3DS2 Flow`
+fixture`Testing new (v67) 3DS2 Flow (handleAction config)`
     .page(BASE_URL)
-    .clientScripts('threeDS2.clientScripts.js')
+    .clientScripts('threeDS2.handleAction.clientScripts.js')
     .requestHooks(logger);
 
 if (apiVersion >= 67) {
-    test('Fill in card number that will trigger frictionless flow', async t => {
-        await start(t, 2000, TEST_SPEED);
-
-        // Set handler for the alert window
-        await t.setNativeDialogHandler(() => true);
-
-        // Fill card fields
-        await cardUtils.fillCardNumber(t, THREEDS2_FRICTIONLESS_CARD);
-        await cardUtils.fillDateAndCVC(t);
-
-        // Expect card to now be valid
-        await t.expect(getIsValid('dropin')).eql(true);
-
-        // Click pay
-        await t
-            .click('.adyen-checkout__card-input .adyen-checkout__button--pay')
-            // Expect no errors
-            .expect(Selector('.adyen-checkout__field--error').exists)
-            .notOk()
-            // Allow time for the ONLY details call, which we expect to be successful
-            .wait(2000)
-            .expect(logger.contains(r => r.request.url.indexOf('/details') > -1 && r.response.statusCode === 200))
-            .ok()
-            // Allow time for the alert to manifest
-            .wait(2000);
-
-        // Check the value of the alert text
-        const history = await t.getNativeDialogHistory();
-        await t.expect(history[0].text).eql('Authorised');
-    });
-
-    test('Fill in card number that will trigger full flow (fingerprint & challenge)', async t => {
+    test('Fill in card number that will trigger full flow (fingerprint & challenge) with challenge window size set in the call to handleAction', async t => {
         logger.clear();
 
         await start(t, 2000, TEST_SPEED);
@@ -98,8 +67,8 @@ if (apiVersion >= 67) {
 
         //        console.log('logger.requests[0].response', logger.requests[0].response);
 
-        // Check challenge window size is read from config prop
-        await t.expect(Selector('.adyen-checkout__threeds2__challenge--04').exists).ok();
+        // Check challenge window size is read from config prop set in handleAction call
+        await t.expect(Selector('.adyen-checkout__threeds2__challenge--01').exists).ok();
 
         // Complete challenge
         await fillChallengeField(t);
@@ -127,7 +96,7 @@ if (apiVersion >= 67) {
         await t.expect(history[0].text).eql('Authorised');
     });
 
-    test('Fill in card number that will trigger challenge-only flow', async t => {
+    test('Fill in card number that will trigger challenge-only flow  with challenge window size set in the call to handleAction', async t => {
         logger.clear();
 
         await start(t, 2000, TEST_SPEED);
@@ -149,8 +118,8 @@ if (apiVersion >= 67) {
             .expect(Selector('.adyen-checkout__field--error').exists)
             .notOk();
 
-        // Check challenge window size is read from config prop
-        await t.expect(Selector('.adyen-checkout__threeds2__challenge--04').exists).ok();
+        // Check challenge window size is read from config prop set in handleAction call
+        await t.expect(Selector('.adyen-checkout__threeds2__challenge--01').exists).ok();
 
         // Complete challenge
         await fillChallengeField(t);
@@ -168,7 +137,7 @@ if (apiVersion >= 67) {
         await t.expect(history[0].text).eql('Authorised');
     });
 } else {
-    test(`Skip testing new 3DS2 flow since api version is too low (v${apiVersion})`, async t => {
+    test(`Skip testing new 3DS2 flow (handleAction) since api version is too low (v${apiVersion})`, async t => {
         await t.wait(250);
     });
 }

--- a/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
+++ b/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
@@ -1,4 +1,5 @@
 import { httpPost } from '../../core/Services/http';
+import { pick } from '../internal/SecuredFields/utils';
 
 /**
  * ThreeDS2DeviceFingerprint, onComplete, calls a new, internal, endpoint which behaves like the /details endpoint but doesn't require the same credentials
@@ -33,7 +34,8 @@ export default function callSubmit3DS2Fingerprint({ data }) {
          * Challenge flow
          */
         if (resData.action?.type === 'threeDS2') {
-            return actionHandler.handleAction(resData.action);
+            // Ensure challengeWindowSize is propagated if there was a (merchant defined) handleAction call proceeding this one that had it set as an option
+            return actionHandler.handleAction(resData.action, pick('challengeWindowSize').from(this.props));
         }
 
         /**

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -184,7 +184,6 @@ const fingerprintFlowPropsDropin = ['elementRef'];
  *  if the /submitThreeDS2Fingerprint response dictates we "handleAction" to create a challenge
  */
 const fingerprintFlowProps = ['createFromAction', 'onAdditionalDetails'];
-// const challengeFlowProps = ['challengeWindowSize'];
 
 /**
  * Add props specifically needed for the type of 3DS2 flow: fingerprint or challenge

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -177,15 +177,14 @@ export const encodeBase64URL = (dataStr: string): string => {
     return base64url;
 };
 
-const fingerprintFlowPropsDropin = ['elementRef', 'challengeWindowSize']; // also pass challengeWindowSize in case its been set directly in the handleAction config object
+const fingerprintFlowPropsDropin = ['elementRef'];
 
 /**
  *  Must contain all props needed for the challenge stage since, in the new 3DS2 flow, the fingerprint component will be the "component" reference
  *  if the /submitThreeDS2Fingerprint response dictates we "handleAction" to create a challenge
  */
-const fingerprintFlowProps = ['createFromAction', 'onAdditionalDetails', 'challengeWindowSize'];
-
-const challengeFlowProps = ['challengeWindowSize'];
+const fingerprintFlowProps = ['createFromAction', 'onAdditionalDetails'];
+// const challengeFlowProps = ['challengeWindowSize'];
 
 /**
  * Add props specifically needed for the type of 3DS2 flow: fingerprint or challenge
@@ -204,7 +203,7 @@ export const get3DS2FlowProps = (actionSubtype, props) => {
     }
 
     // Challenge
-    const rtnObj = pick(challengeFlowProps).from(props);
-    rtnObj.statusType = 'custom';
-    return rtnObj;
+    return {
+        statusType: 'custom'
+    };
 };

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -177,7 +177,7 @@ export const encodeBase64URL = (dataStr: string): string => {
     return base64url;
 };
 
-const fingerprintFlowPropsDropin = ['elementRef'];
+const fingerprintFlowPropsDropin = ['elementRef', 'challengeWindowSize']; // also pass challengeWindowSize in case its been set directly in the handleAction config object
 
 /**
  *  Must contain all props needed for the challenge stage since, in the new 3DS2 flow, the fingerprint component will be the "component" reference

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -55,6 +55,7 @@ const actionTypes = {
             clientKey: props.clientKey,
             _parentInstance: props._parentInstance,
             paymentMethodType: props.paymentMethodType,
+            challengeWindowSize: props.challengeWindowSize, // always pass challengeWindowSize in case it's been set directly in the handleAction config object
 
             // Props unique to a particular flow
             ...get3DS2FlowProps(action.subtype, props)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
If an options object is passed with a (3DS2) call to handleAction
e.g. `component.handleAction(action, {challengeWindowSize: '01'});`
Ensure the `challengeWindowSize` prop is passed through to the actual 3DSChallenge component

## Tested scenarios
Tested both `handleAction` & `createFromAction` in Card component & Dropin
Added e2e tests for Dropin

**Fixed issue**:  COWEB-985
