### PR TITLE
Fix alignment on non-outlined payment method icons on Drop-in

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
@@ -127,7 +127,7 @@
     position: relative;
 }
 
-.adyen-checkout__payment-method__image__wrapper--outline:after {
+.adyen-checkout__payment-method__image__wrapper:after {
     content: '';
     position: absolute;
     top: 0;
@@ -135,6 +135,10 @@
     height: 100%;
     left: 0;
     border-radius: $border-radius-small;
+    border: 1px solid transparent;
+}
+
+.adyen-checkout__payment-method__image__wrapper--outline:after {
     border: 1px solid rgba(0, 27, 43, 0.17);
 }
 


### PR DESCRIPTION
## Summary
- Fix alignment of payment method icons without outline when displayed on the payment method list of the Drop-in component.
