### PR TITLE
Clarifying InputBase handlers

### DIFF
--- a/packages/e2e/tests/cards/binLookup/ui/panLength/panLength.focus.regular.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/panLength/panLength.focus.regular.test.js
@@ -25,7 +25,7 @@ const removeRequestHook = async t => {
     if (currentMock) await t.removeRequestHooks(currentMock); // don't know if this is strictly necessary
 };
 
-fixture.only`Test how Card Component handles binLookup returning a panLength property (or not)`
+fixture`Test how Card Component handles binLookup returning a panLength property (or not)`
     .beforeEach(async t => {
         await t.navigateTo(cardPage.pageUrl);
         // For individual test suites (that rely on binLookup & perhaps are being run in isolation)

--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -92,7 +92,7 @@ function BacsInput(props: BacsInputProps) {
                     required: true,
                     readonly: status === CONFIRM_STATE || status === 'loading',
                     autocorrect: 'off',
-                    onChange: handleChangeFor('holderName', 'blur'),
+                    onBlur: handleChangeFor('holderName', 'blur'),
                     onInput: handleChangeFor('holderName', 'input')
                 })}
             </Field>
@@ -119,7 +119,7 @@ function BacsInput(props: BacsInputProps) {
                         required: true,
                         readonly: status === CONFIRM_STATE || status === 'loading',
                         autocorrect: 'off',
-                        onChange: handleChangeFor('bankAccountNumber', 'blur'),
+                        onBlur: handleChangeFor('bankAccountNumber', 'blur'),
                         onInput: handleChangeFor('bankAccountNumber', 'input')
                     })}
                 </Field>
@@ -145,7 +145,7 @@ function BacsInput(props: BacsInputProps) {
                         required: true,
                         readonly: status === CONFIRM_STATE || status === 'loading',
                         autocorrect: 'off',
-                        onChange: handleChangeFor('bankLocationId', 'blur'),
+                        onBlur: handleChangeFor('bankLocationId', 'blur'),
                         onInput: handleChangeFor('bankLocationId', 'input')
                     })}
                 </Field>
@@ -175,7 +175,7 @@ function BacsInput(props: BacsInputProps) {
                     readonly: status === CONFIRM_STATE || status === 'loading',
                     autocorrect: 'off',
                     onInput: handleChangeFor('shopperEmail', 'input'),
-                    onChange: handleChangeFor('shopperEmail', 'blur')
+                    onBlur: handleChangeFor('shopperEmail', 'blur')
                 })}
             </Field>
 

--- a/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
+++ b/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
@@ -36,7 +36,7 @@ function BankTransferInput(props) {
                 errors={errors.shopperEmail}
                 onToggle={toggleEmailField}
                 onInput={handleChangeFor('shopperEmail', 'input')}
-                onChange={handleChangeFor('shopperEmail', 'blur')}
+                onBlur={handleChangeFor('shopperEmail', 'blur')}
             />
         </div>
     );

--- a/packages/lib/src/components/Blik/components/BlikInput.tsx
+++ b/packages/lib/src/components/Blik/components/BlikInput.tsx
@@ -54,7 +54,7 @@ function BlikInput(props: BlikInputProps) {
                     required: true,
                     autocorrect: 'off',
                     onInput: handleChangeFor('blikCode', 'input'),
-                    onChange: handleChangeFor('blikCode', 'blur'),
+                    onBlur: handleChangeFor('blikCode', 'blur'),
                     placeholder: '123456',
                     maxLength: 6
                 })}

