### PR TITLE
Rename conversionId to checkoutAttemptId

### DIFF
--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -60,12 +60,12 @@ class BaseElement<P extends BaseElementProps> {
      */
     get data(): any {
         const clientData = getProp(this.props, 'modules.risk.data');
-        const conversionId = getProp(this.props, 'modules.analytics.conversionId');
+        const checkoutAttemptId = getProp(this.props, 'modules.analytics.checkoutAttemptId');
         const order = this.state.order || this.props.order;
 
         return {
             ...(clientData && { riskData: { clientData } }),
-            ...(conversionId && { conversionId }),
+            ...(checkoutAttemptId && { checkoutAttemptId }),
             ...(order && { order: { orderData: order.orderData, pspReference: order.pspReference } }),
             ...this.formatData(),
             clientStateDataIndicator: true

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -49,7 +49,7 @@ describe('Analytics', () => {
         };
         const analytics = new Analytics({ analytics: { conversion: false }, loadingContext: '', locale: '', clientKey: '' });
         analytics.send(event);
-        expect(logTelemetryPromiseMock).toHaveBeenCalledWith({ ...event, conversionId: null });
+        expect(logTelemetryPromiseMock).toHaveBeenCalledWith({ ...event, checkoutAttemptId: null });
     });
 
     test('Adds the fields in the payload', () => {
@@ -61,6 +61,6 @@ describe('Analytics', () => {
         };
         const analytics = new Analytics({ analytics: { conversion: false, payload }, loadingContext: '', locale: '', clientKey: '' });
         analytics.send(event);
-        expect(logTelemetryPromiseMock).toHaveBeenCalledWith({ ...payload, ...event, conversionId: null });
+        expect(logTelemetryPromiseMock).toHaveBeenCalledWith({ ...payload, ...event, checkoutAttemptId: null });
     });
 });

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -9,11 +9,11 @@ class Analytics {
         enabled: true,
         telemetry: true,
         conversion: false,
-        conversionId: null,
+        checkoutAttemptId: null,
         experiments: []
     };
 
-    public conversionId = null;
+    public checkoutAttemptId = null;
     public props;
     private readonly logEvent;
     private readonly logTelemetry;
@@ -28,10 +28,10 @@ class Analytics {
 
         const { conversion, enabled } = this.props;
         if (conversion === true && enabled === true) {
-            if (this.props.conversionId) {
-                // handle prefilled conversionId
-                this.conversionId = this.props.conversionId;
-                this.queue.run(this.conversionId);
+            if (this.props.checkoutAttemptId) {
+                // handle prefilled checkoutAttemptId
+                this.checkoutAttemptId = this.props.checkoutAttemptId;
+                this.queue.run(this.checkoutAttemptId);
             }
         }
     }
@@ -40,21 +40,22 @@ class Analytics {
         const { conversion, enabled, payload, telemetry } = this.props;
 
         if (enabled === true) {
-            if (conversion === true && !this.conversionId) {
-                // fetch a new conversionId if none is already available
-                this.collectId().then(conversionId => {
-                    this.conversionId = conversionId;
-                    this.queue.run(this.conversionId);
+            if (conversion === true && !this.checkoutAttemptId) {
+                // fetch a new checkoutAttemptId if none is already available
+                this.collectId().then(checkoutAttemptId => {
+                    this.checkoutAttemptId = checkoutAttemptId;
+                    this.queue.run(this.checkoutAttemptId);
                 });
             }
 
             if (telemetry === true) {
-                const telemetryTask = conversionId => this.logTelemetry({ ...event, ...(payload && { ...payload }), conversionId }).catch(() => {});
+                const telemetryTask = checkoutAttemptId =>
+                    this.logTelemetry({ ...event, ...(payload && { ...payload }), checkoutAttemptId }).catch(() => {});
                 this.queue.add(telemetryTask);
 
-                // Not waiting for conversionId
-                if (!conversion || this.conversionId) {
-                    this.queue.run(this.conversionId);
+                // Not waiting for checkoutAttemptId
+                if (!conversion || this.checkoutAttemptId) {
+                    this.queue.run(this.checkoutAttemptId);
                 }
             }
 

--- a/packages/lib/src/core/Analytics/EventsQueue.ts
+++ b/packages/lib/src/core/Analytics/EventsQueue.ts
@@ -1,4 +1,4 @@
-type EventItem = (conversionId: string) => Promise<any>;
+type EventItem = (checkoutAttemptId: string) => Promise<any>;
 
 class EventsQueue {
     public events: EventItem[] = [];
@@ -7,8 +7,8 @@ class EventsQueue {
         this.events.push(event);
     }
 
-    run(conversionId?: string) {
-        const promises = this.events.map(e => e(conversionId));
+    run(checkoutAttemptId?: string) {
+        const promises = this.events.map(e => e(checkoutAttemptId));
         this.events = [];
 
         return Promise.all(promises);

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -21,9 +21,9 @@ export interface AnalyticsOptions {
     conversion?: boolean;
 
     /**
-     * Reuse a previous conversionId from a previous page
+     * Reuse a previous checkoutAttemptId from a previous page
      */
-    conversionId?: string;
+    checkoutAttemptId?: string;
 
     /**
      * Data to be sent along with the event data


### PR DESCRIPTION
## Summary
We're currently using the v2 of our analytics endpoint, which expects an `checkoutAttemptId` instead of `conversionId`.
