### PR TITLE
[FOC-48755] Modify Swish QR code countdown time to 3 mins

### DIFF
--- a/packages/lib/src/components/Swish/Swish.ts
+++ b/packages/lib/src/components/Swish/Swish.ts
@@ -6,7 +6,7 @@ class SwishElement extends QRLoaderContainer {
         return {
             shouldRedirectOnMobile: true,
             delay: 2000, // ms
-            countdownTime: 15, // min
+            countdownTime: 3, // min
             instructions: 'swish.pendingMessage',
             ...super.formatProps(props)
         };


### PR DESCRIPTION
## Summary
Swish documentation states that the QR code times out after 3 minutes, yet it was displayed for 15 minutes previously. If the QR is scanned after 3 minutes, the payment is no longer valid and Swish app displays an error.

## Tested scenarios
N/A

**Fixed issue**:  FOC-48755
