### PR TITLE
Validating remote assets before merging to master

### DIFF
--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -22,9 +22,9 @@ jobs:
           echo "${{ env.SF_VERSION }}"
 
       - name: Encoding base64
-          run: |
-            BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
-            echo $BTOA_TEST_ORIGIN
+        run: |
+          BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
+          echo $BTOA_TEST_ORIGIN
 #            echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
 
       - name: Showing base64

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -28,8 +28,8 @@ jobs:
 #            echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
 
       - name: Showing base64
-          run: |
-            echo "${{ env.BTOA_TEST_ORIGIN }}"
+        run: |
+          echo "${{ env.BTOA_TEST_ORIGIN }}"
 
       - name: Requesting securedFields
         id: securedFieldsRequest

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -38,4 +38,4 @@ jobs:
           customHeaders: '{"Access-Control-Allow-Origin": "${{secrets.TEST_ORIGIN}}"}'
 
       - name: Log the result
-        run: echo ${{ steps.securedFieldsRequest.outputs.response }}
+        run: echo ${{ steps.securedFieldsRequest.outputs }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -1,10 +1,7 @@
 name: Validate remote assets
 
 on:
-  pull_request:
-    branches-ignore:
-      - '*'
-      - '!feature/**'
+  pull_request: [ 'feature/**' ]
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,12 +23,12 @@ jobs:
 
       - name: Encoding base64
         run: |
-          BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
+          BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64) \
           echo $BTOA_TEST_ORIGIN >> $GITHUB_ENV
 
       - name: Showing base64
         run: |
-          echo "${{ env.BTOA_TEST_ORIGIN }}"
+          echo Hi "${{ env.BTOA_TEST_ORIGIN }}"
 
       - name: Requesting securedFields
         id: securedFieldsRequest

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -17,28 +17,16 @@ jobs:
         run: |
           echo "SF_VERSION=$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)" >> $GITHUB_ENV
 
-      - name: Showing SF_VERSION
-        run: |
-          echo "${{ env.SF_VERSION }}"
-
       - name: Encoding base64
         run: |
           echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
-
-      - name: Showing base64
-        run: |
-          echo "${{ env.BTOA_TEST_ORIGIN }}"
-
-      - name: Testing status code
-        run: |
-          echo "$(curl -s -o /dev/null -w '%{http_code}' https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.5/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}})"
 
       - name: Requesting securedFields
         id: securedFieldsRequest
 #        continue-on-error: true
         uses: fjogeleit/http-request-action@master
         with:
-          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.9/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
+          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/${{ env.SF_VERSION }}/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
           method: "GET"
           customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 
@@ -49,6 +37,3 @@ jobs:
       - name: Message if success
         if: success()
         run: echo "success"
-
-#      - name: Log the result
-#        run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -35,11 +35,20 @@ jobs:
 
       - name: Requesting securedFields
         id: securedFieldsRequest
+        continue-on-error: true
         uses: fjogeleit/http-request-action@master
         with:
           url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.9/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
           method: "GET"
           customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 
-      - name: Log the result
-        run: echo ${{ steps.securedFieldsRequest.outputs.response }}
+      - name: Message if failed
+        if: failure()
+        run: echo "failed"
+
+      - name: Message if failed
+        if: success()
+        run: echo "success"
+
+#      - name: Log the result
+#        run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -32,8 +32,19 @@ jobs:
 
       - name: Message if failed
         if: failure()
-        run: echo "failed"
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: '❌ SecuredFields might not be available live ❌' });
+
 
       - name: Message if success
         if: success()
-        run: echo "success"
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: '🔒 SecuredFields are available live 🔒' });

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -1,10 +1,11 @@
 name: Validate remote assets
 
-on: [push]
-  #pull_request:
-   # branches:
-    #  - main # to be removed
-     # - 'releases/**'
+on:
+  pull_request:
+    branches:
+#      - main # to be removed
+#      - 'releases/**'
+      - 'feature/**'
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   check-secured-fields-assets:
+    if: contains(github.head_ref, 'feature')
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Testing status code
         run: |
-          echo "curl -s -o /dev/null -w '%{http_code}' https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
+          echo "$(curl -s -o /dev/null -w '%{http_code}' https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}})"
 
 #      - name: Requesting securedFields
 #        id: securedFieldsRequest

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -27,7 +27,7 @@ jobs:
 #        continue-on-error: true
         uses: fjogeleit/http-request-action@master
         with:
-          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/${{ env.SF_VERSION }}/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
+          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.9.0/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
           method: "GET"
           customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -12,15 +12,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Getting SF_VERSION
+      - name: Getting SF_VERSION in the codebase
         run: |
           echo "SF_VERSION=$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)" >> $GITHUB_ENV
 
