### PR TITLE
ApplePayElement returns browserInfo

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -10,6 +10,7 @@ import { preparePaymentRequest } from './payment-request';
 import { resolveSupportedVersion, mapBrands } from './utils';
 import { ApplePayElementProps, ApplePayElementData, ApplePaySessionRequest } from './types';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
+import collectBrowserInfo from '../../utils/browserInfo';
 
 const latestSupportedVersion = 11;
 
@@ -49,7 +50,8 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
             paymentMethod: {
                 type: ApplePayElement.type,
                 ...this.state
-            }
+            },
+            browserInfo: this.browserInfo
         };
     }
 
@@ -114,6 +116,10 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
      */
     get isValid(): boolean {
         return true;
+    }
+
+    get browserInfo() {
+        return collectBrowserInfo();
     }
 
     /**

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -1,4 +1,4 @@
-import { PaymentAmount } from '../../types';
+import { BrowserInfo, PaymentAmount } from '../../types';
 import { UIElementProps } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -166,6 +166,7 @@ export interface ApplePayElementData {
         type: string;
         applePayToken: string;
     };
+    browserInfo: BrowserInfo;
 }
 
 export interface ApplePaySessionRequest {


### PR DESCRIPTION
ApplePay component returns `browserInfo` object, as GooglePay and DropIn components do.