### PR TITLE
Remove composition handling & full width char conversion

### DIFF
--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -1,34 +1,15 @@
 import { h } from 'preact';
-import { useState, useCallback, useRef } from 'preact/hooks';
+import { useState, useCallback } from 'preact/hooks';
 import classNames from 'classnames';
-import { convertFullToHalf } from './utils';
 import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
 
 export default function InputBase(props) {
     const { autoCorrect, classNameModifiers, isInvalid, isValid, readonly = null, spellCheck, type, uniqueId, isCollatingErrors } = props;
 
     const [handleChangeHasFired, setHandleChangeHasFired] = useState(false);
-    const isOnComposition = useRef<boolean>(false);
 
     const handleInput = useCallback((event: h.JSX.TargetedCompositionEvent<HTMLInputElement>) => {
-        if (isOnComposition.current) return;
-
-        (event.target as HTMLInputElement).value = convertFullToHalf((event.target as HTMLInputElement).value);
-
         props.onInput(event);
-    }, []);
-
-    const handleOnCompositionStart = useCallback(() => {
-        isOnComposition.current = true;
-    }, []);
-
-    const handleOnCompositionUpdate = useCallback((event: h.JSX.TargetedCompositionEvent<HTMLInputElement>) => {
-        props.onInput(event);
-    }, []);
-
-    const handleOnCompositionEnd = useCallback((event: h.JSX.TargetedCompositionEvent<HTMLInputElement>) => {
-        isOnComposition.current = false;
-        handleInput(event);
     }, []);
 
     const handleChange = useCallback((event: h.JSX.TargetedCompositionEvent<HTMLInputElement>) => {
@@ -73,9 +54,6 @@ export default function InputBase(props) {
             onChange={handleChange}
             onBlur={handleBlur}
             aria-invalid={isInvalid}
-            onCompositionStart={handleOnCompositionStart}
-            onCompositionUpdate={handleOnCompositionUpdate}
-            onCompositionEnd={handleOnCompositionEnd}
         />
     );
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Remove composition handling & full width char conversion from `InputBase`.
The best results in typing both regular and full width chars seems to come from not attempting to handle the composition events or convert full width chars to half width in the text fields based on `InputBase`.

## Tested scenarios
Tested on Desktop, on simulated devices in Browserstack & on actual Android and iPhone devices with both regular and Japanese keyboards


**Relates to issues**:  #1407 & #1439
