### PR TITLE
Optional holderName field was validating and showing an error

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -266,7 +266,7 @@ function CardInput(props: CardInputProps) {
             required={props.holderNameRequired}
             placeholder={props.placeholders.holderName}
             value={formData.holderName}
-            error={!!formErrors.holderName}
+            error={!!formErrors.holderName && props.holderNameRequired}
             isValid={!!formValid.holderName}
             onChange={handleChangeFor('holderName', 'blur')}
             onInput={handleChangeFor('holderName', 'input')}


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Optional holderName field was validating and showing an error when empty and the Pay button is pressed.
Yet it was still possible to complete the other fields and make a payment.

## Tested scenarios
Optional holder name stays untouched when empty and the Pay button is pressed. 
Completing the other fields, and leaving holder name blank, the payment can still be made
