### PR TITLE
Aligning validations in the Address comp

### DIFF
--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -69,8 +69,10 @@ export default function Address(props: AddressProps) {
                 classNameModifiers={[...classNameModifiers, fieldName]}
                 data={data}
                 errors={errors}
+                valid={valid}
                 fieldName={fieldName}
                 onInput={handleChangeFor(fieldName, 'input')}
+                onChange={handleChangeFor(fieldName, 'blur')}
                 onDropdownChange={handleChangeFor(fieldName, 'blur')}
                 specifications={specifications}
             />

--- a/packages/lib/src/components/internal/Address/components/CountryField.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.tsx
@@ -32,7 +32,7 @@ export default function CountryField(props: CountryFieldProps) {
     if (!loaded) return null;
 
     return (
-        <Field label={i18n.get('country')} errorMessage={errorMessage} classNameModifiers={classNameModifiers}>
+        <Field label={i18n.get('country')} errorMessage={errorMessage} classNameModifiers={classNameModifiers} isValid={!!value} showValidIcon={true}>
             {renderFormField('select', {
                 onChange: onDropdownChange,
                 name: 'country',

--- a/packages/lib/src/components/internal/Address/components/CountryField.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.tsx
@@ -32,7 +32,13 @@ export default function CountryField(props: CountryFieldProps) {
     if (!loaded) return null;
 
     return (
-        <Field label={i18n.get('country')} errorMessage={errorMessage} classNameModifiers={classNameModifiers} isValid={!!value} showValidIcon={true}>
+        <Field
+            label={i18n.get('country')}
+            errorMessage={errorMessage}
+            classNameModifiers={classNameModifiers}
+            isValid={!!value}
+            showValidIcon={false}
+        >
             {renderFormField('select', {
                 onChange: onDropdownChange,
                 name: 'country',

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.test.tsx
@@ -6,6 +6,7 @@ import Specifications from '../Specifications';
 const propsMock = {
     errors: {},
     data: {},
+    valid: {},
     specifications: new Specifications()
 };
 

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
@@ -8,8 +8,8 @@ import useCoreContext from '../../../../core/Context/useCoreContext';
 
 function FieldContainer(props: FieldContainerProps) {
     const { i18n } = useCoreContext();
-    const { classNameModifiers = [], data, errors, fieldName, onInput } = props;
-    const errorMessage = !!errors[fieldName];
+    const { classNameModifiers = [], data, errors, valid, fieldName, onInput, onChange } = props;
+    const errorMessage = i18n.get(errors[fieldName]?.errorMessage) || !!errors[fieldName];
     const value: string = data[fieldName];
     const selectedCountry: string = data.country;
     const isOptional: boolean = props.specifications.countryHasOptionalField(selectedCountry, fieldName);
@@ -43,12 +43,13 @@ function FieldContainer(props: FieldContainerProps) {
             );
         default:
             return (
-                <Field label={label} classNameModifiers={classNameModifiers} errorMessage={errorMessage}>
+                <Field label={label} classNameModifiers={classNameModifiers} errorMessage={errorMessage} isValid={valid[fieldName]}>
                     {renderFormField('text', {
                         classNameModifiers,
                         name: fieldName,
                         value,
-                        onInput
+                        onInput,
+                        onChange
                     })}
                 </Field>
             );

--- a/packages/lib/src/components/internal/Address/components/StateField.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.tsx
@@ -35,7 +35,7 @@ export default function StateField(props: StateFieldProps) {
     if (!loaded || !states.length) return null;
 
     return (
-        <Field label={label} classNameModifiers={classNameModifiers} errorMessage={props.errorMessage}>
+        <Field label={label} classNameModifiers={classNameModifiers} errorMessage={props.errorMessage} isValid={!!value} showValidIcon={true}>
             {renderFormField('select', {
                 name: 'stateOrProvince',
                 onChange: onDropdownChange,

--- a/packages/lib/src/components/internal/Address/components/StateField.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.tsx
@@ -35,7 +35,7 @@ export default function StateField(props: StateFieldProps) {
     if (!loaded || !states.length) return null;
 
     return (
-        <Field label={label} classNameModifiers={classNameModifiers} errorMessage={props.errorMessage} isValid={!!value} showValidIcon={true}>
+        <Field label={label} classNameModifiers={classNameModifiers} errorMessage={props.errorMessage} isValid={!!value} showValidIcon={false}>
             {renderFormField('select', {
                 name: 'stateOrProvince',
                 onChange: onDropdownChange,

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -31,7 +31,9 @@ export interface FieldContainerProps {
     errors: AddressStateError;
     fieldName: string;
     key: string;
-    onInput: (e: Event) => void;
+    valid?: object;
+    onInput?: (e: Event) => void;
+    onChange?: (e: Event) => void;
     onDropdownChange: (e: Event) => void;
     readOnly?: boolean;
     specifications: Specifications;
@@ -46,7 +48,7 @@ export interface CountryFieldProps {
     allowedCountries: string[];
     classNameModifiers: string[];
     label: string;
-    errorMessage: boolean;
+    errorMessage: boolean | string;
     onDropdownChange: (e: Event) => void;
     readOnly?: boolean;
     value: string;
@@ -60,7 +62,7 @@ export interface CountryFieldItem {
 export interface StateFieldProps {
     classNameModifiers: string[];
     label: string;
-    errorMessage: boolean;
+    errorMessage: boolean | string;
     onDropdownChange: (e: Event) => void;
     readOnly?: boolean;
     selectedCountry: string;

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -11,6 +11,7 @@ export const getAddressValidationRules = (specifications): ValidatorRules => ({
     },
     default: {
         validate: value => value?.length > 0,
-        modes: ['blur']
+        modes: ['blur'],
+        errorMessage: 'error.va.gen.01' // Incomplete field
     }
 });

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -52,7 +52,8 @@ class Field extends Component<FieldProps, FieldState> {
         isValid,
         label,
         dualBrandingElements,
-        dir
+        dir,
+        showValidIcon
     }) {
         return (
             <div
@@ -110,7 +111,7 @@ class Field extends Component<FieldProps, FieldState> {
                             </span>
                         )}
 
-                        {isValid && !dualBrandingElements && (
+                        {isValid && showValidIcon !== false && !dualBrandingElements && (
                             <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--valid">
                                 <Icon type="checkmark" />
                             </span>

--- a/packages/lib/src/components/internal/FormFields/Field/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Field/types.ts
@@ -19,6 +19,7 @@ export interface FieldProps {
     onFocusField?;
     onFieldBlur?;
     dir?;
+    showValidIcon?: boolean;
 }
 
 export interface FieldState {

--- a/packages/lib/src/components/internal/FormFields/Select/Select.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.scss
@@ -66,6 +66,10 @@
     border-color: $color-alert;
 }
 
+.adyen-checkout__dropdown__button--valid {
+    border-bottom-color: $color-success;
+}
+
 .adyen-checkout__dropdown__button__text {
     overflow: hidden;
     pointer-events: none;

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -166,6 +166,7 @@ function Select(props: SelectProps) {
                 filterInputRef={filterInputRef}
                 filterable={props.filterable}
                 isInvalid={props.isInvalid}
+                isValid={props.isValid}
                 onButtonKeyDown={handleButtonKeyDown}
                 onInput={handleTextFilter}
                 placeholder={props.placeholder}

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -26,7 +26,8 @@ function SelectButton(props: SelectButtonProps) {
                 'adyen-checkout__dropdown__button--readonly': readonly,
                 'adyen-checkout__dropdown__button--active': showList,
                 [styles['adyen-checkout__dropdown__button--active']]: showList,
-                'adyen-checkout__dropdown__button--invalid': props.isInvalid
+                'adyen-checkout__dropdown__button--invalid': props.isInvalid,
+                'adyen-checkout__dropdown__button--valid': props.isValid
             })}
             filterable={props.filterable}
             onClick={!readonly ? props.toggleList : null}

--- a/packages/lib/src/components/internal/FormFields/Select/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Select/types.ts
@@ -11,6 +11,7 @@ export interface SelectProps {
     classNameModifiers: string[];
     filterable: boolean;
     isInvalid: boolean;
+    isValid?: boolean;
     items: SelectItem[];
     name?: string;
     onChange: (e) => void;
@@ -24,6 +25,7 @@ export interface SelectButtonProps {
     filterInputRef;
     filterable: boolean;
     isInvalid: boolean;
+    isValid?: boolean;
     onButtonKeyDown: (e: KeyboardEvent) => void;
     onInput: (e: Event) => void;
     placeholder: string;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Aligning how validations are done in the `Address component` with how they are done elsewhere:
- validation on blur
- (translated) error message shown
- green underline & tick icon when valid

This same has also been applied to the 'Select` component elements (Country & State dropdown) including adding the green tick icon when valid (although with an option to hide this)

## Tested scenarios
How fields in the `Address` component behave when in error or valid is inline with the behaviour of other fields in other components

