### PR TITLE
useLabelElement=false can be used on Field to wrap everything in a div

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -25,10 +25,10 @@ export default function CardNumber(props: CardNumberProps) {
             onFocusField={() => onFocusField(ENCRYPTED_CARD_NUMBER)}
             errorMessage={error && i18n.get(error)}
             isValid={isValid}
-            dualBrandingElements={dualBrandingElements}
             dir={'ltr'}
             name={'encryptedCardNumber'}
             isCollatingErrors={isCollatingErrors}
+            showValidIcon={false}
         >
             <DataSfSpan
                 encryptedFieldType={ENCRYPTED_CARD_NUMBER}

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -47,20 +47,7 @@ class Field extends Component<FieldProps, FieldState> {
         return null;
     }
 
-    renderContent({
-        name,
-        children,
-        errorMessage,
-        helper,
-        inputWrapperModifiers,
-        isLoading,
-        isValid,
-        label,
-        showValidIcon,
-        dualBrandingElements,
-        isCollatingErrors,
-        dir
-    }) {
+    renderContent({ name, children, errorMessage, helper, inputWrapperModifiers, isLoading, isValid, label, showValidIcon, isCollatingErrors, dir }) {
         return (
             <Fragment>
                 {typeof label === 'string' && (
@@ -104,7 +91,7 @@ class Field extends Component<FieldProps, FieldState> {
                         </span>
                     )}
 
-                    {isValid && showValidIcon !== false && !dualBrandingElements && (
+                    {isValid && showValidIcon !== false && (
                         <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--valid">
                             <Icon type="checkmark" />
                         </span>
@@ -143,7 +130,6 @@ class Field extends Component<FieldProps, FieldState> {
         isValid,
         label,
         useLabelElement = true,
-        dualBrandingElements,
         dir,
         showValidIcon,
         isCollatingErrors
@@ -179,7 +165,6 @@ class Field extends Component<FieldProps, FieldState> {
                         isValid,
                         label,
                         showValidIcon,
-                        dualBrandingElements,
                         isCollatingErrors,
                         dir
                     })}

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -1,4 +1,4 @@
-import { Component, cloneElement, toChildArray, h, ComponentChild, VNode } from 'preact';
+import { Component, cloneElement, toChildArray, h, ComponentChild, VNode, Fragment } from 'preact';
 import classNames from 'classnames';
 import './Field.scss';
 import Spinner from '../../Spinner';
@@ -47,7 +47,92 @@ class Field extends Component<FieldProps, FieldState> {
         return null;
     }
 
+    renderContent({
+        name,
+        children,
+        errorMessage,
+        helper,
+        inputWrapperModifiers,
+        isLoading,
+        isValid,
+        label,
+        showValidIcon,
+        dualBrandingElements,
+        isCollatingErrors,
+        dir
+    }) {
+        return (
+            <Fragment>
+                {typeof label === 'string' && (
+                    <span
+                        className={classNames({
+                            'adyen-checkout__label__text': true,
+                            'adyen-checkout__label__text--error': errorMessage
+                        })}
+                    >
+                        {label}
+                    </span>
+                )}
+
+                {typeof label === 'function' && label()}
+
+                {helper && <span className={'adyen-checkout__helper-text'}>{helper}</span>}
+
+                <div
+                    className={classNames([
+                        'adyen-checkout__input-wrapper',
+                        ...inputWrapperModifiers.map(m => `adyen-checkout__input-wrapper--${m}`)
+                    ])}
+                    dir={dir}
+                >
+                    {toChildArray(children).map(
+                        (child: ComponentChild): ComponentChild => {
+                            const childProps = {
+                                isValid,
+                                onFocusHandler: this.onFocus,
+                                onBlurHandler: this.onBlur,
+                                isInvalid: !!errorMessage,
+                                ...(name && { uniqueId: this.uniqueId })
+                            };
+                            return cloneElement(child as VNode, childProps);
+                        }
+                    )}
+
+                    {isLoading && (
+                        <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--loading">
+                            <Spinner size="small" />
+                        </span>
+                    )}
+
+                    {isValid && showValidIcon !== false && !dualBrandingElements && (
+                        <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--valid">
+                            <Icon type="checkmark" />
+                        </span>
+                    )}
+
+                    {errorMessage && (
+                        <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--invalid">
+                            <Icon type="field_error" />
+                        </span>
+                    )}
+                </div>
+
+                {errorMessage && errorMessage.length && (
+                    <span
+                        className={'adyen-checkout__error-text'}
+                        id={`${this.uniqueId}${ARIA_ERROR_SUFFIX}`}
+                        aria-hidden={isCollatingErrors ? 'true' : null}
+                        aria-live={isCollatingErrors ? null : 'polite'}
+                    >
+                        {errorMessage}
+                    </span>
+                )}
+            </Fragment>
+        );
+    }
+
     render({
+        name,
         className = '',
         classNameModifiers = [],
         children,
@@ -57,9 +142,9 @@ class Field extends Component<FieldProps, FieldState> {
         isLoading,
         isValid,
         label,
+        useLabelElement = true,
         dualBrandingElements,
         dir,
-        name,
         showValidIcon,
         isCollatingErrors
     }) {
@@ -75,84 +160,55 @@ class Field extends Component<FieldProps, FieldState> {
                     }
                 )}
             >
-                <label
-                    onClick={this.props.onFocusField}
-                    className={classNames({
-                        'adyen-checkout__label': true,
-                        'adyen-checkout__label--focused': this.state.focused,
-                        'adyen-checkout__label--filled': this.state.filled,
-                        'adyen-checkout__label--disabled': this.props.disabled
-                    })}
-                    htmlFor={name && this.uniqueId}
+                <LabelOrDiv
+                    onFocusField={this.props.onFocusField}
+                    name={name}
+                    disabled={this.props.disabled}
+                    filled={this.state.filled}
+                    focused={this.state.focused}
+                    useLabelElement={useLabelElement}
+                    uniqueId={this.uniqueId}
                 >
-                    {typeof label === 'string' && (
-                        <span
-                            className={classNames({
-                                'adyen-checkout__label__text': true,
-                                'adyen-checkout__label__text--error': errorMessage
-                            })}
-                        >
-                            {label}
-                        </span>
-                    )}
-
-                    {typeof label === 'function' && label()}
-
-                    {helper && <span className={'adyen-checkout__helper-text'}>{helper}</span>}
-
-                    <div
-                        className={classNames([
-                            'adyen-checkout__input-wrapper',
-                            ...inputWrapperModifiers.map(m => `adyen-checkout__input-wrapper--${m}`)
-                        ])}
-                        dir={dir}
-                    >
-                        {toChildArray(children).map(
-                            (child: ComponentChild): ComponentChild => {
-                                const childProps = {
-                                    isValid,
-                                    onFocusHandler: this.onFocus,
-                                    onBlurHandler: this.onBlur,
-                                    isInvalid: !!errorMessage,
-                                    ...(name && { uniqueId: this.uniqueId })
-                                };
-                                return cloneElement(child as VNode, childProps);
-                            }
-                        )}
-
-                        {isLoading && (
-                            <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--loading">
-                                <Spinner size="small" />
-                            </span>
-                        )}
-
-                        {isValid && showValidIcon !== false && !dualBrandingElements && (
-                            <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--valid">
-                                <Icon type="checkmark" />
-                            </span>
-                        )}
-
-                        {errorMessage && (
-                            <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--invalid">
-                                <Icon type="field_error" />
-                            </span>
-                        )}
-                    </div>
-
-                    {errorMessage && errorMessage.length && (
-                        <span
-                            className={'adyen-checkout__error-text'}
-                            id={`${this.uniqueId}${ARIA_ERROR_SUFFIX}`}
-                            aria-hidden={isCollatingErrors ? 'true' : null}
-                            aria-live={isCollatingErrors ? null : 'polite'}
-                        >
-                            {errorMessage}
-                        </span>
-                    )}
-                </label>
+                    {this.renderContent({
+                        name,
+                        children,
+                        errorMessage,
+                        helper,
+                        inputWrapperModifiers,
+                        isLoading,
+                        isValid,
+                        label,
+                        showValidIcon,
+                        dualBrandingElements,
+                        isCollatingErrors,
+                        dir
+                    })}
+                </LabelOrDiv>
             </div>
         );
     }
 }
+
+const LabelOrDiv = ({ onFocusField, focused, filled, disabled, name, uniqueId, useLabelElement, children }) => {
+    const defaultWrapperProps = {
+        onClick: onFocusField,
+        className: classNames({
+            'adyen-checkout__label': true,
+            'adyen-checkout__label--focused': focused,
+            'adyen-checkout__label--filled': filled,
+            'adyen-checkout__label--disabled': disabled
+        })
+    };
+
+    return useLabelElement ? (
+        <label {...defaultWrapperProps} htmlFor={name && uniqueId}>
+            {children}
+        </label>
+    ) : (
+        <div {...defaultWrapperProps} role={'form'}>
+            {children}
+        </div>
+    );
+};
 
 export default Field;

--- a/packages/lib/src/components/internal/FormFields/Field/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Field/types.ts
@@ -22,6 +22,7 @@ export interface FieldProps {
     name?: string;
     showValidIcon?: boolean;
     isCollatingErrors?: boolean;
+    useLabelElement?: boolean;
 }
 
 export interface FieldState {

--- a/packages/lib/src/components/internal/FormFields/Field/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Field/types.ts
@@ -13,7 +13,6 @@ export interface FieldProps {
     isLoading?: boolean;
     isValid?: boolean;
     label?: string | Component;
-    dualBrandingElements?: any;
     onBlur?;
     onFocus?;
     onFocusField?;

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -82,7 +82,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
             )}
 
             {requiredFields.includes('gender') && (
-                <Field errorMessage={!!errors.gender} classNameModifiers={['gender']} name={'gender'}>
+                <Field errorMessage={!!errors.gender} classNameModifiers={['gender']} name={'gender'} useLabelElement={false}>
                     {renderFormField('radio', {
                         i18n,
                         name: generateFieldName('gender'),


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When specifying a Field component you can now use the `useLabelElement` prop to specify whether the `Field` should wrap its content in a `<label>` element (usual, default, behaviour) or not.

The reason for this is that `RadioGroup` elements are exceptions to the usual fields in that they provide their own `<label>` elements. Without this change we end up with labels inside labels - which is not allowed according to the [spec](https://html.spec.whatwg.org/multipage/forms.html#the-label-element) ("no descendant label elements").

This change could be timely considering the prospect of upcoming accessibility audits.
It also aligns `Field.tsx` with how it works in KYC (with an eye on the sharedComponents scenario)

## Tested scenarios
`PersonalDetails` comp, which uses the `RadioGroup`, no longer leads to a  label-inside-a-label in the markup
All tests pass (except the "availableBrands" e2e tests - which are failing for other reasons)


