### PR TITLE
Fix: Importing AddressField type using relative path

### DIFF
--- a/packages/lib/src/components/internal/Address/Specifications.ts
+++ b/packages/lib/src/components/internal/Address/Specifications.ts
@@ -1,6 +1,6 @@
 import { AddressSchema, AddressSpecifications, StringObject } from './types';
 import { ADDRESS_SPECIFICATIONS } from './constants';
-import { AddressField } from 'src/types';
+import { AddressField } from '../../../types';
 
 const SCHEMA_MAX_DEPTH = 2;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Adjusted import to use relative instead of absolute path

**Fixed issue**:  #1592 
