### PR TITLE
Fix for InputBase onchange bug

### DIFF
--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -1,13 +1,30 @@
 import { h } from 'preact';
+import { useState } from 'preact/hooks';
 import classNames from 'classnames';
 import { convertFullToHalf } from './utils';
 
 export default function InputBase(props) {
     const { autoCorrect, classNameModifiers, isInvalid, isValid, readonly = null, spellCheck, type } = props;
 
+    const [handleChangeHasFired, setHandleChangeHasFired] = useState(false);
+
     const handleInput = e => {
         e.target.value = convertFullToHalf(e.target.value);
         props.onInput(e);
+    };
+
+    const handleChange = e => {
+        setHandleChangeHasFired(true);
+        props.onChange(e);
+    };
+
+    const handleBlur = e => {
+        if (!handleChangeHasFired) {
+            props.onChange(e);
+        }
+        setHandleChangeHasFired(false);
+
+        props.onBlur(e);
     };
 
     const inputClassNames = classNames(
@@ -33,6 +50,8 @@ export default function InputBase(props) {
             readOnly={readonly}
             spellCheck={spellCheck}
             autoCorrect={autoCorrect}
+            onChange={handleChange}
+            onBlur={handleBlur}
         />
     );
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
There is bug in InputBase...

### Scenario:
1. An input is in an error state when it loses focus > the onChange handler runs > if this triggers a validation routine then the input shows an error. _Correct!_
2. The input is then interacted with but is left with exactly the same value in it when it loses focus > the onChange handler doesn't run > input can't be validated to show an error. _Wrong!_

### Logic:
- This happens because we are relying on the `'onchange'` event to trigger validation.
- In the first part of the scenario a change occurs in the input (which leads to it getting validated and showing an error).
- But in the second part of the scenario there is no change to the input, so the `'onchange'` event doesn't fire (so no validation & no error).
- Although this is technically correct behaviour, in how `'onchange'` is supposed to work, it is not desirable and leaves the UI in a misleading state.

### Fix:
When the `'onblur'` event fires we check to see if the `'onchange'` event has fired & if it hasn't we call the onChange handler from the onBlur handler (to trigger the validation for the field)

@marcperez @pabloai - since this is a change to a very fundamental, low-level piece of functionality I welcome any comments. Can you foresee any side-effects from this fix?
