### PR TITLE
Prop updates

### DIFF
--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -25,7 +25,7 @@ class BaseElement<P extends BaseElementProps> {
     public _node;
     public _component;
     public eventEmitter = new EventEmitter();
-    private readonly _parentInstance;
+    private readonly _parentInstance: Core;
 
     protected constructor(props: P) {
         this.props = this.formatProps({ ...this.constructor['defaultProps'], ...props });
@@ -116,9 +116,8 @@ class BaseElement<P extends BaseElementProps> {
      */
     public update(props: P): this {
         this.props = this.formatProps({ ...this.props, ...props });
-        this.state = {};
 
-        return this.unmount().remount();
+        return this._node ? this.remount() : this;
     }
 
     /**
@@ -129,9 +128,9 @@ class BaseElement<P extends BaseElementProps> {
             throw new Error('Component is not mounted.');
         }
 
-        const newComponent = component || this.render();
+        this._component = component || this.render();
 
-        render(newComponent, this._node, null);
+        render(this._component, this._node, null);
 
         return this;
     }

--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -3,6 +3,7 @@ import Dropin from './Dropin';
 import AdyenCheckout from '../../core';
 import ThreeDS2DeviceFingerprint from '../ThreeDS2/ThreeDS2DeviceFingerprint';
 import ThreeDS2Challenge from '../ThreeDS2/ThreeDS2Challenge';
+import UIElement from '../UIElement';
 
 const submitMock = jest.fn();
 (global as any).HTMLFormElement.prototype.submit = () => submitMock;
@@ -19,8 +20,15 @@ describe('Dropin', () => {
         test('should return the isValid value of the activePaymentMethod', () => {
             const dropin = new Dropin({});
             mount(dropin.render());
-            dropin.dropinRef.state.activePaymentMethod = { isValid: true };
-            expect(dropin.isValid).toEqual(true);
+
+            setTimeout(() => {
+                dropin.dropinRef.current.state.activePaymentMethod = new (class PaymentMethodTest extends UIElement {
+                    get isValid() {
+                        return true;
+                    }
+                })({});
+                expect(dropin.isValid).toEqual(true);
+            });
         });
     });
 
@@ -35,10 +43,10 @@ describe('Dropin', () => {
         test('should close active payment method', () => {
             const dropin = new Dropin({});
             mount(dropin.render());
-            expect(dropin.dropinRef.state.activePaymentMethod).toBeDefined();
+            expect(dropin.activePaymentMethod).toBeDefined();
 
             dropin.closeActivePaymentMethod();
-            expect(dropin.dropinRef.state.activePaymentMethod).toBeNull();
+            expect(dropin.activePaymentMethod).toBeNull();
         });
     });
 

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -39,7 +39,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         });
     };
 
-    private setStatus = status => {
+    public setStatus = status => {
         this.setState({ status });
     };
 
@@ -57,6 +57,10 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
 
         if (this.state.status.type === 'ready' && prevState.status.type !== 'ready' && this.props.onReady) {
             this.props.onReady();
+        }
+
+        if (this.props.order && !prevProps.order) {
+            this.props.onDropinReset();
         }
     }
 
@@ -83,6 +87,10 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                 this.setState({ isDisabling: false });
             });
     };
+
+    public update(props) {
+        this.state.elements.forEach(element => element.update(props));
+    }
 
     closeActivePaymentMethod() {
         this.setState({ activePaymentMethod: null });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -1,4 +1,5 @@
-import { Component, Fragment, h } from 'preact';
+import { Fragment, h } from 'preact';
+import { useEffect } from 'preact/hooks';
 import classNames from 'classnames';
 import PaymentMethodItem from './PaymentMethodItem';
 import getProp from '../../../../utils/getProp';
@@ -25,75 +26,71 @@ interface PaymentMethodListProps {
     isLoading: boolean;
 }
 
-class PaymentMethodList extends Component<PaymentMethodListProps> {
-    public static defaultProps: PaymentMethodListProps = {
-        paymentMethods: [],
-        activePaymentMethod: null,
-        cachedPaymentMethods: {},
-        orderStatus: null,
-        onSelect: () => {},
-        onDisableStoredPaymentMethod: () => {},
-        isDisabling: false,
-        isLoading: false
-    };
+function PaymentMethodList(props: PaymentMethodListProps) {
+    const onSelect = paymentMethod => () => props.onSelect(paymentMethod);
 
-    componentDidMount() {
+    useEffect(() => {
         // Open first PaymentMethodItem
-        if (this.props.paymentMethods[0]) {
-            const firstPaymentMethod = this.props.paymentMethods[0];
-            const shouldOpenFirstStored = this.props.openFirstStoredPaymentMethod && getProp(firstPaymentMethod, 'props.oneClick') === true;
-            const shouldOpenFirstPaymentMethod = shouldOpenFirstStored || this.props.openFirstPaymentMethod;
+        if (props.paymentMethods[0]) {
+            const firstPaymentMethod = props.paymentMethods[0];
+            const shouldOpenFirstStored = props.openFirstStoredPaymentMethod && getProp(firstPaymentMethod, 'props.oneClick') === true;
+            const shouldOpenFirstPaymentMethod = shouldOpenFirstStored || props.openFirstPaymentMethod;
 
             if (shouldOpenFirstPaymentMethod) {
-                this.onSelect(firstPaymentMethod)();
+                onSelect(firstPaymentMethod)();
             }
         }
-    }
+    }, []);
 
-    public onSelect = paymentMethod => () => this.props.onSelect(paymentMethod);
+    const paymentMethodListClassnames = classNames({
+        [styles['adyen-checkout__payment-methods-list']]: true,
+        'adyen-checkout__payment-methods-list': true,
+        'adyen-checkout__payment-methods-list--loading': props.isLoading
+    });
 
-    render({ paymentMethods, activePaymentMethod, cachedPaymentMethods, isLoading }) {
-        const paymentMethodListClassnames = classNames({
-            [styles['adyen-checkout__payment-methods-list']]: true,
-            'adyen-checkout__payment-methods-list': true,
-            'adyen-checkout__payment-methods-list--loading': isLoading
-        });
+    return (
+        <Fragment>
+            {props.orderStatus && <OrderPaymentMethods order={props.order} orderStatus={props.orderStatus} onOrderCancel={props.onOrderCancel} />}
 
-        return (
-            <Fragment>
-                {this.props.orderStatus && (
-                    <OrderPaymentMethods order={this.props.order} orderStatus={this.props.orderStatus} onOrderCancel={this.props.onOrderCancel} />
-                )}
+            <ul className={paymentMethodListClassnames}>
+                {props.paymentMethods.map((paymentMethod, index, paymentMethodsCollection) => {
+                    const isSelected = props.activePaymentMethod && props.activePaymentMethod._id === paymentMethod._id;
+                    const isLoaded = paymentMethod._id in props.cachedPaymentMethods;
+                    const isNextOneSelected =
+                        props.activePaymentMethod &&
+                        paymentMethodsCollection[index + 1] &&
+                        props.activePaymentMethod._id === paymentMethodsCollection[index + 1]._id;
 
-                <ul className={paymentMethodListClassnames}>
-                    {paymentMethods.map((paymentMethod, index, paymentMethodsCollection) => {
-                        const isSelected = activePaymentMethod && activePaymentMethod._id === paymentMethod._id;
-                        const isLoaded = paymentMethod._id in cachedPaymentMethods;
-                        const isNextOneSelected =
-                            activePaymentMethod &&
-                            paymentMethodsCollection[index + 1] &&
-                            activePaymentMethod._id === paymentMethodsCollection[index + 1]._id;
-
-                        return (
-                            <PaymentMethodItem
-                                className={classNames({ 'adyen-checkout__payment-method--next-selected': isNextOneSelected })}
-                                standalone={paymentMethods.length === 1}
-                                paymentMethod={paymentMethod}
-                                isSelected={isSelected}
-                                isDisabling={isSelected && this.props.isDisabling}
-                                isLoaded={isLoaded}
-                                isLoading={isLoading}
-                                onSelect={this.onSelect(paymentMethod)}
-                                key={paymentMethod._id}
-                                showRemovePaymentMethodButton={this.props.showRemovePaymentMethodButton}
-                                onDisableStoredPaymentMethod={this.props.onDisableStoredPaymentMethod}
-                            />
-                        );
-                    })}
-                </ul>
-            </Fragment>
-        );
-    }
+                    return (
+                        <PaymentMethodItem
+                            className={classNames({ 'adyen-checkout__payment-method--next-selected': isNextOneSelected })}
+                            standalone={props.paymentMethods.length === 1}
+                            paymentMethod={paymentMethod}
+                            isSelected={isSelected}
+                            isDisabling={isSelected && props.isDisabling}
+                            isLoaded={isLoaded}
+                            isLoading={props.isLoading}
+                            onSelect={onSelect(paymentMethod)}
+                            key={paymentMethod._id}
+                            showRemovePaymentMethodButton={props.showRemovePaymentMethodButton}
+                            onDisableStoredPaymentMethod={props.onDisableStoredPaymentMethod}
+                        />
+                    );
+                })}
+            </ul>
+        </Fragment>
+    );
 }
+
+PaymentMethodList.defaultProps = {
+    paymentMethods: [],
+    activePaymentMethod: null,
+    cachedPaymentMethods: {},
+    orderStatus: null,
+    onSelect: () => {},
+    onDisableStoredPaymentMethod: () => {},
+    isDisabling: false,
+    isLoading: false
+} as PaymentMethodListProps;
 
 export default PaymentMethodList;

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -51,6 +51,7 @@ export interface DropinElementProps extends UIElementProps {
 export interface DropinComponentProps extends DropinElementProps {
     onCreateElements: any;
     onChange: (newState?: object) => void;
+    onDropinReset: () => void;
     onOrderCancel?: (order: Order) => void;
 }
 

--- a/packages/lib/src/core/Context/CoreProvider.tsx
+++ b/packages/lib/src/core/Context/CoreProvider.tsx
@@ -1,9 +1,11 @@
-import { Component, h, toChildArray } from 'preact';
+import { h, toChildArray } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 import { CoreContext } from './CoreContext';
+import Language from '../../language/Language';
 
 interface CoreProviderProps {
     loadingContext: string;
-    i18n: any;
+    i18n: Language;
     children?: any;
 }
 
@@ -11,32 +13,21 @@ interface CoreProviderProps {
  * CoreProvider Component
  * Wraps a component delaying the render until after the i18n module is fully loaded
  */
-class CoreProvider extends Component<CoreProviderProps> {
-    public state = {
-        loaded: false
-    };
+function CoreProvider({ children, i18n = new Language(), loadingContext }: CoreProviderProps) {
+    const [loaded, setLoaded] = useState(false);
 
-    componentDidMount() {
-        if (this.props.i18n) {
-            this.props.i18n.loaded.then(() => {
-                this.setState({ loaded: true });
-            });
-        } else {
-            this.setState({ loaded: true });
-        }
+    useEffect(() => {
+        setLoaded(false);
+        i18n.loaded.then(() => {
+            setLoaded(true);
+        });
+    }, [i18n.locale]);
+
+    if (loaded) {
+        return <CoreContext.Provider value={{ i18n: i18n, loadingContext: loadingContext }}>{toChildArray(children)}</CoreContext.Provider>;
     }
 
-    render({ children }: CoreProviderProps) {
-        if (this.state.loaded) {
-            return (
-                <CoreContext.Provider value={{ i18n: this.props.i18n, loadingContext: this.props.loadingContext }}>
-                    {toChildArray(children)}
-                </CoreContext.Provider>
-            );
-        }
-
-        return null;
-    }
+    return null;
 }
 
 export default CoreProvider;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Allows partially updating properties on an existing component through `component.update()`. These updates won't trigger a re-render in most cases (for example, an `amount` update) but will when necessary (mostly partial payment flow).

## Tested scenarios
- Updating with an order still forces a re-render.
- Amount can be updated dynamically

