### PR TITLE
Automatically set loading status on submit

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -76,6 +76,7 @@ class DropinElement extends UIElement<DropinElementProps> {
             return false;
         }
 
+        if (this.props.setStatusAutomatically !== false) this.setStatus('loading');
         return this.props.onSubmit({ data, isValid }, this);
     };
 

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -13,6 +13,9 @@ export interface UIElementProps extends BaseElementProps {
     onAdditionalDetails?: (state: any, element: UIElement) => void;
     onError?: (error, element?: UIElement) => void;
 
+    /** Automatically set status through the payment flow */
+    setStatusAutomatically?: boolean;
+
     type?: string;
     name?: string;
     icon?: string;
@@ -92,6 +95,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> {
                     return false;
                 }
 
+                if (this.props.setStatusAutomatically !== false) this.setStatus('loading');
                 return onSubmit({ data, isValid }, this.elementRef);
             })
             .catch(error => onError(error));

--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -20,7 +20,8 @@ export const GENERIC_OPTIONS = [
     'onChange',
     'onError',
     'onBalanceCheck',
-    'onOrderRequest'
+    'onOrderRequest',
+    'setStatusAutomatically'
 ];
 
 export default {

--- a/packages/playground/src/pages/Dropin/Dropin.js
+++ b/packages/playground/src/pages/Dropin/Dropin.js
@@ -22,7 +22,6 @@ const initCheckout = async () => {
             }
         },
         onSubmit: async (state, component) => {
-            component.setStatus('loading');
             const result = await makePayment(state.data);
 
             // handle actions


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When the submit functionality is triggered, the active component or Drop-in instance will set its status to `loading` automatically. (equivalent of `component.setStatus('loading')`.

This automatic behavior can be turned off by setting the `setStatusAutomatically` prop to `false`.