--- a/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.tsx
+++ b/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.tsx
@@ -81,7 +81,7 @@ function BoletoInput(props) {
                     errors={errors.shopperEmail}
                     onToggle={toggleEmailField}
                     onInput={handleChangeFor('shopperEmail', 'input')}
-                    onChange={handleChangeFor('shopperEmail')}
+                    onBlur={handleChangeFor('shopperEmail', 'blur')}
                 />
             )}
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -71,7 +71,7 @@ describe('CardInput > holderName', () => {
         const placeholderText = i18n.get('creditCard.holderName.placeholder');
 
         const field = screen.getByPlaceholderText(placeholderText);
-        fireEvent.change(field, { target: { value: 'joe blogs' } });
+        fireEvent.blur(field, { target: { value: 'joe blogs' } });
 
         // await waitFor(() => {
         expect(data.holderName).toBe('joe blogs');

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
@@ -74,7 +74,7 @@ export const CardFieldsWrapper = ({
             value={formData.holderName}
             error={!!formErrors.holderName && holderNameRequired}
             isValid={!!formValid.holderName}
-            onChange={handleChangeFor('holderName', 'blur')}
+            onBlur={handleChangeFor('holderName', 'blur')}
             onInput={handleChangeFor('holderName', 'input')}
         />
     );
@@ -123,7 +123,7 @@ export const CardFieldsWrapper = ({
                     value={data.taxNumber}
                     error={!!errors.taxNumber}
                     isValid={!!valid.taxNumber}
-                    onChange={handleChangeFor('taxNumber', 'blur')}
+                    onBlur={handleChangeFor('taxNumber', 'blur')}
                     onInput={handleChangeFor('taxNumber', 'input')}
                 />
             )}
@@ -131,7 +131,7 @@ export const CardFieldsWrapper = ({
             {showBrazilianSSN && (
                 <div className="adyen-checkout__card__socialSecurityNumber">
                     <SocialSecurityNumberBrazil
-                        onChange={handleChangeFor('socialSecurityNumber', 'blur')}
+                        onBlur={handleChangeFor('socialSecurityNumber', 'blur')}
                         onInput={handleChangeFor('socialSecurityNumber', 'input')}
                         error={errors?.socialSecurityNumber}
                         valid={valid?.socialSecurityNumber}

--- a/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
@@ -5,7 +5,7 @@ import { renderFormField } from '../../../../internal/FormFields';
 import { CardHolderNameProps } from './types';
 import styles from '../CardInput.module.scss';
 
-export default function CardHolderName({ onChange, onInput, placeholder, value, required, error = false, isValid }: CardHolderNameProps) {
+export default function CardHolderName({ onBlur, onInput, placeholder, value, required, error = false, isValid }: CardHolderNameProps) {
     const {
         i18n,
         commonProps: { isCollatingErrors }
@@ -26,7 +26,7 @@ export default function CardHolderName({ onChange, onInput, placeholder, value, 
                 placeholder: placeholder || i18n.get('creditCard.holderName.placeholder'),
                 value,
                 required,
-                onChange,
+                onBlur,
                 onInput,
                 isCollatingErrors
             })}

--- a/packages/lib/src/components/Card/components/CardInput/components/KCPAuthentication.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/KCPAuthentication.tsx
@@ -41,7 +41,7 @@ export default function KCPAuthentication(props: KCPProps) {
                     autoComplete: false,
                     value: props.value,
                     required: true,
-                    onChange: props.onChange,
+                    onBlur: props.onBlur,
                     onInput: props.onInput,
                     isCollatingErrors
                 })}

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -27,7 +27,7 @@ export interface CardFieldsProps {
 export interface CardHolderNameProps {
     error: boolean;
     isValid: boolean;
-    onChange: (event: Event) => void;
+    onBlur: (event: Event) => void;
     onInput: (event: Event) => void;
     placeholder?: string;
     required?: boolean;
@@ -120,7 +120,7 @@ export interface KCPProps {
     filled?: boolean;
     focusedElement;
     onFocusField: (str: string) => {};
-    onChange: (event: Event) => void;
+    onBlur: (event: Event) => void;
     onInput: (event: Event) => void;
     taxNumber?: string;
     error: boolean;

--- a/packages/lib/src/components/Dragonpay/components/DragonpayInput/DragonpayInput.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayInput/DragonpayInput.tsx
@@ -57,7 +57,7 @@ export default function DragonpayInput(props: DragonpayInputProps) {
                     className: 'adyen-checkout__input--large',
                     spellCheck: false,
                     onInput: handleChangeFor('shopperEmail', 'input'),
-                    onChange: handleChangeFor('shopperEmail', 'blur')
+                    onBlur: handleChangeFor('shopperEmail', 'blur')
                 })}
             </Field>
 

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -52,7 +52,7 @@ function MBWayInput(props: MBWayInputProps) {
                     placeholder: props.placeholders.telephoneNumber,
                     required: true,
                     autoCorrect: 'off',
-                    onChange: handleChangeFor('telephoneNumber', 'blur'),
+                    onBlur: handleChangeFor('telephoneNumber', 'blur'),
                     onInput: handleChangeFor('telephoneNumber', 'input')
                 })}
             </Field>

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -89,7 +89,7 @@ export default function Address(props: AddressProps) {
                 valid={valid}
                 fieldName={fieldName}
                 onInput={handleChangeFor(fieldName, 'input')}
-                onChange={handleChangeFor(fieldName, 'blur')}
+                onBlur={handleChangeFor(fieldName, 'blur')}
                 onDropdownChange={handleChangeFor(fieldName, 'blur')}
                 specifications={specifications}
                 maxlength={getMaxLengthByFieldAndCountry(countrySpecificFormatters, fieldName, data.country, true)}

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
@@ -15,12 +15,19 @@ function getErrorMessage(errors: AddressStateError, fieldName: string, i18n: Lan
     return i18n.get(errors[fieldName]?.errorMessage) || !!errors[fieldName];
 }
 
+/**
+ * USAGE: Specifically defined as a util to provide a wrapper for fields created within the Address component
+ *
+ * NOT TO BE USED: if you just want to add a Country or State dropdown outside of an Address component
+ * - then you should implement <CountryField> or <StateField> directly
+ */
 function FieldContainer(props: FieldContainerProps) {
     const {
         i18n,
         commonProps: { isCollatingErrors }
     } = useCoreContext();
-    const { classNameModifiers = [], data, errors, valid, fieldName, onInput, onChange, maxlength } = props;
+    const { classNameModifiers = [], data, errors, valid, fieldName, onInput, onBlur, trimOnBlur, maxlength } = props;
+
     const value: string = data[fieldName];
     const selectedCountry: string = data.country;
     const isOptional: boolean = props.specifications.countryHasOptionalField(selectedCountry, fieldName);
@@ -68,9 +75,10 @@ function FieldContainer(props: FieldContainerProps) {
                         name: fieldName,
                         value,
                         onInput,
-                        onChange,
+                        onBlur,
                         isCollatingErrors,
-                        maxlength
+                        maxlength,
+                        trimOnBlur
                     })}
                 </Field>
             );

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -39,11 +39,12 @@ export interface FieldContainerProps {
     key: string;
     valid?: object;
     onInput?: (e: Event) => void;
-    onChange?: (e: Event) => void;
+    onBlur?: (e: Event) => void;
     onDropdownChange: (e: Event) => void;
     readOnly?: boolean;
     specifications: Specifications;
     maxlength?: number;
+    trimOnBlur?: boolean;
 }
 
 export interface ReadOnlyAddressProps {

--- a/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
+++ b/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
@@ -49,7 +49,7 @@ export default function CompanyDetails(props: CompanyDetailsProps) {
                         value: data.name,
                         classNameModifiers: ['name'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur'),
+                        onBlur: eventHandler('blur'),
                         spellCheck: false
                     })}
                 </Field>
@@ -66,7 +66,7 @@ export default function CompanyDetails(props: CompanyDetailsProps) {
                         value: data.registrationNumber,
                         classNameModifiers: ['registrationNumber'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur'),
+                        onBlur: eventHandler('blur'),
                         spellCheck: false
                     })}
                 </Field>

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -111,8 +111,8 @@ class Field extends Component<FieldProps, FieldState> {
                             (child: ComponentChild): ComponentChild => {
                                 const childProps = {
                                     isValid,
-                                    onFocus: this.onFocus,
-                                    onBlur: this.onBlur,
+                                    onFocusHandler: this.onFocus,
+                                    onBlurHandler: this.onBlur,
                                     isInvalid: !!errorMessage,
                                     ...(name && { uniqueId: this.uniqueId })
                                 };

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -1,29 +1,35 @@
 import { h } from 'preact';
-import { useState, useCallback } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
 import classNames from 'classnames';
 import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
 
 export default function InputBase(props) {
     const { autoCorrect, classNameModifiers, isInvalid, isValid, readonly = null, spellCheck, type, uniqueId, isCollatingErrors } = props;
 
-    const [handleChangeHasFired, setHandleChangeHasFired] = useState(false);
+    /**
+     * To avoid confusion with misplaced/misdirected onChange handlers - InputBase only accepts onInput, onBlur & onFocus handlers.
+     * The first 2 being the means by which we expect useForm--handleChangeFor validation functionality to be applied.
+     */
+    if (Object.prototype.hasOwnProperty.call(props, 'onChange')) {
+        console.error('Error: Form fields that rely on InputBase may not have an onChange property');
+    }
 
     const handleInput = useCallback((event: h.JSX.TargetedEvent<HTMLInputElement>) => {
         props.onInput(event);
     }, []);
 
-    const handleChange = useCallback((event: h.JSX.TargetedEvent<HTMLInputElement>) => {
-        setHandleChangeHasFired(true);
-        props?.onChange?.(event);
-    }, []);
-
     const handleBlur = useCallback((event: h.JSX.TargetedEvent<HTMLInputElement>) => {
-        if (!handleChangeHasFired) {
-            props?.onChange?.(event);
+        props?.onBlurHandler?.(event); // From Field component
+
+        if (props.trimOnBlur) {
+            (event.target as HTMLInputElement).value = (event.target as HTMLInputElement).value.trim(); // needed to trim trailing spaces in field (leading spaces can be done via formatting)
         }
-        setHandleChangeHasFired(false);
 
         props?.onBlur?.(event);
+    }, []);
+
+    const handleFocus = useCallback((event: h.JSX.TargetedEvent<HTMLInputElement>) => {
+        props?.onFocusHandler?.(event); // From Field component
     }, []);
 
     const inputClassNames = classNames(
@@ -46,14 +52,14 @@ export default function InputBase(props) {
             {...newProps}
             type={type}
             className={inputClassNames}
-            onInput={handleInput}
             readOnly={readonly}
             spellCheck={spellCheck}
             autoCorrect={autoCorrect}
             aria-describedby={isCollatingErrors ? null : `${uniqueId}${ARIA_ERROR_SUFFIX}`}
-            onChange={handleChange}
-            onBlur={handleBlur}
             aria-invalid={isInvalid}
+            onInput={handleInput}
+            onBlur={handleBlur}
+            onFocus={handleFocus}
         />
     );
 }

--- a/packages/lib/src/components/internal/FormFields/index.tsx
+++ b/packages/lib/src/components/internal/FormFields/index.tsx
@@ -11,10 +11,11 @@ import './FormFields.scss';
 export const renderFormField = (type, props) => {
     const formFieldTypes = {
         boolean: Checkbox,
-        date: InputDate,
-        emailAddress: InputEmail,
         radio: RadioGroup,
         select: Select,
+        // All the following use InputBase
+        date: InputDate,
+        emailAddress: InputEmail,
         tel: InputTelephone,
         text: InputText,
         default: InputText

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -60,7 +60,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         value: data.firstName,
                         classNameModifiers: ['firstName'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur'),
+                        onBlur: eventHandler('blur'),
                         placeholder: placeholders.firstName,
                         spellCheck: false
                     })}
@@ -74,7 +74,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         value: data.lastName,
                         classNameModifiers: ['lastName'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur'),
+                        onBlur: eventHandler('blur'),
                         placeholder: placeholders.lastName,
                         spellCheck: false
                     })}
@@ -111,7 +111,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         value: data.dateOfBirth,
                         classNameModifiers: ['dateOfBirth'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur'),
+                        onBlur: eventHandler('blur'),
                         placeholder: placeholders.dateOfBirth
                     })}
                 </Field>
@@ -130,7 +130,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         value: data.shopperEmail,
                         classNameModifiers: ['shopperEmail'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur'),
+                        onBlur: eventHandler('blur'),
                         placeholder: placeholders.shopperEmail
                     })}
                 </Field>
@@ -149,7 +149,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         value: data.telephoneNumber,
                         classNameModifiers: ['telephoneNumber'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur'),
+                        onBlur: eventHandler('blur'),
                         placeholder: placeholders.telephoneNumber
                     })}
                 </Field>

