### PR TITLE
Improving error message for ClientKey, 3DS2Fingerprint and generic Error responses

### DIFF
--- a/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
+++ b/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
@@ -1,14 +1,17 @@
 import { httpPost } from '../../core/Services/http';
 import { pick } from '../internal/SecuredFields/utils';
+import { ThreeDS2FingerprintResponse } from './types';
 
 /**
- * ThreeDS2DeviceFingerprint, onComplete, calls a new, internal, endpoint which behaves like the /details endpoint but doesn't require the same credentials
+ * ThreeDS2DeviceFingerprint, onComplete, calls a new, internal, endpoint which
+ * behaves like the /details endpoint but doesn't require the same credentials
  */
-export default function callSubmit3DS2Fingerprint({ data }) {
-    httpPost(
+export default function callSubmit3DS2Fingerprint({ data }): void {
+    httpPost<ThreeDS2FingerprintResponse>(
         {
             path: `v1/submitThreeDS2Fingerprint?token=${this.props.clientKey}`,
-            loadingContext: this.props.loadingContext
+            loadingContext: this.props.loadingContext,
+            errorLevel: 'fatal'
         },
         {
             ...data

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -48,3 +48,23 @@ export interface FingerPrintData {
     threeDSMethodNotificationURL: string;
     postMessageDomain: string;
 }
+
+export type ThreeDS2FingerprintResponse = {
+    type: 'action' | 'completed';
+    action?: CheckoutRedirectAction | CheckoutThreeDS2Action;
+    details?: Record<string, string>;
+};
+
+type CheckoutRedirectAction = {
+    type: 'redirect';
+    data: Record<string, string>;
+    method: string;
+    paymentData: string;
+};
+
+type CheckoutThreeDS2Action = {
+    type: 'threeDS2';
+    token: string;
+    subtype: string;
+    authorisationToken: string;
+};

--- a/packages/lib/src/core/Services/http.ts
+++ b/packages/lib/src/core/Services/http.ts
@@ -13,10 +13,21 @@ interface HttpOptions {
     errorLevel?: 'silent' | 'info' | 'warn' | 'error' | 'fatal';
 }
 
-export function http(options: HttpOptions, data?): Promise<any> {
+type AdyenErrorResponse = {
+    errorCode: string;
+    message: string;
+    errorType: string;
+    status: number;
+};
+
+function isAdyenErrorResponse(data: any): data is AdyenErrorResponse {
+    return data && data.errorCode && data.errorType && data.message && data.status;
+}
+
+export function http<T>(options: HttpOptions, data?): Promise<T> {
     const { headers = [], errorLevel = 'warn', loadingContext = FALLBACK_CONTEXT, method = 'GET', path } = options;
 
-    const request = {
+    const request: RequestInit = {
         method,
         mode: 'cors',
         cache: 'default',
@@ -29,21 +40,44 @@ export function http(options: HttpOptions, data?): Promise<any> {
         redirect: 'follow',
         referrerPolicy: 'no-referrer-when-downgrade',
         ...(data && { body: JSON.stringify(data) })
-    } as RequestInit;
+    };
 
     const url = `${loadingContext}${path}`;
 
-    return fetch(url, request)
-        .then(response => {
-            if (response.ok) return response.json();
-            const errorMessage = options.errorMessage || `Service at ${url} is not available`;
+    return (
+        fetch(url, request)
+            .then(async response => {
+                const data = await response.json();
 
-            return handleFetchError(errorMessage, errorLevel);
-        })
-        .catch(e => {
-            const errorMessage = options.errorMessage || `Call to ${url} failed. Error= ${e}`;
-            return handleFetchError(errorMessage, errorLevel);
-        });
+                if (response.ok) {
+                    return data;
+                }
+
+                if (isAdyenErrorResponse(data)) {
+                    return handleFetchError(data.message, errorLevel);
+                }
+
+                const errorMessage = options.errorMessage || `Service at ${url} is not available`;
+                return handleFetchError(errorMessage, errorLevel);
+            })
+            /**
+             * Catch block handles Network error, CORS error, or exception throw by the `handleFetchError`
+             * inside the `then` block
+             */
+            .catch(error => {
+                /**
+                 * If error is instance of AdyenCheckoutError, which means that it was already
+                 * handled by the `handleFetchError` on the `then` block, then we just throw it.
+                 * There is no need to create it again
+                 */
+                if (error instanceof AdyenCheckoutError) {
+                    throw error;
+                }
+
+                const errorMessage = options.errorMessage || `Call to ${url} failed. Error= ${error}`;
+                return handleFetchError(errorMessage, errorLevel);
+            })
+    );
 }
 
 function handleFetchError(message: string, level: string) {
@@ -60,4 +94,7 @@ function handleFetchError(message: string, level: string) {
 }
 
 export const httpGet = (options: HttpOptions, data?): Promise<any> => http({ ...options, method: 'GET' }, data);
-export const httpPost = (options: HttpOptions, data?): Promise<any> => http({ ...options, method: 'POST' }, data);
+
+export function httpPost<T = any>(options: HttpOptions, data?: any) {
+    return http<T>({ ...options, method: 'POST' }, data);
+}

--- a/packages/lib/src/core/Services/sessions/setup-session.ts
+++ b/packages/lib/src/core/Services/sessions/setup-session.ts
@@ -16,7 +16,15 @@ function setupSession(session: Session, options): Promise<CheckoutSessionSetupRe
             : {})
     };
 
-    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal' }, data);
+    return httpPost<CheckoutSessionSetupResponse>(
+        {
+            loadingContext: session.loadingContext,
+            path,
+            errorLevel: 'fatal',
+            errorMessage: 'ERROR: Invalid ClientKey'
+        },
+        data
+    );
 }
 
 export default setupSession;


### PR DESCRIPTION
## Summary
While using sessions, the misconfigured client key error is showing as generic `NETWORK_ERROR`, which makes hard for merchants to find out what is the problem. Besides that, errors for `submitThreeDS2Fingerprint` weren't reported properly.  

This PR has the following changes:
- Passing error message about misconfigured ClientKey to the http request code
- Added `errorLevel: fatal` to `submitThreeDS2Fingerprint` call, so we throw proper error in the console
- Added handler which parses error response from the backend and uses its message property if available

## Tested scenarios
- e2e tests . Got failures on the following tests: `expiryDatePolicies.optional.separate.test.js , expiryDatePolicies.hidden.separate.test.js,  expiryDatePolicies.hidden.regular.test.js, threeDS2.default.size.test.js` , which does not seem to be related to this changes
- Tested on playground making payments with card, google pay, stored card 
<!-- Description of tested scenarios -->


**Fixed issue**:  FOC-54920, COWEB-995
