### PR TITLE
Add constant for easy switching between versions of binLookup

### DIFF
--- a/packages/e2e/tests/_common/cardMocks.js
+++ b/packages/e2e/tests/_common/cardMocks.js
@@ -1,10 +1,11 @@
 import { ClientFunction, RequestMock } from 'testcafe';
 import { BASE_URL } from '../pages';
+import { BIN_LOOKUP_VERSION } from '../cards/utils/constants';
 
 import path from 'path';
 require('dotenv').config({ path: path.resolve('../../', '.env') });
 
-export const binLookupUrl = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+export const binLookupUrl = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 /**
  * Functionality for mocking a /binLookup API response via testcafe's fixture.requestHooks()

--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.reset.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.reset.test.js
@@ -3,10 +3,10 @@ import cu from '../utils/cardUtils';
 const path = require('path');
 require('dotenv').config({ path: path.resolve('../../', '.env') });
 
-import { RequestMock, Selector } from 'testcafe';
-import { start, getIsValid, getIframeSelector } from '../../utils/commonUtils';
+import { Selector } from 'testcafe';
+import { start, getIframeSelector } from '../../utils/commonUtils';
 import { BASE_URL } from '../../pages';
-import { DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE, UNKNOWN_VISA_CARD } from '../utils/constants';
+import { BCMC_DUAL_BRANDED_VISA, UNKNOWN_VISA_CARD } from '../utils/constants';
 
 const cvcSpan = Selector('.adyen-checkout__dropin .adyen-checkout__field__cvc');
 
@@ -14,72 +14,13 @@ const brandingIcon = Selector('.adyen-checkout__dropin .adyen-checkout__card__ca
 
 const dualBrandingIconHolderActive = Selector('.adyen-checkout__payment-method--bcmc .adyen-checkout__card__dual-branding__buttons--active');
 
-const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
-
-/**
- * NOTE - we are mocking the response until such time as we have the correct BIN in the Test DB
- */
-const mockedResponse = {
-    brands: [
-        {
-            brand: 'bcmc',
-            cvcPolicy: 'hidden',
-            enableLuhnCheck: true,
-            showExpiryDate: true,
-            supported: true
-        },
-        {
-            brand: 'visa',
-            cvcPolicy: 'required',
-            enableLuhnCheck: true,
-            showExpiryDate: true,
-            supported: true
-        }
-    ],
-    issuingCountryCode: 'BE',
-    requestId: null
-};
-
-const mockedNullResponse = {
-    requestId: null
-};
-
-let sendNullResponse = false;
-
-const mock = RequestMock()
-    .onRequestTo(request => {
-        return request.url === requestURL && request.method === 'post';
-    })
-    .respond(
-        (req, res) => {
-            const body = JSON.parse(req.body);
-
-            if (sendNullResponse === false) {
-                mockedResponse.requestId = body.requestId;
-                res.setBody(mockedResponse);
-                sendNullResponse = true;
-            } else {
-                mockedNullResponse.requestId = body.requestId;
-                res.setBody(mockedNullResponse);
-                sendNullResponse = false;
-            }
-        },
-        200,
-        {
-            'Access-Control-Allow-Origin': BASE_URL
-        }
-    );
-
 const TEST_SPEED = 1;
 
 const iframeSelector = getIframeSelector('.adyen-checkout__payment-method--bcmc iframe');
 
 const cardUtils = cu(iframeSelector);
 
