### PR TITLE
Disable colormin in postcss config

### DIFF
--- a/packages/lib/config/postcss.config.js
+++ b/packages/lib/config/postcss.config.js
@@ -3,6 +3,6 @@ module.exports = {
         require('stylelint')({ configFile: 'config/stylelint.config.js' }),
         require('postcss-reporter'),
         require('autoprefixer'),
-        require('cssnano')
+        require('cssnano')({ preset: ['default', { colormin: false }] })
     ]
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes #1225. I think this is a bug in cssnano but I feel it's correct to disable colormin whilst it is causing a bug in this package

## Tested scenarios
Built on MacOS


**Fixed issue**:  #1225
