### PR TITLE
Fixing PayPal sessions flow

### DIFF
--- a/packages/lib/src/components/PayPal/defaultProps.ts
+++ b/packages/lib/src/components/PayPal/defaultProps.ts
@@ -55,7 +55,6 @@ const defaultProps: PayPalElementProps = {
     },
 
     // Events
-    onAdditionalDetails: () => {},
     onInit: () => {},
     onClick: () => {},
     onCancel: () => {},


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
PayPal default prop `onAdditionalDetails` was affecting the session flow, since if `onAdditionalDetails` is defined we call it instead of doing the sessions `submitDetails` way

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
- Tested doing payment with session and manual flow on the playground
<!-- Description of tested scenarios -->


**Fixed issue**: FOC-55587
