### PR TITLE
live-au and live-us environments do not resolve to Google Pay PRODUCTION

### DIFF
--- a/packages/lib/src/components/GooglePay/utils.ts
+++ b/packages/lib/src/components/GooglePay/utils.ts
@@ -6,6 +6,8 @@ export function resolveEnvironment(env = 'TEST'): google.payments.api.Environmen
     switch (environment) {
         case 'production':
         case 'live':
+        case 'live-au':
+        case 'live-us':
             return 'PRODUCTION';
         default:
             return 'TEST';


### PR DESCRIPTION
## Summary

The Google Pay `environment` must be populated to be either **TEST** or **PRODUCTION**. There is a `resolveEnvironment` function in `utils.ts` that is used to determine this value based on the Adyen environment.

Currently, this function does not consider the **live-au** and **live-us** environment as **PRODUCTION**, resulting on Google Pay payments failing unless this is explicitly set in the Component configuration.