### PR TITLE
Remove unhandled promise on Google Pay

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -59,14 +59,13 @@ class GooglePay extends UIElement<GooglePayProps> {
                 return onAuthorized(paymentData);
             })
             .catch(error => {
-                this.props.onError(error);
-                return Promise.reject(error);
+                if (this.props.onError) this.props.onError(error);
             });
     };
 
     public submit = () => {
         return this.loadPayment().then(() => {
-            if (this.props.onSubmit) this.props.onSubmit({ data: this.data, isValid: this.isValid }, this.elementRef);
+            if (this.props.onSubmit && this.isValid) this.props.onSubmit({ data: this.data, isValid: this.isValid }, this.elementRef);
         });
     };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix an unhandled rejected promise that was logging a console error when a shopper would cancel a Google Pay payment.