### PR TITLE
ApplePay - Fixing type of onvalidatemerchant callback

### DIFF
--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -129,7 +129,7 @@ export interface ApplePayElementProps extends UIElementProps {
 
     onAuthorized?: (resolve, reject, event: ApplePayJS.ApplePayPaymentAuthorizedEvent) => void;
 
-    onValidateMerchant?: (resolve, reject, event: ApplePayJS.ApplePayValidateMerchantEvent) => void;
+    onValidateMerchant?: (resolve, reject, validationURL: string) => void;
 
     /**
      * {@link https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession/1778013-onpaymentmethodselected}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Function interface does not match with what is being returned. [Docs](https://docs.adyen.com/payment-methods/apple-pay/web-drop-in#drop-in-configuration) also mention that what is returned is an URL.

**Fixed issue**: #1498
