### PR TITLE
Fix/setting status using elementRef on handleError

### DIFF
--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -111,8 +111,14 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
             .catch(this.handleError);
     }
 
+
     protected handleError = (error: AdyenCheckoutError): void => {
-        this.setStatus('ready');
+        /**
+         * Set status using elementRef, which:
+         * - If Drop-in, will set status for Dropin component, and then it will propagate the new status for the active payment method component
+         * - If Component, it will set its own status
+         */
+        this.elementRef.setStatus('ready');
 
         if (this.props.onError) {
             this.props.onError(error, this.elementRef);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

`UIElement # handleError ()` method was setting the status using `this.setStatus` function, which sets the status of the `componentRef`. That means that it was setting the status only of the active payment method.

If the Drop-in is used, its status is kept as 'loading'  and the active payment method Component is set to 'ready', which let the whole Drop-in unusable since its status is 'loading'. (although the active payment method seems usable, but does not work).

The following change is setting the status using `this.elementRef.setStatus`, which makes Drop-in handle the whole `setStatus` logic in case it is being used; otherwise it will fallback to how the Component handles it.