-fixture`Testing Bancontact in Dropin`
-    .page(BASE_URL + '?countryCode=BE')
-    .clientScripts('bancontact.clientScripts.js')
-    .requestHooks(mock);
+fixture`Testing Bancontact in Dropin`.page(BASE_URL + '?countryCode=BE').clientScripts('bancontact.clientScripts.js');
 
 test(
     'Enter card number, that we mock to co-branded bcmc/visa ' +
@@ -89,7 +30,7 @@ test(
     async t => {
         await start(t, 2000, TEST_SPEED);
 
-        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+        await cardUtils.fillCardNumber(t, BCMC_DUAL_BRANDED_VISA);
 
         await t
             .expect(dualBrandingIconHolderActive.exists)
@@ -141,7 +82,7 @@ test(
     async t => {
         await start(t, 2000, TEST_SPEED);
 
-        await cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+        await cardUtils.fillCardNumber(t, BCMC_DUAL_BRANDED_VISA);
 
         await t
             .expect(dualBrandingIconHolderActive.exists)

--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
@@ -1,7 +1,6 @@
 import DropinPage from '../../_models/Dropin.page';
 import CardComponentPage from '../../_models/CardComponent.page';
-import { binLookupUrl, getBinLookupMock, turnOffSDKMocking } from '../../_common/cardMocks';
-import { DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../utils/constants';
+import { BCMC_DUAL_BRANDED_VISA, DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../utils/constants';
 
 const dropinPage = new DropinPage({
     components: {
@@ -9,38 +8,10 @@ const dropinPage = new DropinPage({
     }
 });
 
-/**
- * NOTE - we are mocking the response until such time as we have the correct BIN in the Test DB
- */
-const mockedResponse = {
-    brands: [
-        {
-            brand: 'bcmc',
-            cvcPolicy: 'hidden',
-            enableLuhnCheck: true,
-            showExpiryDate: true,
-            supported: true
-        },
-        {
-            brand: 'visa',
-            cvcPolicy: 'required',
-            enableLuhnCheck: true,
-            showExpiryDate: true,
-            supported: true
-        }
-    ],
-    issuingCountryCode: 'BE',
-    requestId: null
-};
-
-const mock = getBinLookupMock(binLookupUrl, mockedResponse);
-
 fixture`Testing Bancontact in Dropin`
     .beforeEach(async t => {
         await t.navigateTo(`${dropinPage.pageUrl}?countryCode=BE`);
-        await turnOffSDKMocking();
     })
-    .requestHooks(mock)
     .clientScripts('./bancontact.clientScripts.js');
 
 test('#1 Check Bancontact comp is correctly presented at startup', async t => {
@@ -86,7 +57,7 @@ test('#2 Entering digits that our local regEx will recognise as Visa does not af
 test('#3 Enter card number, that we mock to co-branded bcmc/visa ' + 'then complete expiryDate and expect comp to be valid', async t => {
     await dropinPage.cc.numSpan();
 
-    await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+    await dropinPage.cc.cardUtils.fillCardNumber(t, BCMC_DUAL_BRANDED_VISA);
 
     // Dual branded with bcmc logo shown first
     await t
@@ -112,7 +83,7 @@ test(
         // Wait for field to appear in DOM
         await dropinPage.cc.numSpan();
 
-        await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+        await dropinPage.cc.cardUtils.fillCardNumber(t, BCMC_DUAL_BRANDED_VISA);
 
         await dropinPage.cc.cardUtils.fillDate(t, TEST_DATE_VALUE);
 
@@ -152,7 +123,7 @@ test(
         // Wait for field to appear in DOM
         await dropinPage.cc.numSpan();
 
-        await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+        await dropinPage.cc.cardUtils.fillCardNumber(t, BCMC_DUAL_BRANDED_VISA);
 
         await dropinPage.cc.cardUtils.fillDate(t, TEST_DATE_VALUE);
 

--- a/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.v2.test.js
+++ b/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.v2.test.js
@@ -5,9 +5,9 @@ import { RequestLogger, Selector } from 'testcafe';
 import { start, getIframeSelector, getFromWindow } from '../../../utils/commonUtils';
 import cu from '../../utils/cardUtils';
 import { CARDS_URL } from '../../../pages';
-import { DUAL_BRANDED_CARD, REGULAR_TEST_CARD, MAESTRO_CARD, UNKNOWN_BIN_CARD } from '../../utils/constants';
+import { BIN_LOOKUP_VERSION, DUAL_BRANDED_CARD, REGULAR_TEST_CARD, MAESTRO_CARD, UNKNOWN_BIN_CARD } from '../../utils/constants';
 
-const url = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+const url = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 const logger = RequestLogger(
     { url, method: 'post' },

--- a/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.hidden.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.hidden.test.js
@@ -5,14 +5,14 @@ import { Selector, RequestMock } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../../../utils/commonUtils';
 import cu from '../../../utils/cardUtils';
 import { BASE_URL, CARDS_URL } from '../../../../pages';
-import { UNKNOWN_BIN_CARD } from '../../../utils/constants';
+import { BIN_LOOKUP_VERSION, UNKNOWN_BIN_CARD } from '../../../utils/constants';
 
 const cvcSpan = Selector('.card-field .adyen-checkout__field__cvc');
 const optionalCVCSpan = Selector('.card-field .adyen-checkout__field__cvc--optional');
 const cvcLabel = Selector('.card-field .adyen-checkout__label__text');
 const brandingIcon = Selector('.card-field .adyen-checkout__card__cardNumber__brandIcon');
 
-const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 /**
  * NOTE - we are mocking the response until such time as we have a genuine card,

--- a/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.optional.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/binLookup.cvc.optional.test.js
@@ -5,14 +5,14 @@ import { Selector, RequestMock } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../../../utils/commonUtils';
 import cu from '../../../utils/cardUtils';
 import { BASE_URL, CARDS_URL } from '../../../../pages';
-import { UNKNOWN_BIN_CARD } from '../../../utils/constants';
+import { BIN_LOOKUP_VERSION, UNKNOWN_BIN_CARD } from '../../../utils/constants';
 
 const cvcSpan = Selector('.card-field .adyen-checkout__field__cvc');
 const optionalCVCSpan = Selector('.card-field .adyen-checkout__field__cvc--optional');
 const cvcLabel = Selector('.card-field .adyen-checkout__label__text');
 const brandingIcon = Selector('.card-field .adyen-checkout__card__cardNumber__brandIcon');
 
-const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 /**
  * NOTE - we are mocking the response until such time as we have a genuine card,

--- a/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.expiryDate.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.expiryDate.test.js
@@ -5,13 +5,13 @@ import { Selector, RequestMock } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../../../utils/commonUtils';
 import cu from '../../../utils/cardUtils';
 import { BASE_URL, CARDS_URL } from '../../../../pages';
-import { TEST_CVC_VALUE, UNKNOWN_BIN_CARD } from '../../../utils/constants';
+import { BIN_LOOKUP_VERSION, TEST_CVC_VALUE, UNKNOWN_BIN_CARD } from '../../../utils/constants';
 
 const brandingIcon = Selector('.card-field .adyen-checkout__card__cardNumber__brandIcon');
 
 const dateSpan = Selector('.card-field .adyen-checkout__card__exp-date__input');
 
-const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 /**
  * NOTE - we are mocking the response until such time as we have a genuine card,

--- a/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.luhn.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/mocks/plcc.luhn.test.js
@@ -5,11 +5,11 @@ import { Selector, RequestMock } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../../../utils/commonUtils';
 import cu from '../../../utils/cardUtils';
 import { BASE_URL, CARDS_URL } from '../../../../pages';
-import { FAILS_LUHN_CARD } from '../../../utils/constants';
+import { BIN_LOOKUP_VERSION, FAILS_LUHN_CARD } from '../../../utils/constants';
 
 const brandingIcon = Selector('.card-field .adyen-checkout__card__cardNumber__brandIcon');
 
-const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 /**
  * NOTE - we are mocking the response until such time as we have a genuine card,

--- a/packages/e2e/tests/cards/socialSecurityNumber/autoMode/autoMode.test.js
+++ b/packages/e2e/tests/cards/socialSecurityNumber/autoMode/autoMode.test.js
@@ -1,7 +1,7 @@
 import { ClientFunction, RequestMock } from 'testcafe';
 import { start, getIframeSelector, getIsValid } from '../../../utils/commonUtils';
 import cu from '../../utils/cardUtils';
-import { REGULAR_TEST_CARD, TEST_CPF_VALUE } from '../../utils/constants';
+import { BIN_LOOKUP_VERSION, REGULAR_TEST_CARD, TEST_CPF_VALUE } from '../../utils/constants';
 import { CARDS_URL, BASE_URL } from '../../../pages';
 
 const path = require('path');
@@ -21,7 +21,7 @@ const fillSSN = async (t, ssnValue = TEST_CPF_VALUE) => {
     return t.switchToMainWindow().typeText('.adyen-checkout__field--socialSecurityNumber input', ssnValue, { speed: 0.5 });
 };
 
-const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/v2/bin/binLookup?token=${process.env.CLIENT_KEY}`;
+const requestURL = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 const mockedResponse = {
     brands: [

--- a/packages/e2e/tests/cards/utils/constants.js
+++ b/packages/e2e/tests/cards/utils/constants.js
@@ -1,8 +1,11 @@
+export const BIN_LOOKUP_VERSION = 'v3';
+
 export const KOREAN_TEST_CARD = '9490220006611406'; // 9490220006611406 works against Test. For localhost:8080 use: 5067589608564358 + hack in triggerBinLookup
 export const REGULAR_TEST_CARD = '5500000000000004';
 export const DUAL_BRANDED_CARD = '4035501000000008'; // dual branded visa & cartebancaire
 export const MAESTRO_CARD = '5000550000000029';
 export const BCMC_CARD = '6703444444444449'; // actually dual branded bcmc & maestro
+export const BCMC_DUAL_BRANDED_VISA = '4871049999999910'; // dual branded visa & bcmc
 export const UNKNOWN_BIN_CARD = '135410014004955'; // card that is not in the test DBs (uatp)
 export const UNKNOWN_VISA_CARD = '4111111111111111'; // card that is not in the test DBs (visa)
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added constant for easy switching between versions of binLookup
Also removed mocks from Dropin/Bancontact tests now we have appropriate test card in the database

## Tested scenarios
e2e tests pass both with v2 & v3 binLookup


