### PR TITLE
Fixed holderName position when it is with an ErrorPanel

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.scss
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.scss
@@ -40,7 +40,9 @@
     margin: 0 0 $spacing-medium;
 }
 
-.adyen-checkout__card__holderName:nth-child(2) {
+/* When holderName is on top & co-exists with an error panel */
+.adyen-checkout-error-panel--sr-only + .adyen-checkout__card__holderName,
+.adyen-checkout-error-panel + .adyen-checkout__card__holderName{
     margin: 0 0 $spacing-medium;
 }
 

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -141,7 +141,7 @@ export interface BrandObject {
     brand: string;
     cvcPolicy: CVCPolicyType;
     enableLuhnCheck: boolean;
-    showExpiryDate: boolean;
+    showExpiryDate?: boolean;
     expiryDatePolicy?: DatePolicyType;
     showSocialSecurityNumber?: boolean;
     supported: boolean;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed holderName position when it is with an ErrorPanel - if holderName field was positioned on top it wasn't getting it's bottom-margin since it was no longer the first child of it's parent

## Tested scenarios
HolderName field is positioned correctly whether it is above or below the credit card fields


