### PR TITLE
Fix Klarna pointer events on a loading state on Dropin

### DIFF
--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.scss
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.scss
@@ -1,0 +1,3 @@
+.adyen-checkout__klarna-widget {
+    pointer-events: all;
+}

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -1,8 +1,9 @@
 import Script from '../../../../utils/Script';
 import { useEffect, useRef, useState } from 'preact/hooks';
-import { Fragment, h } from 'preact';
+import { h } from 'preact';
 import { KlarnaWidgetAuthorizeResponse, KlarnaWidgetProps } from '../../types';
 import { KLARNA_VARIANTS, KLARNA_WIDGET_URL } from '../../constants';
+import './KlarnaWidget.scss';
 
 export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }: KlarnaWidgetProps) {
     const klarnaWidgetRef = useRef(null);
@@ -91,10 +92,10 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
 
     if (status !== 'error' && status !== 'success') {
         return (
-            <Fragment>
+            <div className="adyen-checkout__klarna-widget">
                 <div ref={klarnaWidgetRef} />
                 {payButton({ status, disabled: status === 'loading', onClick: authorizeKlarna })}
-            </Fragment>
+            </div>
         );
     }
 


### PR DESCRIPTION
Klarna `sdk` actions (in Drop-in) are handled in the same page (Drop-in stays on the page). If a merchant calls `dropin.setStatus('loading')`, that would block the interaction with the Klarna widget. 

This PR makes sure that interaction is still possible.