### PR TITLE
Fix apple pay button displaying

### DIFF
--- a/packages/lib/src/components/ApplePay/components/ApplePayButton.module.scss
+++ b/packages/lib/src/components/ApplePay/components/ApplePayButton.module.scss
@@ -1,7 +1,7 @@
 @supports (-webkit-appearance: -apple-pay-button) {
     .apple-pay-button {
         display: inline-block;
-        -webkit-appearance: -apple-pay-button;
+        -webkit-appearance: -apple-pay-button !important;
         cursor: pointer;
     }
     .apple-pay-button-black {


### PR DESCRIPTION
Problem: 
When I tried to use "applepay" button on my integration, I was dissapointed because I cannot see it in any case. 
Later on clicking on the free space I found that button displaying but for some reason "-webkit-appearance: -apple-pay-button"
property is crossed and do not work.
I found that global property "-webkit-appearance: button" overwrite apple one.
So I make small fix for my project to make it work and want to  share it and help others to save time.
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
After overwriting this with right one any type of buttons: "buy", "check-out" and etc. appers. This solution do not affect on other types of payment systems.
## Tested scenarios
<!-- Description of tested scenarios -->
To test: You need to use "applepay" paymentMethod.

**Fixed issue**:  <!-- #-prefixed issue number -->
