### PR TITLE
Card: removing 'installments' property if shopper selects one time payment

### DIFF
--- a/packages/e2e/tests/_models/CardComponent.page.js
+++ b/packages/e2e/tests/_models/CardComponent.page.js
@@ -9,8 +9,15 @@ import kcp from '../cards/utils/kcpUtils';
  * abstraction of the tested page, and use it in test code to refer to page elements
  */
 export default class CardPage extends BasePage {
-    constructor(baseEl = '.card-field') {
+    /**
+     * @type {InstallmentsComponent}
+     */
+    installments = null;
+
+    constructor(baseEl = '.card-field', internalComponents = {}) {
         super('cards');
+
+        Object.assign(this, internalComponents);
 
         const BASE_EL = baseEl;
 

--- a/packages/e2e/tests/_models/Installments.component.js
+++ b/packages/e2e/tests/_models/Installments.component.js
@@ -1,0 +1,24 @@
+import { t, Selector } from 'testcafe';
+
+export default class InstallmentsComponent {
+    constructor(baseEl = 'div.adyen-checkout__installments') {
+        this.baseEl = Selector(baseEl).with({ timeout: 0 });
+
+        this.radioButtonOneTimeInstallment = this.baseEl.find('.adyen-checkout__radio_group__input[value=onetime]');
+        this.radioButtonInstallments = this.baseEl.find('.adyen-checkout__radio_group__input[value=installments]');
+        this.radioButtonRevolving = this.baseEl.find('.adyen-checkout__radio_group__input[value=revolving]');
+
+        this.installmentsButton = this.baseEl.find('.adyen-checkout__dropdown__button');
+    }
+
+    async selectInstallment(numberOfInstallment) {
+        await t.click(this.radioButtonInstallments);
+        await t.click(this.installmentsButton);
+        const item = this.baseEl.find(`ul > li.adyen-checkout__dropdown__element[data-value="${numberOfInstallment}"]`);
+        await t.click(item);
+    }
+
+    async selectRevolving() {
+        await t.click(this.radioButtonRevolving);
+    }
+}

--- a/packages/e2e/tests/address/address.mocks.js
+++ b/packages/e2e/tests/address/address.mocks.js
@@ -1,4 +1,4 @@
-import { RequestMock, RequestLogger } from 'testcafe';
+import { RequestMock } from 'testcafe';
 import { BASE_URL } from '../pages';
 
 const countriesDatasetUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/datasets/countries/en-US.json';

--- a/packages/e2e/tests/cards/installments/cards.installments.clientScripts.js
+++ b/packages/e2e/tests/cards/installments/cards.installments.clientScripts.js
@@ -1,0 +1,8 @@
+window.cardConfig = {
+    installmentOptions: {
+        mc: {
+            values: [1, 2, 3],
+            plans: ['regular', 'revolving']
+        }
+    }
+};

--- a/packages/e2e/tests/cards/installments/cards.installments.mocks.js
+++ b/packages/e2e/tests/cards/installments/cards.installments.mocks.js
@@ -1,21 +1,16 @@
 import { RequestMock, RequestLogger } from 'testcafe';
 import { BASE_URL } from '../../pages';
 
-// const path = require('path');
-// require('dotenv').config({ path: path.resolve('../../', '.env') });
-
 const paymentUrl = `http://localhost:3024/payments`;
 
 const paymentResponse = {
     resultCode: 'Authorised'
 };
 
-const loggers = {
-    paymentLogger: RequestLogger({ url: paymentUrl, method: 'post' }, { logRequestBody: true })
-};
+const paymentLogger = RequestLogger({ url: paymentUrl, method: 'post' }, { logRequestBody: true });
 
 const mock = RequestMock()
     .onRequestTo(request => request.url === paymentUrl && request.method === 'post')
     .respond(paymentResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL });
 
-export { mock, loggers };
+export { mock, paymentLogger };

--- a/packages/e2e/tests/cards/installments/cards.installments.mocks.js
+++ b/packages/e2e/tests/cards/installments/cards.installments.mocks.js
@@ -1,0 +1,21 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import { BASE_URL } from '../../pages';
+
+// const path = require('path');
+// require('dotenv').config({ path: path.resolve('../../', '.env') });
+
+const paymentUrl = `http://localhost:3024/payments`;
+
+const paymentResponse = {
+    resultCode: 'Authorised'
+};
+
+const loggers = {
+    paymentLogger: RequestLogger({ url: paymentUrl, method: 'post' }, { logRequestBody: true })
+};
+
+const mock = RequestMock()
+    .onRequestTo(request => request.url === paymentUrl && request.method === 'post')
+    .respond(paymentResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL });
+
+export { mock, loggers };

--- a/packages/e2e/tests/cards/installments/cards.installments.test.js
+++ b/packages/e2e/tests/cards/installments/cards.installments.test.js
@@ -1,15 +1,15 @@
 import { CARDS_URL } from '../../pages';
 import CardComponentPage from '../../_models/CardComponent.page';
 import { REGULAR_TEST_CARD } from '../utils/constants';
-import { mock, loggers } from './cards.installments.mocks';
+import { mock, paymentLogger } from './cards.installments.mocks';
 import InstallmentsComponent from '../../_models/Installments.component';
 
 let cardComponent = null;
 
-fixture.only`Cards (Installments)`
+fixture`Cards (Installments)`
     .page(CARDS_URL)
     .clientScripts('./cards.installments.clientScripts.js')
-    .requestHooks([mock, loggers.paymentLogger])
+    .requestHooks([mock, paymentLogger])
     .beforeEach(async t => {
         // handler for alert that's triggered on successful payment
         await t.setNativeDialogHandler(() => true);
@@ -22,10 +22,10 @@ test('should not add installments property to payload if one-time payment is sel
 
     await t
         .click(cardComponent.payButton)
-        .expect(loggers.paymentLogger.count(() => true))
+        .expect(paymentLogger.count(() => true))
         .eql(1)
         .expect(
-            loggers.paymentLogger.contains(record => {
+            paymentLogger.contains(record => {
                 const { installments } = JSON.parse(record.request.body);
                 return installments === undefined;
             })
@@ -40,10 +40,10 @@ test('should not add installments property to payload if 1x installment is selec
 
     await t
         .click(cardComponent.payButton)
-        .expect(loggers.paymentLogger.count(() => true))
+        .expect(paymentLogger.count(() => true))
         .eql(1)
         .expect(
-            loggers.paymentLogger.contains(record => {
+            paymentLogger.contains(record => {
                 const { installments } = JSON.parse(record.request.body);
                 return installments === undefined;
             })
@@ -58,10 +58,10 @@ test('should add revolving plan to payload if selected', async t => {
 
     await t
         .click(cardComponent.payButton)
-        .expect(loggers.paymentLogger.count(() => true))
+        .expect(paymentLogger.count(() => true))
         .eql(1)
         .expect(
-            loggers.paymentLogger.contains(record => {
+            paymentLogger.contains(record => {
                 const { installments } = JSON.parse(record.request.body);
                 return installments.value === 1 && installments.plan === 'revolving';
             })
@@ -76,10 +76,10 @@ test('should add installments value property if regular installment > 1 is selec
 
     await t
         .click(cardComponent.payButton)
-        .expect(loggers.paymentLogger.count(() => true))
+        .expect(paymentLogger.count(() => true))
         .eql(1)
         .expect(
-            loggers.paymentLogger.contains(record => {
+            paymentLogger.contains(record => {
                 const { installments } = JSON.parse(record.request.body);
                 return installments.value === 2;
             })

--- a/packages/e2e/tests/cards/installments/cards.installments.test.js
+++ b/packages/e2e/tests/cards/installments/cards.installments.test.js
@@ -1,0 +1,88 @@
+import { CARDS_URL } from '../../pages';
+import CardComponentPage from '../../_models/CardComponent.page';
+import { REGULAR_TEST_CARD } from '../utils/constants';
+import { mock, loggers } from './cards.installments.mocks';
+import InstallmentsComponent from '../../_models/Installments.component';
+
+let cardComponent = null;
+
+fixture.only`Cards (Installments)`
+    .page(CARDS_URL)
+    .clientScripts('./cards.installments.clientScripts.js')
+    .requestHooks([mock, loggers.paymentLogger])
+    .beforeEach(async t => {
+        // handler for alert that's triggered on successful payment
+        await t.setNativeDialogHandler(() => true);
+        cardComponent = new CardComponentPage('.card-field', { installments: new InstallmentsComponent() });
+    });
+
+test('should not add installments property to payload if one-time payment is selected', async t => {
+    await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+    await cardComponent.cardUtils.fillDateAndCVC(t);
+
+    await t
+        .click(cardComponent.payButton)
+        .expect(loggers.paymentLogger.count(() => true))
+        .eql(1)
+        .expect(
+            loggers.paymentLogger.contains(record => {
+                const { installments } = JSON.parse(record.request.body);
+                return installments === undefined;
+            })
+        )
+        .ok('payment payload has the expected payload');
+});
+
+test('should not add installments property to payload if 1x installment is selected', async t => {
+    await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+    await cardComponent.cardUtils.fillDateAndCVC(t);
+    await cardComponent.installments.selectInstallment(1);
+
+    await t
+        .click(cardComponent.payButton)
+        .expect(loggers.paymentLogger.count(() => true))
+        .eql(1)
+        .expect(
+            loggers.paymentLogger.contains(record => {
+                const { installments } = JSON.parse(record.request.body);
+                return installments === undefined;
+            })
+        )
+        .ok('payment payload has the expected payload');
+});
+
+test('should add revolving plan to payload if selected', async t => {
+    await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+    await cardComponent.cardUtils.fillDateAndCVC(t);
+    await cardComponent.installments.selectRevolving();
+
+    await t
+        .click(cardComponent.payButton)
+        .expect(loggers.paymentLogger.count(() => true))
+        .eql(1)
+        .expect(
+            loggers.paymentLogger.contains(record => {
+                const { installments } = JSON.parse(record.request.body);
+                return installments.value === 1 && installments.plan === 'revolving';
+            })
+        )
+        .ok('payment payload has the expected payload');
+});
+
+test('should add installments value property if regular installment > 1 is selected', async t => {
+    await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+    await cardComponent.cardUtils.fillDateAndCVC(t);
+    await cardComponent.installments.selectInstallment(2);
+
+    await t
+        .click(cardComponent.payButton)
+        .expect(loggers.paymentLogger.count(() => true))
+        .eql(1)
+        .expect(
+            loggers.paymentLogger.contains(record => {
+                const { installments } = JSON.parse(record.request.body);
+                return installments.value === 2;
+            })
+        )
+        .ok('payment payload has the expected payload');
+});

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import { CardElementData, CardElementProps, BinLookupResponse } from './types';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';
 import { CbObjOnBinLookup } from '../internal/SecuredFields/lib/types';
 import { reject } from '../internal/SecuredFields/utils';
+import { hasValidInstallmentsObject } from './components/CardInput/utils';
 
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
@@ -75,7 +76,7 @@ export class CardElement extends UIElement<CardElementProps> {
             ...(this.state.billingAddress && { billingAddress: this.state.billingAddress }),
             ...(this.state.socialSecurityNumber && { socialSecurityNumber: this.state.socialSecurityNumber }),
             ...(includeStorePaymentMethod && { storePaymentMethod: Boolean(this.state.storePaymentMethod) }),
-            ...(this.state.installments && this.state.installments.value && { installments: this.state.installments }),
+            ...(hasValidInstallmentsObject(this.state.installments) && { installments: this.state.installments }),
             browserInfo: this.browserInfo,
             origin: !!window && window.location.origin
         };

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -15,6 +15,7 @@ import {
     SSN_CARD_NAME_TOP
 } from './layouts';
 import { StringObject } from '../../../internal/Address/types';
+import { InstallmentsObj } from './components/Installments/Installments';
 
 export const getCardImageUrl = (brand: string, loadingContext: string): string => {
     const imageOptions = {
@@ -24,6 +25,14 @@ export const getCardImageUrl = (brand: string, loadingContext: string): string =
     };
 
     return getImageUrl(imageOptions)(brand);
+};
+
+/**
+ * Verifies that installment object is valid to send to the Backend.
+ * Valid means that it has 'revolving' plan set, or the number of installments is bigger than one
+ */
+export const hasValidInstallmentsObject = (installments?: InstallmentsObj) => {
+    return installments?.plan === 'revolving' || installments?.value > 1;
 };
 
 export const getLayout = ({ props, showKCP, showBrazilianSSN, countrySpecificSchemas = null }: LayoutObj): string[] => {


### PR DESCRIPTION
## Summary

In case the installments is configured for Card, and shopper selects 'One time payment' or  'Installment: 1x', we shouldn't  add the `installments` property to the payload. 

## Tested scenarios

Added e2e tests

**Fixed issue**: COWEB-1070
