### PR TITLE
Removing Type-Only imports and 'yarn start:fast' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     ],
     "scripts": {
         "start": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
-        "start:fast": "concurrently --kill-others-on-fail \"yarn workspace @adyen/adyen-web start:fast\"  \"yarn workspace @adyen/adyen-web-playground start\" --names \"lib,playground\"",
         "build": "yarn workspace @adyen/adyen-web build",
         "lint": "yarn workspace @adyen/adyen-web lint",
         "test": "yarn workspace @adyen/adyen-web test",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -32,7 +32,6 @@
     },
     "scripts": {
         "start": "npm run dev-server",
-        "start:fast": "EXPERIMENTAL_DEVBUILD=true npm run dev-server",
         "dev-server": "cross-env NODE_ENV=development rollup --watch --config config/rollup.config.js",
         "docs:generate": "typedoc --out docs src --exclude \"**/*+(index|.test).ts\"",
         "build": "rm -rf dist/ && npm run type-check-generate && cross-env NODE_ENV=production rollup --config config/rollup.config.js",

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -6,15 +6,15 @@ import PayButton from './internal/PayButton';
 import { IUIElement, UIElementProps } from './types';
 import { getSanitizedResponse, resolveFinalResult } from './utils';
 import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
-import type { UIElementStatus } from './types';
-import { hasOwnProperty } from "../utils/hasOwnProperty";
+import { UIElementStatus } from './types';
+import { hasOwnProperty } from '../utils/hasOwnProperty';
 
-export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement{
+export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
     protected componentRef: any;
     public elementRef: any;
 
     constructor(props: P) {
-        super({ setStatusAutomatically: true, ...props});
+        super({ setStatusAutomatically: true, ...props });
         this.submit = this.submit.bind(this);
         this.setState = this.setState.bind(this);
         this.onValid = this.onValid.bind(this);
@@ -44,7 +44,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         if (this.props.isInstantPayment) {
             this.elementRef.closeActivePaymentMethod();
         }
-        
+
         if (this.props.setStatusAutomatically) {
             this.elementRef.setStatus('loading');
         }
@@ -112,7 +112,6 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
             .catch(this.handleError);
     }
 
-
     protected handleError = (error: AdyenCheckoutError): void => {
         /**
          * Set status using elementRef, which:
@@ -141,7 +140,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
             if (hasOwnProperty(action, 'action') && hasOwnProperty(action, 'resultCode')) {
                 throw new Error(
                     'handleAction::Invalid Action - the passed action object itself has an "action" property and ' +
-                    'a "resultCode": have you passed in the whole response object by mistake?'
+                        'a "resultCode": have you passed in the whole response object by mistake?'
                 );
             }
             throw new Error('handleAction::Invalid Action - the passed action object does not have a "type" property');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Removed `import type {..` from UIElement. The usage of Type-Only imports forces consumers of the library to have Typescript >= 3.8.0 . Apparently there is no much that can be done as described [here](https://github.com/microsoft/TypeScript/issues/41844) . Quickest win for now is to update the import of the UIElement
- Removed `yarn start:fast` script

**Related issue**:  #1553 
