### PR TITLE
Correctly call onPaymentCompleted on Google Pay component

### DIFF
--- a/packages/lib/src/components/GooglePay/defaultProps.ts
+++ b/packages/lib/src/components/GooglePay/defaultProps.ts
@@ -32,7 +32,6 @@ export default {
 
     // Callbacks
     onAuthorized: params => params,
-    onSubmit: () => {},
     onClick: resolve => resolve(),
 
     // CardParameters


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Correctly call onPaymentCompleted on Google Pay component when using Checkout Sessions

## Tested scenarios
- Making a payment on a Google Pay standalone component correctly calls the `onPaymentCompleted` event.