--- a/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
@@ -66,7 +66,7 @@ export function PhoneInput(props) {
                                         name={props.phoneName}
                                         value={data.phoneNumber}
                                         onInput={handleChangeFor('phoneNumber', 'input')}
-                                        onChange={handleChangeFor('phoneNumber', 'blur')}
+                                        onBlur={handleChangeFor('phoneNumber', 'blur')}
                                         placeholder="123 456 789"
                                         className="adyen-checkout__input adyen-checkout__input--phoneNumber"
                                         autoCorrect="off"

--- a/packages/lib/src/components/internal/SendCopyToEmail/SendCopyToEmail.tsx
+++ b/packages/lib/src/components/internal/SendCopyToEmail/SendCopyToEmail.tsx
@@ -6,7 +6,7 @@ import useCoreContext from '../../../core/Context/useCoreContext';
 import Field from '../FormFields/Field';
 
 export default function SendCopyToEmail(props) {
-    const { errors, value, onInput, onChange } = props;
+    const { errors, value, onInput, onBlur } = props;
     const { i18n } = useCoreContext();
     const [sendCopyToEmail, setSendCopyToEmail] = useState(false);
 
@@ -34,7 +34,7 @@ export default function SendCopyToEmail(props) {
                         spellCheck: false,
                         value,
                         onInput,
-                        onChange
+                        onBlur
                     })}
                 </Field>
             )}

