### PR TITLE
Updating Bancontact default props

### DIFF
--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -7,6 +7,11 @@ class BancontactElement extends CardElement {
         super(props);
     }
 
+    protected static defaultProps = {
+        ...CardElement.defaultProps,
+        brands: ['bcmc', 'maestro', 'visa']
+    };
+
     /**
      * Now that the Bancontact (BCMC) Card component can accept a number dual branded with Visa (which requires a CVC) it has to be handled differently
      * at creation time (no automatic removing of the CVC securedField).
@@ -16,8 +21,6 @@ class BancontactElement extends CardElement {
     formatProps(props: CardElementProps) {
         return {
             ...super.formatProps(props),
-            // Override display brands - these are also the brands that will be considered "supported" by /binLookup
-            brands: ['bcmc', 'maestro', 'visa'],
             type: 'bcmc', // Force type (only for the Dropin is type automatically set to 'bcmc') - this will bypass the regEx brand detection
             cvcPolicy: CVC_POLICY_HIDDEN
         };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Moved `brands` from `Bancontact#formatProps` to `Bancontact#defaultProps`. 
   - With this change, the Component won't ignore the brands that are specified in the `brands` configuration property. 

## Tested scenarios
1.  Edit the bancontact creation at `playground/Cards.js` file, adding `brands` property to it:
```javascript
    window.bancontact = checkout.create('bcmc', { brands: ['bcmc', 'visa'] }).mount('.bancontact-field');
```
2. Then try out a Maestro card and verify that it is an invalid card
<!-- Description of tested scenarios -->