### PR TITLE
Showing Instant Payment Method if showPayButton is set to false

### DIFF
--- a/packages/lib/src/components/Dropin/elements/createInstantPaymentElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createInstantPaymentElements.ts
@@ -9,6 +9,6 @@ import UIElement from '../../UIElement';
  * @param create - Reference to the main instance `Core#create` method
  */
 const createInstantPaymentElements = (paymentMethods: PaymentMethod[] = [], props, create): Promise<UIElement[]> | [] =>
-    paymentMethods.length ? createElements(paymentMethods, { ...props, isInstantPayment: true }, create) : [];
+    paymentMethods.length ? createElements(paymentMethods, { ...props, isInstantPayment: true, showPayButton: true }, create) : [];
 
 export default createInstantPaymentElements;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Forcing instant payment method button to show up if `showPayButton` is set to `false`. By default, it should always show up.

**Fixed issue**: COWEB-1075
