### PR TITLE
Release 5.3.1

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -44,6 +44,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "5.3.0"
+        "@adyen/adyen-web": "5.3.1"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,7 +22,7 @@
         "./dist/adyen.css": "./dist/adyen.css",
         "./package.json": "./package.json"
     },
-    "version": "5.3.0",
+    "version": "5.3.1",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -16,7 +16,7 @@ export const GIFT_CARD = 'giftcard';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.7.3';
+export const SF_VERSION = '3.7.2';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -46,6 +46,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "5.3.0"
+        "@adyen/adyen-web": "5.3.1"
     }
 }


### PR DESCRIPTION
## Summary

- Reverting Secured fields version to `3.7.2`, as `3.7.3` isn't available live yet