### PR TITLE
Dropin component: match method signatures

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -107,7 +107,7 @@ class DropinElement extends UIElement<DropinElementProps> {
         return [storedElements, elements, instantPaymentElements];
     };
 
-    public handleAction(action: PaymentAction, props = {}): this | null {
+    public handleAction(action: PaymentAction, props = {}): UIElement | null {
         if (!action || !action.type) throw new Error('Invalid Action');
 
         if (action.type !== 'redirect' && this.activePaymentMethod?.updateWithAction) {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -135,7 +135,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         return state;
     };
 
-    public handleAction(action: PaymentAction, props = {}): UIElement {
+    public handleAction(action: PaymentAction, props = {}): UIElement | null {
         if (!action || !action.type) throw new Error('Invalid Action');
 
         const paymentAction = this._parentInstance.createFromAction(action, {


### PR DESCRIPTION
## Summary

The signature of `Dropin.handleAction` and `UIElement.handleAction` do not match causing an error when integrating with Angular (i.e. [Adyen Angular Sample App](https://github.com/adyen-examples/adyen-angular-online-payments)).

**Note**: this didn't raise any problem when integrating Adyen-Web with a Node implementation.

@ribeiroguilherme As discussed I have updated both signatures to match 

Here is the error stack:

```
Error: node_modules/@adyen/adyen-web/dist/types/components/Dropin/Dropin.d.ts:94:5 - error TS2416: Property 'handleAction' in type 'DropinElement' is not assignable to the same property in base type 'UIElement<DropinElementProps>'.
  Type '(action: PaymentAction, props?: {} | undefined) => this | null' is not assignable to type '(action: PaymentAction, props?: {} | undefined) => UIElement<any>'.
    Type 'this | null' is not assignable to type 'UIElement<any>'.
      Type 'null' is not assignable to type 'UIElement<any>'.

     handleAction(action: PaymentAction, props?: {}): this | null;
```