### PR TITLE
Added trimOnBlur property to all fields used within an Address component

### DIFF
--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -93,6 +93,7 @@ export default function Address(props: AddressProps) {
                 onDropdownChange={handleChangeFor(fieldName, 'blur')}
                 specifications={specifications}
                 maxlength={getMaxLengthByFieldAndCountry(countrySpecificFormatters, fieldName, data.country, true)}
+                trimOnBlur={true}
             />
         );
     };


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added `trimOnBlur` property to all fields used within an `Address` component. This strips whitespace from both ends as a field loses focus.


**Fixed issue**:  Alternative fix to [#1556](https://github.com/Adyen/adyen-web/pull/1556)
