### PR TITLE
Required holderName field, without a formatter, was throwing an error…

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/validate.ts
+++ b/packages/lib/src/components/Card/components/CardInput/validate.ts
@@ -23,7 +23,7 @@ export const cardInputValidationRules: ValidatorRules = {
         {
             // Will fire at startup and when triggerValidation is called and also applies as text is input
             modes: ['blur'],
-            validate: value => value.trim().length > 0 // i.e. are there chars other than spaces?
+            validate: value => value?.trim().length > 0 // i.e. are there chars other than spaces?
         }
     ],
     default: [


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Required holderName field, without a formatter, was throwing an error if validated whilst empty. Pressing Pay saw the field stay as it was (whilst internally we threw an error)

## Tested scenarios
Required holderName field now correctly validates (goes red, error message) if Pay is pressed whilst the field is empty
