### PR TITLE
Fixes padding for payment method focus state

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.scss
@@ -38,6 +38,10 @@
     position: relative;
     transition: background .1s ease-out;
     width: 100%;
+
+    .adyen-checkout__payment-method__header__title {
+        padding: $spacing-none;
+    }
 }
 
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
@@ -55,15 +55,16 @@
     justify-content: space-between;
     font-weight: 400;
     font-size: $font-size-medium;
-    padding: $spacing-medium - $spacing-xsmall;
-    padding-left: $spacing-xxlarge - $spacing-xsmall;
+    $payment-button-padding: $spacing-xsmall;
+    padding: $spacing-medium - $payment-button-padding;
+    padding-left: $spacing-xxlarge - $payment-button-padding;
     position: relative;
     transition: background 0.1s ease-out;
     width: 100%;
 
     [dir='rtl'] & {
-        padding: $spacing-medium - $spacing-xsmall;
-        padding-right: $spacing-xxlarge - $spacing-xsmall;
+        padding: $spacing-medium - $payment-button-padding;
+        padding-right: $spacing-xxlarge - $payment-button-padding;
     }
 
     .adyen-checkout__payment-method--standalone & {

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
@@ -55,15 +55,15 @@
     justify-content: space-between;
     font-weight: 400;
     font-size: $font-size-medium;
-    padding: 16px;
-    padding-left: 48px;
+    padding: $spacing-medium - $spacing-xsmall;
+    padding-left: $spacing-xxlarge - $spacing-xsmall;
     position: relative;
     transition: background 0.1s ease-out;
     width: 100%;
 
     [dir='rtl'] & {
-        padding: 16px;
-        padding-right: 48px;
+        padding: $spacing-medium - $spacing-xsmall;
+        padding-right: $spacing-xxlarge - $spacing-xsmall;
     }
 
     .adyen-checkout__payment-method--standalone & {
@@ -81,7 +81,7 @@
     border: none;
     background: none;
     cursor: pointer;
-    padding: 0;
+    padding: $spacing-xsmall;
     color: $color-black;
     font-size: 1em;
     font-weight: 400;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Focus state border was right against the text and icon of the payment method button. This improves it by adding some padding and remove some padding from its container.

## Tested scenarios
<!-- Description of tested scenarios -->
- Tested focus on payment methods
- Tested partial payments / order payments for side effects

**Fixed issue**:  <!-- #-prefixed issue number -->
