### PR TITLE
Updating paymentMethodResponse access modifier 

### DIFF
--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -15,7 +15,7 @@ import { hasOwnProperty } from '../utils/hasOwnProperty';
 
 class Core {
     public session: Session;
-    private paymentMethodsResponse: PaymentMethodsResponse;
+    public paymentMethodsResponse: PaymentMethodsResponse;
     public modules: any;
     public options: CoreOptions;
     public components = [];


### PR DESCRIPTION
## Summary

Currently the access modifier for `paymentMethodResponse` is private, which does not allow devs that are using Angular/Typescript to do what is described [here on our docs](https://docs.adyen.com/payment-methods/cards/web-component?tab=_code_sessions_code__1#step-2). As workaround, merchants need to use `@ts-ignore` to make it work.

**Fixed issue**: COWEB-1061
