### PR TITLE
Clarifying 3DS2 challenge error

### DIFF
--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -4,6 +4,7 @@ import Challenge from './components/Challenge';
 import { ErrorObject } from './components/utils';
 import { DEFAULT_CHALLENGE_WINDOW_SIZE } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
+import { hasOwnProperty } from '../../utils/hasOwnProperty';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;
@@ -29,7 +30,14 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
     render() {
         // existy used because threeds2InMDFlow will send empty string for paymentData and we should be allowed to proceed with this
         if (!existy(this.props.paymentData)) {
-            this.props.onError({ errorCode: 'threeds2.challenge', message: 'No paymentData received. Challenge cannot proceed' });
+            /**
+             *  One component is used for both old and new 3DS2 challenge flows
+             *   - The presence of useOriginalFlow indicates the old flow which used paymentData from the 3DS2 action
+             *   - The new flow uses authorisationToken from the 3DS2 action, passed internally in a prop called paymentData
+             */
+            const dataTypeForError = hasOwnProperty(this.props, 'useOriginalFlow') ? 'paymentData' : 'authorisationToken';
+
+            this.props.onError({ errorCode: 'threeds2.challenge', message: `No ${dataTypeForError} received. Challenge cannot proceed` });
             return null;
         }
 


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Clarifying wording of 3DS2 challenge error.
For the original flow the error fires when `paymentData` not being present; in the new `/submit3DS2Fingerprint` flow it fires when `authorisationData` is not present.


