### PR TITLE
Fixes bug with Select not reseting when clicking outside

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -98,7 +98,7 @@ function Select({
             ? !e.composedPath().includes(selectContainerRef.current)
             : !selectContainerRef.current.contains(e.target);
         if (clickIsOutside) {
-            setShowList(false);
+            closeList();
         }
     };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

When clicking outside of a select input the state was not being properly reset.

## Tested scenarios
<!-- Description of tested scenarios -->

* Test scenario showed in the ticket

**Fixed issue**:  <!-- #-prefixed issue number -->

#1497 