### PR TITLE
Enable Funding option for Paypal SDK

### DIFF
--- a/packages/lib/src/components/PayPal/types.ts
+++ b/packages/lib/src/components/PayPal/types.ts
@@ -181,6 +181,7 @@ export interface PaypalSettings {
     vault?: boolean;
     'client-id': string;
     'integration-date': string;
+    'enable-funding': string;
     components: string;
 }
 

--- a/packages/lib/src/components/PayPal/utils.ts
+++ b/packages/lib/src/components/PayPal/utils.ts
@@ -56,6 +56,7 @@ const getPaypalSettings = ({
         vault,
         'client-id': clientId,
         'integration-date': INTEGRATION_DATE,
+        'enable-funding': 'paylater',
         components: 'buttons,funding-eligibility'
     };
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added `enable-funding=paylater` to PayPal SDK URL, so `PayLater` button can show up as expected for the available countries.

## Tested scenarios
- Tested setting the country to FR / US / AU and confirming that `PayLater` button shows up
<!-- Description of tested scenarios -->


**Fixed issue**:  COWEB-1082