-      - name: Encoding base64
+      - name: Encoding test origin URL to base64
         run: |
           echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
 
-      - name: Requesting securedFields
+      - name: Requesting securedFields in production
         id: securedFieldsRequest
         uses: fjogeleit/http-request-action@master
         with:
@@ -28,17 +28,17 @@ jobs:
           method: "GET"
           customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 
-      - name: Message if failed
+      - name: Comment PR that request failed
         if: failure()
         uses: actions/github-script@0.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: '⚠️ WARNING: SecuredFields v${{ env.SF_VERSION }} might not be available live. ⚠️ });
+            github.issues.createComment({ issue_number, owner, repo, body: '⚠️ WARNING: SecuredFields v${{ env.SF_VERSION }} might not be available live ⚠️ });
 
 
-      - name: Message if success
+      - name: Comment PR that request succeeded
         if: success()
         uses: actions/github-script@0.3.0
         with:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-secured-fields-assets:
-    if: contains(github.head_ref, 'feature')
+    if: contains(github.head_ref, 'release')
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -3,7 +3,8 @@ name: Validate remote assets
 on:
   pull_request:
     branches:
-      - 'feature/*'
+      - master
+      - 'feature/**'
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -3,7 +3,7 @@ name: Validate remote assets
 on:
   pull_request:
     branches:
-      - 'feature/**'
+      - master
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{secrets.TEST_ORIGIN}}"
           method: "GET"
-          customHeaders: "{ 'Access-Control-Allow-Origin': '${{secrets.TEST_ORIGIN}}' }"
+          customHeaders: '{"Access-Control-Allow-Origin": "${{secrets.TEST_ORIGIN}}"}'
 
       - name: Log the result
         run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,7 +23,8 @@ jobs:
 
       - name: Encoding base64
         run: |
-          BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64) \
+          BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
+          echo $BTOA_TEST_ORIGIN
           echo $BTOA_TEST_ORIGIN >> $GITHUB_ENV
 
       - name: Showing base64

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Encoding base64
           run: |
-            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64) >> $GITHUB_ENV
-            
+            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
+
       - name: Showing base64
           run: |
             echo "${{ env.BTOA_TEST_ORIGIN }}"

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Requesting securedFields
         id: securedFieldsRequest
-        continue-on-error: true
+#        continue-on-error: true
         uses: fjogeleit/http-request-action@master
         with:
           url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.9/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
@@ -46,7 +46,7 @@ jobs:
         if: failure()
         run: echo "failed"
 
-      - name: Message if failed
+      - name: Message if success
         if: success()
         run: echo "success"
 

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -33,7 +33,7 @@ jobs:
         id: securedFieldsRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{secrets.TEST_ORIGIN}}"
+          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
           method: "GET"
           customHeaders: '{"Access-Control-Allow-Origin": "${{secrets.TEST_ORIGIN}}"}'
 

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -25,11 +25,11 @@ jobs:
         run: |
           BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
           echo $BTOA_TEST_ORIGIN
-          echo $BTOA_TEST_ORIGIN >> $GITHUB_ENV
+          $BTOA_TEST_ORIGIN >> $GITHUB_ENV
 
       - name: Showing base64
         run: |
-          echo Hi "${{ env.BTOA_TEST_ORIGIN }}"
+          echo "${{ env.BTOA_TEST_ORIGIN }}"
 
       - name: Requesting securedFields
         id: securedFieldsRequest

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Testing status code
         run: |
-          echo "$(curl -s -o /dev/null -w '%{http_code}' https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}})"
+          echo "$(curl -s -o /dev/null -w '%{http_code}' https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.5/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}})"
 
 #      - name: Requesting securedFields
 #        id: securedFieldsRequest

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -3,8 +3,7 @@ name: Validate remote assets
 on:
   pull_request:
     branches:
