### PR TITLE
Restoring missing detectedBrands prop to error object

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
@@ -170,7 +170,6 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
 
     it('should clear the previously generated "unsupported card" error & propagate to the onError callback', () => {
         unsupportedCardErrObj.error = '';
-        delete unsupportedCardErrObj.detectedBrands;
 
         expect(wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj)).toBe(false);
     });
@@ -182,7 +181,6 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
 
     it('should clear the previously generated "unsupported card" error & then a regular error is handled correctly', () => {
         unsupportedCardErrObj.error = '';
-        delete unsupportedCardErrObj.detectedBrands;
 
         wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj);
 
@@ -209,7 +207,7 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
 
     it('should clear the previously generated "unsupported card" error & then a handleOnFieldValid call is handled correctly', () => {
         unsupportedCardErrObj.error = '';
-        delete unsupportedCardErrObj.detectedBrands;
+
         wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj);
 
         expect(

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
@@ -62,7 +62,7 @@ const unsupportedCardErrObj = {
     type: 'card',
     fieldType: 'encryptedCardNumber',
     error: ERROR_CODES[ERROR_MSG_UNSUPPORTED_CARD_ENTERED],
-    binLookupBrands: ['cartebancaire']
+    detectedBrands: ['cartebancaire']
 };
 
 const regularErrObj = {
@@ -164,22 +164,26 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
     });
 
     it('should see that the "unsupported card" error has set state on the SecuredFieldsProvider', () => {
-        expect(wrapper.instance().state.hasUnsupportedCard).toBe(true);
+        expect(wrapper.instance().state.hasUnsupportedCard.length).toEqual(1);
         expect(wrapper.instance().state.errors.encryptedCardNumber).toEqual(ERROR_CODES[ERROR_MSG_UNSUPPORTED_CARD_ENTERED]);
     });
 
     it('should clear the previously generated "unsupported card" error & propagate to the onError callback', () => {
         unsupportedCardErrObj.error = '';
+        delete unsupportedCardErrObj.detectedBrands;
+
         expect(wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj)).toBe(false);
     });
 
     it('should see that the cleared "unsupported card" error has reset state on the SecuredFieldsProvider', () => {
-        expect(wrapper.instance().state.hasUnsupportedCard).toBe(false);
+        expect(wrapper.instance().state.hasUnsupportedCard).toBe(null);
         expect(wrapper.instance().state.errors.encryptedCardNumber).toBe(false);
     });
 
     it('should clear the previously generated "unsupported card" error & then a regular error is handled correctly', () => {
         unsupportedCardErrObj.error = '';
+        delete unsupportedCardErrObj.detectedBrands;
+
         wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj);
 
         expect(wrapper.instance().handleOnError(regularErrObj)).toBe(true);
@@ -189,8 +193,10 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
 
     it('should re-generate an "unsupported card" error and then a handleOnFieldValid call should be ignored', () => {
         unsupportedCardErrObj.error = 'Unsupported card';
+        unsupportedCardErrObj.detectedBrands = ['cartebancaire'];
+
         wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj);
-        expect(wrapper.instance().state.hasUnsupportedCard).toBe(true);
+        expect(wrapper.instance().state.hasUnsupportedCard.length).toEqual(1);
 
         expect(wrapper.instance().handleOnFieldValid({ fieldType: 'encryptedCardNumber' })).toBe(false);
         expect(wrapper.instance().state.valid.encryptedCardNumber).toBe(false);
@@ -203,6 +209,7 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
 
     it('should clear the previously generated "unsupported card" error & then a handleOnFieldValid call is handled correctly', () => {
         unsupportedCardErrObj.error = '';
+        delete unsupportedCardErrObj.detectedBrands;
         wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj);
 
         expect(

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
@@ -164,7 +164,7 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
     });
 
     it('should see that the "unsupported card" error has set state on the SecuredFieldsProvider', () => {
-        expect(wrapper.instance().state.hasUnsupportedCard.length).toEqual(1);
+        expect(wrapper.instance().state.detectedUnsupportedCardsArray.length).toEqual(1);
         expect(wrapper.instance().state.errors.encryptedCardNumber).toEqual(ERROR_CODES[ERROR_MSG_UNSUPPORTED_CARD_ENTERED]);
     });
 
@@ -175,7 +175,7 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
     });
 
     it('should see that the cleared "unsupported card" error has reset state on the SecuredFieldsProvider', () => {
-        expect(wrapper.instance().state.hasUnsupportedCard).toBe(null);
+        expect(wrapper.instance().state.detectedUnsupportedCardsArray).toBe(null);
         expect(wrapper.instance().state.errors.encryptedCardNumber).toBe(false);
     });
 
@@ -194,7 +194,7 @@ describe('<SecuredFieldsProvider /> handling an unsupported card', () => {
         unsupportedCardErrObj.detectedBrands = ['cartebancaire'];
 
         wrapper.instance().handleUnsupportedCard(unsupportedCardErrObj);
-        expect(wrapper.instance().state.hasUnsupportedCard.length).toEqual(1);
+        expect(wrapper.instance().state.detectedUnsupportedCardsArray.length).toEqual(1);
 
         expect(wrapper.instance().handleOnFieldValid({ fieldType: 'encryptedCardNumber' })).toBe(false);
         expect(wrapper.instance().state.valid.encryptedCardNumber).toBe(false);

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -246,7 +246,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             .forEach(field => {
                 // For each detected error pass an error object to the handler (calls error callback & sets state)
                 const errorObj: CbObjOnError = getErrorObject(field, this.rootNode, state);
-                this.handleOnError(errorObj, !!state.hasUnsupportedCard);
+                this.handleOnError(errorObj, !!state.detectedUnsupportedCardsArray);
                 // Inform the secured-fields instance of which fields have been found to have errors
                 if (this.csf && this.csf.isValidated) {
                     this.csf.isValidated(field, errorObj.error);
@@ -269,7 +269,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
                     errorI18n: this.props.i18n.get(this.state.errors[key]),
                     error: this.state.errors[key],
                     rootNode: this.rootNode,
-                    ...(this.state.hasUnsupportedCard && { detectedBrands: this.state.hasUnsupportedCard })
+                    ...(this.state.detectedUnsupportedCardsArray && { detectedBrands: this.state.detectedUnsupportedCardsArray })
                 };
             } else {
                 acc[key] = null;
@@ -282,10 +282,10 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
     public processBinLookupResponse(binLookupResponse: BinLookupResponse, resetObject: SingleBrandResetObject): void {
         // If we were dealing with an unsupported card and now we have a valid /binLookup response - reset state and inform CSF
         // (Scenario: from an unsupportedCard state the shopper has pasted another number long enough to trigger a /binLookup)
-        if (this.state.hasUnsupportedCard) {
+        if (this.state.detectedUnsupportedCardsArray) {
             this.setState(prevState => ({
                 errors: { ...prevState.errors, [ENCRYPTED_CARD_NUMBER]: false },
-                hasUnsupportedCard: null
+                detectedUnsupportedCardsArray: null
             }));
 
             // If we have some sort of binLookupResponse object then this isn't the reset caused by digits dropping below a threshold

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -246,7 +246,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             .forEach(field => {
                 // For each detected error pass an error object to the handler (calls error callback & sets state)
                 const errorObj: CbObjOnError = getErrorObject(field, this.rootNode, state);
-                this.handleOnError(errorObj, state.hasUnsupportedCard);
+                this.handleOnError(errorObj, !!state.hasUnsupportedCard);
                 // Inform the secured-fields instance of which fields have been found to have errors
                 if (this.csf && this.csf.isValidated) {
                     this.csf.isValidated(field, errorObj.error);
@@ -265,10 +265,11 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
                     isValid: false,
                     errorMessage: getError(this.state.errors[key]),
                     // For v5 the object found in state.errors should also contain the additional properties that used to be sent to the onError callback
-                    // namely: translation, errorCode & ref to rootNode
+                    // namely: translation, errorCode, a ref to rootNode &, in the case of failed binLookup, an array of the detectedBrands
                     errorI18n: this.props.i18n.get(this.state.errors[key]),
                     error: this.state.errors[key],
-                    rootNode: this.rootNode
+                    rootNode: this.rootNode,
+                    ...(this.state.hasUnsupportedCard && { detectedBrands: this.state.hasUnsupportedCard })
                 };
             } else {
                 acc[key] = null;
@@ -284,7 +285,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
         if (this.state.hasUnsupportedCard) {
             this.setState(prevState => ({
                 errors: { ...prevState.errors, [ENCRYPTED_CARD_NUMBER]: false },
-                hasUnsupportedCard: false
+                hasUnsupportedCard: null
             }));
 
             // If we have some sort of binLookupResponse object then this isn't the reset caused by digits dropping below a threshold

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -174,7 +174,7 @@ function handleOnError(cbObj: CbObjOnError, hasUnsupportedCard: boolean = null):
     this.setState(
         prevState => ({
             errors: { ...prevState.errors, [cbObj.fieldType]: errorCode || false },
-            hasUnsupportedCard: hasUnsupportedCard !== null ? cbObj.detectedBrands ?? null : null,
+            hasUnsupportedCard: !hasUnsupportedCard ? null : cbObj.detectedBrands,
             // If dealing with an unsupported card ensure these card number related fields are reset re. pasting a full, unsupported card straight in
             ...(hasUnsupportedCard && { data: { ...prevState.data, [ENCRYPTED_CARD_NUMBER]: undefined } }),
             ...(hasUnsupportedCard && { valid: { ...prevState.valid, [ENCRYPTED_CARD_NUMBER]: false } }),

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -58,7 +58,7 @@ function handleOnConfigSuccess(cbObj: CbObjOnConfigSuccess): void {
  */
 function handleOnAllValid(status: CbObjOnAllValid): boolean {
     // Form cannot be valid whilst there is an unsupported card
-    if (this.state.hasUnsupportedCard) {
+    if (this.state.detectedUnsupportedCardsArray) {
         return false;
     }
 
@@ -78,7 +78,7 @@ function handleOnAllValid(status: CbObjOnAllValid): boolean {
  */
 function handleOnFieldValid(field: CbObjOnFieldValid): boolean {
     // A card number field cannot be valid whilst there is an unsupported card
-    if (this.state.hasUnsupportedCard && field.fieldType === ENCRYPTED_CARD_NUMBER) {
+    if (this.state.detectedUnsupportedCardsArray && field.fieldType === ENCRYPTED_CARD_NUMBER) {
         return false;
     }
 
@@ -174,7 +174,7 @@ function handleOnError(cbObj: CbObjOnError, hasUnsupportedCard: boolean = null):
     this.setState(
         prevState => ({
             errors: { ...prevState.errors, [cbObj.fieldType]: errorCode || false },
-            hasUnsupportedCard: !hasUnsupportedCard ? null : cbObj.detectedBrands,
+            detectedUnsupportedCardsArray: !hasUnsupportedCard ? null : cbObj.detectedBrands,
             // If dealing with an unsupported card ensure these card number related fields are reset re. pasting a full, unsupported card straight in
             ...(hasUnsupportedCard && { data: { ...prevState.data, [ENCRYPTED_CARD_NUMBER]: undefined } }),
             ...(hasUnsupportedCard && { valid: { ...prevState.valid, [ENCRYPTED_CARD_NUMBER]: false } }),

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -174,7 +174,7 @@ function handleOnError(cbObj: CbObjOnError, hasUnsupportedCard: boolean = null):
     this.setState(
         prevState => ({
             errors: { ...prevState.errors, [cbObj.fieldType]: errorCode || false },
-            hasUnsupportedCard: hasUnsupportedCard !== null ? hasUnsupportedCard : false,
+            hasUnsupportedCard: hasUnsupportedCard !== null ? cbObj.detectedBrands ?? null : null,
             // If dealing with an unsupported card ensure these card number related fields are reset re. pasting a full, unsupported card straight in
             ...(hasUnsupportedCard && { data: { ...prevState.data, [ENCRYPTED_CARD_NUMBER]: undefined } }),
             ...(hasUnsupportedCard && { valid: { ...prevState.valid, [ENCRYPTED_CARD_NUMBER]: false } }),

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -11,7 +11,7 @@ export interface SFPState {
     isSfpValid?: boolean;
     autoCompleteName?: string;
     billingAddress?: AddressData;
-    hasUnsupportedCard?: string[];
+    detectedUnsupportedCardsArray?: string[];
     hasKoreanFields?: boolean;
     showSocialSecurityNumber?: boolean;
     expiryDatePolicy?: DatePolicyType;

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -11,7 +11,7 @@ export interface SFPState {
     isSfpValid?: boolean;
     autoCompleteName?: string;
     billingAddress?: AddressData;
-    hasUnsupportedCard?: boolean;
+    hasUnsupportedCard?: string[];
     hasKoreanFields?: boolean;
     showSocialSecurityNumber?: boolean;
     expiryDatePolicy?: DatePolicyType;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The change with how we handle errors in v5 meant that a prop, `detectedBrands` was no longer being propagated when `/binLookup` failed.
In keeping with previous solutions to this problem we now store that prop so it can be added to the stored error object and so can be accessed when required.
This is of particular importance for the Custom card component.

## Tested scenarios
All test pass.
`detectedBrands` can be accessed (in the `onChange` callback) and passed into other merchant defined handlers e.g. `onError` handlers for the Custom card component.

