### PR TITLE
Atome layout fix

### DIFF
--- a/packages/lib/src/components/Atome/Atome.tsx
+++ b/packages/lib/src/components/Atome/Atome.tsx
@@ -1,17 +1,13 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
-import { ALLOWED_COUNTRIES, BILLING_ADDRESS_SPECIFICATION } from './config';
+import { ATOME_SUPPORTED_COUNTRIES, BILLING_ADDRESS_SPECIFICATION } from './config';
 
 export default class Atome extends OpenInvoiceContainer {
     public static type = 'atome';
 
     formatProps(props) {
         return {
-            ...super.formatProps(props),
-            visibility: {
-                deliveryAddress: 'hidden',
-                companyDetails: 'hidden'
-            },
-            allowedCountries: ALLOWED_COUNTRIES,
+            ...super.formatProps({ ...props, ...{ visibility: { deliveryAddress: 'hidden', companyDetails: 'hidden' } } }),
+            allowedCountries: ATOME_SUPPORTED_COUNTRIES,
             personalDetailsRequiredFields: ['firstName', 'lastName', 'telephoneNumber'],
             billingAddressRequiredFields: ['country', 'street', 'postalCode'],
             billingAddressSpecification: BILLING_ADDRESS_SPECIFICATION

--- a/packages/lib/src/components/Atome/config.ts
+++ b/packages/lib/src/components/Atome/config.ts
@@ -1,29 +1,34 @@
-import { COUNTRY, POSTAL_CODE, STREET } from '../internal/Address/constants';
+import { COUNTRIES_WITH_CUSTOM_SPECIFICATION, COUNTRY, POSTAL_CODE, STREET } from '../internal/Address/constants';
 import { AddressSpecifications } from '../internal/Address/types';
 
-export const ALLOWED_COUNTRIES = ['ID', 'PH', 'TH', 'VN', 'JP', 'TW', 'KR', 'SG', 'MY', 'HK'];
+const ATOME_ADDRESS_SPECIFICATION = {
+    labels: {
+        [STREET]: 'address'
+    },
+    schema: [
+        STREET,
+        [
+            [COUNTRY, 70],
+            [POSTAL_CODE, 30]
+        ]
+    ]
+};
+
+export const ATOME_SUPPORTED_COUNTRIES = ['ID', 'PH', 'TH', 'VN', 'JP', 'TW', 'KR', 'SG', 'MY', 'HK'];
 
 /**
- * Creates Address Specification for each country that Atome supports.
+ * Creates Address Specification according to the Atome UI. This specification overrides all available specifications
  *
  * This custom specification is needed in order to create the desired layout of the Atome billing address part. The usage of the
  * 'default' layout specification from the Address component does not align correctly the available fields, therefore we need to
  * create this customization.
  */
-export const BILLING_ADDRESS_SPECIFICATION = ALLOWED_COUNTRIES.reduce((memo: AddressSpecifications, countryCode: string) => {
-    return {
-        ...memo,
-        [countryCode]: {
-            labels: {
-                [STREET]: 'address'
-            },
-            schema: [
-                STREET,
-                [
-                    [COUNTRY, 70],
-                    [POSTAL_CODE, 30]
-                ]
-            ]
-        }
-    };
-}, {});
+export const BILLING_ADDRESS_SPECIFICATION = COUNTRIES_WITH_CUSTOM_SPECIFICATION.reduce(
+    (memo: AddressSpecifications, countryCode: string) => {
+        return {
+            ...memo,
+            [countryCode]: ATOME_ADDRESS_SPECIFICATION
+        };
+    },
+    { default: ATOME_ADDRESS_SPECIFICATION }
+);

--- a/packages/lib/src/components/internal/Address/constants.ts
+++ b/packages/lib/src/components/internal/Address/constants.ts
@@ -66,3 +66,5 @@ export const ADDRESS_SPECIFICATIONS: AddressSpecifications = {
         schema: [COUNTRY, [[STREET, 70], [HOUSE_NUMBER_OR_NAME, 30]], [[POSTAL_CODE, 30], [CITY, 70]], STATE_OR_PROVINCE]
     }
 };
+
+export const COUNTRIES_WITH_CUSTOM_SPECIFICATION = Object.keys(ADDRESS_SPECIFICATIONS);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Hiding 'bank details' part
- Adjusted billing address form layout to be the same for all countries