### PR TITLE
Allow any character on card holder name field

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/validate.ts
+++ b/packages/lib/src/components/Card/components/CardInput/validate.ts
@@ -2,10 +2,7 @@ import { ValidatorRules } from '../../../../utils/Validator/Validator';
 import { formatCPFCNPJ } from '../../../Boleto/components/SocialSecurityNumberBrazil/utils';
 import validateSSN from '../../../Boleto/components/SocialSecurityNumberBrazil/validate';
 
-const digitRegEx = /[0-9]/g; // detect digits
-
 export const cardInputFormatters = {
-    holderName: value => value.replace(digitRegEx, ''), // allow anything except digits
     socialSecurityNumber: formatCPFCNPJ
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR removes any special formatting for the card holder name field. Previously digits were not allowed, but some company names and test codes might contain those.

**Fixed issue**:  #1211
