### PR TITLE
Adds merchantOrigin for Google Pay

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -50,5 +50,15 @@ describe('GooglePay', () => {
             const gpay = new GooglePay({ configuration: { merchantId: 'abcdef', gatewayMerchantId: 'TestMerchant' } });
             expect(gpay.props.configuration.merchantId).toEqual('abcdef');
         });
+
+        test('Retrieves merchantId from configuration', () => {
+            const gpay = new GooglePay({
+                configuration: {
+                    gatewayMerchantId: 'TestMerchant',
+                    merchantOrigin: 'example.com'
+                }
+            });
+            expect(gpay.props.configuration.merchantOrigin).toEqual('example.com');
+        });
     });
 });

--- a/packages/lib/src/components/GooglePay/requests.test.ts
+++ b/packages/lib/src/components/GooglePay/requests.test.ts
@@ -56,6 +56,15 @@ describe('Google Pay Requests', () => {
             expect(paymentRequest.apiVersion).toBeDefined();
             expect(paymentRequest.apiVersionMinor).toBeDefined();
         });
+
+        test('should pass merchantOrigin correctly', () => {
+            const paymentRequest = initiatePaymentRequest({
+                ...defaultProps,
+                configuration: { ...defaultProps.configuration, merchantOrigin: 'example.com' }
+            });
+
+            expect(paymentRequest.merchantInfo.merchantOrigin).toBe('example.com');
+        });
     });
 
     describe('isReadyToPayRequest', () => {

--- a/packages/lib/src/components/GooglePay/requests.ts
+++ b/packages/lib/src/components/GooglePay/requests.ts
@@ -1,6 +1,6 @@
 import { getDecimalAmount } from '../../utils/amount-util';
 import config from './config';
-import { GooglePayProps } from './types';
+import {GooglePaymentDataRequest, GooglePayProps} from './types';
 
 /**
  * Configure your site's support for payment methods supported by the Google Pay API.
@@ -56,14 +56,15 @@ export function getTransactionInfo({
     };
 }
 
-export function initiatePaymentRequest({ configuration, ...props }: GooglePayProps): google.payments.api.PaymentDataRequest {
+export function initiatePaymentRequest({ configuration, ...props }: GooglePayProps): GooglePaymentDataRequest {
     return {
         apiVersion: config.API_VERSION,
         apiVersionMinor: config.API_VERSION_MINOR,
         transactionInfo: getTransactionInfo(props),
         merchantInfo: {
             merchantId: configuration.merchantId,
-            merchantName: configuration.merchantName
+            merchantName: configuration.merchantName,
+            merchantOrigin: configuration.merchantOrigin
         },
         allowedPaymentMethods: [
             {

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -19,6 +19,12 @@ export interface GooglePayPropsConfiguration {
      * @see https://developers.google.com/pay/api/web/reference/request-objects#MerchantInfo
      */
     merchantName?: string;
+
+
+    /**
+     * Merchant fully qualified domain name.
+     */
+    merchantOrigin?: string;
 }
 
 export interface GooglePayProps extends UIElementProps {
@@ -123,4 +129,13 @@ export interface GooglePayProps extends UIElementProps {
     // Events
     onClick?: (resolve, reject) => void;
     onAuthorized?: (paymentData: google.payments.api.PaymentData) => void;
+}
+
+// Used to add undocumented google payment options
+export interface GooglePaymentDataRequest extends google.payments.api.PaymentDataRequest {
+    merchantInfo: ExtendedMerchantInfo
+}
+
+export interface ExtendedMerchantInfo extends google.payments.api.MerchantInfo {
+    merchantOrigin?: string
 }


### PR DESCRIPTION
## Summary
Adds new field `merchantOrigin` to Google Pay configuration.

## Tested scenarios
<!-- Description of tested scenarios -->

* Google Pay Element gets the configuration
* Google Pay receives said configuration 
