### PR TITLE
Fixes CSP error caused by regenerator-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,32 @@
 {
-    "name": "@adyen/adyen-web-main",
-    "keywords": [
-        "adyen",
-        "adyen-web",
-        "checkout",
-        "payment",
-        "payments",
-        "components"
-    ],
-    "private": true,
-    "workspaces": [
-        "packages/*"
-    ],
-    "scripts": {
-        "start": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
-        "start:fast": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start:fast\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
-        "build": "yarn workspace @adyen/adyen-web build",
-        "lint": "yarn workspace @adyen/adyen-web lint",
-        "test": "yarn workspace @adyen/adyen-web test",
-        "test:watch": "yarn workspace @adyen/adyen-web test:watch",
-        "test:coverage": "yarn workspace @adyen/adyen-web test:coverage",
-        "test:e2e": "yarn build && yarn workspace @adyen/adyen-web-e2e test:e2e",
-        "type-check": "yarn workspace @adyen/adyen-web type-check"
-    },
-    "dependencies": {
-        "concurrently": "^6.2.0"
-    }
+  "name": "@adyen/adyen-web-main",
+  "keywords": [
+    "adyen",
+    "adyen-web",
+    "checkout",
+    "payment",
+    "payments",
+    "components"
+  ],
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "start": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
+    "start:fast": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start:fast\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
+    "build": "yarn workspace @adyen/adyen-web build",
+    "lint": "yarn workspace @adyen/adyen-web lint",
+    "test": "yarn workspace @adyen/adyen-web test",
+    "test:watch": "yarn workspace @adyen/adyen-web test:watch",
+    "test:coverage": "yarn workspace @adyen/adyen-web test:coverage",
+    "test:e2e": "yarn build && yarn workspace @adyen/adyen-web-e2e test:e2e",
+    "type-check": "yarn workspace @adyen/adyen-web type-check"
+  },
+  "resolutions": {
+    "**/regenerator-runtime": "^0.13.9"
+  },
+  "dependencies": {
+    "concurrently": "^6.2.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-  "name": "@adyen/adyen-web-main",
-  "keywords": [
-    "adyen",
-    "adyen-web",
-    "checkout",
-    "payment",
-    "payments",
-    "components"
-  ],
-  "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
-  "scripts": {
-    "start": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
-    "start:fast": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start:fast\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
-    "build": "yarn workspace @adyen/adyen-web build",
-    "lint": "yarn workspace @adyen/adyen-web lint",
-    "test": "yarn workspace @adyen/adyen-web test",
-    "test:watch": "yarn workspace @adyen/adyen-web test:watch",
-    "test:coverage": "yarn workspace @adyen/adyen-web test:coverage",
-    "test:e2e": "yarn build && yarn workspace @adyen/adyen-web-e2e test:e2e",
-    "type-check": "yarn workspace @adyen/adyen-web type-check"
-  },
-  "resolutions": {
-    "**/regenerator-runtime": "^0.13.9"
-  },
-  "dependencies": {
-    "concurrently": "^6.2.0"
-  }
+    "name": "@adyen/adyen-web-main",
+    "keywords": [
+        "adyen",
+        "adyen-web",
+        "checkout",
+        "payment",
+        "payments",
+        "components"
+    ],
+    "private": true,
+    "workspaces": [
+        "packages/*"
+    ],
+    "scripts": {
+        "start": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
+        "start:fast": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start:fast\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
+        "build": "yarn workspace @adyen/adyen-web build",
+        "lint": "yarn workspace @adyen/adyen-web lint",
+        "test": "yarn workspace @adyen/adyen-web test",
+        "test:watch": "yarn workspace @adyen/adyen-web test:watch",
+        "test:coverage": "yarn workspace @adyen/adyen-web test:coverage",
+        "test:e2e": "yarn build && yarn workspace @adyen/adyen-web-e2e test:e2e",
+        "type-check": "yarn workspace @adyen/adyen-web type-check"
+    },
+    "resolutions": {
+        "**/regenerator-runtime": "^0.13.9"
+    },
+    "dependencies": {
+        "concurrently": "^6.2.0"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10666,10 +10666,10 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+regenerator-runtime@0.13.9, regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
We got a report from PayByLink that they where experiencing CSP errors. This was being caused by https://github.com/facebook/regenerator/issues/450

This PR solves this issue by setting the `regenerator-runtime` to version `^0.13.9` across all packages. For this a `resolutions` is set on the global `package.json` because of a bug in yarn. When https://github.com/yarnpkg/yarn/issues/5039 is fixed we can move this resolution inside `lib` workspace.

## Tested scenarios
<!-- Description of tested scenarios -->

PayByLink tested this in their local setup

**Fixed issue**:  <!-- #-prefixed issue number -->
