### PR TITLE
DropinPage model is instantiated with an object containing refs to other page models

### DIFF
--- a/packages/e2e/tests/_models/CardComponent.page.js
+++ b/packages/e2e/tests/_models/CardComponent.page.js
@@ -9,10 +9,10 @@ import kcp from '../cards/utils/kcpUtils';
  * abstraction of the tested page, and use it in test code to refer to page elements
  */
 export default class CardPage extends BasePage {
-    constructor() {
+    constructor(baseEl = '.card-field') {
         super('cards');
 
-        const BASE_EL = '.card-field';
+        const BASE_EL = baseEl;
 
         /**
          * CardNumber

--- a/packages/e2e/tests/_models/Dropin.page.js
+++ b/packages/e2e/tests/_models/Dropin.page.js
@@ -1,65 +1,36 @@
 import { ClientFunction, Selector } from 'testcafe';
 import BasePage from './BasePage';
-import { getIframeSelector } from '../utils/commonUtils';
-import cu from '../cards/utils/cardUtils';
 
 /**
- * The Page Model Pattern is a test automation pattern that allows you to create an
- * abstraction of the tested page, and use it in test code to refer to page elements
+ * Expects a 'components' property in the object sent to the constructor containing instances of other Page models
+ * e.g.
+ * const dropinPage = new DropinPage({
+ *   components: {
+ *     cc: new CardComponentPage('.adyen-checkout__payment-method--bcmc')
+ *   }
+ * });
  */
 export default class DropinPage extends BasePage {
-    constructor(pmSelector) {
+    constructor({ components }) {
         super('');
+
+        Object.assign(this, components);
 
         const BASE_EL = '.adyen-checkout__dropin';
 
         /**
-         * ###################
-         * Credit card related
-         * ###################
+         * ###############################################
+         * Credit card related (but only appear in Dropin)
+         * ###############################################
          */
+        // Regular branding
         this.brandsHolder = Selector(`${BASE_EL} .adyen-checkout__payment-method__brands`);
         this.brandsImages = this.brandsHolder.find('img');
 
-        /**
-         * CardNumber
-         */
-        // Top level <div>
-        this.numHolder = Selector(`${BASE_EL} .adyen-checkout__field--cardNumber`);
-        // The <span> that holds the iframe
-        this.numSpan = Selector(`${BASE_EL} .adyen-checkout__card__cardNumber__input`);
-
-        // The <img> el that holds the card brand logo (actually a child of this.numSpan)
-        this.brandingIcon = Selector(`${BASE_EL} .adyen-checkout__card__cardNumber__brandIcon`);
-
-        /**
-         * ExpiryDate
-         */
-        // Top level <div>
-        this.dateHolder = Selector(`${BASE_EL} .adyen-checkout__field__exp-date`);
-        // The <span> that holds the iframe
-        this.dateSpan = Selector(`${BASE_EL} .adyen-checkout__card__exp-date__input`);
-
-        /**
-         * CVC
-         */
-        // Top level <div>
-        this.cvcHolder = Selector(`${BASE_EL} .adyen-checkout__field__cvc`);
-        // The <span> that holds the iframe
-        this.cvcSpan = Selector(`${BASE_EL} .adyen-checkout__card__cvc__input`);
-
-        /**
-         * Dual branding
-         */
+        // Dual branding
         this.dualBrandingIconHolder = Selector(`${BASE_EL} .adyen-checkout__card__dual-branding__buttons`);
         this.dualBrandingIconHolderActive = Selector(`${BASE_EL} .adyen-checkout__card__dual-branding__buttons--active`);
         this.dualBrandingImages = this.dualBrandingIconHolderActive.find('img');
-
-        /**
-         * iframe utils
-         */
-        this.iframeSelector = getIframeSelector(`${BASE_EL} ${pmSelector} iframe`);
-        this.cardUtils = cu(this.iframeSelector);
     }
 
     getFromState = ClientFunction(path => {

--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
@@ -1,8 +1,13 @@
 import DropinPage from '../../_models/Dropin.page';
+import CardComponentPage from '../../_models/CardComponent.page';
 import { binLookupUrl, getBinLookupMock, turnOffSDKMocking } from '../../_common/cardMocks';
 import { DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../utils/constants';
 
-const dropinPage = new DropinPage('.adyen-checkout__payment-method--bcmc');
+const dropinPage = new DropinPage({
+    components: {
+        cc: new CardComponentPage('.adyen-checkout__payment-method--bcmc')
+    }
+});
 
 /**
  * NOTE - we are mocking the response until such time as we have the correct BIN in the Test DB
@@ -40,7 +45,7 @@ fixture`Testing Bancontact in Dropin`
 
 test('Check Bancontact comp is correctly presented at startup', async t => {
     // Wait for field to appear in DOM
-    await dropinPage.numSpan();
+    await t.wait(1000);
 
     await t.expect(dropinPage.brandsImages.count).eql(3);
 
@@ -56,32 +61,32 @@ test('Check Bancontact comp is correctly presented at startup', async t => {
         .ok();
 
     // Hidden cvc field
-    await t.expect(dropinPage.cvcHolder.filterHidden().exists).ok();
+    await t.expect(dropinPage.cc.cvcHolder.filterHidden().exists).ok();
 
     // BCMC logo in number field
     await t
-        .expect(dropinPage.numSpan.exists)
+        .expect(dropinPage.cc.numSpan.exists)
         .ok()
-        .expect(dropinPage.brandingIcon.withAttribute('alt', 'bcmc').exists)
+        .expect(dropinPage.cc.brandingIcon.withAttribute('alt', 'bcmc').exists)
         .ok();
 });
 
 test('Entering digits that our local regEx will recognise as Visa does not affect the UI', async t => {
-    await dropinPage.numSpan();
+    await dropinPage.cc.numSpan();
 
-    await dropinPage.cardUtils.fillCardNumber(t, '41');
+    await dropinPage.cc.cardUtils.fillCardNumber(t, '41');
 
     // BCMC logo still in number field
-    await t.expect(dropinPage.brandingIcon.withAttribute('alt', 'bcmc').exists).ok();
+    await t.expect(dropinPage.cc.brandingIcon.withAttribute('alt', 'bcmc').exists).ok();
 
     // Hidden cvc field
-    await t.expect(dropinPage.cvcHolder.filterHidden().exists).ok();
+    await t.expect(dropinPage.cc.cvcHolder.filterHidden().exists).ok();
 });
 
 test('Enter card number, that we mock to co-branded bcmc/visa ' + 'then complete expiryDate and expect comp to be valid', async t => {
-    await dropinPage.numSpan();
+    await dropinPage.cc.numSpan();
 
-    await dropinPage.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+    await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
 
     // Dual branded with bcmc logo shown first
     await t
@@ -92,7 +97,7 @@ test('Enter card number, that we mock to co-branded bcmc/visa ' + 'then complete
         .expect(dropinPage.dualBrandingImages.nth(1).withAttribute('data-value', 'visa').exists)
         .ok();
 
-    await dropinPage.cardUtils.fillDate(t, TEST_DATE_VALUE);
+    await dropinPage.cc.cardUtils.fillDate(t, TEST_DATE_VALUE);
 
     // Expect comp to now be valid
     await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(true);
@@ -105,11 +110,11 @@ test(
         'then click BCMC logo and expect comp to be valid again',
     async t => {
         // Wait for field to appear in DOM
-        await dropinPage.numSpan();
+        await dropinPage.cc.numSpan();
 
-        await dropinPage.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+        await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
 
-        await dropinPage.cardUtils.fillDate(t, TEST_DATE_VALUE);
+        await dropinPage.cc.cardUtils.fillDate(t, TEST_DATE_VALUE);
 
         // Expect comp to now be valid
         await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(true);
@@ -118,10 +123,10 @@ test(
         await t.click(dropinPage.dualBrandingImages.nth(1));
 
         // Visible CVC field
-        await t.expect(dropinPage.cvcHolder.filterVisible().exists).ok();
+        await t.expect(dropinPage.cc.cvcHolder.filterVisible().exists).ok();
 
         // Expect iframe to exist in CVC field and with aria-required set to true
-        await dropinPage.cardUtils.checkIframeForAttrVal(t, 2, 'encryptedSecurityCode', 'aria-required', 'true');
+        await dropinPage.cc.cardUtils.checkIframeForAttrVal(t, 2, 'encryptedSecurityCode', 'aria-required', 'true');
 
         // Expect comp not to be valid
         await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(false);
@@ -130,7 +135,7 @@ test(
         await t.click(dropinPage.dualBrandingImages.nth(0));
 
         // Hidden CVC field
-        await t.expect(dropinPage.cvcHolder.filterHidden().exists).ok();
+        await t.expect(dropinPage.cc.cvcHolder.filterHidden().exists).ok();
 
         // Expect comp to be valid
         await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(true);
@@ -144,11 +149,11 @@ test(
         'then enter CVC and expect comp to be valid',
     async t => {
         // Wait for field to appear in DOM
-        await dropinPage.numSpan();
+        await dropinPage.cc.numSpan();
 
-        await dropinPage.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+        await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
 
-        await dropinPage.cardUtils.fillDate(t, TEST_DATE_VALUE);
+        await dropinPage.cc.cardUtils.fillDate(t, TEST_DATE_VALUE);
 
         // Expect comp to now be valid
         await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(true);
@@ -160,7 +165,7 @@ test(
         await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(false);
 
         // fill CVC
-        await dropinPage.cardUtils.fillCVC(t, TEST_CVC_VALUE);
+        await dropinPage.cc.cardUtils.fillCVC(t, TEST_CVC_VALUE);
 
         // Expect comp to now be valid
         await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(true);


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
re. e2e tests
Following a suggestion from @ribeiroguilherme - the `DropinPage` model is now instantiated with an object containing refs to other page models.
This allows us to isolate code in our Component pages and reuse them within the Dropin page.

## Tested scenarios
All e2e tests pass
