### PR TITLE
Atome payment method

### DIFF
--- a/packages/lib/src/components/Atome/Atome.test.ts
+++ b/packages/lib/src/components/Atome/Atome.test.ts
@@ -1,0 +1,28 @@
+import Atome from './Atome';
+
+describe('Atome', () => {
+    test('should be required for personal details only the firstName, lastName and telephoneNumber', () => {
+        const atome = new Atome({});
+
+        expect(atome.props.personalDetailsRequiredFields.length).toBe(3);
+        expect(atome.props.personalDetailsRequiredFields.includes('firstName')).toBeTruthy();
+        expect(atome.props.personalDetailsRequiredFields.includes('lastName')).toBeTruthy();
+        expect(atome.props.personalDetailsRequiredFields.includes('telephoneNumber')).toBeTruthy();
+    });
+
+    test('should be required for billing address only the country, street and postal code', () => {
+        const atome = new Atome({});
+
+        expect(atome.props.billingAddressRequiredFields.length).toBe(3);
+        expect(atome.props.billingAddressRequiredFields.includes('country')).toBeTruthy();
+        expect(atome.props.billingAddressRequiredFields.includes('street')).toBeTruthy();
+        expect(atome.props.billingAddressRequiredFields.includes('postalCode')).toBeTruthy();
+    });
+
+    test('should hide companyDetails and deliveryAddress sections', () => {
+        const atome = new Atome({});
+
+        expect(atome.props.visibility.deliveryAddress).toBe('hidden');
+        expect(atome.props.visibility.companyDetails).toBe('hidden');
+    });
+});

--- a/packages/lib/src/components/Atome/Atome.tsx
+++ b/packages/lib/src/components/Atome/Atome.tsx
@@ -1,18 +1,20 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
-import { ALLOWED_COUNTRIES } from './config';
+import { ALLOWED_COUNTRIES, BILLING_ADDRESS_SPECIFICATION } from './config';
 
-export default class Affirm extends OpenInvoiceContainer {
+export default class Atome extends OpenInvoiceContainer {
     public static type = 'atome';
 
     formatProps(props) {
         return {
             ...super.formatProps(props),
-            allowedCountries: ALLOWED_COUNTRIES,
-            personalDetailsRequiredFields: ['firstName', 'lastName', 'telephoneNumber'],
             visibility: {
                 deliveryAddress: 'hidden',
                 companyDetails: 'hidden'
-            }
+            },
+            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES,
+            personalDetailsRequiredFields: ['firstName', 'lastName', 'telephoneNumber'],
+            billingAddressRequiredFields: ['country', 'street', 'postalCode'],
+            billingAddressSpecification: BILLING_ADDRESS_SPECIFICATION
         };
     }
 }

--- a/packages/lib/src/components/Atome/Atome.tsx
+++ b/packages/lib/src/components/Atome/Atome.tsx
@@ -1,0 +1,18 @@
+import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
+import { ALLOWED_COUNTRIES } from './config';
+
+export default class Affirm extends OpenInvoiceContainer {
+    public static type = 'atome';
+
+    formatProps(props) {
+        return {
+            ...super.formatProps(props),
+            allowedCountries: ALLOWED_COUNTRIES,
+            personalDetailsRequiredFields: ['firstName', 'lastName', 'telephoneNumber'],
+            visibility: {
+                deliveryAddress: 'hidden',
+                companyDetails: 'hidden'
+            }
+        };
+    }
+}

--- a/packages/lib/src/components/Atome/Atome.tsx
+++ b/packages/lib/src/components/Atome/Atome.tsx
@@ -11,7 +11,7 @@ export default class Atome extends OpenInvoiceContainer {
                 deliveryAddress: 'hidden',
                 companyDetails: 'hidden'
             },
-            allowedCountries: props.countryCode ? [props.countryCode] : ALLOWED_COUNTRIES,
+            allowedCountries: ALLOWED_COUNTRIES,
             personalDetailsRequiredFields: ['firstName', 'lastName', 'telephoneNumber'],
             billingAddressRequiredFields: ['country', 'street', 'postalCode'],
             billingAddressSpecification: BILLING_ADDRESS_SPECIFICATION

--- a/packages/lib/src/components/Atome/config.ts
+++ b/packages/lib/src/components/Atome/config.ts
@@ -1,18 +1,29 @@
 import { COUNTRY, POSTAL_CODE, STREET } from '../internal/Address/constants';
+import { AddressSpecifications } from '../internal/Address/types';
 
 export const ALLOWED_COUNTRIES = ['ID', 'PH', 'TH', 'VN', 'JP', 'TW', 'KR', 'SG', 'MY', 'HK'];
 
