### PR TITLE
isAvailable method optimization

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -140,7 +140,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
         }
 
         if (window.ApplePaySession && ApplePaySession.canMakePayments() && ApplePaySession.supportsVersion(this.props.version)) {
-            return Promise.resolve(ApplePaySession.canMakePayments());
+            return Promise.resolve(true);
         }
 
         return Promise.reject(new Error('Apple Pay is not available on this device'));


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Apple Pay availability check (isAvailable method) blocks JS main thread for about 1.2s. It’s caused by ApplePaySesssion `canMakePayments` method which blocks JS main thread for about 0.6s. Together with my colleague we’ve found that `canMakePayments` is invoked twice redundantly in `isAvailable` function - changed this to a more proficient one. (Returns true instead of redundant invoke, which won't change API behavior)

## Tested scenarios
<!-- Description of tested scenarios -->

Use console.time to check duration of `isAvailable` function provided by Adyen, and canMakePayments alone provided by ApplePaySession object

## Repro

> console.time("isAvailable");
window.ApplePaySession.canMakePayments();
console.timeEnd("isAvailable");
[Debug] isAvailable: 502.007ms

> console.time("isAvailableRedundant");
window.ApplePaySession.canMakePayments();
window.ApplePaySession.canMakePayments();
console.timeEnd("isAvailableRedundant");
[Debug] isAvailableRedundant: 1042.874ms