### PR TITLE
Add CarteBancaire support to Apple Pay component

### DIFF
--- a/packages/lib/src/components/ApplePay/utils.ts
+++ b/packages/lib/src/components/ApplePay/utils.ts
@@ -19,7 +19,8 @@ export function mapBrands(brands) {
         jcb: 'jcb',
         electron: 'electron',
         maestro: 'maestro',
-        girocard: 'girocard'
+        girocard: 'girocard',
+        cartebancaire: 'cartesBancaires'
     };
 
     return brands.reduce((accumulator, item) => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Add support for Carte Bancaire to Apple Pay component's map of supported networks.
