### PR TITLE
Map 'securedfields' to 'card' if 'type' prop not set in custom card config object

### DIFF
--- a/packages/e2e/app/src/pages/CustomCards/CustomCards.js
+++ b/packages/e2e/app/src/pages/CustomCards/CustomCards.js
@@ -36,7 +36,7 @@ const initCheckout = async () => {
 
     window.securedFields2 = checkout
         .create('securedfields', {
-            type: 'card',
+            //            type: 'card',// Deliberately exclude to ensure a default value is set
             brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro', 'cartebancaire'],
             onConfigSuccess,
             onBrand,

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -21,7 +21,7 @@ export class SecuredFieldsElement extends UIElement {
     formatProps(props) {
         return {
             ...props,
-            type: props.type === 'scheme' ? 'card' : props.type
+            type: props.type === 'scheme' || props.type === 'securedfields' ? 'card' : props.type
         };
     }
 


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
There was an issue (with brand recognition) triggered by the merchant not setting a `type` prop (with value `'card'`) when instantiating the Custom card component.
This prop was marked as optional in our Docs - but apparently was not!
It now is - if no `type` prop is set it is now forced to `'card'`

## Tested scenarios
All test pass


**Fixed issue**:  DEV-53178
