### PR TITLE
useForm improvements

### DIFF
--- a/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
+++ b/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
@@ -4,12 +4,13 @@ import './BankTransferInput.scss';
 import SendCopyToEmail from '../../../internal/SendCopyToEmail/SendCopyToEmail';
 import { useEffect, useState } from 'preact/hooks';
 import useForm from '../../../../utils/useForm';
+import { BankTransferSchema } from '../../types';
 
 function BankTransferInput(props) {
     const { i18n } = useCoreContext();
     const [showingEmail, setShowingEmail] = useState(false);
 
-    const { handleChangeFor, triggerValidation, data, valid, errors, isValid, setSchema } = useForm({
+    const { handleChangeFor, triggerValidation, data, valid, errors, isValid, setSchema } = useForm<BankTransferSchema>({
         schema: [],
         defaultData: props.data
     });

--- a/packages/lib/src/components/BankTransfer/types.ts
+++ b/packages/lib/src/components/BankTransfer/types.ts
@@ -16,3 +16,7 @@ export interface BankTransferState extends UIElementProps {
     };
     isValid: boolean;
 }
+
+export interface BankTransferSchema {
+    shopperEmail?: string;
+}

--- a/packages/lib/src/components/Blik/components/BlikInput.tsx
+++ b/packages/lib/src/components/Blik/components/BlikInput.tsx
@@ -18,7 +18,7 @@ interface BlikInputDataState {
 
 function BlikInput(props: BlikInputProps) {
     const { i18n, loadingContext } = useCoreContext();
-    const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm({
+    const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm<BlikInputDataState>({
         schema: ['blikCode'],
         rules: {
             blikCode: {

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -15,7 +15,6 @@ import { ErrorPanelObj } from '../../../../core/Errors/ErrorPanel';
 import { extractPropsForCardFields, extractPropsForSFP, getLayout, sortErrorsForPanel } from './utils';
 import { AddressData } from '../../../../types';
 import Specifications from '../../../internal/Address/Specifications';
-import { ValidationRuleResult } from '../../../../utils/Validator/Validator';
 import { StoredCardFieldsWrapper } from './components/StoredCardFieldsWrapper';
 import { CardFieldsWrapper } from './components/CardFieldsWrapper';
 import getImage from '../../../../utils/get-image';
@@ -207,8 +206,8 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
         // Validate SecuredFields
         sfp.current.showValidation();
 
-        // Validates holderName & SSN & KCP (taxNumber)
-        triggerValidation();
+        // Validate holderName & SSN & KCP (taxNumber) but *not* billingAddress
+        triggerValidation(['holderName', 'socialSecurityNumber', 'taxNumber']);
 
         // Validate Address
         if (billingAddressRef?.current) billingAddressRef.current.showValidation();
@@ -274,13 +273,9 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
         });
 
         // Check if billingAddress errors object has any properties that aren't null or undefined
-        // NOTE: when showValidation is called on the Address component it calls back twice - once, incorrectly, with formErrors.billingAddress as an instance of ValidationRuleResult
-        // and second time round, correctly  with formErrors.billingAddress as an object containing ValidationRuleResults mapped to address keys (street, city etc)
-        // - so we need to ignore the first callback TODO - investigate why this happens
-        const addressHasErrors =
-            formErrors.billingAddress && !(formErrors.billingAddress instanceof ValidationRuleResult)
-                ? Object.entries(formErrors.billingAddress).reduce((acc, [, error]) => acc || error != null, false)
-                : false;
+        const addressHasErrors = formErrors.billingAddress
+            ? Object.entries(formErrors.billingAddress).reduce((acc, [, error]) => acc || error != null, false)
+            : false;
 
         // Errors
         setErrors({

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -4,7 +4,7 @@ import { PaymentAmount } from '../../../../types';
 import { InstallmentOptions } from './components/types';
 import { ValidationResult } from '../../../internal/PersonalDetails/types';
 import { CVCPolicyType, DatePolicyType } from '../../../internal/SecuredFields/lib/types';
-import { ValidationRuleResult } from '../../../../utils/Validator/Validator';
+import { ValidationRuleResult } from '../../../../utils/Validator/ValidationRuleResult';
 import Specifications from '../../../internal/Address/Specifications';
 import { AddressSchema, StringObject } from '../../../internal/Address/types';
 import { CbObjOnError, StylesObject } from '../../../internal/SecuredFields/lib/types';

--- a/packages/lib/src/components/Card/components/CardInput/validate.test.ts
+++ b/packages/lib/src/components/Card/components/CardInput/validate.test.ts
@@ -5,9 +5,9 @@ const taxNumValidationFn = getRuleByNameAndMode('taxNumber', 'blur');
 
 describe('validate holder name', () => {
     test('validates a card holder name', () => {
-        expect(holderNameValidationFn('')).toBe(false);
+        expect(holderNameValidationFn('')).toBe(null);
         expect(holderNameValidationFn('John Smith')).toBe(true);
-        expect(holderNameValidationFn('   ')).toBe(false);
+        expect(holderNameValidationFn('   ')).toBe(null);
         // expect(validateHolderName(undefined)).toBe(false);
         // expect(validateHolderName(null)).toBe(false);
     });
@@ -15,7 +15,7 @@ describe('validate holder name', () => {
 
 describe('validate tax number', () => {
     test('validates a tax number is 6 or 10 digits', () => {
-        expect(taxNumValidationFn('')).toBe(false);
+        expect(taxNumValidationFn('')).toBe(null);
         expect(taxNumValidationFn('12345')).toBe(false);
         expect(taxNumValidationFn('123456')).toBe(true);
         expect(taxNumValidationFn('1234567')).toBe(false);

--- a/packages/lib/src/components/Card/components/CardInput/validate.ts
+++ b/packages/lib/src/components/Card/components/CardInput/validate.ts
@@ -1,6 +1,7 @@
 import { ValidatorRules } from '../../../../utils/Validator/types';
 import { formatCPFCNPJ } from '../../../internal/SocialSecurityNumberBrazil/utils';
 import validateSSN from '../../../internal/SocialSecurityNumberBrazil/validate';
+import { isEmpty } from '../../../internal/SecuredFields/lib/utilities/commonUtils';
 
 export const cardInputFormatters = {
     socialSecurityNumber: formatCPFCNPJ
@@ -10,14 +11,17 @@ export const cardInputValidationRules: ValidatorRules = {
     socialSecurityNumber: [
         {
             modes: ['blur'],
-            validate: validateSSN,
+            validate: value => {
+                if (isEmpty(value)) return null;
+                return validateSSN(value);
+            },
             errorMessage: 'boleto.socialSecurityNumber.invalid'
         }
     ],
     taxNumber: [
         {
             modes: ['blur'],
-            validate: value => value?.length === 6 || value?.length === 10,
+            validate: value => (isEmpty(value) ? null : value?.length === 6 || value?.length === 10),
             errorMessage: 'creditCard.taxNumber.invalid'
         }
     ],
@@ -25,7 +29,7 @@ export const cardInputValidationRules: ValidatorRules = {
         {
             // Will fire at startup and when triggerValidation is called and also applies as text is input
             modes: ['blur'],
-            validate: value => value?.trim().length > 0, // i.e. are there chars other than spaces?
+            validate: value => (isEmpty(value) ? null : true), // true, if there are chars other than spaces
             errorMessage: 'creditCard.holderName.invalid'
         }
     ],

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -1,7 +1,7 @@
 import { AddressField, AddressData } from '../../../types';
 import Specifications from './Specifications';
 import { ValidatorRules } from '../../../utils/Validator/types';
-import { ValidationRuleResult } from '../../../utils/Validator/Validator';
+import { ValidationRuleResult } from '../../../utils/Validator/ValidationRuleResult';
 
 // Describes an object with unknown keys whose value is always a string
 export type StringObject = {

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -1,6 +1,7 @@
 import { ValidatorRules, ValidatorRule } from '../../../utils/Validator/types';
 import { countrySpecificFormatters } from './validate.formats';
 import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD } from '../../../core/Errors/constants';
+import { isEmpty } from '../SecuredFields/lib/utilities/commonUtils';
 
 const createPatternByDigits = (digits: number) => {
     return {
@@ -70,12 +71,13 @@ export const getAddressValidationRules = (specifications): ValidatorRules => {
                         }
                     };
 
+                    if (isEmpty(val)) return null;
+
                     const pattern = postalCodePatterns[country]?.pattern;
                     return pattern ? pattern.test(val) : !!val; // No pattern? Accept any, filled, value.
                 }
-
                 // Default rule
-                return !!val;
+                return isEmpty(val) ? null : true;
             },
             errorMessage: ERROR_CODES[ERROR_MSG_INCOMPLETE_FIELD]
         },
@@ -83,13 +85,13 @@ export const getAddressValidationRules = (specifications): ValidatorRules => {
             validate: (value, context) => {
                 const selectedCountry = context.state?.data?.country;
                 const isOptional = selectedCountry && specifications.countryHasOptionalField(selectedCountry, 'houseNumberOrName');
-                return isOptional || value?.length > 0;
+                return isOptional || (isEmpty(value) ? null : true);
             },
             modes: ['blur'],
             errorMessage: ERROR_CODES[ERROR_MSG_INCOMPLETE_FIELD]
         },
         default: {
-            validate: value => value?.length > 0,
+            validate: value => (isEmpty(value) ? null : true), // true, if there are chars other than spaces
             modes: ['blur'],
             errorMessage: ERROR_CODES[ERROR_MSG_INCOMPLETE_FIELD]
         }

--- a/packages/lib/src/components/internal/IssuerList/IssuerList.test.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerList.test.tsx
@@ -66,8 +66,9 @@ describe('IssuerList', () => {
 
         let callbackData = { data: { issuer: null }, valid: { issuer: false }, errors: { issuer: null }, isValid: false };
 
-        expect(onChangeCb).toBeCalledTimes(1);
+        expect(onChangeCb).toBeCalledTimes(2);
         expect(onChangeCb.mock.calls[0][0]).toStrictEqual(callbackData);
+        expect(onChangeCb.mock.calls[1][0]).toStrictEqual(callbackData);
 
         wrapper
             .find('.adyen-checkout__issuer-button-group button')
@@ -76,8 +77,8 @@ describe('IssuerList', () => {
 
         callbackData = { data: { issuer: '3' }, valid: { issuer: true }, errors: { issuer: null }, isValid: true };
 
-        expect(onChangeCb).toBeCalledTimes(2);
-        expect(onChangeCb.mock.calls[1][0]).toStrictEqual(callbackData);
+        expect(onChangeCb).toBeCalledTimes(3);
+        expect(onChangeCb.mock.calls[2][0]).toStrictEqual(callbackData);
     });
 
     test('UI should not render invalid highlighted issuers', () => {

--- a/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
@@ -6,12 +6,13 @@ import Field from '../FormFields/Field';
 import useForm from '../../../utils/useForm';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import './PhoneInput.scss';
+import { PhoneInputSchema } from './types';
 
 export function PhoneInput(props) {
     const { i18n } = useCoreContext();
     const [status, setStatus] = useState('ready');
     const showPrefix = !!props?.items?.length;
-    const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm({
+    const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm<PhoneInputSchema>({
         schema: [...(showPrefix ? ['phonePrefix'] : []), 'phoneNumber'],
         defaultData: { ...(showPrefix ? { phonePrefix: props.selected } : {}) },
         rules: {

--- a/packages/lib/src/components/internal/PhoneInput/types.ts
+++ b/packages/lib/src/components/internal/PhoneInput/types.ts
@@ -30,3 +30,8 @@ export interface PhoneInputState {
     };
     isValid?: boolean;
 }
+
+export interface PhoneInputSchema {
+    phoneNumber?: string;
+    phonePrefix?: string;
+}

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/commonUtils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/commonUtils.ts
@@ -19,7 +19,7 @@ const objToString = Object.prototype.toString;
  * // => false
  * ```
  */
-function isArray(prop) {
+export function isArray(prop) {
     return typeof prop === 'object' && prop !== null && Object.prototype.toString.call(prop) === '[object Array]';
 }
 
@@ -28,7 +28,7 @@ function isArray(prop) {
  *
  * @returns Number
  */
-function generateRandomNumber() {
+export function generateRandomNumber() {
     if (!window.crypto) {
         // eslint-disable-next-line
         return (Math.random() * 0x100000000) | 0;
@@ -60,7 +60,7 @@ function generateRandomNumber() {
  * @param x -
  * @returns
  */
-function existy(x) {
+export function existy(x) {
     return x != null;
 }
 
@@ -73,7 +73,7 @@ function existy(x) {
  * @param x -
  * @returns
  */
-function truthy(x) {
+export function truthy(x) {
     return x !== false && existy(x);
 }
 
@@ -91,7 +91,7 @@ function isObjectLike(value) {
 /**
  * Recursively compare 2 objects
  */
-function objectsDeepEqual(x, y) {
+export function objectsDeepEqual(x, y) {
     const xType = typeof x;
     const yType = typeof y;
     if (x && y && xType === 'object' && xType === yType) {
@@ -169,7 +169,7 @@ function isString(value) {
  * falsy(true) // => false
  * ```
  */
-function falsy(x) {
+export function falsy(x) {
     // Is null, undefined or false
     if (!truthy(x)) {
         return true;
@@ -199,7 +199,7 @@ function falsy(x) {
  * Inverse of falsy - returns true if x is NOT null, undefined, false, 0, NaN, empty object or array, empty string
  * @param x -
  */
-function notFalsy(x) {
+export function notFalsy(x) {
     return !falsy(x);
 }
 
@@ -207,7 +207,7 @@ function notFalsy(x) {
  * This function allows us to partially apply any number of variables to functions that take any number of parameters.
  * @returns \{function(): *\}
  */
-function partial(...args) {
+export function partial(...args) {
     // Store the args array
     const myArgs = args;
 
@@ -221,14 +221,5 @@ function partial(...args) {
     return partialFn;
 }
 
-export {
-    generateRandomNumber,
-    existy,
-    falsy,
-    isArray,
-    objectsDeepEqual,
-    notFalsy,
-    partial,
-    truthy
-    //    wait
-};
+// Not null or undefined or only spaces
+export const isEmpty = input => !!(input == null || /^[\s]*$/.test(input));

--- a/packages/lib/src/utils/Validator/ValidationRuleResult.ts
+++ b/packages/lib/src/utils/Validator/ValidationRuleResult.ts
@@ -1,0 +1,26 @@
+import { ErrorMessageObject } from './types';
+
+/**
+ * Holds the result of a validation
+ */
+export class ValidationRuleResult {
+    private readonly shouldValidate: boolean;
+    public isValid: boolean;
+    public errorMessage: string | ErrorMessageObject;
+
+    constructor(rule, value, mode, context) {
+        this.shouldValidate = rule.modes.includes(mode);
+        this.isValid = rule.validate(value, context);
+        this.errorMessage = rule.errorMessage;
+    }
+
+    /**
+     * Whether the validation is considered an error.
+     * A field is only considered to be an error if the validation rule applies to the current mode i.e. 'blur' or 'input'.
+     * Also, if a validation function returns a null value e.g. when the field is empty, then the field will not be considered to be in error
+     * unless the whole form is being validated
+     */
+    hasError(isValidatingForm = false): boolean {
+        return isValidatingForm ? !this.isValid && this.shouldValidate : this.isValid != null && !this.isValid && this.shouldValidate;
+    }
+}

--- a/packages/lib/src/utils/Validator/Validator.test.ts
+++ b/packages/lib/src/utils/Validator/Validator.test.ts
@@ -1,8 +1,10 @@
 import Validator from './Validator';
 
+const mockRules = {};
+
 describe('Validator', () => {
     test('Fields are valid by default', () => {
-        const validator = new Validator();
+        const validator = new Validator(mockRules);
 
         // defaults validation for unknown fields
         expect(validator.validate({ key: 'aNewField', value: '123' }).hasError()).toBe(false);

--- a/packages/lib/src/utils/Validator/types.ts
+++ b/packages/lib/src/utils/Validator/types.ts
@@ -1,3 +1,5 @@
+import { ValidationRuleResult } from './ValidationRuleResult';
+
 type ValidatorMode = 'blur' | 'input';
 
 export type ErrorMessageObject = {
@@ -46,3 +48,5 @@ export interface FieldContext {
         [key: string]: any;
     };
 }
+
+export type ValidationRuleResults = { [key: string]: ValidationRuleResult };

--- a/packages/lib/src/utils/useForm/types.ts
+++ b/packages/lib/src/utils/useForm/types.ts
@@ -1,15 +1,18 @@
-import { ValidationResult } from '../../components/internal/PersonalDetails/types';
 import { ValidatorRules } from '../Validator/types';
 
-export type FormState<DataState> = {
-    schema: string[];
-    data: DataState;
+export type FormState<FormSchema> = {
+    schema?: string[];
+    data: FormSchema;
     errors: {
-        [key: string]: ValidationResult;
+        [key: string]: any;
     };
     valid: {
         [key: string]: boolean;
     };
+    fieldProblems?: {
+        [key: string]: any;
+    };
+    isValid?: boolean;
 };
 
 export type FormProps = {
@@ -17,6 +20,13 @@ export type FormProps = {
     [key: string]: any;
 };
 
-export type DefaultDataState = {
-    [key: string]: any;
-};
+export interface Form<FormSchema> extends FormState<FormSchema> {
+    handleChangeFor: (key: string, mode?: string) => (e: any) => void;
+    triggerValidation: (schema?: any) => void;
+    setSchema: (schema: any) => void;
+    setData: (key: string, value: any) => void;
+    setValid: (key: string, value: any) => void;
+    setErrors: (key: string, value: any) => void;
+    mergeForm: (formValue: any) => void;
+    setFieldProblems: (fieldProblems: any) => void;
+}

--- a/packages/lib/src/utils/useForm/useForm.test.tsx
+++ b/packages/lib/src/utils/useForm/useForm.test.tsx
@@ -1,8 +1,13 @@
 import useForm from './useForm';
 import { renderHook, act } from '@testing-library/preact-hooks';
+import { Form } from './types';
 
 describe('useForm', () => {
     const defaultSchema = ['firstName', 'lastName'];
+    type defaultSchemaType = {
+        firstName: string;
+        lastName: string;
+    };
     const defaultData = { firstName: 'John' };
 
     describe('schema', () => {
@@ -36,7 +41,7 @@ describe('useForm', () => {
 
     describe('defaultData', () => {
         it('should set defaultData', () => {
-            const { result } = renderHook(() => useForm({ schema: defaultSchema, defaultData }));
+            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema, defaultData }));
 
             expect(result.current.data.firstName).toEqual(defaultData.firstName);
             expect(result.current.data.lastName).toEqual(null);
@@ -67,7 +72,7 @@ describe('useForm', () => {
         const firstNameValue = 'John';
 
         it('should handle changes for a field', () => {
-            const { result } = renderHook(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }));
 
             act(() => {
                 result.current.handleChangeFor('firstName')(firstNameValue);
@@ -100,6 +105,10 @@ describe('useForm', () => {
                     valid: {
                         firstName: false,
                         lastName: false
+                    },
+                    fieldProblems: {
+                        firstName: null,
+                        lastName: null
                     }
                 }
             };
@@ -108,7 +117,7 @@ describe('useForm', () => {
         });
 
         it('should set the value of a checkbox', () => {
-            const { result } = renderHook(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }));
             const mockEvent = { target: { type: 'checkbox' } };
 
             // call once to set to "checked"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Improvements to `useForm/Reducer/Validator` functionality.
- can perform 'partial' validations using just a subset of the form schema
- can leave a field empty without triggering an error (aligns with PM-9057)
- stronger types
- ability to merge form data (in the case of nested forms)
- retrieving previous values if keys removed/re-added to the schema

These improvements bring our form validation mechanism into line with KYC & the "shared components" concept

## Tested scenarios
All e2e and unit tests pass

**Fixed issue**:  discussions in PM-9057 (and offline) about consistency in how we validate fields and not treating a field as in error if the user interacts with it & leaves it empty. (Obviously if we validate the whole form and the field is required then it registers as "in error")
