### PR TITLE
Fix paymentMethod type on components

### DIFF
--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -165,7 +165,7 @@ class Core {
          * When PaymentMethod is defined as a string - retrieve a component from the componentsMap and recall this function passing in a valid class
          */
         if (typeof PaymentMethod === 'string' && paymentMethods[PaymentMethod]) {
-            return this.handleCreate(paymentMethods[PaymentMethod], options);
+            return this.handleCreate(paymentMethods[PaymentMethod], { type: PaymentMethod, ...options });
         }
 
         /**


### PR DESCRIPTION
## Summary
When creating a component (not on the Drop-in flow), the specific payment method type used gets lost if not explicitly set on the props (`{ type: '...' }`).
On payment methods which share a single component (e.g. Klarna: `klarna`, `klarna_account`...), this is causes the default (`klarna`, on this example), to be returned in the output. As a side effect of this, the wrong data from the `paymentMethodsResponse` is used too.

This PR makes sure that a `type` is always set when creating a component.