### PR TITLE
name prop on Field comp

### DIFF
--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
@@ -143,6 +143,7 @@ function AchInput(props) {
                                         className={'adyen-checkout__pm__holderName'}
                                         errorMessage={!!errors.holderName && i18n.get('ach.accountHolderNameField.invalid')}
                                         isValid={!!valid.holderName}
+                                        name={'holderName'}
                                     >
                                         {renderFormField('text', {
                                             className: `adyen-checkout__pm__holderName__input ${styles['adyen-checkout__input']}`,

--- a/packages/lib/src/components/Ach/components/AchInput/components/AchSFInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/components/AchSFInput.tsx
@@ -2,10 +2,14 @@ import { h } from 'preact';
 import classNames from 'classnames';
 import styles from '../AchInput.module.scss';
 import Field from '../../../../internal/FormFields/Field';
+import { DATA_ENCRYPTED_FIELD_ATTR, DATA_INFO } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import DataSfSpan from '../../../../Card/components/CardInput/components/DataSfSpan';
 
 const AchSFInput = ({ id, dataInfo, className = '', label, focused, filled, errorMessage = '', isValid = false, onFocusField, dir }) => {
     const capitalisedId = id.charAt(0).toUpperCase() + id.slice(1);
     const encryptedIdStr = `encrypted${capitalisedId}`;
+
+    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: encryptedIdStr, [DATA_INFO]: dataInfo };
 
     return (
         <Field
@@ -18,10 +22,10 @@ const AchSFInput = ({ id, dataInfo, className = '', label, focused, filled, erro
             isValid={isValid}
             className={className}
             dir={dir}
+            name={id}
         >
-            <span
-                data-cse={encryptedIdStr}
-                data-info={dataInfo}
+            <DataSfSpan
+                {...opts}
                 className={classNames({
                     'adyen-checkout__input': true,
                     'adyen-checkout__input--large': true,

--- a/packages/lib/src/components/Ach/components/AchInput/components/AchSFInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/components/AchSFInput.tsx
@@ -2,14 +2,11 @@ import { h } from 'preact';
 import classNames from 'classnames';
 import styles from '../AchInput.module.scss';
 import Field from '../../../../internal/FormFields/Field';
-import { DATA_ENCRYPTED_FIELD_ATTR, DATA_INFO } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import DataSfSpan from '../../../../Card/components/CardInput/components/DataSfSpan';
 
 const AchSFInput = ({ id, dataInfo, className = '', label, focused, filled, errorMessage = '', isValid = false, onFocusField, dir }) => {
     const capitalisedId = id.charAt(0).toUpperCase() + id.slice(1);
     const encryptedIdStr = `encrypted${capitalisedId}`;
-
-    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: encryptedIdStr, [DATA_INFO]: dataInfo };
 
     return (
         <Field
@@ -25,7 +22,8 @@ const AchSFInput = ({ id, dataInfo, className = '', label, focused, filled, erro
             name={id}
         >
             <DataSfSpan
-                {...opts}
+                encryptedFieldType={encryptedIdStr}
+                data-info={dataInfo}
                 className={classNames({
                     'adyen-checkout__input': true,
                     'adyen-checkout__input--large': true,

--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -79,6 +79,7 @@ function BacsInput(props: BacsInputProps) {
                 label={i18n.get('bacs.accountHolderName')}
                 errorMessage={errors.holderName ? i18n.get('bacs.accountHolderName.invalid') : false}
                 isValid={valid.holderName}
+                name={'accountHolderName'}
             >
                 {renderFormField('text', {
                     name: 'bacs.accountHolderName',
@@ -106,6 +107,7 @@ function BacsInput(props: BacsInputProps) {
                     })}
                     classNameModifiers={['col-70']}
                     isValid={valid.bankAccountNumber}
+                    name={'bankAccountNumber'}
                 >
                     {renderFormField('text', {
                         value: data.bankAccountNumber,
@@ -131,6 +133,7 @@ function BacsInput(props: BacsInputProps) {
                     })}
                     classNameModifiers={['col-30']}
                     isValid={valid.bankLocationId}
+                    name={'bankLocationId'}
                 >
                     {renderFormField('text', {
                         value: data.bankLocationId,
@@ -156,6 +159,7 @@ function BacsInput(props: BacsInputProps) {
                     'adyen-checkout__field--inactive': status === CONFIRM_STATE || status === 'loading'
                 })}
                 isValid={valid.shopperEmail}
+                name={'emailAddress'}
             >
                 {renderFormField('emailAddress', {
                     value: data.shopperEmail,

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -5,12 +5,7 @@ import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { CVCProps } from './types';
 import styles from '../CardInput.module.scss';
-import {
-    CVC_POLICY_HIDDEN,
-    CVC_POLICY_OPTIONAL,
-    CVC_POLICY_REQUIRED,
-    DATA_ENCRYPTED_FIELD_ATTR
-} from '../../../../internal/SecuredFields/lib/configuration/constants';
+import { CVC_POLICY_HIDDEN, CVC_POLICY_OPTIONAL, CVC_POLICY_REQUIRED } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import DataSfSpan from './DataSfSpan';
 
 export default function CVC(props: CVCProps) {
@@ -46,8 +41,6 @@ export default function CVC(props: CVCProps) {
 
     const fieldLabel = cvcPolicy !== CVC_POLICY_OPTIONAL ? label : i18n.get('creditCard.cvcField.title.optional');
 
-    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedSecurityCode' };
-
     return (
         <Field
             label={fieldLabel}
@@ -61,7 +54,7 @@ export default function CVC(props: CVCProps) {
             dir={'ltr'}
             name={'encryptedSecurityCode'}
         >
-            <DataSfSpan {...opts} className={cvcClassnames} />
+            <DataSfSpan encryptedFieldType={'encryptedSecurityCode'} className={cvcClassnames} />
 
             <CVCHint frontCVC={frontCVC} />
         </Field>

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -5,7 +5,13 @@ import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { CVCProps } from './types';
 import styles from '../CardInput.module.scss';
-import { CVC_POLICY_HIDDEN, CVC_POLICY_OPTIONAL, CVC_POLICY_REQUIRED } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import {
+    CVC_POLICY_HIDDEN,
+    CVC_POLICY_OPTIONAL,
+    CVC_POLICY_REQUIRED,
+    DATA_ENCRYPTED_FIELD_ATTR
+} from '../../../../internal/SecuredFields/lib/configuration/constants';
+import DataSfSpan from './DataSfSpan';
 
 export default function CVC(props: CVCProps) {
     const {
@@ -40,6 +46,8 @@ export default function CVC(props: CVCProps) {
 
     const fieldLabel = cvcPolicy !== CVC_POLICY_OPTIONAL ? label : i18n.get('creditCard.cvcField.title.optional');
 
+    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedSecurityCode' };
+
     return (
         <Field
             label={fieldLabel}
@@ -51,8 +59,9 @@ export default function CVC(props: CVCProps) {
             errorMessage={error && i18n.get(error)}
             isValid={isValid}
             dir={'ltr'}
+            name={'encryptedSecurityCode'}
         >
-            <span className={cvcClassnames} data-cse="encryptedSecurityCode" />
+            <DataSfSpan {...opts} className={cvcClassnames} />
 
             <CVCHint frontCVC={frontCVC} />
         </Field>

--- a/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
@@ -14,6 +14,7 @@ export default function CardHolderName({ onChange, onInput, placeholder, value, 
             className={'adyen-checkout__card__holderName'}
             errorMessage={error && i18n.get('creditCard.holderName.invalid')}
             isValid={!!isValid}
+            name={'holderName'}
         >
             {renderFormField('text', {
                 className: `adyen-checkout__card__holderName__input ${styles['adyen-checkout__input']}`,

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -7,13 +7,10 @@ import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { CardNumberProps } from './types';
 import styles from '../CardInput.module.scss';
 import DataSfSpan from './DataSfSpan';
-import { DATA_ENCRYPTED_FIELD_ATTR } from '../../../../internal/SecuredFields/lib/configuration/constants';
 
 export default function CardNumber(props: CardNumberProps) {
     const { i18n } = useCoreContext();
     const { error = '', isValid = false, onFocusField = () => {}, dualBrandingElements, dualBrandingChangeHandler, dualBrandingSelected } = props;
-
-    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedCardNumber' };
 
     return (
         <Field
@@ -29,7 +26,7 @@ export default function CardNumber(props: CardNumberProps) {
             name={'encryptedCardNumber'}
         >
             <DataSfSpan
-                {...opts}
+                encryptedFieldType={'encryptedCardNumber'}
                 className={classNames({
                     'adyen-checkout__input': true,
                     'adyen-checkout__input--large': true,

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -6,10 +6,14 @@ import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { CardNumberProps } from './types';
 import styles from '../CardInput.module.scss';
+import DataSfSpan from './DataSfSpan';
+import { DATA_ENCRYPTED_FIELD_ATTR } from '../../../../internal/SecuredFields/lib/configuration/constants';
 
 export default function CardNumber(props: CardNumberProps) {
     const { i18n } = useCoreContext();
     const { error = '', isValid = false, onFocusField = () => {}, dualBrandingElements, dualBrandingChangeHandler, dualBrandingSelected } = props;
+
+    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedCardNumber' };
 
     return (
         <Field
@@ -22,9 +26,10 @@ export default function CardNumber(props: CardNumberProps) {
             isValid={isValid}
             dualBrandingElements={dualBrandingElements}
             dir={'ltr'}
+            name={'encryptedCardNumber'}
         >
-            <span
-                data-cse="encryptedCardNumber"
+            <DataSfSpan
+                {...opts}
                 className={classNames({
                     'adyen-checkout__input': true,
                     'adyen-checkout__input--large': true,
@@ -37,7 +42,7 @@ export default function CardNumber(props: CardNumberProps) {
                 })}
             >
                 {props.showBrandIcon && !dualBrandingElements && <BrandIcon brandsConfiguration={props.brandsConfiguration} brand={props.brand} />}
-            </span>
+            </DataSfSpan>
 
             {dualBrandingElements && !error && (
                 <div

--- a/packages/lib/src/components/Card/components/CardInput/components/DataSfSpan.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DataSfSpan.tsx
@@ -1,0 +1,10 @@
+import { h } from 'preact';
+import { DATA_UID } from '../../../../internal/SecuredFields/lib/configuration/constants';
+
+/**
+ * Exists to make the uniqueId created by the Field comp accessible to the SFP via a data-uid attr
+ */
+export default function DataSfSpan(props) {
+    const opts = { ...props, [DATA_UID]: props.uniqueId };
+    return <span {...opts}>{props.children}</span>;
+}

--- a/packages/lib/src/components/Card/components/CardInput/components/DataSfSpan.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DataSfSpan.tsx
@@ -1,10 +1,17 @@
 import { h } from 'preact';
-import { DATA_UID } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import { DATA_ENCRYPTED_FIELD_ATTR, DATA_INFO, DATA_UID } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import { SfSpanProps } from './types';
 
 /**
- * Exists to make the uniqueId created by the Field comp accessible to the SFP via a data-uid attr
+ * Extract the relevant props and write them as attributes to the span that will contain the securedFields iframe
+ * Specifically exists to make the uniqueId created by the Field comp accessible to the SFP via a data-uid attr
  */
-export default function DataSfSpan(props) {
-    const opts = { ...props, [DATA_UID]: props.uniqueId };
+export default function DataSfSpan(props: SfSpanProps) {
+    const opts = {
+        [DATA_ENCRYPTED_FIELD_ATTR]: props.encryptedFieldType,
+        [DATA_INFO]: props['data-info'],
+        [DATA_UID]: props.uniqueId,
+        className: props.className
+    };
     return <span {...opts}>{props.children}</span>;
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -4,7 +4,6 @@ import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { ExpirationDateProps } from './types';
 import styles from '../CardInput.module.scss';
-import { DATA_ENCRYPTED_FIELD_ATTR } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import DataSfSpan from './DataSfSpan';
 
 export default function ExpirationDate(props: ExpirationDateProps) {
@@ -14,8 +13,6 @@ export default function ExpirationDate(props: ExpirationDateProps) {
     const fieldClassnames = classNames(className, {
         [styles['adyen-checkout__card__exp-date__input--hidden']]: hideDateForBrand
     });
-
-    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedExpiryDate' };
 
     return (
         <Field
@@ -31,7 +28,7 @@ export default function ExpirationDate(props: ExpirationDateProps) {
             name={'encryptedExpiryDate'}
         >
             <DataSfSpan
-                {...opts}
+                encryptedFieldType={'encryptedExpiryDate'}
                 className={classNames(
                     'adyen-checkout__input',
                     'adyen-checkout__input--small',

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -4,6 +4,8 @@ import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { ExpirationDateProps } from './types';
 import styles from '../CardInput.module.scss';
+import { DATA_ENCRYPTED_FIELD_ATTR } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import DataSfSpan from './DataSfSpan';
 
 export default function ExpirationDate(props: ExpirationDateProps) {
     const { label, focused, filled, onFocusField, className = '', error = '', isValid = false, hideDateForBrand = false } = props;
@@ -12,6 +14,8 @@ export default function ExpirationDate(props: ExpirationDateProps) {
     const fieldClassnames = classNames(className, {
         [styles['adyen-checkout__card__exp-date__input--hidden']]: hideDateForBrand
     });
+
+    const opts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedExpiryDate' };
 
     return (
         <Field
@@ -24,9 +28,10 @@ export default function ExpirationDate(props: ExpirationDateProps) {
             errorMessage={error && i18n.get(error)}
             isValid={isValid}
             dir={'ltr'}
+            name={'encryptedExpiryDate'}
         >
-            <span
-                data-cse="encryptedExpiryDate"
+            <DataSfSpan
+                {...opts}
                 className={classNames(
                     'adyen-checkout__input',
                     'adyen-checkout__input--small',

--- a/packages/lib/src/components/Card/components/CardInput/components/KCPAuthentication.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/KCPAuthentication.tsx
@@ -6,6 +6,7 @@ import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { KCPProps } from './types';
 import styles from '../CardInput.module.scss';
+import DataSfSpan from './DataSfSpan';
 
 export default function KCPAuthentication(props: KCPProps) {
     const { i18n } = useCoreContext();
@@ -25,6 +26,7 @@ export default function KCPAuthentication(props: KCPProps) {
                 errorMessage={props.error && i18n.get('creditCard.taxNumber.invalid')}
                 isValid={props.isValid}
                 dir={'ltr'}
+                name={'kcpTaxNumberOrDOB'}
             >
                 {renderFormField('tel', {
                     className: `adyen-checkout__card__kcp-taxNumber__input ${styles['adyen-checkout__input']}`,
@@ -48,9 +50,10 @@ export default function KCPAuthentication(props: KCPProps) {
                 errorMessage={props.encryptedPasswordState.errors && i18n.get('creditCard.encryptedPassword.invalid')}
                 isValid={props.encryptedPasswordState.valid}
                 dir={'ltr'}
+                name={'encryptedPassword'}
             >
-                <span
-                    data-cse="encryptedPassword"
+                <DataSfSpan
+                    encryptedFieldType="encryptedPassword"
                     className={classNames({
                         'adyen-checkout__input': true,
                         'adyen-checkout__input--large': true,

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -1,5 +1,6 @@
 import { PaymentAmount } from '../../../../../types';
 import { CardBrandsConfiguration } from '../../../types';
+import { ComponentChildren } from 'preact';
 
 export interface BrandIconProps {
     brand: string;
@@ -141,4 +142,12 @@ export interface StoredCardFieldsProps {
     onFocusField: any;
     valid: any;
     status: string;
+}
+
+export interface SfSpanProps {
+    encryptedFieldType: string;
+    className: string;
+    uniqueId?: string; // not optional - but added in DataSfSpan comp rather than passed to it
+    children?: ComponentChildren; // as above
+    ['data-info']?: string; // optional
 }

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -6,7 +6,8 @@ import Alert from '../../internal/Alert';
 import GiftcardResult from './GiftcardResult';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import { PaymentAmount } from '../../../types';
-import { GIFT_CARD } from '../../internal/SecuredFields/lib/configuration/constants';
+import { DATA_ENCRYPTED_FIELD_ATTR, DATA_INFO, GIFT_CARD } from '../../internal/SecuredFields/lib/configuration/constants';
+import DataSfSpan from '../../Card/components/CardInput/components/DataSfSpan';
 
 interface GiftcardComponentProps {
     onChange: (state) => void;
@@ -94,6 +95,9 @@ class Giftcard extends Component<GiftcardComponentProps> {
             }
         };
 
+        const numOpts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedCardNumber', [DATA_INFO]: '{"length":"15-32", "maskInterval":4}' };
+        const pinOpts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedSecurityCode', [DATA_INFO]: '{"length":"3-10", "maskInterval": 0}' };
+
         return (
             <div className="adyen-checkout__giftcard">
                 {this.state.status === 'error' && <Alert icon={'cross'}>{i18n.get('error.message.unknown')}</Alert>}
@@ -115,10 +119,10 @@ class Giftcard extends Component<GiftcardComponentProps> {
                                 focused={focusedElement === 'encryptedCardNumber'}
                                 onFocusField={() => setFocusOn('encryptedCardNumber')}
                                 dir={'ltr'}
+                                name={'encryptedCardNumber'}
                             >
-                                <span
-                                    data-cse="encryptedCardNumber"
-                                    data-info='{"length":"15-32", "maskInterval":4}'
+                                <DataSfSpan
+                                    {...numOpts}
                                     className={classNames({
                                         'adyen-checkout__input': true,
                                         'adyen-checkout__input--large': true,
@@ -137,10 +141,10 @@ class Giftcard extends Component<GiftcardComponentProps> {
                                     focused={focusedElement === 'encryptedSecurityCode'}
                                     onFocusField={() => setFocusOn('encryptedSecurityCode')}
                                     dir={'ltr'}
+                                    name={'encryptedSecurityCode'}
                                 >
-                                    <span
-                                        data-cse="encryptedSecurityCode"
-                                        data-info='{"length":"3-10", "maskInterval": 0}'
+                                    <DataSfSpan
+                                        {...pinOpts}
                                         className={classNames({
                                             'adyen-checkout__input': true,
                                             'adyen-checkout__input--large': true,

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -6,7 +6,7 @@ import Alert from '../../internal/Alert';
 import GiftcardResult from './GiftcardResult';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import { PaymentAmount } from '../../../types';
-import { DATA_ENCRYPTED_FIELD_ATTR, DATA_INFO, GIFT_CARD } from '../../internal/SecuredFields/lib/configuration/constants';
+import { GIFT_CARD } from '../../internal/SecuredFields/lib/configuration/constants';
 import DataSfSpan from '../../Card/components/CardInput/components/DataSfSpan';
 
 interface GiftcardComponentProps {
@@ -95,9 +95,6 @@ class Giftcard extends Component<GiftcardComponentProps> {
             }
         };
 
-        const numOpts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedCardNumber', [DATA_INFO]: '{"length":"15-32", "maskInterval":4}' };
-        const pinOpts = { [DATA_ENCRYPTED_FIELD_ATTR]: 'encryptedSecurityCode', [DATA_INFO]: '{"length":"3-10", "maskInterval": 0}' };
-
         return (
             <div className="adyen-checkout__giftcard">
                 {this.state.status === 'error' && <Alert icon={'cross'}>{i18n.get('error.message.unknown')}</Alert>}
@@ -122,7 +119,8 @@ class Giftcard extends Component<GiftcardComponentProps> {
                                 name={'encryptedCardNumber'}
                             >
                                 <DataSfSpan
-                                    {...numOpts}
+                                    encryptedFieldType="encryptedCardNumber"
+                                    data-info='{"length":"15-32", "maskInterval":4}'
                                     className={classNames({
                                         'adyen-checkout__input': true,
                                         'adyen-checkout__input--large': true,
@@ -144,7 +142,8 @@ class Giftcard extends Component<GiftcardComponentProps> {
                                     name={'encryptedSecurityCode'}
                                 >
                                     <DataSfSpan
-                                        {...pinOpts}
+                                        encryptedFieldType="encryptedSecurityCode"
+                                        data-info='{"length":"3-10", "maskInterval": 0}'
                                         className={classNames({
                                             'adyen-checkout__input': true,
                                             'adyen-checkout__input--large': true,

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -44,6 +44,7 @@ function MBWayInput(props: MBWayInputProps) {
                 className={classNames('adyen-checkout__input--phone-number')}
                 isValid={valid.telephoneNumber}
                 dir={'ltr'}
+                name={'telephoneNumber'}
             >
                 {renderFormField('tel', {
                     value: data.telephoneNumber,

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -107,6 +107,7 @@ export class SecuredFieldsElement extends UIElement {
                     rootNode={this._node}
                     onChange={this.setState}
                     onBinValue={this.onBinValue}
+                    implementationType={'custom'}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/internal/Address/components/CountryField.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.tsx
@@ -32,7 +32,7 @@ export default function CountryField(props: CountryFieldProps) {
     if (!loaded) return null;
 
     return (
-        <Field label={i18n.get('country')} errorMessage={errorMessage} classNameModifiers={classNameModifiers}>
+        <Field label={i18n.get('country')} errorMessage={errorMessage} classNameModifiers={classNameModifiers} name={'country'}>
             {renderFormField('select', {
                 onChange: onDropdownChange,
                 name: 'country',

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
@@ -43,7 +43,7 @@ function FieldContainer(props: FieldContainerProps) {
             );
         default:
             return (
-                <Field label={label} classNameModifiers={classNameModifiers} errorMessage={errorMessage}>
+                <Field label={label} classNameModifiers={classNameModifiers} errorMessage={errorMessage} name={fieldName}>
                     {renderFormField('text', {
                         classNameModifiers,
                         name: fieldName,

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
@@ -43,7 +43,7 @@ function FieldContainer(props: FieldContainerProps) {
             );
         default:
             return (
-                <Field label={label} classNameModifiers={classNameModifiers} errorMessage={errorMessage} isValid={valid[fieldName]}>
+                <Field label={label} classNameModifiers={classNameModifiers} errorMessage={errorMessage} isValid={valid[fieldName]} name={fieldName}>
                     {renderFormField('text', {
                         classNameModifiers,
                         name: fieldName,

--- a/packages/lib/src/components/internal/Address/components/StateField.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.tsx
@@ -35,7 +35,7 @@ export default function StateField(props: StateFieldProps) {
     if (!loaded || !states.length) return null;
 
     return (
-        <Field label={label} classNameModifiers={classNameModifiers} errorMessage={props.errorMessage}>
+        <Field label={label} classNameModifiers={classNameModifiers} errorMessage={props.errorMessage} name={'stateOrProvince'}>
             {renderFormField('select', {
                 name: 'stateOrProvince',
                 onChange: onDropdownChange,

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -1,4 +1,5 @@
 import { ValidatorRules } from '../../../utils/Validator/Validator';
+import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD } from '../../../core/Errors/constants';
 
 export const getAddressValidationRules = (specifications): ValidatorRules => ({
     houseNumberOrName: {
@@ -12,6 +13,6 @@ export const getAddressValidationRules = (specifications): ValidatorRules => ({
     default: {
         validate: value => value?.length > 0,
         modes: ['blur'],
-        errorMessage: 'error.va.gen.01' // Incomplete field
+        errorMessage: ERROR_CODES[ERROR_MSG_INCOMPLETE_FIELD]
     }
 });

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -60,7 +60,7 @@ class Field extends Component<FieldProps, FieldState> {
         dualBrandingElements,
         dir,
         name,
-               showValidIcon
+        showValidIcon
     }) {
         return (
             <div

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -4,8 +4,12 @@ import './Field.scss';
 import Spinner from '../../Spinner';
 import Icon from '../../Icon';
 import { FieldProps, FieldState } from './types';
+import { getUniqueId } from '../../../../utils/idGenerator';
+import { ARIA_ERROR_SUFFIX } from '../../../../core/Errors/constants';
 
 class Field extends Component<FieldProps, FieldState> {
+    private readonly uniqueId: string;
+
     constructor(props) {
         super(props);
 
@@ -13,6 +17,8 @@ class Field extends Component<FieldProps, FieldState> {
 
         this.onFocus = this.onFocus.bind(this);
         this.onBlur = this.onBlur.bind(this);
+
+        this.uniqueId = getUniqueId(`adyen-checkout-${this.props.name}`);
     }
 
     onFocus(e) {
@@ -52,7 +58,8 @@ class Field extends Component<FieldProps, FieldState> {
         isValid,
         label,
         dualBrandingElements,
-        dir
+        dir,
+        name
     }) {
         return (
             <div
@@ -74,6 +81,7 @@ class Field extends Component<FieldProps, FieldState> {
                         'adyen-checkout__label--filled': this.state.filled,
                         'adyen-checkout__label--disabled': this.props.disabled
                     })}
+                    htmlFor={name && this.uniqueId}
                 >
                     {typeof label === 'string' && (
                         <span
@@ -99,7 +107,13 @@ class Field extends Component<FieldProps, FieldState> {
                     >
                         {toChildArray(children).map(
                             (child: ComponentChild): ComponentChild => {
-                                const childProps = { isValid, onFocus: this.onFocus, onBlur: this.onBlur, isInvalid: !!errorMessage };
+                                const childProps = {
+                                    isValid,
+                                    onFocus: this.onFocus,
+                                    onBlur: this.onBlur,
+                                    isInvalid: !!errorMessage,
+                                    ...(name && { uniqueId: this.uniqueId })
+                                };
                                 return cloneElement(child as VNode, childProps);
                             }
                         )}
@@ -124,7 +138,7 @@ class Field extends Component<FieldProps, FieldState> {
                     </div>
 
                     {errorMessage && errorMessage.length && (
-                        <span className={'adyen-checkout__error-text'} aria-live="polite">
+                        <span className={'adyen-checkout__error-text'} aria-live="polite" id={`${this.uniqueId}${ARIA_ERROR_SUFFIX}`}>
                             {errorMessage}
                         </span>
                     )}

--- a/packages/lib/src/components/internal/FormFields/Field/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Field/types.ts
@@ -19,6 +19,7 @@ export interface FieldProps {
     onFocusField?;
     onFieldBlur?;
     dir?;
+    name?: string;
 }
 
 export interface FieldState {

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -2,9 +2,10 @@ import { h } from 'preact';
 import { useState } from 'preact/hooks';
 import classNames from 'classnames';
 import { convertFullToHalf } from './utils';
+import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
 
 export default function InputBase(props) {
-    const { autoCorrect, classNameModifiers, isInvalid, isValid, readonly = null, spellCheck, type } = props;
+    const { autoCorrect, classNameModifiers, isInvalid, isValid, readonly = null, spellCheck, type, uniqueId } = props;
 
     const [handleChangeHasFired, setHandleChangeHasFired] = useState(false);
 
@@ -39,10 +40,11 @@ export default function InputBase(props) {
     );
 
     // Don't spread classNameModifiers to input element (it ends up as an attribute on the element itself)
-    const { classNameModifiers: cnm, ...newProps } = props;
+    const { classNameModifiers: cnm, uniqueId: uid, ...newProps } = props;
 
     return (
         <input
+            id={uniqueId}
             {...newProps}
             type={type}
             className={inputClassNames}
@@ -50,6 +52,7 @@ export default function InputBase(props) {
             readOnly={readonly}
             spellCheck={spellCheck}
             autoCorrect={autoCorrect}
+            aria-describedby={`${uniqueId}${ARIA_ERROR_SUFFIX}`}
             onChange={handleChange}
             onBlur={handleBlur}
         />

--- a/packages/lib/src/components/internal/FormFields/RadioGroup/RadioGroup.tsx
+++ b/packages/lib/src/components/internal/FormFields/RadioGroup/RadioGroup.tsx
@@ -2,35 +2,43 @@ import { h } from 'preact';
 import cx from 'classnames';
 import './RadioGroup.scss';
 import { RadioGroupProps } from './types';
+import { getUniqueId } from '../../../../utils/idGenerator';
 
 export default function RadioGroup(props: RadioGroupProps) {
-    const { items, i18n, name, onChange, value, isInvalid } = props;
+    const { items, i18n, name, onChange, value, isInvalid, uniqueId } = props;
+
+    const uniqueIdBase = uniqueId?.replace(/[0-9]/g, '').substring(0, uniqueId.lastIndexOf('-'));
 
     return (
         <div className="adyen-checkout__radio_group">
-            {items.map(item => (
-                <label key={item.id} className="adyen-checkout__radio_group__input-wrapper">
-                    <input
-                        type="radio"
-                        checked={value === item.id}
-                        className="adyen-checkout__radio_group__input"
-                        name={name}
-                        onChange={onChange}
-                        onClick={onChange}
-                        value={item.id}
-                    />
-                    <span
-                        className={cx([
-                            'adyen-checkout__label__text',
-                            'adyen-checkout__radio_group__label',
-                            props.className,
-                            { 'adyen-checkout__radio_group__label--invalid': isInvalid }
-                        ])}
-                    >
-                        {i18n.get(item.name)}
-                    </span>
-                </label>
-            ))}
+            {items.map(item => {
+                const uniqueId = getUniqueId(uniqueIdBase);
+                return (
+                    <div key={item.id} className="adyen-checkout__radio_group__input-wrapper">
+                        <input
+                            id={uniqueId}
+                            type="radio"
+                            checked={value === item.id}
+                            className="adyen-checkout__radio_group__input"
+                            name={name}
+                            onChange={onChange}
+                            onClick={onChange}
+                            value={item.id}
+                        />
+                        <label
+                            className={cx([
+                                'adyen-checkout__label__text',
+                                'adyen-checkout__radio_group__label',
+                                props.className,
+                                { 'adyen-checkout__radio_group__label--invalid': isInvalid }
+                            ])}
+                            htmlFor={uniqueId}
+                        >
+                            {i18n.get(item.name)}
+                        </label>
+                    </div>
+                );
+            })}
         </div>
     );
 }

--- a/packages/lib/src/components/internal/FormFields/RadioGroup/types.ts
+++ b/packages/lib/src/components/internal/FormFields/RadioGroup/types.ts
@@ -13,4 +13,5 @@ export interface RadioGroupProps {
     name?: string;
     onChange: (e) => void;
     value?: string;
+    uniqueId?: string;
 }

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -8,8 +8,21 @@ import { keys } from './constants';
 import { SelectItem, SelectProps } from './types';
 import styles from './Select.module.scss';
 import './Select.scss';
+import { ARIA_ERROR_SUFFIX } from '../../../../core/Errors/constants';
 
-function Select(props: SelectProps) {
+function Select({
+    items = [],
+    className = '',
+    classNameModifiers = [],
+    filterable = true,
+    readonly = false,
+    onChange = () => {},
+    selected,
+    name,
+    isInvalid,
+    placeholder,
+    uniqueId
+}: SelectProps) {
     const filterInputRef = useRef(null);
     const selectContainerRef = useRef(null);
     const toggleButtonRef = useRef(null);
@@ -18,7 +31,7 @@ function Select(props: SelectProps) {
     const [showList, setShowList] = useState<boolean>(false);
     const selectListId: string = useMemo(() => `select-${uuid()}`, []);
 
-    const active: SelectItem = props.items.find(i => i.id === props.selected) || ({} as SelectItem);
+    const active: SelectItem = items.find(i => i.id === selected) || ({} as SelectItem);
 
     /**
      * Closes the selectList, empties the text filter and focuses the button element
@@ -42,7 +55,7 @@ function Select(props: SelectProps) {
         if (!target.getAttribute('data-disabled')) {
             closeList();
             const value = target.getAttribute('data-value');
-            props.onChange({ target: { value, name: props.name } });
+            onChange({ target: { value, name: name } });
         }
     };
 
@@ -52,13 +65,13 @@ function Select(props: SelectProps) {
      * @param e - KeyboardEvent
      */
     const handleButtonKeyDown = (e: KeyboardEvent) => {
-        if (e.key === keys.enter && props.filterable && showList && textFilter) {
+        if (e.key === keys.enter && filterable && showList && textFilter) {
             handleSelect(e);
         } else if (e.key === keys.escape) {
             // When user has focused Select button but not yet moved into Select list - close list and keep focus on the Select Button re. a11y guidelines
             // https://w3c.github.io/aria-practices/examples/disclosure/disclosure-navigation.html
             closeList();
-        } else if ([keys.arrowUp, keys.arrowDown, keys.enter].includes(e.key) || (e.key === keys.space && (!props.filterable || !showList))) {
+        } else if ([keys.arrowUp, keys.arrowDown, keys.enter].includes(e.key) || (e.key === keys.space && (!filterable || !showList))) {
             e.preventDefault();
             setShowList(true);
             if (selectListRef.current?.firstElementChild) {
@@ -108,7 +121,7 @@ function Select(props: SelectProps) {
                 e.preventDefault();
                 if (target.previousElementSibling) {
                     (target.previousElementSibling as HTMLElement).focus();
-                } else if (props.filterable && filterInputRef.current) {
+                } else if (filterable && filterInputRef.current) {
                     filterInputRef.current.focus();
                 }
                 break;
@@ -138,7 +151,7 @@ function Select(props: SelectProps) {
     };
 
     useEffect(() => {
-        if (showList && props.filterable && filterInputRef.current) {
+        if (showList && filterable && filterInputRef.current) {
             filterInputRef.current.focus();
         }
     }, [showList]);
@@ -156,28 +169,30 @@ function Select(props: SelectProps) {
             className={cx([
                 'adyen-checkout__dropdown',
                 styles['adyen-checkout__dropdown'],
-                props.className,
-                ...props.classNameModifiers.map(m => `adyen-checkout__dropdown--${m}`)
+                className,
+                ...classNameModifiers.map(m => `adyen-checkout__dropdown--${m}`)
             ])}
             ref={selectContainerRef}
         >
             <SelectButton
+                id={uniqueId ?? null}
                 active={active}
                 filterInputRef={filterInputRef}
-                filterable={props.filterable}
-                isInvalid={props.isInvalid}
+                filterable={filterable}
+                isInvalid={isInvalid}
                 onButtonKeyDown={handleButtonKeyDown}
                 onInput={handleTextFilter}
-                placeholder={props.placeholder}
-                readonly={props.readonly}
+                placeholder={placeholder}
+                readonly={readonly}
                 selectListId={selectListId}
                 showList={showList}
                 toggleButtonRef={toggleButtonRef}
                 toggleList={toggleList}
+                ariaDescribedBy={uniqueId ? `${uniqueId}${ARIA_ERROR_SUFFIX}` : null}
             />
             <SelectList
                 active={active}
-                items={props.items}
+                items={items}
                 onKeyDown={handleListKeyDown}
                 onSelect={handleSelect}
                 selectListId={selectListId}

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -36,6 +36,8 @@ function SelectButton(props: SelectButtonProps) {
             title={active.name || props.placeholder}
             toggleButtonRef={props.toggleButtonRef}
             type={!props.filterable ? 'button' : null}
+            aria-describedby={props.ariaDescribedBy}
+            id={props.id}
         >
             {!showList || !props.filterable ? (
                 <Fragment>

--- a/packages/lib/src/components/internal/FormFields/Select/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Select/types.ts
@@ -17,6 +17,7 @@ export interface SelectProps {
     placeholder: string;
     readonly: boolean;
     selected: string;
+    uniqueId?: string;
 }
 
 export interface SelectButtonProps {
@@ -32,6 +33,8 @@ export interface SelectButtonProps {
     showList: boolean;
     toggleButtonRef;
     toggleList: (e: Event) => void;
+    id?: string;
+    ariaDescribedBy: string;
 }
 
 export interface SelectListProps {

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -104,6 +104,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     classNameModifiers={['col-50', 'lastName']}
                     errorMessage={getErrorMessage(errors.dateOfBirth)}
                     helper={isDateInputSupported ? null : i18n.get('dateOfBirth.format')}
+                    name={'dateOfBirth'}
                 >
                     {renderFormField('date', {
                         name: generateFieldName('dateOfBirth'),
@@ -122,6 +123,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     classNameModifiers={['shopperEmail']}
                     errorMessage={getErrorMessage(errors.shopperEmail)}
                     dir={'ltr'}
+                    name={'emailAddress'}
                 >
                     {renderFormField('emailAddress', {
                         name: generateFieldName('shopperEmail'),
@@ -140,6 +142,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     classNameModifiers={['telephoneNumber']}
                     errorMessage={getErrorMessage(errors.telephoneNumber)}
                     dir={'ltr'}
+                    name={'telephoneNumber'}
                 >
                     {renderFormField('tel', {
                         name: generateFieldName('telephoneNumber'),

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -49,7 +49,12 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
     return (
         <Fieldset classNameModifiers={['personalDetails']} label={label}>
             {requiredFields.includes('firstName') && (
-                <Field label={i18n.get('firstName')} classNameModifiers={['col-50', 'firstName']} errorMessage={!!errors.firstName}>
+                <Field
+                    label={i18n.get('firstName')}
+                    classNameModifiers={['col-50', 'firstName']}
+                    errorMessage={!!errors.firstName}
+                    name={'firstName'}
+                >
                     {renderFormField('text', {
                         name: generateFieldName('firstName'),
                         value: data.firstName,
@@ -63,7 +68,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
             )}
 
             {requiredFields.includes('lastName') && (
-                <Field label={i18n.get('lastName')} classNameModifiers={['col-50', 'lastName']} errorMessage={!!errors.lastName}>
+                <Field label={i18n.get('lastName')} classNameModifiers={['col-50', 'lastName']} errorMessage={!!errors.lastName} name={'lastName'}>
                     {renderFormField('text', {
                         name: generateFieldName('lastName'),
                         value: data.lastName,
@@ -77,7 +82,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
             )}
 
             {requiredFields.includes('gender') && (
-                <Field errorMessage={!!errors.gender} classNameModifiers={['gender']}>
+                <Field errorMessage={!!errors.gender} classNameModifiers={['gender']} name={'gender'}>
                     {renderFormField('radio', {
                         i18n,
                         name: generateFieldName('gender'),

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProvider.ts
@@ -179,7 +179,8 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             },
             isKCP: this.state.hasKoreanFields,
             legacyInputMode: this.props.legacyInputMode,
-            minimumExpiryDate: this.props.minimumExpiryDate
+            minimumExpiryDate: this.props.minimumExpiryDate,
+            implementationType: this.props.implementationType || 'components'
         };
 
         this.csf = initCSF(csfSetupObj);

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -34,3 +34,7 @@ export const CVC_POLICY_HIDDEN = 'hidden';
 
 export const DATE_POLICY_REQUIRED = CVC_POLICY_REQUIRED;
 export const DATE_POLICY_HIDDEN = CVC_POLICY_HIDDEN;
+
+export const DATA_ENCRYPTED_FIELD_ATTR = 'data-cse';
+export const DATA_INFO = 'data-info';
+export const DATA_UID = 'data-uid';

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -14,7 +14,7 @@ export const GIFT_CARD = 'giftcard';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.5.3';
+export const SF_VERSION = '3.5.4';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/handleConfig.ts
@@ -56,6 +56,9 @@ export function handleConfig(): void {
     // To configure the minimum expiry date to a merchant defined value - this means the card has to be valid until at least this date
     this.config.minimumExpiryDate = this.props.minimumExpiryDate || null;
 
+    // To distinguish between regular 'components' initiated securedField or 'custom' card component
+    this.config.implementationType = this.props.implementationType;
+
     this.config.sfLogAtStart = this.props._b$dl === true;
 
     let sfBundleType: string = this.config.isCreditCardType ? 'card' : this.props.type;

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
@@ -35,6 +35,7 @@ export interface SFInternalConfig {
     cvcPolicy: CVCPolicyType;
     legacyInputMode: boolean;
     minimumExpiryDate: string;
+    uid: string;
 }
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/AbstractSecuredField.ts
@@ -36,6 +36,7 @@ export interface SFInternalConfig {
     legacyInputMode: boolean;
     minimumExpiryDate: string;
     uid: string;
+    implementationType: string;
 }
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
@@ -60,7 +60,8 @@ const setupObj = {
     holderEl: nodeHolder,
     legacyInputMode: null,
     minimumExpiryDate: null,
-    uid: null
+    uid: null,
+    implementationType: null
 };
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.test.ts
@@ -59,7 +59,8 @@ const setupObj = {
     loadingContext: null,
     holderEl: nodeHolder,
     legacyInputMode: null,
-    minimumExpiryDate: null
+    minimumExpiryDate: null,
+    uid: null
 };
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
@@ -143,7 +143,8 @@ class SecuredField extends AbstractSecuredField {
             trimTrailingSeparator: this.config.trimTrailingSeparator,
             isCreditCardType: this.config.isCreditCardType,
             legacyInputMode: this.config.legacyInputMode,
-            minimumExpiryDate: this.config.minimumExpiryDate
+            minimumExpiryDate: this.config.minimumExpiryDate,
+            uid: this.config.uid
         };
 
         if (process.env.NODE_ENV === 'development' && window._b$dl) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/SecuredField.ts
@@ -144,7 +144,8 @@ class SecuredField extends AbstractSecuredField {
             isCreditCardType: this.config.isCreditCardType,
             legacyInputMode: this.config.legacyInputMode,
             minimumExpiryDate: this.config.minimumExpiryDate,
-            uid: this.config.uid
+            uid: this.config.uid,
+            implementationType: this.config.implementationType
         };
 
         if (process.env.NODE_ENV === 'development' && window._b$dl) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
@@ -1,5 +1,12 @@
 import { select, getAttribute } from '../utilities/dom';
-import { ENCRYPTED_EXPIRY_YEAR, DATE_POLICY_REQUIRED, CVC_POLICY_REQUIRED } from '../configuration/constants';
+import {
+    ENCRYPTED_EXPIRY_YEAR,
+    DATE_POLICY_REQUIRED,
+    CVC_POLICY_REQUIRED,
+    DATA_ENCRYPTED_FIELD_ATTR,
+    DATA_INFO,
+    DATA_UID
+} from '../configuration/constants';
 import { existy } from '../utilities/commonUtils';
 import cardType from '../utilities/cardType';
 import { CVCPolicyType, SFSetupObject } from './AbstractSecuredField';
@@ -21,8 +28,7 @@ let cvcPolicy: CVCPolicyType;
  * Handles specific functionality related to configuring & creating SecuredFields
  */
 export function createSecuredFields(): number {
-    // Detect DOM elements that qualify as securedField holders
-    this.encryptedAttrName = 'data-encrypted-field';
+    this.encryptedAttrName = DATA_ENCRYPTED_FIELD_ATTR;
 
     if (process.env.NODE_ENV === 'development' && window._b$dl) {
         logger.log('\n### CreateSF::createSecuredFields:: this.state.type=', this.state.type);
@@ -30,13 +36,7 @@ export function createSecuredFields(): number {
     }
 
     // Detect DOM elements that qualify as securedField holders
-    let securedFields: HTMLElement[] = select(this.props.rootNode, `[${this.encryptedAttrName}]`);
-
-    // Fallback to old attr name
-    if (!securedFields.length) {
-        this.encryptedAttrName = 'data-cse';
-        securedFields = select(this.props.rootNode, `[${this.encryptedAttrName}]`);
-    }
+    const securedFields: HTMLElement[] = select(this.props.rootNode, `[${this.encryptedAttrName}]`);
 
     cvcPolicy = CVC_POLICY_REQUIRED;
 
@@ -135,12 +135,14 @@ export function setupSecuredField(pItem: HTMLElement): void {
         this.state.hasSeparateDateFields = true;
     }
 
-    const extraFieldData: string = getAttribute(pItem, 'data-info');
+    const extraFieldData: string = getAttribute(pItem, DATA_INFO);
+    const uid = getAttribute(pItem, DATA_UID);
 
     // ////// CREATE SecuredField passing in configObject of props that will be set on the SecuredField instance
     const setupObj: SFSetupObject = {
         fieldType,
         extraFieldData,
+        uid,
         txVariant: this.state.type,
         cardGroupTypes: this.config.cardGroupTypes,
         iframeUIConfig: this.config.iframeUIConfig ? this.config.iframeUIConfig : {},

--- a/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/core/createSecuredFields.ts
@@ -156,7 +156,8 @@ export function setupSecuredField(pItem: HTMLElement): void {
         showWarnings: this.config.showWarnings,
         holderEl: pItem,
         legacyInputMode: this.config.legacyInputMode,
-        minimumExpiryDate: this.config.minimumExpiryDate
+        minimumExpiryDate: this.config.minimumExpiryDate,
+        implementationType: this.config.implementationType
     };
 
     const sf: SecuredField = new SecuredField(setupObj, this.props.i18n)

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -46,6 +46,7 @@ interface CSFCommonProps {
     iframeUIConfig?: object;
     legacyInputMode?: boolean;
     minimumExpiryDate?: string;
+    implementationType?: string;
 }
 
 /**

--- a/packages/lib/src/core/Errors/constants.ts
+++ b/packages/lib/src/core/Errors/constants.ts
@@ -8,6 +8,8 @@ export const ERROR_MSG_INVALID_FIELD = 'field not valid';
 export const ERROR_MSG_CLEARED = 'error was cleared';
 export const ERROR_MSG_MBWAY_EMAIL_INVALID = 'Not valid email address';
 
+export const ARIA_ERROR_SUFFIX = '-ariaError';
+
 /**
  * Error Codes
  * @example error.va.sf-cc-num.01

--- a/packages/lib/src/utils/idGenerator.ts
+++ b/packages/lib/src/utils/idGenerator.ts
@@ -1,0 +1,6 @@
+let idCounter = Date.now();
+
+export const getUniqueId = (prefix = 'field') => {
+    idCounter += 1;
+    return `${prefix}-${idCounter}`;
+};


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
All `<Field>` components should have a `name` property.
This ensures that their `<label>` elements get a `for` attribute and that the related input is then given an `id` that matches the value of the `for` attribute.
It also means that if `errorMessage` is set to true that the related input gets a `aria-describedby` attribute that matches the `id` on the related error field:
```html
<div class="adyen-checkout__field>
  <label class="adyen-checkout__label" for="adyen-checkout-firstName-1628695646178">
    <div class="adyen-checkout__input-wrapper">
      <input id="adyen-checkout-firstName-1628695646178" aria-describedby="adyen-checkout-firstName-1628695646178-ariaError">  
    </div>
    <span class="adyen-checkout__error-text" id="adyen-checkout-firstName-1628695646178-ariaError">Field is required</span>
  </label>
</div>
```

#### Related:
Related to this is how  the `label`, `for` attribute and `id` are set on `RadioGroup` input elements.
These have a more complex structure that the usual `Field` / `input` setup but are also dealt with in this PR