-      - master
-      - 'feature/**'
+      - feature/**
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Encoding base64
           run: |
-            echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
+            BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
+            echo $BTOA_TEST_ORIGIN
+#            echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
 
       - name: Showing base64
           run: |

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -1,11 +1,9 @@
 name: Validate remote assets
 
-on: [pull_request]
-#  pull_request:
-#    branches:
-#      - main # to be removed
-#      - 'releases/**'
-#      - 'feature/**'
+on:
+  pull_request:
+    branches:
+      - 'feature/**'
 
 jobs:
   check-secured-fields-assets:
@@ -27,7 +25,7 @@ jobs:
 #        continue-on-error: true
         uses: fjogeleit/http-request-action@master
         with:
-          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.9.0/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
+          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/${{ env.SF_VERSION }}/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
           method: "GET"
           customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -20,3 +20,12 @@ jobs:
       - name: Showing SF_VERSION
         run: |
           echo "${{ env.SF_VERSION }}"
+
+      - name: Requesting securedFields
+        id: securedFieldsRequest
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{secrets.TEST_ORIGIN}}"
+
+      - name: Log the result
+        run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -29,13 +29,17 @@ jobs:
         run: |
           echo "${{ env.BTOA_TEST_ORIGIN }}"
 
-      - name: Requesting securedFields
-        id: securedFieldsRequest
-        uses: fjogeleit/http-request-action@master
-        with:
-          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
-          method: "GET"
-          customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
+      - name: Testing status code
+        run: |
+          echo "curl -s -o /dev/null -w '%{http_code}' https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
+
+#      - name: Requesting securedFields
+#        id: securedFieldsRequest
+#        uses: fjogeleit/http-request-action@master
+#        with:
+#          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
+#          method: "GET"
+#          customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 
       - name: Log the result
         run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
           method: "GET"
-          customHeaders: '{"Access-Control-Allow-Origin": "${{secrets.TEST_ORIGIN}}"}'
+          customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 
       - name: Log the result
-        run: echo ${{ steps.securedFieldsRequest.outputs }}
+        run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Encoding base64
         run: |
           BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
-          echo $BTOA_TEST_ORIGIN
-#            echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
+          echo $BTOA_TEST_ORIGIN >> $GITHUB_ENV
 
       - name: Showing base64
         run: |

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{secrets.TEST_ORIGIN}}"
           method: "GET"
+          customHeaders: "{ 'Access-Control-Allow-Origin': '${{secrets.TEST_ORIGIN}}' }"
 
       - name: Log the result
         run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -1,0 +1,35 @@
+name: Validate remote assets
+
+on: [push]
+  #pull_request:
+   # branches:
+    #  - main # to be removed
+     # - 'releases/**'
+
+jobs:
+  check-secured-fields-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Testing grep value
+        run: |
+          grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2
+  
+      - name: Testing grep value 2
+        run: |
+          grep -e 'SF_VERSION' $GITHUB_WORKSPACE/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2
+
+      - name: Get SF version
+        run: |
+          echo ::set-env name=SF_VERSION::$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)
+
+      #- name: Get SF version 2
+      #  run: |
+      #   echo ::set-env name=SF_VERSION::$(grep -e 'SF_VERSION' $GITHUB_WORKSPACE/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)
+
+      - name: Show SF version
+        run: |
+          echo ${{ env.SF_VERSION }}
+

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -3,7 +3,7 @@ name: Validate remote assets
 on:
   pull_request:
     branches:
-      - 'feature/**'
+      - 'feature/*'
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -16,20 +16,24 @@ jobs:
       - name: Testing grep value
         run: |
           grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2
-  
+
       - name: Testing grep value 2
         run: |
-          grep -e 'SF_VERSION' $GITHUB_WORKSPACE/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2
+          echo "SF_VERSION=$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)" >> $GITHUB_ENV
 
-      - name: Get SF version
+      - name: Shwoing version
         run: |
-          echo ::set-env name=SF_VERSION::$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)
+          echo "${{ env.SF_VERSION }}"
+
+      #- name: Get SF version
+      #  run: |
+      #    echo ::set-env name=SF_VERSION::$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)
 
       #- name: Get SF version 2
       #  run: |
       #   echo ::set-env name=SF_VERSION::$(grep -e 'SF_VERSION' $GITHUB_WORKSPACE/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)
 
-      - name: Show SF version
-        run: |
-          echo ${{ env.SF_VERSION }}
+      #- name: Show SF version
+      #  run: |
+      #    echo ${{ env.SF_VERSION }}
 

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -3,7 +3,7 @@ name: Validate remote assets
 on:
   pull_request:
     branches:
-      - feature/**
+      - 'feature/**'
 
 jobs:
   check-secured-fields-assets:
@@ -22,7 +22,6 @@ jobs:
 
       - name: Requesting securedFields
         id: securedFieldsRequest
-#        continue-on-error: true
         uses: fjogeleit/http-request-action@master
         with:
           url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/${{ env.SF_VERSION }}/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Encoding base64
           run: |
-            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64) >> $GITHUB_ENV
+            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64) >> $GITHUB_ENV \
             echo "${{ env.BTOA_TEST_ORIGIN }}"
 
       - name: Requesting securedFields

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -2,8 +2,9 @@ name: Validate remote assets
 
 on:
   pull_request:
-    branches:
-      - 'feature/**'
+    branches-ignore:
+      - '*'
+      - '!feature/**'
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -13,27 +13,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Testing grep value
-        run: |
-          grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2
-
-      - name: Testing grep value 2
+      - name: Getting SF_VERSION
         run: |
           echo "SF_VERSION=$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)" >> $GITHUB_ENV
 
-      - name: Shwoing version
+      - name: Showing SF_VERSION
         run: |
           echo "${{ env.SF_VERSION }}"
-
-      #- name: Get SF version
-      #  run: |
-      #    echo ::set-env name=SF_VERSION::$(grep -e 'SF_VERSION' packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)
-
-      #- name: Get SF version 2
-      #  run: |
-      #   echo ::set-env name=SF_VERSION::$(grep -e 'SF_VERSION' $GITHUB_WORKSPACE/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts | cut -d "'" -f2)
-
-      #- name: Show SF version
-      #  run: |
-      #    echo ${{ env.SF_VERSION }}
-

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,7 +23,10 @@ jobs:
 
       - name: Encoding base64
           run: |
-            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64) >> $GITHUB_ENV \
+            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64) >> $GITHUB_ENV
+            
+      - name: Showing base64
+          run: |
             echo "${{ env.BTOA_TEST_ORIGIN }}"
 
       - name: Requesting securedFields

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -26,6 +26,7 @@ jobs:
         uses: fjogeleit/http-request-action@master
         with:
           url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{secrets.TEST_ORIGIN}}"
+          method: "GET"
 
       - name: Log the result
         run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Encoding base64
           run: |
-            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
+            echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
 
       - name: Showing base64
           run: |

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -23,9 +23,7 @@ jobs:
 
       - name: Encoding base64
         run: |
-          BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)
-          echo $BTOA_TEST_ORIGIN
-          $BTOA_TEST_ORIGIN >> $GITHUB_ENV
+          echo "BTOA_TEST_ORIGIN=$(echo ${{ secrets.TEST_ORIGIN }} | base64)" >> $GITHUB_ENV
 
       - name: Showing base64
         run: |

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -33,13 +33,13 @@ jobs:
         run: |
           echo "$(curl -s -o /dev/null -w '%{http_code}' https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.5/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}})"
 
-#      - name: Requesting securedFields
-#        id: securedFieldsRequest
-#        uses: fjogeleit/http-request-action@master
-#        with:
-#          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.3/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
-#          method: "GET"
-#          customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
+      - name: Requesting securedFields
+        id: securedFieldsRequest
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: "https://checkoutshopper-live-us.adyen.com/checkoutshopper/securedfields/${{secrets.TEST_CLIENT_KEY}}/3.7.9/securedFields.html?type=card&d=${{env.BTOA_TEST_ORIGIN}}"
+          method: "GET"
+          customHeaders: '{"Origin": "${{secrets.TEST_ORIGIN}}"}'
 
       - name: Log the result
         run: echo ${{ steps.securedFieldsRequest.outputs.response }}

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -1,11 +1,11 @@
 name: Validate remote assets
 
-on:
-  pull_request:
-    branches:
+on: [pull_request]
+#  pull_request:
+#    branches:
 #      - main # to be removed
 #      - 'releases/**'
-      - 'feature/**'
+#      - 'feature/**'
 
 jobs:
   check-secured-fields-assets:

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -1,7 +1,9 @@
 name: Validate remote assets
 
 on:
-  pull_request: [ 'feature/**' ]
+  pull_request:
+    branches:
+      - 'feature/**'
 
 jobs:
   check-secured-fields-assets:
@@ -33,7 +35,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: '❌ SecuredFields might not be available live ❌' });
+            github.issues.createComment({ issue_number, owner, repo, body: '⚠️ WARNING: SecuredFields v${{ env.SF_VERSION }} might not be available live. ⚠️ });
 
 
       - name: Message if success
@@ -43,4 +45,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: '🔒 SecuredFields are available live 🔒' });
+            github.issues.createComment({ issue_number, owner, repo, body: '✅ SecuredFields v${{ env.SF_VERSION }} are available live' });

--- a/.github/workflows/validate-remote-assets.yml
+++ b/.github/workflows/validate-remote-assets.yml
@@ -21,6 +21,11 @@ jobs:
         run: |
           echo "${{ env.SF_VERSION }}"
 
+      - name: Encoding base64
+          run: |
+            echo "BTOA_TEST_ORIGIN=$( ${{ secrets.TEST_ORIGIN }} | base64) >> $GITHUB_ENV
+            echo "${{ env.BTOA_TEST_ORIGIN }}"
+
       - name: Requesting securedFields
         id: securedFieldsRequest
         uses: fjogeleit/http-request-action@master


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

- Adding Github Action which validates that secured fields assets are available live when creating a release branch
  - As outcome, the script writes in the PR if the assets are live or not;
  - The developer can still merge the PR even if the secured fields aren't live. This script aims to warn the developers in case that the assets are not there

## Tested scenarios
- Tested using invalid secured fields url and check if github bot wrote in the PR
- Tested using valid secured fields url and check if github bot wrote in the PR