### PR TITLE
Increase securedFields version to 3.7.5

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -16,7 +16,7 @@ export const GIFT_CARD = 'giftcard';
 export const ENCRYPTED_BANK_ACCNT_NUMBER_FIELD = 'encryptedBankAccountNumber';
 export const ENCRYPTED_BANK_LOCATION_FIELD = 'encryptedBankLocationId';
 
-export const SF_VERSION = '3.7.4';
+export const SF_VERSION = '3.7.5';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Increase securedFields version to 3.7.5
(The necessary sf files go Live today: 10/01/22)
This bumps the sf version to one that contains the polyfill for `Array.fill`

## Tested scenarios
All e2e test pass with this version bump

