### PR TITLE
Card - Updating position of available brands

### DIFF
--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
@@ -1,6 +1,7 @@
 import DropinPage from '../../_models/Dropin.page';
 import CardComponentPage from '../../_models/CardComponent.page';
 import { BCMC_DUAL_BRANDED_VISA, DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../utils/constants';
+import { Selector } from 'testcafe';
 
 const dropinPage = new DropinPage({
     components: {
@@ -18,17 +19,17 @@ test('#1 Check Bancontact comp is correctly presented at startup', async t => {
     // Wait for field to appear in DOM
     await t.wait(1000);
 
-    await t.expect(dropinPage.brandsImages.count).eql(3);
+    const brandsInsidePaymentMethod = Selector('.adyen-checkout__card__brands');
+    const images = brandsInsidePaymentMethod.find('img');
 
     // Expect 3 card brand logos to be displayed (not concerned about order)
+    await t.expect(images.count).eql(3);
     await t
-        .expect(dropinPage.brandsHolder.exists)
+        .expect(images.nth(0).withAttribute('alt', 'bcmc').exists)
         .ok()
-        .expect(dropinPage.brandsImages.withAttribute('alt', 'bcmc').exists)
+        .expect(images.nth(1).withAttribute('alt', 'visa').exists)
         .ok()
-        .expect(dropinPage.brandsImages.withAttribute('alt', 'visa').exists)
-        .ok()
-        .expect(dropinPage.brandsImages.withAttribute('alt', 'maestro').exists)
+        .expect(images.nth(2).withAttribute('alt', 'maestro').exists)
         .ok();
 
     // Hidden cvc field

--- a/packages/e2e/tests/cards/availableBrands/component/availableBrands.clientScripts.js
+++ b/packages/e2e/tests/cards/availableBrands/component/availableBrands.clientScripts.js
@@ -1,4 +1,3 @@
 window.cardConfig = {
-    brands: ['visa', 'mc', 'amex', 'discover', 'cup', 'maestro', 'bijcard', 'dineXrs', 'jcb', 'synchrony_cbcc'],
-    showBrandsUnderCardNumber: true
+    brands: ['visa', 'mc', 'amex', 'discover', 'cup', 'maestro', 'bijcard', 'dineXrs', 'jcb', 'synchrony_cbcc']
 };

--- a/packages/e2e/tests/cards/availableBrands/component/availableBrands.disabled.clientScripts.js
+++ b/packages/e2e/tests/cards/availableBrands/component/availableBrands.disabled.clientScripts.js
@@ -1,0 +1,4 @@
+window.cardConfig = {
+    brands: ['visa', 'mc', 'amex', 'discover', 'cup', 'maestro', 'bijcard', 'dineXrs', 'jcb', 'synchrony_cbcc'],
+    showBrandsUnderCardNumber: false
+};

--- a/packages/e2e/tests/cards/availableBrands/component/availableBrands.test.js
+++ b/packages/e2e/tests/cards/availableBrands/component/availableBrands.test.js
@@ -8,12 +8,12 @@ fixture`Cards - Available brands on Card Component`.page(CARDS_URL).beforeEach(a
     cardComponent = new CardComponent('.card-field');
 });
 
-test('Available brands show underneath Card Number field if property `showBrandsUnderCardNumber` is set', async t => {
+test('Available brands dont show underneath Card Number field if property `showBrandsUnderCardNumber` is set to false', async t => {
+    const brandsInsidePaymentMethod = Selector('.adyen-checkout__card__brands');
+    await t.expect(brandsInsidePaymentMethod.find('img').count).eql(0);
+}).clientScripts('./availableBrands.disabled.clientScripts.js');
+
+test('Available brands show underneath Card Number field by default', async t => {
     const brandsInsidePaymentMethod = Selector('.adyen-checkout__card__brands');
     await t.expect(brandsInsidePaymentMethod.find('img').count).eql(10);
 }).clientScripts('./availableBrands.clientScripts.js');
-
-test('Available brands dont show underneath Card Number field by default', async t => {
-    const brandsInsidePaymentMethod = Selector('.adyen-checkout__card__brands');
-    await t.expect(brandsInsidePaymentMethod.find('img').count).eql(0);
-});

--- a/packages/e2e/tests/cards/availableBrands/dropin/availableBrands.clientScripts.js
+++ b/packages/e2e/tests/cards/availableBrands/dropin/availableBrands.clientScripts.js
@@ -1,7 +1,7 @@
 window.mainConfiguration = {
     paymentMethodsConfiguration: {
         card: {
-            showBrandsUnderCardNumber: true
+            showBrandsUnderCardNumber: false
         }
     }
 };

--- a/packages/e2e/tests/cards/availableBrands/dropin/availableBrands.compactView.test.js
+++ b/packages/e2e/tests/cards/availableBrands/dropin/availableBrands.compactView.test.js
@@ -8,7 +8,6 @@ let dropinPage = null;
 fixture`Cards - Available Brands (Compact view)`
     .page(DROPIN_SESSIONS_URL)
     .requestHooks([mock])
-    .clientScripts('availableBrands.clientScripts.js')
     .beforeEach(() => {
         dropinPage = new DropinPage({});
     });

--- a/packages/e2e/tests/cards/availableBrands/dropin/availableBrands.defaultView.test.js
+++ b/packages/e2e/tests/cards/availableBrands/dropin/availableBrands.defaultView.test.js
@@ -8,6 +8,7 @@ let dropinPage = null;
 fixture`Cards - Available Brands (Default view)`
     .page(DROPIN_SESSIONS_URL)
     .requestHooks([mock])
+    .clientScripts('./availableBrands.clientScripts.js')
     .beforeEach(() => {
         dropinPage = new DropinPage({});
     });

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -15,7 +15,7 @@ export class CardElement extends UIElement<CardElementProps> {
 
     protected static defaultProps = {
         onBinLookup: () => {},
-        showBrandsUnderCardNumber: false,
+        showBrandsUnderCardNumber: true,
         SRConfig: {}
     };
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -53,8 +53,8 @@ describe('CardInput', () => {
 });
 
 describe('CardInput - Brands beneath Card Number field', () => {
-    test('should not render brands if property `showBrandsUnderCardNumber` isnt set', () => {
-        const wrapper = mount(<CardInput i18n={i18n} />);
+    test('should not render brands if property `showBrandsUnderCardNumber` is set to false', () => {
+        const wrapper = mount(<CardInput i18n={i18n} showBrandsUnderCardNumber={false} />);
         expect(wrapper.find('span.adyen-checkout__card__brands').exists()).toBeFalsy();
     });
 
@@ -68,6 +68,16 @@ describe('CardInput - Brands beneath Card Number field', () => {
         expect(wrapper.find('.adyen-checkout__card__brands__brand-wrapper--disabled')).toHaveLength(0);
     });
 
+    test('should render brands if property `showBrandsUnderCardNumber` is not set', () => {
+        const brandsIcons = [
+            { name: 'visa', icon: 'visa.png' },
+            { name: 'mc', icon: 'mc.png' }
+        ];
+        const wrapper = mount(<CardInput i18n={i18n} brandsIcons={brandsIcons} />);
+        expect(wrapper.find('.adyen-checkout__card__brands__brand-wrapper')).toHaveLength(2);
+        expect(wrapper.find('.adyen-checkout__card__brands__brand-wrapper--disabled')).toHaveLength(0);
+    });
+
     test('should disable the brands icons that are not detected', () => {
         const detectedBrand = 'visa';
         const brandsIcons = [
@@ -75,7 +85,7 @@ describe('CardInput - Brands beneath Card Number field', () => {
             { name: 'mc', icon: 'mc.png' },
             { name: 'amex', icon: 'amex.png' }
         ];
-        const wrapper = mount(<CardInput i18n={i18n} brand={detectedBrand} showBrandsUnderCardNumber brandsIcons={brandsIcons} />);
+        const wrapper = mount(<CardInput i18n={i18n} brand={detectedBrand} brandsIcons={brandsIcons} />);
         const brands = wrapper.find('.adyen-checkout__card__brands__brand-wrapper');
 
         expect(brands.at(0).is('.adyen-checkout__card__brands__brand-wrapper--disabled')).toBeFalsy();

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
@@ -5,7 +5,7 @@
   flex-basis: auto;
   flex-shrink: 1;
   flex-wrap: wrap;
-  height: 16px;
+  gap: 4px;
   margin-top: -8px;
   margin-bottom: 16px;
 }
@@ -22,7 +22,6 @@
 .adyen-checkout__card__brands__brand-wrapper {
   display: inline-block;
   height: 16px;
-  margin-right: 4px;
   transition: opacity .2s ease-out;
   width: 24px;
   position: relative;

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
@@ -12,7 +12,7 @@ interface PaymentMethodBrandsProps {
 }
 
 const AvailableBrands = ({ brands, activeBrand }: PaymentMethodBrandsProps) => {
-    if (!brands.length) {
+    if (!brands?.length) {
         return null;
     }
 

--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -11,6 +11,7 @@ export default {
     enableStoreDetails: false,
     hasCVC: true,
     showBrandIcon: true,
+    showBrandsUnderCardNumber: true,
     positionHolderNameOnTop: false,
     billingAddressRequired: false,
     billingAddressRequiredFields: ['street', 'houseNumberOrName', 'postalCode', 'city', 'stateOrProvince', 'country'],

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.test.tsx
@@ -19,8 +19,13 @@ describe('PaymentMethodBrands', () => {
         expect(wrapper.find(CompactView)).toHaveLength(1);
     });
 
-    test('should render all brands if compact view is not set', () => {
+    test('should render compact view if prop is not', () => {
         const wrapper = mount(<PaymentMethodBrands brands={brands} isPaymentMethodSelected />);
+        expect(wrapper.find(CompactView)).toHaveLength(1);
+    });
+
+    test('should not render compact view if prop is set to false', () => {
+        const wrapper = mount(<PaymentMethodBrands brands={brands} isPaymentMethodSelected isCompactView={false} />);
         expect(wrapper.find(PaymentMethodIcon)).toHaveLength(6);
     });
 });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
@@ -10,7 +10,7 @@ interface PaymentMethodBrandsProps {
     isCompactView?: boolean;
 }
 
-const PaymentMethodBrands = ({ activeBrand, brands, isPaymentMethodSelected, isCompactView = false }: PaymentMethodBrandsProps) => {
+const PaymentMethodBrands = ({ activeBrand, brands, isPaymentMethodSelected, isCompactView = true }: PaymentMethodBrandsProps) => {
     if (isCompactView) {
         return <CompactView brands={brands} isPaymentMethodSelected={isPaymentMethodSelected} />;
     }

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
@@ -58,6 +58,7 @@
     $payment-button-padding: $spacing-xsmall;
     padding: $spacing-medium - $payment-button-padding;
     padding-left: $spacing-xxlarge - $payment-button-padding;
+    padding-right: $spacing-medium;
     position: relative;
     transition: background 0.1s ease-out;
     width: 100%;

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -31,9 +31,6 @@ export async function initSession() {
         paymentMethodsConfiguration: {
             paywithgoogle: {
                 buttonType: 'plain'
-            },
-            card: {
-                showBrandsUnderCardNumber: true
             }
         }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10666,7 +10666,7 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
+regenerator-runtime@0.13.9, regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10666,7 +10666,7 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@0.13.9, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- `showBrandsUnderCardNumber` now has `true` as default value, which means it will be enabled by default for merchants, and they have to opt out for this new UI change.
- Styles were fixed - They weren't working as expected when merchant had many available brands. 

## Tested scenarios
- Adjusted e2e and unit tests
