### PR TITLE
Allow ApplePay's onPaymentAuthorized event to complete with merchant provided status and customized errors.

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePayService.ts
+++ b/packages/lib/src/components/ApplePay/ApplePayService.ts
@@ -66,8 +66,8 @@ class ApplePayService {
      */
     onpaymentauthorized(event: ApplePayJS.ApplePayPaymentAuthorizedEvent, onPaymentAuthorized) {
         return new Promise((resolve, reject) => onPaymentAuthorized(resolve, reject, event))
-            .then(() => {
-                this.session.completePayment(ApplePaySession.STATUS_SUCCESS);
+            .then(response => {
+                this.session.completePayment(response);
             })
             .catch(() => {
                 this.session.completePayment(ApplePaySession.STATUS_FAILURE);


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

The OnPaymentAuthorized event on ApplePay can complete with the [ApplePayAuthorizationResult](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentauthorizationresult) object that allows custom error messages targeted for specific fields using [ApplePayError](https://developer.apple.com/documentation/apple_pay_on_the_web/applepayerror) objects. 

Currently Adyen is only passing positive or negative status towards ApplePay without any way of customizing negative outcomes.


## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->



**Fixed issue**:  This PR passes along the response from `onPaymentAuthorized` promise towards the `ApplePaysession.completePayment`

