### PR TITLE
Correctly call onPaymentCompleted on Apple Pay component

### DIFF
--- a/packages/lib/src/components/ApplePay/defaultProps.ts
+++ b/packages/lib/src/components/ApplePay/defaultProps.ts
@@ -76,8 +76,6 @@ const defaultProps = {
 
     // Events
     onClick: resolve => resolve(),
-    onSubmit: () => {},
-    onError: () => {},
     onAuthorized: resolve => resolve(),
     onPaymentMethodSelected: null,
     onShippingContactSelected: null,

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -117,11 +117,14 @@ export interface ApplePayElementProps extends UIElementProps {
     applicationData?: string;
 
     // Events
+
     onClick?: (resolve, reject) => void;
-    onSubmit?: (state, component) => void;
-    onError?: (error) => void;
+
+    /** @internal */
     onCancel?: () => void;
+
     onAuthorized?: (resolve, reject, event: ApplePayJS.ApplePayPaymentAuthorizedEvent) => void;
+
     onValidateMerchant?: (resolve, reject, event: ApplePayJS.ApplePayValidateMerchantEvent) => void;
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Correctly call onPaymentCompleted on Apple Pay component when using Checkout Sessions

## Tested scenarios
* Making a payment on an Apple Pay standalone component correctly calls the `onPaymentCompleted` event.

