### PR TITLE
Release Adyen Web 4.6.0

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -44,6 +44,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "4.5.0"
+        "@adyen/adyen-web": "4.6.0"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,7 +22,7 @@
         "./dist/adyen.css": "./dist/adyen.css",
         "./package.json": "./package.json"
     },
-    "version": "4.5.0",
+    "version": "4.6.0",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -46,6 +46,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "4.5.0"
+        "@adyen/adyen-web": "4.6.0"
     }
 }


### PR DESCRIPTION
## New

* ApplePay component supports Girocard #1076

## Improvements

* Updated the Google Pay icon to better align with [Google Pay's brand guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines) #1102
* PayPal Credit can be turned off #1075 
* Multiple PayPal components can be mounted in the same page #1075 

## Fixes

* Fixed a double submit call on the Apple Pay component when using a custom button #1085
* Fixed broken issuer images on the IssuerList component #1092
