### PR TITLE
Fix/a11y issues

### DIFF
--- a/packages/e2e/tests/cards/kcp/startWithKCP/startWithKCP.test.js
+++ b/packages/e2e/tests/cards/kcp/startWithKCP/startWithKCP.test.js
@@ -38,6 +38,9 @@ test(
         'then check card state for taxNumber & password entries, ' +
         'then replace card number with non-korean card and check taxNumber and password state are cleared',
     async t => {
+        // For some reason, at full speed, testcafe can fail to fill in the taxNumber correctly
+        await t.setTestSpeed(0.9);
+
         await cardPage.numHolder();
 
         // Complete form with korean card number
@@ -79,6 +82,9 @@ test(
         'then complete form and expect component to be valid & to be able to pay,' +
         'then replace card number with korean card and expect component to be valid & to be able to pay',
     async t => {
+        // For some reason, at full speed, testcafe can fail to fill in the taxNumber correctly
+        await t.setTestSpeed(0.9);
+
         await cardPage.numHolder();
 
         // handler for alert that's triggered on successful payment

--- a/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
+++ b/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
@@ -16,6 +16,9 @@ test(
         'then check new iframe field is correctly set up, ' +
         'then complete the form & check component becomes valid',
     async t => {
+        // For some reason, at full speed, testcafe can fail to fill in the taxNumber correctly
+        await t.setTestSpeed(0.9);
+
         // Wait for field to appear in DOM
         await cardPage.numHolder();
 
@@ -51,6 +54,9 @@ test(
         'then fill in all KCP details & check card state for taxNumber & password entries, ' +
         'then delete card number and check taxNumber and password state are cleared',
     async t => {
+        // For some reason, at full speed, testcafe can fail to fill in the taxNumber correctly
+        await t.setTestSpeed(0.9);
+
         await cardPage.numHolder();
 
         // Complete form with korean card number
@@ -89,6 +95,9 @@ test(
         'then complete form and expect component to be valid & to be able to pay,' +
         'then replace card number with non-korean card and expect component to be valid & to be able to pay',
     async t => {
+        // For some reason, at full speed, testcafe can fail to fill in the taxNumber correctly
+        await t.setTestSpeed(0.9);
+
         await cardPage.numHolder();
 
         // handler for alert that's triggered on successful payment
@@ -131,6 +140,9 @@ test(
         'then complete form except for password field,' +
         'expect component not to be valid and for password field to show error',
     async t => {
+        // For some reason, at full speed, testcafe can fail to fill in the taxNumber correctly
+        await t.setTestSpeed(0.9);
+
         await cardPage.numHolder();
 
         // Complete form with korean card number

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.default.size.test.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.default.size.test.js
@@ -83,7 +83,7 @@ test('Fill in card number that will trigger full flow (fingerprint & challenge)'
 
     // Check the value of the alert text
     const history = await t.getNativeDialogHistory();
-    await t.expect(history[0].text).eql('Authorised');
+    await t.expect(history[0].text).eql('Authorised', { timeout: 3000 });
 });
 
 test('Fill in card number that will trigger challenge-only flow', async t => {
@@ -123,5 +123,5 @@ test('Fill in card number that will trigger challenge-only flow', async t => {
 
     // Check the value of the alert text
     const history = await t.getNativeDialogHistory();
-    await t.expect(history[0].text).eql('Authorised');
+    await t.expect(history[0].text).eql('Authorised', { timeout: 3000 });
 });

--- a/packages/e2e/tests/utils/commonUtils.js
+++ b/packages/e2e/tests/utils/commonUtils.js
@@ -6,7 +6,7 @@ export const getInputSelector = (fieldType, withSelector = false) => {
 };
 
 export const getAriaErrorField = (fieldType, withSelector = false) => {
-    const selStr = `#${fieldType}-ariaErrorField`;
+    const selStr = `#${fieldType}-ariaError`;
     return withSelector ? Selector(selStr) : selStr;
 };
 

--- a/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
@@ -18,6 +18,7 @@ export default function BrandIcon({ brand, brandsConfiguration = {} }: BrandIcon
             onError={handleError}
             alt={brand}
             src={imageUrl}
+            aria-hidden={'true'}
         />
     );
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
@@ -11,7 +11,7 @@ export default function CVCHint({ frontCVC = false }: CVCHintProps) {
 
     /* eslint-disable max-len */
     return (
-        <div className={hintClassnames}>
+        <div className={hintClassnames} aria-hidden={true}>
             <svg
                 className={'adyen-checkout__card__cvc__hint adyen-checkout__card__cvc__hint--front'}
                 width="27"

--- a/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
@@ -23,6 +23,7 @@ const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected, brandsConfig
             src={imageUrl}
             onClick={onClick}
             data-value={dataValue}
+            aria-hidden={'true'}
         />
     );
 };

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodIcon.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodIcon.tsx
@@ -30,7 +30,6 @@ const PaymentMethodIcon = ({ src, altDescription, type, disabled = false }: Paym
                 className={`adyen-checkout__payment-method__image ${styles['adyen-checkout__payment-method__image']}`}
                 src={src}
                 alt={altDescription}
-                focusable="false"
             />
         </span>
     );

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -16,7 +16,7 @@ export const GIFT_CARD = 'giftcard';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.7.1';
+export const SF_VERSION = '3.7.2';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
@@ -2,7 +2,11 @@ export default function createIframe({ src, title = 'iframe element', policy = '
     const iframeEl = document.createElement('iframe');
     iframeEl.setAttribute('src', src);
     iframeEl.setAttribute('class', 'js-iframe');
-    iframeEl.setAttribute('title', title);
+    if (title !== '' && title.trim().length !== 0) {
+        iframeEl.setAttribute('title', title);
+    } else {
+        iframeEl.setAttribute('role', 'presentation');
+    }
     iframeEl.setAttribute('frameborder', '0'); // deprecated but still necessary for IE TODO re-test this on next round of IE testing
     iframeEl.setAttribute('scrolling', 'no');
     iframeEl.setAttribute('allowtransparency', 'true');

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
@@ -1,4 +1,9 @@
-export default function createIframe({ src, title = 'iframe element', policy = 'origin', styleStr = 'border: none; height:100%; width:100%;' }) {
+export default function createIframe({
+    src,
+    title = 'iframe element',
+    policy = 'origin',
+    styleStr = 'border: none; height:100%; width:100%; overflow:hidden;'
+}) {
     const iframeEl = document.createElement('iframe');
     iframeEl.setAttribute('src', src);
     iframeEl.setAttribute('class', 'js-iframe');
@@ -7,8 +12,6 @@ export default function createIframe({ src, title = 'iframe element', policy = '
     } else {
         iframeEl.setAttribute('role', 'presentation');
     }
-    iframeEl.setAttribute('frameborder', '0'); // deprecated but still necessary for IE TODO re-test this on next round of IE testing
-    iframeEl.setAttribute('scrolling', 'no');
     iframeEl.setAttribute('allowtransparency', 'true');
     iframeEl.setAttribute('style', styleStr);
     iframeEl.setAttribute('referrerpolicy', policy); // Necessary for ClientKey to work

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/createIframe.ts
@@ -7,11 +7,13 @@ export default function createIframe({
     const iframeEl = document.createElement('iframe');
     iframeEl.setAttribute('src', src);
     iframeEl.setAttribute('class', 'js-iframe');
-    if (title !== '' && title.trim().length !== 0) {
-        iframeEl.setAttribute('title', title);
-    } else {
+    // For a11y some merchants want to be able to remove the title element on the iframe - seeing the info it carries as extraneous for the screenreader
+    if (title === '' || title.trim().length === 0 || title === 'none') {
         iframeEl.setAttribute('role', 'presentation');
+    } else {
+        iframeEl.setAttribute('title', title);
     }
+
     iframeEl.setAttribute('allowtransparency', 'true');
     iframeEl.setAttribute('style', styleStr);
     iframeEl.setAttribute('referrerpolicy', policy); // Necessary for ClientKey to work


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Tackling a11y issues in COWEB-982:
- adding `aria-hidden="true"` on cvc hint div
       re. FOC-54217 (a11y spreadsheet ticket 4)
- adding `aria-hidden="true"` on card brand logos in CardNumber field
      re. COWEB-1032 (a11y spreadsheet ticket 9.3)
- Add possibility to configure securedFields iframe `title` to not exist and instead replace it with `role="presentation"`.  
      re. COWEB-1032 (a11y spreadsheet ticket 9.1)
- Removed `focusable` attr on the `<img>` elements for the card brands list in the Dropin
      re. COWEB-983 (a11y spreadsheet ticket 1.1)
- Removed deprecated `scrolling` & `frameborder` attributes from securedFields iframe
      re. COWEB-983 (a11y spreadsheet ticket 1.2)

## Tested scenarios
re. removing `scrolling` & `frameborder` attributes from securedFields iframe - iframe still works in IE11 (tested in Browserstack Windows 8.1 & 10)


**Fixed issue**:  (see refs above)
