### PR TITLE
Address - Trim whitespace from tail of postal code

### DIFF
--- a/packages/lib/src/utils/validator-utils.test.ts
+++ b/packages/lib/src/utils/validator-utils.test.ts
@@ -1,0 +1,19 @@
+import { trimValWithOneSpace } from './validator-utils';
+
+describe('trimValWithOneSpace', () => {
+    test('Should clear whitespace from both ends', () => {
+        expect(trimValWithOneSpace('  A99 9AA  ')).toBe('A99 9AA');
+    });
+
+    test('Should replace multiple spaces with one', () => {
+        expect(trimValWithOneSpace('A99   9AA')).toBe('A99 9AA');
+    });
+
+    test('Should not change a string with no whitespace', () => {
+        expect(trimValWithOneSpace('A99 9AA')).toBe('A99 9AA');
+    });
+
+    test('Should trim both ends and clean up multiple spaces', () => {
+        expect(trimValWithOneSpace('  A99   9AA  ')).toBe('A99 9AA');
+    });
+});

--- a/packages/lib/src/utils/validator-utils.ts
+++ b/packages/lib/src/utils/validator-utils.ts
@@ -21,5 +21,5 @@ export const SPECIAL_CHARS = '?\\-\\+_=!@#$%^&*(){}~<>\\[\\]\\/\\\\'; // N.B. di
 // Generates a regEx ideal for use in a String.replace call for use in a formatter
 export const getFormattingRegEx = (specChars: string, flags = 'g') => new RegExp(`[${specChars}]`, flags);
 
-// Trim start and never allow more than 1 space on the end
-export const trimValWithOneSpace = (val: string) => val.trimStart().replace(/\s+/g, ' ');
+// Trim start, end, and never allow more than 1 space between
+export const trimValWithOneSpace = (val: string) => val.trimStart().trimEnd().replace(/\s+/g, ' ');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
- Mobile users are likely to have whitespace automatically put onto the tail of their input by their keyboards.
- Whitespace on the tail of a string is considered invalid by the postcode field validation

## Tested scenarios
<!-- Description of tested scenarios -->
- Trims whitespace from start and end of string
- Still replaces multiple spaces with 1
- Does not modify already valid strings

**Fixed issue**:  <!-- #-prefixed issue number -->
- N/A - No open issue. Bug was encountered in support ticket.