-export const BILLING_ADDRESS_SPECIFICATION = {
-    default: {
-        labels: {
-            [STREET]: 'address'
-        },
-        schema: [
-            STREET,
-            [
-                [COUNTRY, 70],
-                [POSTAL_CODE, 30]
+/**
+ * Creates Address Specification for each country that Atome supports.
+ *
+ * This custom specification is needed in order to create the desired layout of the Atome billing address part. The usage of the
+ * 'default' layout specification from the Address component does not align correctly the available fields, therefore we need to
+ * create this customization.
+ */
+export const BILLING_ADDRESS_SPECIFICATION = ALLOWED_COUNTRIES.reduce((memo: AddressSpecifications, countryCode: string) => {
+    return {
+        ...memo,
+        [countryCode]: {
+            labels: {
+                [STREET]: 'address'
+            },
+            schema: [
+                STREET,
+                [
+                    [COUNTRY, 70],
+                    [POSTAL_CODE, 30]
+                ]
             ]
-        ]
-    }
-};
+        }
+    };
+}, {});

--- a/packages/lib/src/components/Atome/config.ts
+++ b/packages/lib/src/components/Atome/config.ts
@@ -1,0 +1,1 @@
+export const ALLOWED_COUNTRIES = ['ID', 'PH', 'TH', 'VN', 'JP', 'TW', 'KR', 'SG', 'MY', 'HK'];

--- a/packages/lib/src/components/Atome/config.ts
+++ b/packages/lib/src/components/Atome/config.ts
@@ -1,1 +1,18 @@
+import { COUNTRY, POSTAL_CODE, STREET } from '../internal/Address/constants';
+
 export const ALLOWED_COUNTRIES = ['ID', 'PH', 'TH', 'VN', 'JP', 'TW', 'KR', 'SG', 'MY', 'HK'];
+
+export const BILLING_ADDRESS_SPECIFICATION = {
+    default: {
+        labels: {
+            [STREET]: 'address'
+        },
+        schema: [
+            STREET,
+            [
+                [COUNTRY, 70],
+                [POSTAL_CODE, 30]
+            ]
+        ]
+    }
+};

--- a/packages/lib/src/components/Atome/index.ts
+++ b/packages/lib/src/components/Atome/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Atome';

--- a/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
+++ b/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
@@ -2,8 +2,19 @@ import { h } from 'preact';
 import UIElement from '../../UIElement';
 import OpenInvoice from '../../internal/OpenInvoice';
 import CoreProvider from '../../../core/Context/CoreProvider';
+import { UIElementProps } from '../../types';
+import { AddressSpecifications } from '../../internal/Address/types';
 
-export default class OpenInvoiceContainer extends UIElement {
+interface OpenInvoiceElementProps extends UIElementProps {
+    consentCheckboxLabel?: h.JSX.Element;
+    billingAddressRequiredFields?: string[];
+    billingAddressSpecification?: AddressSpecifications;
+
+    // TODO: add other props for OpenInvoiceElement
+    [key: string]: any;
+}
+
+export default class OpenInvoiceContainer extends UIElement<OpenInvoiceElementProps> {
     protected static defaultProps = {
         onChange: () => {},
         data: { companyDetails: {}, personalDetails: {}, billingAddress: {}, deliveryAddress: {} },
@@ -76,7 +87,6 @@ export default class OpenInvoiceContainer extends UIElement {
                     }}
                     {...this.props}
                     {...this.state}
-                    consentCheckbox={this.props.consentCheckbox}
                     onChange={this.setState}
                     onSubmit={this.submit}
                     payButton={this.payButton}

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -1,6 +1,7 @@
 import { AfterPay, AfterPayB2B } from './AfterPay';
 import AmazonPay from './AmazonPay';
 import ApplePay from './ApplePay';
+import Atome from './Atome';
 import { BillDeskOnline, BillDeskWallet } from './BillDesk';
 import Card from './Card';
 import Bancontact from './Card/Bancontact';
@@ -62,6 +63,7 @@ const componentsMap = {
     amazonpay: AmazonPay,
     amex: Card,
     applepay: ApplePay,
+    atome: Atome,
     bankTransfer_IBAN: BankTransfer,
     bcmc: Bancontact,
     bcmc_mobile: BcmcMobile,

--- a/packages/lib/src/components/internal/Address/Specifications.ts
+++ b/packages/lib/src/components/internal/Address/Specifications.ts
@@ -60,7 +60,7 @@ class Specifications {
      * @param country - The selected country
      */
     getKeyForField(fieldName: string, country: string): string {
-        return this.specifications?.[country]?.labels?.[fieldName] || fieldName;
+        return this.specifications?.[country]?.labels?.[fieldName] || this.specifications?.default?.labels?.[fieldName] || fieldName;
     }
 
     /**

--- a/packages/lib/src/components/internal/Address/constants.ts
+++ b/packages/lib/src/components/internal/Address/constants.ts
@@ -2,7 +2,7 @@ import { AddressSpecifications } from './types';
 
 export const FALLBACK_VALUE = 'N/A';
 export const ADDRESS_SCHEMA = ['street', 'houseNumberOrName', 'postalCode', 'city', 'stateOrProvince', 'country'] as const;
-const [STREET, HOUSE_NUMBER_OR_NAME, POSTAL_CODE, CITY, STATE_OR_PROVINCE, COUNTRY] = ADDRESS_SCHEMA;
+export const [STREET, HOUSE_NUMBER_OR_NAME, POSTAL_CODE, CITY, STATE_OR_PROVINCE, COUNTRY] = ADDRESS_SCHEMA;
 
 // prettier-ignore
 export const ADDRESS_SPECIFICATIONS: AddressSpecifications = {

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -105,6 +105,8 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
                 <Address
                     allowedCountries={props.allowedCountries}
                     countryCode={countryCode}
+                    requiredFields={props.billingAddressRequiredFields}
+                    specifications={props.billingAddressSpecification}
                     data={data.billingAddress}
                     label="billingAddress"
                     onChange={handleFieldset('billingAddress')}

--- a/packages/lib/src/components/internal/OpenInvoice/types.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/types.ts
@@ -1,5 +1,6 @@
 import { AddressData, FieldsetVisibility, PersonalDetailsSchema } from '../../../types';
 import { CompanyDetailsSchema } from '../CompanyDetails/types';
+import { AddressSpecifications } from '../Address/types';
 
 export interface OpenInvoiceVisibility {
     companyDetails?: FieldsetVisibility;
@@ -23,6 +24,8 @@ export interface OpenInvoiceProps {
     showPayButton?: boolean;
     visibility?: OpenInvoiceVisibility;
     personalDetailsRequiredFields?: string[];
+    billingAddressRequiredFields?: string[];
+    billingAddressSpecification?: AddressSpecifications;
 }
 
 export interface OpenInvoiceStateData {

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -6,7 +6,7 @@ import { getSearchParameters } from '../../utils';
 
 export async function initManual() {
     const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
-    
+
     window.checkout = await AdyenCheckout({
         amount,
         countryCode,

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -6,7 +6,6 @@ import { getSearchParameters } from '../../utils';
 
 export async function initManual() {
     const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
-
     window.checkout = await AdyenCheckout({
         amount,
         countryCode,

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -31,25 +31,20 @@ export async function initSession() {
         paymentMethodsConfiguration: {
             paywithgoogle: {
                 buttonType: 'plain'
-            },
-            atome: {
-                data: {
-                    personalDetails: {
-                        firstName: 'Jan',
-                        lastName: 'Jansen',
-                        shopperEmail: 'shopper@testemail.com',
-                        telephoneNumber: '+17203977880'
-                    },
-                    billingAddress: {
-                        city: 'Boulder',
-                        country: 'SG',
-                        houseNumberOrName: '242',
-                        postalCode: '803022',
-                        stateOrProvince: 'CO',
-                        street: 'Silver Cloud Lane'
-                    }
-                }
             }
+            // atome: {
+            //     data: {
+            //         personalDetails: {
+            //             firstName: 'Jan',
+            //             lastName: 'Jansen',
+            //             telephoneNumber: '80002018'
+            //         },
+            //         billingAddress: {
+            //             postalCode: '803022',
+            //             street: 'Silver Cloud Lane'
+            //         }
+            //     }
+            // }
         }
     });
 

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -31,6 +31,24 @@ export async function initSession() {
         paymentMethodsConfiguration: {
             paywithgoogle: {
                 buttonType: 'plain'
+            },
+            atome: {
+                data: {
+                    personalDetails: {
+                        firstName: 'Jan',
+                        lastName: 'Jansen',
+                        shopperEmail: 'shopper@testemail.com',
+                        telephoneNumber: '+17203977880'
+                    },
+                    billingAddress: {
+                        city: 'Boulder',
+                        country: 'SG',
+                        houseNumberOrName: '242',
+                        postalCode: '803022',
+                        stateOrProvince: 'CO',
+                        street: 'Silver Cloud Lane'
+                    }
+                }
             }
         }
     });

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -32,19 +32,6 @@ export async function initSession() {
             paywithgoogle: {
                 buttonType: 'plain'
             }
-            // atome: {
-            //     data: {
-            //         personalDetails: {
-            //             firstName: 'Jan',
-            //             lastName: 'Jansen',
-            //             telephoneNumber: '80002018'
-            //         },
-            //         billingAddress: {
-            //             postalCode: '803022',
-            //             street: 'Silver Cloud Lane'
-            //         }
-            //     }
-            // }
         }
     });
 

--- a/packages/playground/src/pages/OpenInvoices/OpenInvoices.html
+++ b/packages/playground/src/pages/OpenInvoices/OpenInvoices.html
@@ -55,6 +55,15 @@
                         <div class="affirm-field"></div>
                     </div>
                 </div>
+
+                <div class="merchant-checkout__payment-method">
+                    <div class="merchant-checkout__payment-method__header">
+                        <h2>Atome</h2>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div class="atome-field"></div>
+                    </div>
+                </div>
             </form>
         </main>
 

--- a/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
+++ b/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
@@ -95,7 +95,7 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsData => {
     // RATEPAY
     window.ratepay = checkout
         .create('ratepay', {
-            countryCode: 'US', // 'DE' / 'AT' / 'CH'
+            countryCode: 'DE', // 'DE' / 'AT' / 'CH'
             visibility: {
                 personalDetails: 'editable', // editable [default] / readOnly / hidden
                 billingAddress: 'editable',
@@ -112,11 +112,10 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsData => {
                 personalDetails: {
                     firstName: 'Robert',
                     lastName: 'Jahnsen',
-                    shopperEmail: 'shopper@testemail.com',
-                    telephoneNumber: '+17203977880'
+                    telephoneNumber: '80002018'
                 },
                 billingAddress: {
-                    postalCode: '803022',
+                    postalCode: '111111',
                     street: 'Silver Cloud Lane'
                 }
             }

--- a/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
+++ b/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
@@ -103,4 +103,23 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsData => {
             }
         })
         .mount('.ratepay-field');
+
+    // ATOME
+    window.atome = checkout
+        .create('atome', {
+            countryCode: 'SG',
+            data: {
+                personalDetails: {
+                    firstName: 'Robert',
+                    lastName: 'Jahnsen',
+                    shopperEmail: 'shopper@testemail.com',
+                    telephoneNumber: '+17203977880'
+                },
+                billingAddress: {
+                    postalCode: '803022',
+                    street: 'Silver Cloud Lane'
+                }
+            }
+        })
+        .mount('.atome-field');
 });

--- a/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
+++ b/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
@@ -95,7 +95,7 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsData => {
     // RATEPAY
     window.ratepay = checkout
         .create('ratepay', {
-            countryCode: 'DE', // 'DE' / 'AT' / 'CH'
+            countryCode: 'US', // 'DE' / 'AT' / 'CH'
             visibility: {
                 personalDetails: 'editable', // editable [default] / readOnly / hidden
                 billingAddress: 'editable',

--- a/packages/playground/src/services.js
+++ b/packages/playground/src/services.js
@@ -32,9 +32,12 @@ export const makeDetailsCall = data =>
         })
         .catch(err => console.error(err));
 
-export const createSession = (data, config = {}) => {
-    // NOTE: Merging data object. DO NOT do this in production.
-    return httpPost('sessions', data)
+export const createSession = data => {
+    const payload = {
+        ...data,
+        lineItems: paymentsConfig.lineItems
+    };
+    return httpPost('sessions', payload)
         .then(response => {
             if (response.error) throw 'Session initiation failed';
             return response;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added Atome payment method
- Started creating the interface of `OpenInvoiceContainer` as there was no interface defined before. I added the props used by this PR, but the remaining props need to be added afterwards.
- Introduced two new props on `OpenInvoiceContainer`: 
   - `billingAddressRequiredFields`: similar to the current `personalDetailsRequiredFields`, but for billing address
   - `billingAddressSpecification`: The billing address form needs to be customized in certain way that some of the default fields won't be shown for this payment method. Therefore the UI needs to be adjusted accordingly to not have empty space gaps. This property allows to pass an `specification` which dictates which fields to show and their position in the UI


## Tested scenarios
- Tested manually the whole payment flow using Atome as Component and as part of Drop-in
- Added unit tests to make sure only required fields are being passed to the OpenInvoice component


**Fixed issue**: COWEB-1051
