### PR TITLE
Throw an error if we notice that the environment & type of clientKey don't match

### DIFF
--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -195,6 +195,12 @@ class Core {
         this.paymentMethodsResponse = new PaymentMethodsResponse(this.options.paymentMethodsResponse ?? this.options.paymentMethods, this.options);
         delete this.options.paymentMethods;
 
+        // Check for clientKey/environment mismatch
+        const clientKeyType = this.options.clientKey.substr(0, 4);
+        if (!this.options.loadingContext.includes(clientKeyType)) {
+            throw new Error(`Error: you are using a ${clientKeyType} clientKey against the ${this.options.environment} environment`);
+        }
+
         return this;
     };
 


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Throw an error if we notice that the environment & type of clientKey don't match.
This should also help to prevent the "Invalid client key" error that securedFields can sometimes throw

## Tested scenarios
Error throw when using Live environment but Test clientKey & vice versa
