### PR TITLE
Adjusting 'Selector' to not force focus when click outside happens

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -98,7 +98,8 @@ function Select({
             ? !e.composedPath().includes(selectContainerRef.current)
             : !selectContainerRef.current.contains(e.target);
         if (clickIsOutside) {
-            closeList();
+            setTextFilter(null);
+            setShowList(false);
         }
     };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`closeList()` method forces UI to focus on input, blocking the user to interact with other fields in this case

## Tested scenarios
e2e and unit tests