### PR TITLE
Add `onAuthorizedBeforeSubmit` for ApplePay

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -58,7 +58,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     }
 
     private startSession(onPaymentAuthorized) {
-        const { version, onValidateMerchant, onCancel, onPaymentMethodSelected, onShippingMethodSelected, onShippingContactSelected } = this.props;
+        const { version, onValidateMerchant, onCancel, onPaymentMethodSelected, onShippingMethodSelected, onShippingContactSelected, onAuthorizedBeforeSubmit } = this.props;
 
         return new Promise((resolve, reject) => this.props.onClick(resolve, reject)).then(() => {
             const paymentRequest = preparePaymentRequest({
@@ -77,7 +77,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
                     if (!!event.payment.token && !!event.payment.token.paymentData) {
                         this.setState({ applePayToken: btoa(JSON.stringify(event.payment.token.paymentData)) });
                     }
-
+                    onAuthorizedBeforeSubmit(resolve, reject, event);
                     super.submit();
                     onPaymentAuthorized(resolve, reject, event);
                 }

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -78,7 +78,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
                         this.setState({ applePayToken: btoa(JSON.stringify(event.payment.token.paymentData)) });
                     }
                     if(onAuthorizedBeforeSubmit) {
-                        await new Promise((resolve, reject) => onAuthorizedBeforeSubmit(resolve, reject, event));
+                        await new Promise((resolve) => onAuthorizedBeforeSubmit(resolve, reject, event));
                     }
                     super.submit();
                     onPaymentAuthorized(resolve, reject, event);

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -73,11 +73,13 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
                 onShippingMethodSelected,
                 onShippingContactSelected,
                 onValidateMerchant: onValidateMerchant || this.validateMerchant,
-                onPaymentAuthorized: (resolve, reject, event) => {
+                onPaymentAuthorized: async (resolve, reject, event) => {
                     if (!!event.payment.token && !!event.payment.token.paymentData) {
                         this.setState({ applePayToken: btoa(JSON.stringify(event.payment.token.paymentData)) });
                     }
-                    onAuthorizedBeforeSubmit(resolve, reject, event);
+                    if(onAuthorizedBeforeSubmit) {
+                        await new Promise((resolve, reject) => onAuthorizedBeforeSubmit(resolve, reject, event));
+                    }
                     super.submit();
                     onPaymentAuthorized(resolve, reject, event);
                 }

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -128,6 +128,7 @@ export interface ApplePayElementProps extends UIElementProps {
     onCancel?: () => void;
 
     onAuthorized?: (resolve, reject, event: ApplePayJS.ApplePayPaymentAuthorizedEvent) => void;
+    onAuthorizedBeforeSubmit?: (resolve, reject, event: ApplePayJS.ApplePayPaymentAuthorizedEvent) => void;
 
     onValidateMerchant?: (resolve, reject, validationURL: string) => void;
 


### PR DESCRIPTION
## Summary

Having access to the apple pay `event` before submitting is important. Adding an event that is`onAuthorizedBeforeSubmit` would help solve this so you don't have to implement it with apple pay without Adyen.

Adding `onAuthorizedBeforeSubmit` event here solves this:

```diff
onPaymentAuthorized: (resolve, reject, event) => {
    if (!!event.payment.token && !!event.payment.token.paymentData) {
        this.setState({ applePayToken: btoa(JSON.stringify(event.payment.token.paymentData)) });
    }

+   if(onAuthorizedBeforeSubmit) {
+      await new Promise((resolve) => onAuthorizedBeforeSubmit(resolve, reject, event));
+  }
    super.submit();
    onPaymentAuthorized(resolve, reject, event);
}
```

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  [https://github.com/Adyen/adyen-web/issues/1579](https://github.com/Adyen/adyen-web/issues/1579)