### PR TITLE
Button - Updating secondary button CSS

### DIFF
--- a/packages/lib/src/components/Donation/components/DonationComponent.tsx
+++ b/packages/lib/src/components/Donation/components/DonationComponent.tsx
@@ -100,7 +100,8 @@ export default function DonationComponent(props) {
 
                 {showCancelButton && (
                     <Button
-                        classNameModifiers={['ghost', 'decline']}
+                        classNameModifiers={['decline']}
+                        variant="ghost"
                         onClick={handleDecline}
                         disabled={status === 'loading'}
                         label={`${i18n.get('notNowButton')} ›`}

--- a/packages/lib/src/components/internal/Button/Button.scss
+++ b/packages/lib/src/components/internal/Button/Button.scss
@@ -87,6 +87,41 @@
 
     &.adyen-checkout__button--secondary {
         padding: 10px 12px;
+        background: $color-white;
+        border: 1px solid $color-black;
+        color: $color-black;
+
+        &:hover {
+            background: $color-gray-lighter;
+            box-shadow: 0px 2px 4px rgba(27, 42, 60, 0.2), 0px 4px 5px rgba(27, 42, 60, 0.14);;
+        }
+
+        &:active,
+        &:active:hover {
+            background: $color-gray-lighter;
+            box-shadow: none;
+        }
+
+        &:disabled {
+            &,
+            &:hover {
+                box-shadow: none;
+                cursor: not-allowed;
+                border-color: #99A3AD;
+                background-color: $color-gray-lighter;
+                opacity: 0.5;
+                user-select: all;
+            }
+        }
+
+        .adyen-checkout__spinner {
+            border-color: $color-black;
+            border-top-color: transparent;
+        }
+    }
+
+    &.adyen-checkout__button--action {
+        padding: 10px 12px;
         background: rgba(0, 102, 255, 0.1);
         border: 1px solid transparent;
         color: $color-blue;

--- a/packages/lib/src/components/internal/Button/Button.test.tsx
+++ b/packages/lib/src/components/internal/Button/Button.test.tsx
@@ -1,5 +1,5 @@
-import { mount } from 'enzyme';
 import { h } from 'preact';
+import { mount } from 'enzyme';
 import Button from './Button';
 
 const i18n = { get: key => key };
@@ -44,5 +44,26 @@ describe('Button', () => {
     test('Uses a custom label when a status is defined', () => {
         const wrapper = getWrapper({ label: 'label', status: 'loading' });
         expect(wrapper.find('.adyen-checkout__spinner').length > 0).toBe(true);
+    });
+
+    test('Renders primary button as default', () => {
+        const wrapper = getWrapper({});
+        expect(wrapper.find('.adyen-checkout__button').length).toBe(1);
+        expect(wrapper.find('.adyen-checkout__button--primary').length).toBe(0);
+    });
+
+    test('Renders secondary button', () => {
+        const wrapper = getWrapper({ variant: 'secondary ' });
+        expect(wrapper.find('.adyen-checkout__button--secondary').length).toBe(1);
+    });
+
+    test('Renders action button', () => {
+        const wrapper = getWrapper({ variant: 'action ' });
+        expect(wrapper.find('.adyen-checkout__button--action').length).toBe(1);
+    });
+
+    test('Renders ghost button', () => {
+        const wrapper = getWrapper({ variant: 'ghost ' });
+        expect(wrapper.find('.adyen-checkout__button--ghost').length).toBe(1);
     });
 });

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -8,9 +8,9 @@ import { ButtonProps, ButtonState } from './types';
 class Button extends Component<ButtonProps, ButtonState> {
     public static defaultProps = {
         status: 'default',
+        variant: 'primary',
         disabled: false,
         label: '',
-        secondary: false,
         inline: false,
         target: '_self',
         onClick: () => {}
@@ -31,16 +31,16 @@ class Button extends Component<ButtonProps, ButtonState> {
         }, delay);
     };
 
-    render({ classNameModifiers = [], disabled, href, icon, secondary, inline, label, status }, { completed }) {
+    render({ classNameModifiers = [], disabled, href, icon, inline, label, status, variant }, { completed }) {
         const { i18n } = useCoreContext();
 
         const buttonIcon = icon ? <img className="adyen-checkout__button__icon" src={icon} alt="" aria-hidden="true" /> : '';
 
         const modifiers = [
             ...classNameModifiers,
+            ...(variant !== 'primary' ? [variant] : []),
             ...(inline ? ['inline'] : []),
             ...(completed ? ['completed'] : []),
-            ...(secondary ? ['secondary'] : []),
             ...(status === 'loading' || status === 'redirect' ? ['loading'] : [])
         ];
 
@@ -50,7 +50,7 @@ class Button extends Component<ButtonProps, ButtonState> {
             loading: <Spinner size="medium" />,
             redirect: (
                 <span className="adyen-checkout__button__content">
-                    <Spinner size="small" inline />
+                    <Spinner size="medium" inline />
                     {i18n.get('payButton.redirecting')}
                 </span>
             ),

--- a/packages/lib/src/components/internal/Button/types.ts
+++ b/packages/lib/src/components/internal/Button/types.ts
@@ -5,10 +5,12 @@ export interface ButtonProps {
      */
     classNameModifiers?: string[];
 
+    variant: 'primary' | 'secondary' | 'ghost' | 'action';
+
     disabled?: boolean;
     label?: string;
     icon?: string;
-    secondary?: boolean;
+    // secondary?: boolean;
     inline?: boolean;
     href?: string;
     target?: string;

--- a/packages/lib/src/components/internal/Button/types.ts
+++ b/packages/lib/src/components/internal/Button/types.ts
@@ -4,13 +4,10 @@ export interface ButtonProps {
      * Class name modifiers will be used as: `adyen-checkout__image--${modifier}`
      */
     classNameModifiers?: string[];
-
     variant: 'primary' | 'secondary' | 'ghost' | 'action';
-
     disabled?: boolean;
     label?: string;
     icon?: string;
-    // secondary?: boolean;
     inline?: boolean;
     href?: string;
     target?: string;

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -208,32 +208,27 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
 
                 {this.props.instructions && <div className="adyen-checkout__qr-loader__instructions">{i18n.get(this.props.instructions)}</div>}
 
-                {/*{this.props.copyBtn && (*/}
-                <div className="adyen-checkout__qr-loader__actions">
-                    <Button
-                        inline
-                        variant="action"
-                        onClick={(e, { complete }) => {
-                            copyToClipboard(this.props.qrCodeData);
-                            complete();
-                        }}
-                        icon={getImageUrl({ loadingContext, imageFolder: 'components/' })('copy')}
-                        label={i18n.get('button.copy')}
-                    />
-                </div>
-                {/*)}*/}
+                {this.props.copyBtn && (
+                    <div className="adyen-checkout__qr-loader__actions">
+                        <Button
+                            inline
+                            variant="action"
+                            onClick={(e, { complete }) => {
+                                copyToClipboard(this.props.qrCodeData);
+                                complete();
+                            }}
+                            icon={getImageUrl({ loadingContext, imageFolder: 'components/' })('copy')}
+                            label={i18n.get('button.copy')}
+                        />
+                    </div>
+                )}
 
-                {/*{url && (*/}
-                <div className="adyen-checkout__qr-loader__app-link">
-                    <span className="adyen-checkout__qr-loader__separator__label">{i18n.get('or')}</span>
-                    <Button
-                        variant="secondary"
-                        classNameModifiers={['qr-loader']}
-                        onClick={() => this.redirectToApp(url)}
-                        label={i18n.get('openApp')}
-                    />
-                </div>
-                {/*)}*/}
+                {url && (
+                    <div className="adyen-checkout__qr-loader__app-link">
+                        <span className="adyen-checkout__qr-loader__separator__label">{i18n.get('or')}</span>
+                        <Button classNameModifiers={['qr-loader']} onClick={() => this.redirectToApp(url)} label={i18n.get('openApp')} />
+                    </div>
+                )}
             </div>
         );
     }

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -208,27 +208,32 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
 
                 {this.props.instructions && <div className="adyen-checkout__qr-loader__instructions">{i18n.get(this.props.instructions)}</div>}
 
-                {this.props.copyBtn && (
-                    <div className="adyen-checkout__qr-loader__actions">
-                        <Button
-                            inline
-                            secondary
-                            onClick={(e, { complete }) => {
-                                copyToClipboard(this.props.qrCodeData);
-                                complete();
-                            }}
-                            icon={getImageUrl({ loadingContext, imageFolder: 'components/' })('copy')}
-                            label={i18n.get('button.copy')}
-                        />
-                    </div>
-                )}
+                {/*{this.props.copyBtn && (*/}
+                <div className="adyen-checkout__qr-loader__actions">
+                    <Button
+                        inline
+                        variant="action"
+                        onClick={(e, { complete }) => {
+                            copyToClipboard(this.props.qrCodeData);
+                            complete();
+                        }}
+                        icon={getImageUrl({ loadingContext, imageFolder: 'components/' })('copy')}
+                        label={i18n.get('button.copy')}
+                    />
+                </div>
+                {/*)}*/}
 
-                {url && (
-                    <div className="adyen-checkout__qr-loader__app-link">
-                        <span className="adyen-checkout__qr-loader__separator__label">{i18n.get('or')}</span>
-                        <Button classNameModifiers={['qr-loader']} onClick={() => this.redirectToApp(url)} label={i18n.get('openApp')} />
-                    </div>
-                )}
+                {/*{url && (*/}
+                <div className="adyen-checkout__qr-loader__app-link">
+                    <span className="adyen-checkout__qr-loader__separator__label">{i18n.get('or')}</span>
+                    <Button
+                        variant="secondary"
+                        classNameModifiers={['qr-loader']}
+                        onClick={() => this.redirectToApp(url)}
+                        label={i18n.get('openApp')}
+                    />
+                </div>
+                {/*)}*/}
             </div>
         );
     }

--- a/packages/lib/src/components/internal/Voucher/Voucher.tsx
+++ b/packages/lib/src/components/internal/Voucher/Voucher.tsx
@@ -83,7 +83,7 @@ export default function Voucher({ voucherDetails = [], className = '', ...props 
                             <li className="adyen-checkout__voucher-result__actions__item">
                                 <Button
                                     inline
-                                    secondary
+                                    variant="action"
                                     onClick={(e, { complete }) => {
                                         copyToClipboard(props.reference);
                                         complete();
@@ -98,7 +98,7 @@ export default function Voucher({ voucherDetails = [], className = '', ...props 
                             <li className="adyen-checkout__voucher-result__actions__item">
                                 <Button
                                     inline
-                                    secondary
+                                    variant="action"
                                     href={props.downloadUrl}
                                     icon={getImage({ loadingContext, imageFolder: 'components/' })('download')}
                                     label={props.downloadButtonText || i18n.get('button.download')}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added prop 'variant' to `Button` which is used to set the variant of the button instead of setting the variants by  using true/false (Example:`<Button  secondary={true} action={true}  ghost={true} ... />`
- Updated secondary variant CSS to match according to our designs
- The 'old' secondary variant now is called 'action' variant
- Updated Components which were using the 'old' secondary variant to use the 'action' variant

## Tested scenarios
- Added unit tests checking classnames

**Fixed issue**:  <!-- #-prefixed issue number --> CODS-1031
