### PR TITLE
Fallback to Redirect type when payment method is not recognized during 'create'

### DIFF
--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -109,9 +109,10 @@ class Core {
      *
      * @returns new UIElement
      */
-    public create<T extends keyof PaymentMethods>(paymentMethod: T | string, options?: PaymentMethodOptions<T>): InstanceType<PaymentMethods[T]>;
+    public create<T extends keyof PaymentMethods>(paymentMethod: T, options?: PaymentMethodOptions<T>): InstanceType<PaymentMethods[T]>;
     public create<T extends new (...args: any) => T, P extends ConstructorParameters<T>>(paymentMethod: T, options?: P[0]): T;
-    public create(paymentMethod, options) {
+    public create(paymentMethod: string, options?: PaymentMethodOptions<'redirect'>): InstanceType<PaymentMethods['redirect']>;
+    public create(paymentMethod: any, options?: any): any {
         const props = this.getPropsForComponent(options);
         return paymentMethod ? this.handleCreate(paymentMethod, props) : this.handleCreateError();
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
With the current implementation, if a payment method does not match with the any pm's of the `componentsMap`, then we render a `Redirect` component. Although typescript complains about that since the PM wasn't declared in the mapping.

This PR adds function overload to the `create` method which returns `RedirectElement` if the provided payment method does not match with the current dictionary.

## Tested scenarios
- unit test, lint, type-check
- tried to create the component `checkout.create('directEbanking')` and verified that it returns `RedirectElement` 

**Fixed issue**: #1555 
