### PR TITLE
Fixed card holder name validation - only reject digits

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -265,9 +265,9 @@ function CardInput(props: CardInputProps) {
         <CardHolderName
             required={props.holderNameRequired}
             placeholder={props.placeholders.holderName}
-            value={data.holderName}
-            error={!!errors.holderName}
-            isValid={!!valid.holderName}
+            value={formData.holderName}
+            error={!!formErrors.holderName}
+            isValid={!!formValid.holderName}
             onChange={handleChangeFor('holderName', 'blur')}
             onInput={handleChangeFor('holderName', 'input')}
         />

--- a/packages/lib/src/components/Card/components/CardInput/validate.ts
+++ b/packages/lib/src/components/Card/components/CardInput/validate.ts
@@ -2,10 +2,10 @@ import { ValidatorRules } from '../../../../utils/Validator/Validator';
 import { formatCPFCNPJ } from '../../../Boleto/components/SocialSecurityNumberBrazil/utils';
 import validateSSN from '../../../Boleto/components/SocialSecurityNumberBrazil/validate';
 
-const nonLetterRegEx = /[^A-Z\s]/gi; // detect anything that's not a letter or spaces
+const digitRegEx = /[0-9]/g; // detect digits
 
 export const cardInputFormatters = {
-    holderName: value => value.replace(nonLetterRegEx, ''),
+    holderName: value => value.replace(digitRegEx, ''), // allow anything except digits
     socialSecurityNumber: formatCPFCNPJ
 };
 
@@ -26,7 +26,7 @@ export const cardInputValidationRules: ValidatorRules = {
         {
             // Will fire at startup and when triggerValidation is called and also applies as text is input
             modes: ['blur'],
-            validate: value => value.trim().length > 0 // i.e. are there chars other than spaces?
+            validate: value => value && value.trim().length > 0 // i.e. are there chars other than spaces?
         }
     ],
     default: [

--- a/packages/lib/src/components/Card/components/CardInput/validate.ts
+++ b/packages/lib/src/components/Card/components/CardInput/validate.ts
@@ -26,7 +26,7 @@ export const cardInputValidationRules: ValidatorRules = {
         {
             // Will fire at startup and when triggerValidation is called and also applies as text is input
             modes: ['blur'],
-            validate: value => value && value.trim().length > 0 // i.e. are there chars other than spaces?
+            validate: value => value.trim().length > 0 // i.e. are there chars other than spaces?
         }
     ],
     default: [


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed card holder name formatting and validation - now we accept everything _except_ digits

## Tested scenarios
Use can type in punctuation marks and letters from other languages like ö
