### PR TITLE
Stop adding classNameModifiers as attribute to inputs

### DIFF
--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -21,9 +21,11 @@ export default function InputBase(props) {
         classNameModifiers.map(m => `adyen-checkout__input--${m}`)
     );
 
+    const { classNameModifiers: cnm, ...newProps } = props;
+
     return (
         <input
-            {...props}
+            {...newProps}
             type={type}
             className={inputClassNames}
             onInput={handleInput}

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -21,6 +21,7 @@ export default function InputBase(props) {
         classNameModifiers.map(m => `adyen-checkout__input--${m}`)
     );
 
+    // Don't spread classNameModifiers to input element (it ends up as an attribute on the element itself)
     const { classNameModifiers: cnm, ...newProps } = props;
 
     return (


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When `classNameModifiers` was being passed as a prop to `renderFormField` (and on to `inputBase`), as well as performing the required role of adding to the classes for a field, it was also being written as an attribute to the `input` element

## Tested scenarios
`input` elements no longer end up with a `classNameModifiers` attribute

