### PR TITLE
Add onOrderCancel to sessions

### DIFF
--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -41,6 +41,8 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                 }
             }
         );
+
+        this.onOrderCancel = this.getOnOrderCancel();
     };
 
     public setStatus = (status: UIElementStatus, props: DropinStatusProps = {}) => {
@@ -93,12 +95,12 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
     }
 
     /**
-     * onOrderCancelBuilder decides which onOrderCancel logic should be used, manual or sessions
+     * getOnOrderCancel decides which onOrderCancel logic should be used, manual or sessions
      */
-    private onOrderCancelBuilder = () => {
+    private getOnOrderCancel = () => {
         if (this.props.onOrderCancel) {
             return (data: onOrderCancelData) => {
-                return this.props.onOrderCancel(data);
+                this.props.onOrderCancel(data);
             };
         }
         if (this.props.session) {
@@ -110,6 +112,8 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         }
         return null;
     };
+
+    private onOrderCancel: (data: onOrderCancelData) => void;
 
     render(props, { elements, instantPaymentElements, status, activePaymentMethod, cachedPaymentMethods }) {
         const isLoading = status.type === 'loading';
@@ -140,7 +144,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                                 cachedPaymentMethods={cachedPaymentMethods}
                                 order={this.props.order}
                                 orderStatus={this.state.orderStatus}
-                                onOrderCancel={this.onOrderCancelBuilder()}
+                                onOrderCancel={this.onOrderCancel}
                                 onSelect={this.handleOnSelectPaymentMethod}
                                 openFirstPaymentMethod={this.props.openFirstPaymentMethod}
                                 openFirstStoredPaymentMethod={this.props.openFirstStoredPaymentMethod}

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -5,7 +5,6 @@ import getOrderStatus from '../../../core/Services/order-status';
 import { DropinComponentProps, DropinComponentState, DropinStatusProps } from '../types';
 import './DropinComponent.scss';
 import { UIElementStatus } from '../../types';
-import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 
 export class DropinComponent extends Component<DropinComponentProps, DropinComponentState> {
     public state: DropinComponentState = {

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -65,10 +65,14 @@ export interface DropinElementProps extends UIElementProps {
     onDisableStoredPaymentMethod?: (storedPaymentMethod, resolve, reject) => void;
 }
 
+export interface onOrderCancelData {
+    order: Order;
+}
+
 export interface DropinComponentProps extends DropinElementProps {
     onCreateElements: any;
     onChange: (newState?: object) => void;
-    onOrderCancel?: (order: Order) => void;
+    onOrderCancel?: (data: onOrderCancelData) => void;
 }
 
 interface DropinStatus {

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -4,6 +4,7 @@ import UIElement from './UIElement';
 import Core from '../core';
 import Analytics from '../core/Analytics';
 import RiskElement from '../core/RiskModule';
+import Session from "../core/CheckoutSession";
 
 export interface PaymentResponse {
     action?: PaymentAction;
@@ -42,10 +43,7 @@ export interface IUIElement {
 export type UIElementStatus = 'ready' | 'loading' | 'error' | 'success';
 
 export interface UIElementProps extends BaseElementProps {
-    session?: {
-        id: string;
-        data: string;
-    };
+    session?: Session;
     onChange?: (state: any, element: UIElement) => void;
     onValid?: (state: any, element: UIElement) => void;
     beforeSubmit?: (state: any, element: UIElement, actions: any) => Promise<void>;

--- a/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
+++ b/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
@@ -11,8 +11,10 @@ import {
     CheckoutSessionDetailsResponse,
     CheckoutSessionOrdersResponse,
     CheckoutSessionPaymentResponse,
-    CheckoutSessionSetupResponse
+    CheckoutSessionSetupResponse,
 } from '../../types';
+import cancelOrder from '../Services/sessions/cancel-order';
+import {onOrderCancelData} from "../../components/Dropin/types";
 
 class Session {
     private readonly session: CheckoutSession;
@@ -110,6 +112,20 @@ class Session {
             return response;
         });
     }
+
+    /**
+     * Cancels an order for the current session
+     */
+    cancelOrder(data: onOrderCancelData): Promise<CheckoutSessionOrdersResponse> {
+        return cancelOrder(data.order, this).then(response => {
+            if (response.sessionData) {
+                this.updateSessionData(response.sessionData);
+            }
+
+            return response;
+        });
+    }
+
 
     /**
      * Gets the stored session but only if the current id and the stored id match

--- a/packages/lib/src/core/Services/sessions/cancel-order.ts
+++ b/packages/lib/src/core/Services/sessions/cancel-order.ts
@@ -1,0 +1,19 @@
+import { httpPost } from '../http';
+import Session from '../../CheckoutSession';
+import {CheckoutSessionOrdersResponse, Order} from '../../../types';
+import { API_VERSION } from './constants';
+
+/**
+ */
+function cancelOrder(order: Order, session: Session): Promise<CheckoutSessionOrdersResponse> {
+    const path = `${API_VERSION}/sessions/${session.id}/orders/cancel?clientKey=${session.clientKey}`;
+
+    const data = {
+        sessionData: session.data,
+        order: order
+    };
+
+    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal' }, data);
+}
+
+export default cancelOrder;

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -28,6 +28,9 @@ export async function initSession() {
         onError: (error, component) => {
             console.error(error.message, component);
         },
+        // onOrderCancel: data => {
+        //     console.error('onOrderCancel', data);
+        // },
         paymentMethodsConfiguration: {
             paywithgoogle: {
                 buttonType: 'plain'

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -28,9 +28,6 @@ export async function initSession() {
         onError: (error, component) => {
             console.error(error.message, component);
         },
-        // onOrderCancel: data => {
-        //     console.error('onOrderCancel', data);
-        // },
         paymentMethodsConfiguration: {
             paywithgoogle: {
                 buttonType: 'plain'


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This objective of this PR is to add onOrderCancel handling when using the dropin with sessions. 


## Tested scenarios
<!-- Description of tested scenarios -->
* Checked if orderCancel is trigged correctly with sessions
  * Checked if it handles endpoint failure
* Checked if onOrderCancel is trigger in the manual implementation
* Checked if onOrderCancel is not passed the button is not shown


**Fixed issue**:  <!-- #-prefixed issue number -->
