### PR TITLE
Dragonpay - Hiding issuer image for otc_philippines tx variant

### DIFF
--- a/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.test.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.test.tsx
@@ -1,0 +1,18 @@
+import { h } from 'preact';
+import { shallow } from 'enzyme';
+import DragonpayVoucherResult from './DragonpayVoucherResult';
+import Voucher from '../../../internal/Voucher';
+
+describe('DragonpayVoucherResult', () => {
+    test('should not render issuer image for dragonpay_otc_philippines', () => {
+        const wrapper = shallow(<DragonpayVoucherResult issuer="BPXB" paymentMethodType="dragonpay_otc_philippines" />);
+        const voucher = wrapper.find('Voucher');
+        expect(voucher.props()).toHaveProperty('issuerImageUrl', null);
+    });
+
+    test('should render issuer image for dragonpay_otc_non_banking', () => {
+        const wrapper = shallow(<DragonpayVoucherResult issuer="BPXB" paymentMethodType="dragonpay_otc_non_banking" />);
+        const voucher = wrapper.find('Voucher');
+        expect(voucher.props()).toHaveProperty('issuerImageUrl', 'images/logos/dragonpay_otc_non_banking/bpxb.svg');
+    });
+});

--- a/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.tsx
@@ -8,7 +8,8 @@ import { VoucherDetail } from '../../../internal/Voucher/types';
 export default function DragonpayVoucherResult(props: DragonpayVoucherResultProps) {
     const { reference, totalAmount, surcharge, expiresAt, alternativeReference, instructionsUrl, icon, issuer, paymentMethodType } = props;
     const { loadingContext, i18n } = useCoreContext();
-    const issuerImageUrl = getIssuerImageUrl({ loadingContext }, paymentMethodType)(issuer.toLowerCase());
+    const issuerImageUrl =
+        paymentMethodType !== 'dragonpay_otc_philippines' ? getIssuerImageUrl({ loadingContext }, paymentMethodType)(issuer.toLowerCase()) : null;
 
     return (
         <Voucher

--- a/packages/lib/src/components/internal/Voucher/Voucher.test.tsx
+++ b/packages/lib/src/components/internal/Voucher/Voucher.test.tsx
@@ -20,10 +20,18 @@ describe('Voucher', () => {
     });
 
     test('Render VoucherDetails', () => {
-        const voucherDetails = [{ label: 'item 1', value: '1' }, { label: 'item 2', value: '2' }];
+        const voucherDetails = [
+            { label: 'item 1', value: '1' },
+            { label: 'item 2', value: '2' }
+        ];
         const wrapper = mount(<Voucher {...outputDetails} voucherDetails={voucherDetails} />);
         expect(wrapper.find('.adyen-checkout__voucher-result__amount').text()).toBe('100');
         expect(wrapper.find('.adyen-checkout__link--voucher-result-instructions').length).toBe(1);
         expect(wrapper.find('.adyen-checkout__voucher-result__code > span').text()).toBe('123456');
+    });
+
+    test('should not render issuer image if issuerImageUrl prop is not provided', () => {
+        const wrapper = mount(<Voucher {...outputDetails} issuerImageUrl={null} />);
+        expect(wrapper.find('.adyen-checkout__voucher-result__image__issuer').exists()).toBeFalsy();
     });
 });


### PR DESCRIPTION
## Summary
- Hiding issuer logo image for `dragonpay_otc_philippines` tx variant

## Tested scenarios
- Create `dragonpay_otc_philippines` using `createFromAction` on our `Vouchers` page in the playground, and check that issuer image does not show
