### PR TITLE
Fix/pasting unsupported card

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -31,7 +31,7 @@
         "html-webpack-plugin": "^4.5.2",
         "node-sass": "^6.0.0",
         "prettier": "^1.19.1",
-        "sass-loader": "^10.1.1",
+        "sass-loader": "^10.2.0",
         "source-map-loader": "^1.1.3",
         "style-loader": "^2.0.0",
         "testcafe": "~1.13.0",

--- a/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SecuredFieldsProviderHandlers.ts
@@ -88,7 +88,8 @@ function handleOnFieldValid(field: CbObjOnFieldValid): boolean {
          * For a field that has just received valid:true (field has just been completed & encrypted) - mark the error state for this field as false
          * For a field that has just received valid:false (field was encrypted, now is not)
          *  - field is either in a state of being incomplete but without errors (digit deleted) - so mark the error state for this field as false
-         *  or has switched from valid/encrypted state to being in error (digit edited to one that puts the field in error) - so keep any error that might just have been set
+         *  or has switched from valid/encrypted state to being in error (digit edited to one that puts the field in error) - so keep any error that
+         *  might just have been set
          */
         errors: { ...prevState.errors, [field.fieldType]: prevState.errors[field.fieldType] ?? false }
     });
@@ -147,7 +148,11 @@ function handleOnError(cbObj: CbObjOnError, hasUnsupportedCard: boolean = null):
     this.setState(
         prevState => ({
             errors: { ...prevState.errors, [cbObj.fieldType]: errorCode || false },
-            hasUnsupportedCard: hasUnsupportedCard !== null ? hasUnsupportedCard : false
+            hasUnsupportedCard: hasUnsupportedCard !== null ? hasUnsupportedCard : false,
+            // If dealing with an unsupported card ensure these card number related fields are reset re. pasting a full, unsupported card straight in
+            ...(hasUnsupportedCard && { data: { ...prevState.data, [ENCRYPTED_CARD_NUMBER]: undefined } }),
+            ...(hasUnsupportedCard && { valid: { ...prevState.valid, [ENCRYPTED_CARD_NUMBER]: false } }),
+            ...(hasUnsupportedCard && { isSfpValid: false })
         }),
         () => {
             this.props.onChange(this.state);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In the Card component, if card details are filled out correctly and then a full unsupported card number is _pasted_ in - the Card's state is not being correctly updated.
Namely `card.state.data.encryptedCardNumber` is not being overwritten and set to`undefined` and nor is `card.state.valid` reset to `false`.
Also `card.state.isValid` is not reset to `false`

## Tested scenarios
All e2e tests still run


**Fixed issue**:  COWEB-1014
