### PR TITLE
Make composition event handlers camelCase

### DIFF
--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -72,11 +72,9 @@ export default function InputBase(props) {
             onChange={handleChange}
             onBlur={handleBlur}
             aria-invalid={isInvalid}
-            /* eslint-disable react/no-unknown-property */
-            oncompositionstart={handleOnCompositionStart}
-            oncompositionupdate={handleOnCompositionUpdate}
-            oncompositionend={handleOnCompositionEnd}
-            /* eslint-enable react/no-unknown-property */
+            onCompositionStart={handleOnCompositionStart}
+            onCompositionUpdate={handleOnCompositionUpdate}
+            onCompositionEnd={handleOnCompositionEnd}
         />
     );
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The fix for the fullwidth characters [#1407](https://github.com/Adyen/adyen-web/pull/1407) is causing problems on Android devices.
Merchants report that shoppers are unable to type a name into the credit card's holderName input.
The issue seems to lie in the way the handlers for the composition events are defined using lowercase text. If these handlers are defined using camelCase then the issue is solved
i.e. `oncompositionstart` -> `onCompositionStart`

## Tested scenarios
Was able to recreate the issue on an Android device.
Defining the handlers using camelCase allowed me to then input a name into the holderName field

