### PR TITLE
Adjusting text field to handle fullwidth characters

### DIFF
--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState } from 'preact/hooks';
+import { useState, useCallback, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 import { convertFullToHalf } from './utils';
 import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
@@ -8,11 +8,27 @@ export default function InputBase(props) {
     const { autoCorrect, classNameModifiers, isInvalid, isValid, readonly = null, spellCheck, type, uniqueId } = props;
 
     const [handleChangeHasFired, setHandleChangeHasFired] = useState(false);
+    const isOnComposition = useRef<boolean>(false);
 
     const handleInput = e => {
+        if (isOnComposition.current) return;
+
         e.target.value = convertFullToHalf(e.target.value);
         props.onInput(e);
     };
+
+    const handleOnCompositionStart = useCallback(() => {
+        isOnComposition.current = true;
+    }, []);
+
+    const handleOnCompositionUpdate = useCallback((event: h.JSX.TargetedCompositionEvent<HTMLInputElement>) => {
+        props.onInput(event);
+    }, []);
+
+    const handleOnCompositionEnd = useCallback((event: h.JSX.TargetedCompositionEvent<HTMLInputElement>) => {
+        isOnComposition.current = false;
+        handleInput(event);
+    }, []);
 
     const handleChange = e => {
         setHandleChangeHasFired(true);
@@ -55,6 +71,11 @@ export default function InputBase(props) {
             aria-describedby={`${uniqueId}${ARIA_ERROR_SUFFIX}`}
             onChange={handleChange}
             onBlur={handleBlur}
+            /* eslint-disable react/no-unknown-property */
+            oncompositionstart={handleOnCompositionStart}
+            oncompositionupdate={handleOnCompositionUpdate}
+            oncompositionend={handleOnCompositionEnd}
+            /* eslint-enable react/no-unknown-property */
         />
     );
 }


### PR DESCRIPTION
## Summary

Our text field wasn't handling fullwidth characters gracefully, due to the fact that we were not using `composition` events in order to accept text inputed by an IME.

When typing Japanese for example, the IME is activated and the user combine letters and the IME suggest words. This interaction wasn't working before.

## Tested scenarios
- Unit tests , e2e-tests
- Used iOS Simulator to simulate iPhone using Japanese keyboard
- Tested on Windows 10 with Japanese keyboard

**Fixed issue**:  <!-- #-prefixed issue number -->
COWEB-1049
