### PR TITLE
Prevent session submitDetails call when onAdditionalDetails event is present

### DIFF
--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -110,8 +110,12 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> {
     };
 
     protected handleAdditionalDetails = state => {
-        if (this.props.onAdditionalDetails) this.props.onAdditionalDetails(state, this.elementRef);
-        if (this.props.session) this.submitAdditionalDetails(state.data);
+        if (this.props.onAdditionalDetails) {
+            this.props.onAdditionalDetails(state, this.elementRef);
+        } else if (this.props.session) {
+            this.submitAdditionalDetails(state.data);
+        }
+
         return state;
     };
 


### PR DESCRIPTION
## Summary
When using the Checkout Session flow, but implementing only the `onAdditionalDetails` event, the session automatic details call still gets triggered. This behavior is not desired, as only one should be called.

This PR ensures the `onAdditionalDetails` event gets called exclusively if present.

## Tested scenarios
- If `onAdditionalDetails` is present, it will be called and the internal session details call won't.
- If no `onAdditionalDetails` is present and a `session` is, the internal session details call is correctly triggered.