### PR TITLE
More descriptive errors when whole response object passed to handleAction

### DIFF
--- a/packages/e2e/tests/cards/binLookup/ui/panLength/panLength.focus.regular.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/panLength/panLength.focus.regular.test.js
@@ -25,7 +25,7 @@ const removeRequestHook = async t => {
     if (currentMock) await t.removeRequestHooks(currentMock); // don't know if this is strictly necessary
 };
 
-fixture.only`Test how Card Component handles binLookup returning a panLength property (or not)`
+fixture`Test how Card Component handles binLookup returning a panLength property (or not)`
     .beforeEach(async t => {
         await t.navigateTo(cardPage.pageUrl);
         // For individual test suites (that rely on binLookup & perhaps are being run in isolation)

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -8,6 +8,7 @@ import { DropinElementProps, InstantPaymentTypes } from './types';
 import { getCommonProps } from './components/utils';
 import { createElements, createStoredElements } from './elements';
 import createInstantPaymentElements from './elements/createInstantPaymentElements';
+import { hasOwnProperty } from '../../utils/hasOwnProperty';
 
 const SUPPORTED_INSTANT_PAYMENTS = ['paywithgoogle', 'applepay'];
 
@@ -108,7 +109,15 @@ class DropinElement extends UIElement<DropinElementProps> {
     };
 
     public handleAction(action: PaymentAction, props = {}): UIElement | null {
-        if (!action || !action.type) throw new Error('Invalid Action');
+        if (!action || !action.type) {
+            if (hasOwnProperty(action, 'action') && hasOwnProperty(action, 'resultCode')) {
+                throw new Error(
+                    'handleAction::Invalid Action - the passed action object itself has an "action" property and ' +
+                        'a "resultCode": have you passed in the whole response object by mistake?'
+                );
+            }
+            throw new Error('handleAction::Invalid Action - the passed action object does not have a "type" property');
+        }
 
         if (action.type !== 'redirect' && this.activePaymentMethod?.updateWithAction) {
             return this.activePaymentMethod.updateWithAction(action);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -7,6 +7,7 @@ import { IUIElement, UIElementProps } from './types';
 import { getSanitizedResponse, resolveFinalResult } from './utils';
 import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
 import type { UIElementStatus } from './types';
+import { hasOwnProperty } from "../utils/hasOwnProperty";
 
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement{
     protected componentRef: any;
@@ -136,7 +137,15 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     };
 
     public handleAction(action: PaymentAction, props = {}): UIElement | null {
-        if (!action || !action.type) throw new Error('Invalid Action');
+        if (!action || !action.type) {
+            if (hasOwnProperty(action, 'action') && hasOwnProperty(action, 'resultCode')) {
+                throw new Error(
+                    'handleAction::Invalid Action - the passed action object itself has an "action" property and ' +
+                    'a "resultCode": have you passed in the whole response object by mistake?'
+                );
+            }
+            throw new Error('handleAction::Invalid Action - the passed action object does not have a "type" property');
+        }
 
         const paymentAction = this._parentInstance.createFromAction(action, {
             ...props,

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -123,6 +123,15 @@ class Core {
      * @returns new UIElement
      */
     public createFromAction(action: PaymentAction, options = {}): UIElement {
+        if (!action || !action.type) {
+            if (hasOwnProperty(action, 'action') && hasOwnProperty(action, 'resultCode')) {
+                throw new Error(
+                    'createFromAction::Invalid Action - the passed action object itself has an "action" property and ' +
+                        'a "resultCode": have you passed in the whole response object by mistake?'
+                );
+            }
+            throw new Error('createFromAction::Invalid Action - the passed action object does not have a "type" property');
+        }
         if (action.type) {
             const paymentMethodsConfiguration = getComponentConfiguration(action.type, this.options.paymentMethodsConfiguration);
             const props = { ...processGlobalOptions(this.options), ...paymentMethodsConfiguration, ...this.getPropsForComponent(options) };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
I get the impression that quite a lot of 3DS2 errors come from calling `handleAction` or `createFromAction` by passing it the full response object rather than the `response.action` object.
So I have made more explicit errors in these functions, detecting this scenario & explaining what the merchant has done wrong

(Also removed a `.only` from an e2e test)

## Tested scenarios
In both `Dropin` & `Card`, with both `handleAction` & `createFromAction` passing in the whole response object triggers a new error.
Whilst in above scenarios correctly passing in `response.action` works correctly

All unit & e2e tests pass