### PR TITLE
Add support for Amazon Pay multi-currency solution

### DIFF
--- a/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
@@ -14,7 +14,7 @@ export default function AmazonPayButton(props: AmazonPayButtonProps) {
 
     const handleOnClick = () => {
         new Promise(props.onClick).then(this.initCheckout).catch(error => {
-            props.onError(error, this.componentRef);
+            if (props.onError) props.onError(error, this.componentRef);
         });
     };
 

--- a/packages/lib/src/components/AmazonPay/config.ts
+++ b/packages/lib/src/components/AmazonPay/config.ts
@@ -1,3 +1,5 @@
+import { LedgerCurrencies } from './types';
+
 const AMAZONPAY_GET_CHECKOUT_DETAILS_ENDPOINT = 'v1/AmazonPayUtility/getCheckoutDetails';
 const AMAZONPAY_SIGN_STRING_ENDPOINT = 'v1/AmazonPayUtility/signString';
 const AMAZONPAY_UPDATE_CHECKOUT_SESSION_ENDPOINT = 'v1/AmazonPayUtility/updateCheckoutSession';
@@ -7,6 +9,12 @@ const AMAZONPAY_URL_US = 'https://static-na.payments-amazon.com/checkout.js';
 
 const FALLBACK_LOCALE_EU = 'en_GB';
 const FALLBACK_LOCALE_US = 'en_US';
+
+const LEDGER_CURRENCIES_PER_REGION: LedgerCurrencies = {
+    EU: 'EUR',
+    UK: 'GBP',
+    US: 'USD'
+};
 
 const SUPPORTED_LOCALES_EU = ['en_GB', 'de_DE', 'fr_FR', 'it_IT', 'es_ES'] as const;
 const SUPPORTED_LOCALES_US = ['en_US'] as const;
@@ -19,6 +27,7 @@ export {
     AMAZONPAY_URL_US,
     FALLBACK_LOCALE_EU,
     FALLBACK_LOCALE_US,
+    LEDGER_CURRENCIES_PER_REGION,
     SUPPORTED_LOCALES_EU,
     SUPPORTED_LOCALES_US
 };

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -12,8 +12,8 @@ declare global {
 type ButtonColor = 'Gold' | 'LightGray' | 'DarkGray';
 type Placement = 'Home' | 'Product' | 'Cart' | 'Checkout' | 'Other';
 type ProductType = 'PayOnly' | 'PayAndShip';
-export type Currency = 'USD' | 'EUR' | 'GBP';
-export type Region = 'US' | 'EU' | 'UK';
+export type Currency = 'EUR' | 'GBP' | 'USD';
+export type Region = 'EU' | 'UK' | 'US';
 export type SupportedLocale = typeof SUPPORTED_LOCALES_EU[number] | typeof SUPPORTED_LOCALES_US[number];
 
 export interface AmazonPayConfiguration {
@@ -169,16 +169,22 @@ interface AddressDetails {
 
 export interface ChargeAmount {
     amount: string;
-    currencyCode: string;
+    currencyCode: Currency;
 }
+
+export type LedgerCurrencies = {
+    [key in Region]: Currency;
+};
 
 export interface PayloadJSON {
     addressDetails?: AddressDetails;
     deliverySpecifications?: DeliverySpecifications;
     merchantMetadata?: MerchantMetadata;
     paymentDetails?: {
-        paymentIntent: 'Confirm';
         chargeAmount: ChargeAmount;
+        paymentIntent: 'Confirm';
+        presentmentCurrency: Currency;
+        totalOrderAmount: ChargeAmount;
     };
     storeId: string;
     webCheckoutDetails: {

--- a/packages/lib/src/components/AmazonPay/utils.test.ts
+++ b/packages/lib/src/components/AmazonPay/utils.test.ts
@@ -1,4 +1,13 @@
-import { getCheckoutLocale } from './utils';
+import { getChargeAmount, getCheckoutLocale, getPayloadJSON } from './utils';
+
+describe('getChargeAmount', () => {
+    test('should return the amount in the Amazon format', () => {
+        expect(getChargeAmount({ currency: 'EUR', value: 12345 })).toMatchObject({ amount: '123.45', currencyCode: 'EUR' });
+        expect(getChargeAmount({ currency: 'GBP', value: 12345 })).toMatchObject({ amount: '123.45', currencyCode: 'GBP' });
+        expect(getChargeAmount({ currency: 'JPY', value: 12345 })).toMatchObject({ amount: '12345', currencyCode: 'JPY' });
+        expect(getChargeAmount({ currency: 'USD', value: 12345 })).toMatchObject({ amount: '123.45', currencyCode: 'USD' });
+    });
+});
 
 describe('getCheckoutLocale', () => {
     test('should return the fallback for the passed region if the locale is not supported', () => {
@@ -6,5 +15,16 @@ describe('getCheckoutLocale', () => {
         expect(getCheckoutLocale('en_GB', 'US')).toBe('en_US');
         expect(getCheckoutLocale('xx_XX', 'EU')).toBe('en_GB');
         expect(getCheckoutLocale('xx_XX', 'US')).toBe('en_US');
+    });
+});
+
+describe('getPayloadJSON', () => {
+    test('should return a paymentDetails object when checkoutMode is ProcessOrder', () => {
+        const props = {
+            amount: { currency: 'EUR', value: 1234 },
+            configuration: { storeId: '123' }
+        };
+        expect(getPayloadJSON({ ...props, checkoutMode: 'ProcessOrder' }).paymentDetails).toBeDefined();
+        expect(getPayloadJSON({ ...props }).paymentDetails).not.toBeDefined();
     });
 });


### PR DESCRIPTION
## Summary
- Add support for Amazon Pay multi-currency solution
- Update type definitions.
- Fix onError being called without checking its existence.

## Tested scenarios
Added unit tests