### PR TITLE
Fetch the right properties from the paymentMethods response 

### DIFF
--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -133,12 +133,13 @@ class Core {
          * Once we receive a valid class for a Component - create a new instance of it
          */
         if (isValidClass) {
-            const paymentMethodsDetails = !options.supportedShopperInteractions ? this.paymentMethodsResponse.find(PaymentMethod.type) : [];
+            console.log(PaymentMethod.type, options.type);
+            const paymentMethodsDetails = !options.supportedShopperInteractions ? this.paymentMethodsResponse.find(options.type) : [];
 
             // NOTE: will only have a value if a paymentMethodsConfiguration object is defined at top level, in the config object set when a
             // new AdyenCheckout is initialised.
             const paymentMethodsConfiguration = getComponentConfiguration(
-                PaymentMethod.type,
+                options.type,
                 this.options.paymentMethodsConfiguration,
                 !!options.storedPaymentMethodId
             );

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -133,7 +133,6 @@ class Core {
          * Once we receive a valid class for a Component - create a new instance of it
          */
         if (isValidClass) {
-            console.log(PaymentMethod.type, options.type);
             const paymentMethodsDetails = !options.supportedShopperInteractions ? this.paymentMethodsResponse.find(options.type) : [];
 
             // NOTE: will only have a value if a paymentMethodsConfiguration object is defined at top level, in the config object set when a


### PR DESCRIPTION



## Summary
- Fetch the right properties from the paymentMethods response on components with multiple txVariants

## Tested scenarios
- `klarna_paynow` properties are set correctly, not defaulting to the base `klarna` ones.

