### PR TITLE
Feature/configurable giftcard names

### DIFF
--- a/packages/e2e/tests/_models/GiftCardComponent.page.js
+++ b/packages/e2e/tests/_models/GiftCardComponent.page.js
@@ -1,0 +1,46 @@
+import { ClientFunction, Selector } from 'testcafe';
+import BasePage from './BasePage';
+import { getIframeSelector } from '../utils/commonUtils';
+import cu from '../cards/utils/cardUtils';
+
+/**
+ * The Page Model Pattern is a test automation pattern that allows you to create an
+ * abstraction of the tested page, and use it in test code to refer to page elements
+ */
+export default class GiftCardPage extends BasePage {
+    constructor(baseEl = '.adyen-checkout__giftcard') {
+        super('cards');
+
+        const BASE_EL = baseEl;
+
+        /**
+         * CardNumber
+         */
+        // Top level el
+        this.pmHolder = Selector(`${BASE_EL}`);
+
+        // El that holds the title (in the dropin)
+        this.nameSpan = Selector(`${BASE_EL} .adyen-checkout__payment-method__name`);
+
+        // The <img> el that holds the card brand logo (actually a child of this.numSpan)
+        this.brandingIcon = Selector(`${BASE_EL} .adyen-checkout__payment-method__image`);
+
+        /**
+         * iframe utils
+         */
+        this.iframeSelector = getIframeSelector(`${BASE_EL} iframe`);
+        this.cardUtils = cu(this.iframeSelector);
+
+        /**
+         * Pay button
+         */
+        this.payButton = Selector(`${BASE_EL} .adyen-checkout__button--pay`);
+    }
+
+    getFromState = ClientFunction(path => {
+        const splitPath = path.split('.');
+        const reducer = (xs, x) => (xs && xs[x] !== undefined ? xs[x] : undefined);
+
+        return splitPath.reduce(reducer, window.card.state);
+    });
+}

--- a/packages/e2e/tests/_models/GiftCardComponent.page.js
+++ b/packages/e2e/tests/_models/GiftCardComponent.page.js
@@ -8,8 +8,8 @@ import cu from '../cards/utils/cardUtils';
  * abstraction of the tested page, and use it in test code to refer to page elements
  */
 export default class GiftCardPage extends BasePage {
-    constructor(baseEl = '.adyen-checkout__giftcard') {
-        super('cards');
+    constructor(baseEl = '.card-field') {
+        super('giftcards');
 
         const BASE_EL = baseEl;
 
@@ -24,6 +24,8 @@ export default class GiftCardPage extends BasePage {
 
         // The <img> el that holds the card brand logo (actually a child of this.numSpan)
         this.brandingIcon = Selector(`${BASE_EL} .adyen-checkout__payment-method__image`);
+
+        this.balanceDisplay = Selector(`${BASE_EL} .adyen-checkout__giftcard-result__balance`);
 
         /**
          * iframe utils

--- a/packages/e2e/tests/giftcards/brandsConfiguration/brandsConfiguration.clientScripts.js
+++ b/packages/e2e/tests/giftcards/brandsConfiguration/brandsConfiguration.clientScripts.js
@@ -1,0 +1,13 @@
+window.mainConfiguration = {
+    allowPaymentMethods: ['giftcard'],
+    paymentMethodsConfiguration: {
+        giftcard: {
+            brandsConfiguration: {
+                genericgiftcard: {
+                    icon: 'https://checkoutshopper-test.adyen.com/checkoutshopper/images/logos/mc.svg',
+                    name: 'Gifty mcGiftface'
+                }
+            }
+        }
+    }
+};

--- a/packages/e2e/tests/giftcards/brandsConfiguration/giftcard.dropin.brandsConfiguration.test.js
+++ b/packages/e2e/tests/giftcards/brandsConfiguration/giftcard.dropin.brandsConfiguration.test.js
@@ -1,0 +1,25 @@
+import DropinPage from '../../_models/Dropin.page';
+import GiftCardPage from '../../_models/GiftCardComponent.page';
+
+const dropinPage = new DropinPage({
+    components: {
+        giftcard: new GiftCardPage('.adyen-checkout__payment-method--giftcard')
+    }
+});
+
+fixture`Testing Giftcard with brandsConfiguration in Dropin`
+    .beforeEach(async t => {
+        await t.navigateTo(dropinPage.pageUrl);
+    })
+    .clientScripts('./brandsConfiguration.clientScripts.js');
+
+test.only('#1 Check Giftcard comp receives custom name and icon from brandsConfiguration object', async t => {
+    // Wait for el to appear in DOM
+    await dropinPage.giftcard.pmHolder();
+
+    // Custom name
+    await t.expect(dropinPage.giftcard.nameSpan.innerText).eql('Gifty mcGiftface');
+
+    // Custom card icon
+    await t.expect(dropinPage.giftcard.brandingIcon.getAttribute('src')).contains('mc.svg');
+});

--- a/packages/e2e/tests/giftcards/brandsConfiguration/giftcard.dropin.brandsConfiguration.test.js
+++ b/packages/e2e/tests/giftcards/brandsConfiguration/giftcard.dropin.brandsConfiguration.test.js
@@ -13,7 +13,7 @@ fixture`Testing Giftcard with brandsConfiguration in Dropin`
     })
     .clientScripts('./brandsConfiguration.clientScripts.js');
 
-test.only('#1 Check Giftcard comp receives custom name and icon from brandsConfiguration object', async t => {
+test('#1 Check Giftcard comp receives custom name and icon from brandsConfiguration object', async t => {
     // Wait for el to appear in DOM
     await dropinPage.giftcard.pmHolder();
 

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -48,7 +48,7 @@ export class GiftcardElement extends UIElement {
     }
 
     get displayName() {
-        return this.props.name;
+        return this.props.brandsConfiguration[this.props.brand]?.name || this.props.name;
     }
 
     private handleBalanceCheck = data => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently we allow merchants to edit the logos for gift cards based on brand using the `icon` property in the `brandsConfiguration` object within `paymentMethodsConfiguration`.
Some merchants also want to edit the names for giftcards using this same logic.
This PR enables that with a `brandsConfiguration` object that looks like this:
```
paymentMethodsConfiguration: {
            giftcard: {
                brandsConfiguration: {
                    svs: {
                        icon: 'https://mymerchant.com/icons/customIcon.svg',
                        name: 'custom gift card name'
                    }
                }
            }
        }
```

## Tested scenarios
Added new e2e test to see that custom name and logo are read from `brandsConfiguration`


**Fixed issue**:  DEV-51927