--- a/packages/lib/src/components/internal/SocialSecurityNumberBrazil/BrazilPersonalDetail.tsx
+++ b/packages/lib/src/components/internal/SocialSecurityNumberBrazil/BrazilPersonalDetail.tsx
@@ -17,7 +17,7 @@ export function BrazilPersonalDetail(props) {
                         spellcheck: false,
                         value: data.firstName,
                         onInput: handleChangeFor('firstName', 'input'),
-                        onChange: handleChangeFor('firstName')
+                        onBlur: handleChangeFor('firstName', 'blur')
                     })}
                 </Field>
 
@@ -28,7 +28,7 @@ export function BrazilPersonalDetail(props) {
                         spellcheck: false,
                         value: data.lastName,
                         onInput: handleChangeFor('lastName', 'input'),
-                        onChange: handleChangeFor('lastName')
+                        onBlur: handleChangeFor('lastName', 'blur')
                     })}
                 </Field>
 
@@ -37,7 +37,7 @@ export function BrazilPersonalDetail(props) {
                     error={errors.socialSecurityNumber}
                     valid={valid.socialSecurityNumber}
                     onInput={handleChangeFor('socialSecurityNumber', 'input')}
-                    onChange={handleChangeFor('socialSecurityNumber')}
+                    onBlur={handleChangeFor('socialSecurityNumber', 'blur')}
                 />
             </div>
         </div>

--- a/packages/lib/src/components/internal/SocialSecurityNumberBrazil/SocialSecurityNumberBrazil.tsx
+++ b/packages/lib/src/components/internal/SocialSecurityNumberBrazil/SocialSecurityNumberBrazil.tsx
@@ -3,7 +3,7 @@ import renderFormField from '../../internal/FormFields';
 import Field from '../../internal/FormFields/Field';
 import useCoreContext from '../../../core/Context/useCoreContext';
 
-export default function({ onChange, onInput, valid = false, error = null, data = '', required = false }) {
+export default function({ onBlur, onInput, valid = false, error = null, data = '', required = false }) {
     const {
         i18n,
         commonProps: { isCollatingErrors }
@@ -25,7 +25,7 @@ export default function({ onChange, onInput, valid = false, error = null, data =
                 value: data,
                 maxLength: 18,
                 onInput,
-                onChange,
+                onBlur,
                 required,
                 isCollatingErrors
             })}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
##### Description:
To avoid confusion with misplaced/misdirected onChange handlers - `InputBase` only accepts `onInput, onBlur & onFocus` handlers.
The first 2 being the means by which we expect `useForm`--`handleChangeFor` validation functionality to be applied.

#####  Rationale:
1). InputBase currently contains code which was added to fix a bug in useForm which was described so:
> Fixes useForm 'bug'
-Scenario:
1: An input is in an error state when it loses focus > the onChange handler runs > if this triggers a validation routine then the input shows an error. Correct!
2: The input is then interacted with but is left with exactly the same value in it when it loses focus > the onChange handler doesn't run > input can't be validated to show an error. Wrong!
-Logic:
This happens because we are relying on the 'onchange' event.
In the first part of the scenario a change occurs in the input (which leads to it getting validated and showing an error).
But in the second part of the scenario there is no change to the input, so the 'onchange' event doesn't fire (so no validation & no error).
Although this is technically correct behaviour, in how 'onchange' is supposed to work, it is not desirable and leaves the UI in a misleading state.
-Fix:
When the 'onblur' event fires we check to see if the 'onchange' event has fired & if it hasn't we call the onChange handler (to trigger the validation for the field)


2). There is also an issue if our components are ever brought into a codebase using preact/compat - which happened in KYC and was described so:
> If preact/compat is used anywhere in the app then it will "normalise" the onChange event to use onInput behaviour (https://github.com/preactjs/preact/issues/1410#issuecomment-473470561)
In other words most onChange events will be internally converted to onInput events, (https://preactjs.com/guide/v10/differences-to-react/#use-oninput-instead-of-onchange)
This means that we lose any events that are intended to be fired when the input loses focus i.e. handleChangeFor(‘myField’, ‘blur’)

##### Conclusion
I have previously addressed and fixed this issue in the KYC codebase
And we have also talked in Checkout in the past about clarifying the `useForm>handleChangeFor` situation where we attach the `handleChangeFor` event to `onChange` yet describe the rule as `‘blur’` (the idea was that we would instead use `onBlur`)
So I have now applied the changes from KYC here.
This fixes both bugs and will also help to realign InputBase between the 2 codebases with an eye on the sharedComponents scenario

## Tested scenarios
All unit & e2e tests pass

