### PR TITLE
Add Eight digit issuer bin prop

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleEncryption.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleEncryption.ts
@@ -74,6 +74,11 @@ export function handleEncryption(pFeedbackObj: SFFeedbackObj): void {
         callbackObjectsArr[0].endDigits = pFeedbackObj.endDigits;
     }
 
+    // For number field - add the 8 digit issuerBin to the encryption object
+    if (fieldType === ENCRYPTED_CARD_NUMBER && truthy(pFeedbackObj.issuerBin)) {
+        callbackObjectsArr[0].issuerBin = +pFeedbackObj.issuerBin;
+    }
+
     // BROADCAST VALID STATE OF INDIVIDUAL INPUTS - passing the encryption objects
     for (i = 0, len = callbackObjectsArr.length; i < len; i += 1) {
         this.callbacks.onFieldValid(callbackObjectsArr[i]);

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -117,8 +117,8 @@ export interface CbObjOnBinLookup {
     brands?: string[];
     // New for CustomCard
     supportedBrandsRaw?: BrandObject[];
-    isReset?: boolean;
     rootNode?: HTMLElement;
+    isReset?: boolean; // Used internally - not propagated to merchant callback
 }
 
 export interface CbObjOnError {

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -93,6 +93,7 @@ export interface CbObjOnFieldValid {
     rootNode: HTMLElement;
     blob?: string;
     endDigits?: string;
+    issuerBin?: number;
 }
 
 export interface CbObjOnAutoComplete {
@@ -170,6 +171,7 @@ export interface SFFeedbackObj {
     maxLength?: number;
     error?: string;
     endDigits?: string;
+    issuerBin?: string;
     type?: string;
     binValue?: string;
     focus?: boolean;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
From 1st April 2022 the PCI rules change and we are allowed to expose the 8 digit bin value on cards whose PAN is >=16 digits.
The `issuerBin` prop will be added to the object sent to the `onFieldValid` callback
Relies on securedFields `v3.9.0` which is already Live

## Tested scenarios
Tested via unit tests in securedFields


**Fixed issue**:  FOC-57768
