### PR TITLE
Feature/mb way international phone number

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/validate.ts
+++ b/packages/lib/src/components/Card/components/CardInput/validate.ts
@@ -1,7 +1,7 @@
 import { ValidatorRules } from '../../../../utils/Validator/types';
 import { formatCPFCNPJ } from '../../../internal/SocialSecurityNumberBrazil/utils';
 import validateSSN from '../../../internal/SocialSecurityNumberBrazil/validate';
-import { isEmpty } from '../../../internal/SecuredFields/lib/utilities/commonUtils';
+import { isEmpty } from '../../../../utils/validator-utils';
 
 export const cardInputFormatters = {
     socialSecurityNumber: formatCPFCNPJ

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -31,6 +31,8 @@ export class MBWayElement extends UIElement {
             paymentMethod: {
                 type: MBWayElement.type,
                 ...(this.state.data?.phoneNumber && { telephoneNumber: this.state.data.phoneNumber })
+                // TODO - add once the backend can handle it & we know exactly what the key should be called
+                // ...(this.state.data?.phonePrefix && { telephoneNumberPrefix: this.state.data.phonePrefix })
             }
         };
     }

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -18,7 +18,7 @@ export class MBWayElement extends UIElement {
                 phonePrefix: data.phonePrefix || '+351' // if not specified default to Portuguese country code
             },
             placeholders: {
-                phoneNumber: placeholders.telephoneNumber || placeholders.phoneNumber || '932 123 456'
+                phoneNumber: placeholders.telephoneNumber || placeholders.phoneNumber || '932123456'
             }
         };
     }
@@ -30,9 +30,7 @@ export class MBWayElement extends UIElement {
         return {
             paymentMethod: {
                 type: MBWayElement.type,
-                ...(this.state.data?.phoneNumber && { telephoneNumber: this.state.data.phoneNumber })
-                // TODO - add once the backend can handle it & we know exactly what the key should be called
-                // ...(this.state.data?.phonePrefix && { telephoneNumberPrefix: this.state.data.phonePrefix })
+                ...(this.state.data?.phoneNumber && { telephoneNumber: this.state.data.phonePrefix + this.state.data.phoneNumber })
             }
         };
     }

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -14,10 +14,11 @@ export class MBWayElement extends UIElement {
         return {
             ...props,
             data: {
-                telephoneNumber: data.telephoneNumber || data.phoneNumber
+                phoneNumber: data.telephoneNumber || data.phoneNumber,
+                phonePrefix: data.phonePrefix || '+351' // if not specified default to Portuguese country code
             },
             placeholders: {
-                telephoneNumber: placeholders.telephoneNumber || placeholders.phoneNumber || '+351 932 123 456'
+                phoneNumber: placeholders.telephoneNumber || placeholders.phoneNumber || '932 123 456'
             }
         };
     }
@@ -29,7 +30,7 @@ export class MBWayElement extends UIElement {
         return {
             paymentMethod: {
                 type: MBWayElement.type,
-                ...(this.state.data?.telephoneNumber && { telephoneNumber: this.state.data.telephoneNumber })
+                ...(this.state.data?.phoneNumber && { telephoneNumber: this.state.data.phoneNumber })
             }
         };
     }

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -48,10 +48,6 @@ function MBWayInput(props: MBWayInputProps) {
     }, []);
 
     const onChange = ({ data, valid, errors, isValid }) => {
-        console.log('\n### MBWayInput::onChange:: data=', data);
-        // console.log('### MBWayInput::onChange:: valid=', valid);
-        // console.log('### MBWayInput::onChange:: errors=', errors);
-        // console.log('### MBWayInput::onChange:: isValid=', isValid);
         props.onChange({ data, valid, errors, isValid });
     };
 

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -1,13 +1,12 @@
 import { h } from 'preact';
-import { useState, useLayoutEffect, useRef } from 'preact/hooks';
+import { useState, useRef } from 'preact/hooks';
 import useCoreContext from '../../../../core/Context/useCoreContext';
 import { MBWayInputProps } from './types';
 import './MBWayInput.scss';
-import getDataset from '../../../../core/Services/get-dataset';
-import { DataSet } from '../../../../core/Services/data-set';
 import PhoneInput from '../../../internal/PhoneInputNew';
 import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
 import LoadingWrapper from '../../../internal/LoadingWrapper';
+import usePhonePrefixes from '../../../internal/PhoneInputNew/usePhonePrefixes';
 
 function MBWayInput(props: MBWayInputProps) {
     const { i18n, loadingContext } = useCoreContext();
@@ -16,46 +15,23 @@ function MBWayInput(props: MBWayInputProps) {
 
     const { allowedCountries = [] } = props;
 
-    const [phonePrefixes, setPhonePrefixes] = useState<DataSet>([]);
-    const [status, setStatus] = useState<string>('loading');
+    const [status, setStatus] = useState<string>('ready');
 
     this.setStatus = setStatus;
     this.showValidation = phoneInputRef?.current?.triggerValidation;
 
-    useLayoutEffect(() => {
-        getDataset('phonenumbers', loadingContext)
-            .then(response => {
-                const countriesFilter = country => allowedCountries.includes(country.id);
-                const filteredCountries = allowedCountries.length ? response.filter(countriesFilter) : response;
-                const mappedCountries = filteredCountries.map(item => {
-                    // Get country flags (magic! - shifts the country code characters to the correct position of the emoji in the unicode space)
-                    const codePoints: number[] = item.id
-                        .toUpperCase()
-                        .split('')
-                        .map(char => 127397 + char.charCodeAt(0));
+    const { loadingStatus: prefixLoadingStatus, phonePrefixes, error } = usePhonePrefixes({ allowedCountries, loadingContext });
 
-                    // Get flag emoji + space at end (it doesn't work to add spaces in the template literal, below)
-                    const flag = String.fromCodePoint ? String.fromCodePoint(...codePoints) + '\u00A0\u00A0' : '';
-
-                    return { id: item.prefix, name: `${flag} ${item.prefix} (${item.id})`, selectedOptionName: `${flag} ${item.prefix}` };
-                });
-
-                setPhonePrefixes(mappedCountries || []);
-                setStatus('ready');
-            })
-            .catch(error => {
-                props.onError(new AdyenCheckoutError('ERROR', error));
-                setPhonePrefixes([]);
-                setStatus('ready');
-            });
-    }, []);
+    if (error) {
+        props.onError(new AdyenCheckoutError('ERROR', error));
+    }
 
     const onChange = ({ data, valid, errors, isValid }) => {
         props.onChange({ data, valid, errors, isValid });
     };
 
     return (
-        <LoadingWrapper status={status}>
+        <LoadingWrapper status={prefixLoadingStatus}>
             <div className="adyen-checkout__mb-way">
                 <PhoneInput {...props} items={phonePrefixes} ref={phoneInputRef} onChange={onChange} data={props.data} />
 

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -1,13 +1,12 @@
 import { h } from 'preact';
-import { useState, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
+import { useState, useLayoutEffect, useRef } from 'preact/hooks';
 import useCoreContext from '../../../../core/Context/useCoreContext';
-import { MBWayDataState, MBWayInputProps } from './types';
+import { MBWayInputProps } from './types';
 import './MBWayInput.scss';
-import useForm from '../../../../utils/useForm';
 import getDataset from '../../../../core/Services/get-dataset';
 import { DataSet } from '../../../../core/Services/data-set';
 import PhoneInput from '../../../internal/PhoneInputNew';
-const phoneNumberRegEx = /^[+]*[0-9]{1,4}[\s/0-9]*$/;
+import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
 
 function MBWayInput(props: MBWayInputProps) {
     const { i18n, loadingContext } = useCoreContext();
@@ -15,24 +14,9 @@ function MBWayInput(props: MBWayInputProps) {
     const phoneInputRef = useRef(null);
 
     const { allowedCountries = [] } = props;
+
     const [phonePrefixes, setPhonePrefixes] = useState<DataSet>([]);
-
-    const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm<MBWayDataState>({
-        schema: ['telephoneNumber'],
-        defaultData: props.data,
-        rules: {
-            telephoneNumber: {
-                validate: num => phoneNumberRegEx.test(num) && num.length >= 7,
-                errorMessage: 'mobileNumber.invalid',
-                modes: ['blur']
-            }
-        },
-        formatters: {
-            telephoneNumber: num => num.replace(/[^0-9+\s]/g, '')
-        }
-    });
-
-    const [status, setStatus] = useState('ready');
+    const [status, setStatus] = useState<string>('ready');
 
     this.setStatus = setStatus;
     this.showValidation = phoneInputRef?.current?.triggerValidation;
@@ -56,21 +40,18 @@ function MBWayInput(props: MBWayInputProps) {
                 });
 
                 setPhonePrefixes(mappedCountries || []);
-                // setLoaded(true);
             })
             .catch(error => {
-                console.log('### MBWayInput::getDataset:: phonenumbers:: error=', error);
+                props.onError(new AdyenCheckoutError('ERROR', error));
                 setPhonePrefixes([]);
-                // setLoaded(true);
             });
     }, []);
 
-    useEffect(() => {
-        props.onChange({ data, valid, errors, isValid });
-    }, [data, valid, errors, isValid]);
-
     const onChange = ({ data, valid, errors, isValid }) => {
-        console.log('### MBWayInput::onChange:: data=', data);
+        console.log('\n### MBWayInput::onChange:: data=', data);
+        // console.log('### MBWayInput::onChange:: valid=', valid);
+        // console.log('### MBWayInput::onChange:: errors=', errors);
+        // console.log('### MBWayInput::onChange:: isValid=', isValid);
         props.onChange({ data, valid, errors, isValid });
     };
 
@@ -85,6 +66,7 @@ function MBWayInput(props: MBWayInputProps) {
 
 MBWayInput.defaultProps = {
     onChange: () => {},
+    phoneNumberKey: 'mobileNumber',
     phoneNumberErrorKey: 'mobileNumber.invalid'
 };
 

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -4,7 +4,6 @@ import useCoreContext from '../../../../core/Context/useCoreContext';
 import { MBWayInputProps } from './types';
 import './MBWayInput.scss';
 import PhoneInput from '../../../internal/PhoneInputNew';
-import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
 import LoadingWrapper from '../../../internal/LoadingWrapper';
 import usePhonePrefixes from '../../../internal/PhoneInputNew/usePhonePrefixes';
 
@@ -20,11 +19,7 @@ function MBWayInput(props: MBWayInputProps) {
     this.setStatus = setStatus;
     this.showValidation = phoneInputRef?.current?.triggerValidation;
 
-    const { loadingStatus: prefixLoadingStatus, phonePrefixes, error } = usePhonePrefixes({ allowedCountries, loadingContext });
-
-    if (error) {
-        props.onError(new AdyenCheckoutError('ERROR', error));
-    }
+    const { loadingStatus: prefixLoadingStatus, phonePrefixes } = usePhonePrefixes({ allowedCountries, loadingContext, handleError: props.onError });
 
     const onChange = ({ data, valid, errors, isValid }) => {
         props.onChange({ data, valid, errors, isValid });

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -7,6 +7,7 @@ import getDataset from '../../../../core/Services/get-dataset';
 import { DataSet } from '../../../../core/Services/data-set';
 import PhoneInput from '../../../internal/PhoneInputNew';
 import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
+import LoadingWrapper from '../../../internal/LoadingWrapper';
 
 function MBWayInput(props: MBWayInputProps) {
     const { i18n, loadingContext } = useCoreContext();
@@ -16,7 +17,7 @@ function MBWayInput(props: MBWayInputProps) {
     const { allowedCountries = [] } = props;
 
     const [phonePrefixes, setPhonePrefixes] = useState<DataSet>([]);
-    const [status, setStatus] = useState<string>('ready');
+    const [status, setStatus] = useState<string>('loading');
 
     this.setStatus = setStatus;
     this.showValidation = phoneInputRef?.current?.triggerValidation;
@@ -40,10 +41,12 @@ function MBWayInput(props: MBWayInputProps) {
                 });
 
                 setPhonePrefixes(mappedCountries || []);
+                setStatus('ready');
             })
             .catch(error => {
                 props.onError(new AdyenCheckoutError('ERROR', error));
                 setPhonePrefixes([]);
+                setStatus('ready');
             });
     }, []);
 
@@ -52,11 +55,13 @@ function MBWayInput(props: MBWayInputProps) {
     };
 
     return (
-        <div className="adyen-checkout__mb-way">
-            <PhoneInput {...props} items={phonePrefixes} ref={phoneInputRef} onChange={onChange} data={props.data} />
+        <LoadingWrapper status={status}>
+            <div className="adyen-checkout__mb-way">
+                <PhoneInput {...props} items={phonePrefixes} ref={phoneInputRef} onChange={onChange} data={props.data} />
 
-            {props.showPayButton && props.payButton({ status, label: i18n.get('confirmPurchase') })}
-        </div>
+                {props.showPayButton && props.payButton({ status, label: i18n.get('confirmPurchase') })}
+            </div>
+        </LoadingWrapper>
     );
 }
 

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 import useCoreContext from '../../../../core/Context/useCoreContext';
 import Field from '../../../internal/FormFields/Field';
@@ -7,10 +7,22 @@ import { renderFormField } from '../../../internal/FormFields';
 import { MBWayDataState, MBWayInputProps } from './types';
 import './MBWayInput.scss';
 import useForm from '../../../../utils/useForm';
+import getDataset from '../../../../core/Services/get-dataset';
+import { DataSet } from '../../../../core/Services/data-set';
+import PhoneInput from '../../../internal/PhoneInputNew';
 const phoneNumberRegEx = /^[+]*[0-9]{1,4}[\s/0-9]*$/;
 
 function MBWayInput(props: MBWayInputProps) {
-    const { i18n } = useCoreContext();
+    const {
+        i18n,
+        loadingContext
+        // commonProps: { isCollatingErrors }
+    } = useCoreContext();
+
+    const phoneInputRef = useRef(null);
+
+    const { allowedCountries = [] } = props;
+    const [phonePrefixes, setPhonePrefixes] = useState<DataSet>([]);
 
     const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm<MBWayDataState>({
         schema: ['telephoneNumber'],
@@ -32,21 +44,37 @@ function MBWayInput(props: MBWayInputProps) {
     this.setStatus = setStatus;
     this.showValidation = triggerValidation;
 
+    useLayoutEffect(() => {
+        getDataset('phonenumbers', loadingContext)
+            .then(response => {
+                const countriesFilter = country => allowedCountries.includes(country.id);
+                const newCountries = allowedCountries.length ? response.filter(countriesFilter) : response;
+                console.log('### MBWayInput::newCountries:: ', newCountries);
+                setPhonePrefixes(newCountries || []);
+                // setLoaded(true);
+            })
+            .catch(error => {
+                console.log('### MBWayInput::getDataset:: phonenumbers:: error=', error);
+                setPhonePrefixes([]);
+                // setLoaded(true);
+            });
+    }, []);
+
     useEffect(() => {
         props.onChange({ data, valid, errors, isValid });
     }, [data, valid, errors, isValid]);
 
     return (
         <div className="adyen-checkout__mb-way">
-            <Field
-                errorMessage={!!errors.telephoneNumber && i18n.get('mobileNumber.invalid')}
-                label={i18n.get('mobileNumber')}
-                className={classNames('adyen-checkout__input--phone-number')}
-                isValid={valid.telephoneNumber}
-                dir={'ltr'}
-                name={'telephoneNumber'}
-            >
-                {renderFormField('tel', {
+            {/*<Field*/}
+            {/*    errorMessage={!!errors.telephoneNumber && i18n.get('mobileNumber.invalid')}*/}
+            {/*    label={i18n.get('mobileNumber')}*/}
+            {/*    className={classNames('adyen-checkout__input--phone-number')}*/}
+            {/*    isValid={valid.telephoneNumber}*/}
+            {/*    dir={'ltr'}*/}
+            {/*    name={'telephoneNumber'}*/}
+            {/*>*/}
+            {/*{renderFormField('tel', {
                     value: data.telephoneNumber,
                     className: 'adyen-checkout__pm__phoneNumber__input',
                     placeholder: props.placeholders.telephoneNumber,
@@ -54,8 +82,10 @@ function MBWayInput(props: MBWayInputProps) {
                     autoCorrect: 'off',
                     onBlur: handleChangeFor('telephoneNumber', 'blur'),
                     onInput: handleChangeFor('telephoneNumber', 'input')
-                })}
-            </Field>
+                })}*/}
+
+            <PhoneInput {...props} items={phonePrefixes} ref={phoneInputRef} />
+            {/*</Field>*/}
 
             {props.showPayButton && props.payButton({ status, label: i18n.get('confirmPurchase') })}
         </div>

--- a/packages/lib/src/components/MBWay/components/MBWayInput/types.ts
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/types.ts
@@ -2,13 +2,17 @@ import { UIElementProps } from '../../../types';
 
 export interface MBWayInputData {
     telephoneNumber?: string;
+    phoneNumber?: string;
+    phonePrefix?: string;
 }
 
 export interface MBWayInputProps extends UIElementProps {
     data?: MBWayInputData;
     placeholders?: MBWayInputData;
     onChange: (state) => void;
-    allowedCountries: string[];
+    allowedCountries?: string[];
+    requiredFields?: string[];
+    phoneNumberKey?: string;
 }
 
 export interface MBWayDataState {

--- a/packages/lib/src/components/MBWay/components/MBWayInput/types.ts
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/types.ts
@@ -8,6 +8,7 @@ export interface MBWayInputProps extends UIElementProps {
     data?: MBWayInputData;
     placeholders?: MBWayInputData;
     onChange: (state) => void;
+    allowedCountries: string[];
 }
 
 export interface MBWayDataState {

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -1,7 +1,7 @@
 import { ValidatorRules, ValidatorRule } from '../../../utils/Validator/types';
 import { countrySpecificFormatters } from './validate.formats';
 import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD } from '../../../core/Errors/constants';
-import { isEmpty } from '../SecuredFields/lib/utilities/commonUtils';
+import { isEmpty } from '../../../utils/validator-utils';
 
 const createPatternByDigits = (digits: number) => {
     return {

--- a/packages/lib/src/components/internal/FormFields/FormFields.scss
+++ b/packages/lib/src/components/internal/FormFields/FormFields.scss
@@ -136,10 +136,6 @@
     color: $color-alert;
 }
 
-.adyen-checkout__input--invalid {
-    border-color: $color-alert;
-}
-
 .adyen-checkout__input--valid {
     border-bottom-color: $color-success;
 }

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -1,13 +1,12 @@
+.adyen-checkout__phone-input-new {
+    direction: ltr;
 
-
-/* NEW */
-.adyen-checkout__phone-input {
     .adyen-checkout__input-wrapper {
         width: 100%;
 
         .adyen-checkout__input {
-            height: auto;
             padding: 0;
+            height: auto;
             /* stylelint-disable */
             &:focus-within {
                 border: 1px solid #06f;
@@ -19,17 +18,12 @@
             /* stylelint-enable */
         }
 
-
-        .adyen-kyc-field {
-            margin-bottom: 0;
-        }
-
         .adyen-checkout__dropdown__button {
-            border: 0;
-            border-bottom-right-radius: 0;
-            border-top-right-radius: 0;
-            height: 40px;
             width: auto;
+            border: 0;
+            height: 35px;
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
 
             &::after {
                 box-sizing: revert;
@@ -39,9 +33,9 @@
 
         .adyen-checkout-input__phone-number {
             //@include adl-inline-component-box($adl-inline-components-height-medium, false, 0);
-            height: 40px;
-            line-height: 40px;
-            min-height: 40px;
+            height: 35px;
+            line-height: 35px;
+            min-height: 35px;
             padding-bottom: 0;
             padding-top: 0;
             border: 1px solid transparent;
@@ -69,10 +63,6 @@
             flex: 3;
         }
 
-        .adyen-kyc__countryFlag {
-            position: absolute;
-        }
-
         .adyen-checkout__dropdown__button--active {
             box-shadow: none;
 
@@ -80,7 +70,6 @@
                 box-shadow: none;
             }
         }
-
     }
 
     .adyen-checkout-phone-input__error-holder {

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -1,0 +1,89 @@
+
+
+/* NEW */
+.adyen-checkout__phone-input {
+    .adyen-checkout__input-wrapper {
+        width: 100%;
+
+        .adyen-checkout__input {
+            height: auto;
+            padding: 0;
+            /* stylelint-disable */
+            &:focus-within {
+                border: 1px solid #06f;
+
+                .adyen-checkout-countrycode-selector {
+                    border-right: 1px solid #06f;
+                }
+            }
+            /* stylelint-enable */
+        }
+
+
+        .adyen-kyc-field {
+            margin-bottom: 0;
+        }
+
+        .adyen-checkout__dropdown__button {
+            border: 0;
+            border-bottom-right-radius: 0;
+            border-top-right-radius: 0;
+            height: 40px;
+            width: auto;
+
+            &::after {
+                box-sizing: revert;
+                height: 10px;
+            }
+        }
+
+        .adyen-checkout-input__phone-number {
+            //@include adl-inline-component-box($adl-inline-components-height-medium, false, 0);
+            height: 40px;
+            line-height: 40px;
+            min-height: 40px;
+            padding-bottom: 0;
+            padding-top: 0;
+            border: 1px solid transparent;
+            padding-left: 15px;
+
+            &:focus-within {
+                border: 1px solid transparent;
+            }
+        }
+
+        .adyen-checkout-countrycode-selector {
+            border-right: 1px solid #dce0e5;
+            flex: 1;
+            min-width: 140px;
+        }
+
+        .adyen-checkout-input__phoneInput {
+            align-items: center;
+            display: flex;
+        }
+
+        .adyen-checkout-phone-number {
+            align-items: center;
+            display: flex;
+            flex: 3;
+        }
+
+        .adyen-kyc__countryFlag {
+            position: absolute;
+        }
+
+        .adyen-checkout__dropdown__button--active {
+            box-shadow: none;
+
+            &:hover {
+                box-shadow: none;
+            }
+        }
+
+    }
+
+    .adyen-checkout-phone-input__error-holder {
+        margin-top: -10px;
+    }
+}

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -43,7 +43,7 @@
         }
 
         // Example of better BEM naming i.e. 'adyen-checkout-input' as the Base
-        .adyen-checkout-input__phone-number {
+        .adyen-checkout-field__input--phone-number {
             height: 35px;
             line-height: 35px;
             min-height: 35px;
@@ -64,7 +64,8 @@
             min-width: 140px;
         }
 
-        .adyen-checkout-input--phoneInput {
+        // Style with better BEM naming i.e. 'adyen-checkout-field' as the Base, 'input-holder' as the element, 'phone-input' as the Modifier
+        .adyen-checkout-field__input-holder--phone-input {
             align-items: center;
             display: flex;
         }

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -60,8 +60,8 @@
 
         .adyen-checkout-dropdown--countrycode-selector {
             border-right: 1px solid #dce0e5;
-            min-width: 130px;
-            width: 130px;
+            min-width: 134px;
+            width: 134px;
         }
 
         .adyen-checkout-input-holder--phone-input {

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -1,23 +1,25 @@
-.adyen-checkout__phone-input-new {
+.adyen-checkout-phone-input--new {
     direction: ltr;
 
+    // inherited style (FormFields.scss)
     .adyen-checkout__input-wrapper {
         width: 100%;
 
+        // inherited style (FormFields.scss)
         .adyen-checkout__input {
             padding: 0;
             height: auto;
-            /* stylelint-disable */
-            &:focus-within {
-                border: 1px solid #06f;
 
-                .adyen-checkout-countrycode-selector {
-                    border-right: 1px solid #06f;
-                }
-            }
-            /* stylelint-enable */
+            &:focus-within {
+                 border: 1px solid #06f;
+
+                 .adyen-checkout-dropdown--countrycode-selector {
+                     border-right: 1px solid #06f;
+                 }
+             }
         }
 
+        // inherited style (Select.scss)
         .adyen-checkout__dropdown__button {
             width: auto;
             border: 0;
@@ -25,14 +27,23 @@
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
 
-            &::after {
+            &:after {
                 box-sizing: revert;
                 height: 10px;
             }
         }
 
+        // inherited style (Select.scss)
+        .adyen-checkout__dropdown__button--active {
+            box-shadow: none;
+
+            &:hover {
+                box-shadow: none;
+            }
+        }
+
+        // Example of better BEM naming i.e. 'adyen-checkout-input' as the Base
         .adyen-checkout-input__phone-number {
-            //@include adl-inline-component-box($adl-inline-components-height-medium, false, 0);
             height: 35px;
             line-height: 35px;
             min-height: 35px;
@@ -42,17 +53,18 @@
             padding-left: 15px;
 
             &:focus-within {
-                border: 1px solid transparent;
+                border: 1px solid #06f;
+                box-shadow: 0 0 0 2px #99c2ff;
             }
         }
 
-        .adyen-checkout-countrycode-selector {
+        .adyen-checkout-dropdown--countrycode-selector {
             border-right: 1px solid #dce0e5;
             flex: 1;
             min-width: 140px;
         }
 
-        .adyen-checkout-input__phoneInput {
+        .adyen-checkout-input--phoneInput {
             align-items: center;
             display: flex;
         }
@@ -61,14 +73,6 @@
             align-items: center;
             display: flex;
             flex: 3;
-        }
-
-        .adyen-checkout__dropdown__button--active {
-            box-shadow: none;
-
-            &:hover {
-                box-shadow: none;
-            }
         }
     }
 

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -43,7 +43,7 @@
         }
 
         // Example of better BEM naming i.e. 'adyen-checkout-input' as the Base
-        .adyen-checkout-field__input--phone-number {
+        .adyen-checkout-input--phone-number {
             height: 35px;
             line-height: 35px;
             min-height: 35px;
@@ -60,12 +60,12 @@
 
         .adyen-checkout-dropdown--countrycode-selector {
             border-right: 1px solid #dce0e5;
-            flex: 1;
-            min-width: 140px;
+            //flex: 1;
+            min-width: 130px;
+            width: 130px;
         }
 
-        // Style with better BEM naming i.e. 'adyen-checkout-field' as the Base, 'input-holder' as the element, 'phone-input' as the Modifier
-        .adyen-checkout-field__input-holder--phone-input {
+        .adyen-checkout-input-holder--phone-input {
             align-items: center;
             display: flex;
         }

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -60,7 +60,6 @@
 
         .adyen-checkout-dropdown--countrycode-selector {
             border-right: 1px solid #dce0e5;
-            //flex: 1;
             min-width: 130px;
             width: 130px;
         }

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -59,8 +59,13 @@ function PhoneInput(props) {
 
     const getPhoneFieldError = useCallback(
         field => {
-            const errMsg = i18n.get(errors[field]?.errorMessage);
-            return errMsg ? errMsg : null;
+            if (errors[field]) {
+                const propsField = field === 'phoneNumber' ? 'phoneNumberErrorKey' : 'phonePrefixErrorKey';
+                const key = props[propsField] ? props[propsField] : errors[field].errorMessage;
+                const errMsg = i18n.get(key);
+                return errMsg ? errMsg : null;
+            }
+            return null;
         },
         [errors]
     );

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -5,8 +5,7 @@ import Field from '../FormFields/Field';
 import renderFormField from '../FormFields';
 import useForm from '../../../utils/useForm';
 import useCoreContext from '../../../core/Context/useCoreContext';
-// import './PhoneInput.scss';
-import '../PhoneInput/PhoneInput.scss';
+import './PhoneInput.scss';
 import { phoneFormatters, phoneValidationRules } from './validate';
 // import { PhoneInputProps, PhoneInputSchema } from './types';
 import { PhoneInputSchema } from './types';
@@ -62,12 +61,12 @@ function PhoneInput(props) {
      * The <Field> element assigns a uniqueId which it uses for the \<label for=\> attribute.
      * This uniqueId is then passed as a prop to the first child of the field
      *  (which is usually an element created by renderFormField) where it is assigned to the id attribute of that element.
-     * However here we have a different use case and the uniqueId is written to the <div class="adyen-kyc-input"> which in this case
+     * However here we have a different use case and the uniqueId is written to the <div class="adyen-checkout__input"> which in this case
      *  is the first child of the <Field>.
      * In order to retrieve this uniqueId and assign it to the phoneNumber input (to thus link <label> and <input> - we need this function.
      */
     const getRelatedUniqueId = () => {
-        const holder = document.querySelector('.adyen-kyc-phone-input [uniqueid]');
+        const holder = document.querySelector('.adyen-checkout__phone-input [uniqueid]');
         return holder ? holder.getAttribute('uniqueid') : null;
     };
 
@@ -80,31 +79,31 @@ function PhoneInput(props) {
     );
 
     const uniqueIDPhonePrefix = useMemo(() => {
-        return getUniqueId('adyen-kyc-phonePrefix');
+        return getUniqueId('adyen-checkout-phonePrefix');
     }, []);
 
     return (
-        <div className="adyen-kyc-phone-input">
+        <div className="adyen-checkout__phone-input">
             <Field
                 name={'phoneNumber'}
                 label={i18n.get('mobileNumber')}
                 className={classNames({
-                    'adyen-kyc-phone-input__holder': true
+                    'adyen-checkout__input--phone-number': true
                 })}
                 inputWrapperModifiers={['phoneInput']}
                 isValid={valid.phoneNumber}
             >
                 <div
                     className={classNames({
-                        'adyen-kyc-input': true,
-                        'adyen-kyc-input--invalid': !!errors.phoneNumber || !!errors.phonePrefix,
-                        'adyen-kyc-field--valid': (showPrefix ? valid.phonePrefix : true) && valid.phoneNumber,
-                        'adyen-kyc-input__phoneInput': true // Better BEM naming
+                        'adyen-checkout__input': true,
+                        'adyen-checkout__input--invalid': !!errors.phoneNumber || !!errors.phonePrefix,
+                        'adyen-checkout__input--valid': (showPrefix ? valid.phonePrefix : true) && valid.phoneNumber,
+                        'adyen-checkout-input__phoneInput': true // Better BEM naming
                     })}
                 >
                     {showPrefix &&
                         renderFormField('select', {
-                            className: 'adyen-kyc-countrycode-selector ',
+                            className: 'adyen-checkout-countrycode-selector ',
                             items: mappedPrefixes,
                             onChange: handleChangeFor('phonePrefix'),
                             // readonly: formUtils.isReadOnly('phonePrefix'),
@@ -115,7 +114,7 @@ function PhoneInput(props) {
                         })}
 
                     {showNumber && (
-                        <div className="adyen-kyc-phone-number">
+                        <div className="adyen-checkout-phone-number">
                             <input
                                 id={getRelatedUniqueId()}
                                 type="tel"
@@ -124,7 +123,7 @@ function PhoneInput(props) {
                                 onBlur={handleChangeFor('phoneNumber', 'blur')}
                                 // readOnly={formUtils.isReadOnly('phoneNumber')}
                                 // placeholder={formUtils.getPlaceholder('phoneNumber', '123456789')}
-                                className="adyen-kyc-input adyen-kyc-input__phone-number"
+                                className="adyen-checkout__input adyen-checkout-input__phone-number"
                                 autoCorrect="off"
                                 aria-required={true}
                                 aria-label={i18n.get('mobileNumber')}
@@ -135,15 +134,15 @@ function PhoneInput(props) {
                     )}
                 </div>
             </Field>
-            {props.showInlineErrors && (
-                <div className="adyen-kyc-phone-input__error-holder">
+            {!isCollatingErrors && (
+                <div className="adyen-checkout-phone-input__error-holder">
                     {showPrefix && getPhoneFieldError('phonePrefix') && (
-                        <span className={'adyen-kyc-error-text'} aria-live="polite" id={`${uniqueIDPhonePrefix}${ARIA_ERROR_SUFFIX}`}>
+                        <span className={'adyen-checkout__error-text'} aria-live="polite" id={`${uniqueIDPhonePrefix}${ARIA_ERROR_SUFFIX}`}>
                             {getPhoneFieldError('phonePrefix')}
                         </span>
                     )}
                     {showNumber && getPhoneFieldError('phoneNumber') && (
-                        <span className={'adyen-kyc-error-text'} aria-live="polite" id={`${getRelatedUniqueId()}${ARIA_ERROR_SUFFIX}`}>
+                        <span className={'adyen-checkout__error-text'} aria-live="polite" id={`${getRelatedUniqueId()}${ARIA_ERROR_SUFFIX}`}>
                             {getPhoneFieldError('phoneNumber')}
                         </span>
                     )}

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -38,6 +38,13 @@ function PhoneInput(props) {
         setSchema(schema);
     }, [schema.toString()]);
 
+    // Force re-validation of the phoneNumber when data.phonePrefix changes (since the validation rules will also change)
+    useEffect((): void => {
+        if (data.phoneNumber) {
+            handleChangeFor('phoneNumber', 'blur')(data.phoneNumber);
+        }
+    }, [data.phonePrefix]);
+
     useEffect(() => {
         props.onChange({ data, valid, errors, isValid });
     }, [data, valid, errors, isValid]);

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -7,15 +7,11 @@ import useForm from '../../../utils/useForm';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import './PhoneInput.scss';
 import { phoneFormatters, phoneValidationRules } from './validate';
-// import { PhoneInputProps, PhoneInputSchema } from './types';
-import { PhoneInputSchema } from './types';
+import { PhoneInputProps, PhoneInputSchema } from './types';
 import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
 import { getUniqueId } from '../../../utils/idGenerator';
 
-export const phoneFields: Array<keyof PhoneInputSchema> = ['phonePrefix', 'phoneNumber'];
-
-// function PhoneInput(props: PhoneInputProps) {
-function PhoneInput(props) {
+function PhoneInput(props: PhoneInputProps) {
     const {
         i18n,
         commonProps: { isCollatingErrors }
@@ -30,7 +26,7 @@ function PhoneInput(props) {
         ...props,
         schema,
         defaultData: props.data,
-        rules: props.validators || phoneValidationRules,
+        rules: phoneValidationRules,
         formatters: phoneFormatters
     });
 

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -53,7 +53,7 @@ function PhoneInput(props) {
      * In order to retrieve this uniqueId and assign it to the phoneNumber input (to thus link <label> and <input> - we need this function.
      */
     const getRelatedUniqueId = () => {
-        const holder = document.querySelector('.adyen-checkout__phone-input-new [uniqueid]');
+        const holder = document.querySelector('.adyen-checkout-phone-input--new [uniqueid]');
         return holder ? holder.getAttribute('uniqueid') : null;
     };
 
@@ -75,7 +75,7 @@ function PhoneInput(props) {
     }, []);
 
     return (
-        <div className="adyen-checkout__phone-input-new">
+        <div className="adyen-checkout-phone-input--new">
             <Field
                 name={'phoneNumber'}
                 label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}
@@ -87,15 +87,17 @@ function PhoneInput(props) {
             >
                 <div
                     className={classNames({
+                        // Styles from FormFields.scss
                         'adyen-checkout__input': true,
                         'adyen-checkout__input--invalid': !!errors.phoneNumber || !!errors.phonePrefix,
                         'adyen-checkout__input--valid': (showPrefix ? valid.phonePrefix : true) && valid.phoneNumber,
-                        'adyen-checkout-input__phoneInput': true // Better BEM naming
+                        // Style from local PhoneInput.scss with better BEM naming i.e. 'adyen-checkout-input' as the Base, 'phoneInput' as the Modifier
+                        'adyen-checkout-input--phoneInput': true
                     })}
                 >
                     {showPrefix &&
                         renderFormField('select', {
-                            className: 'adyen-checkout-countrycode-selector ',
+                            className: 'adyen-checkout-dropdown--countrycode-selector',
                             items: props.items,
                             onChange: handleChangeFor('phonePrefix'),
                             // readonly: props.phonePrefixIsReadonly,

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -1,0 +1,160 @@
+import { h } from 'preact';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import classNames from 'classnames';
+import Field from '../FormFields/Field';
+import renderFormField from '../FormFields';
+import useForm from '../../../utils/useForm';
+import useCoreContext from '../../../core/Context/useCoreContext';
+// import './PhoneInput.scss';
+import '../PhoneInput/PhoneInput.scss';
+import { phoneFormatters, phoneValidationRules } from './validate';
+// import { PhoneInputProps, PhoneInputSchema } from './types';
+import { PhoneInputSchema } from './types';
+// import formUtilities from '../../../utils/formUtils';
+import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
+import { getUniqueId } from '../../../utils/idGenerator';
+
+export const phoneFields: Array<keyof PhoneInputSchema> = ['phonePrefix', 'phoneNumber'];
+
+// function PhoneInput(props: PhoneInputProps) {
+function PhoneInput(props) {
+    const {
+        i18n,
+        commonProps: { isCollatingErrors }
+    } = useCoreContext();
+    const [mappedPrefixes, setMappedPrefixes] = useState([]);
+
+    const schema = props.requiredFields || [...(props?.items?.length ? ['phonePrefix'] : []), 'phoneNumber'];
+    const showPrefix = schema.includes('phonePrefix') && !!props?.items?.length;
+    const showNumber = schema.includes('phoneNumber');
+
+    const { handleChangeFor, data, valid, errors, isValid, triggerValidation, setSchema } = useForm<PhoneInputSchema>({
+        i18n,
+        ...props,
+        schema,
+        defaultData: props.data,
+        rules: props.validators || phoneValidationRules,
+        formatters: phoneFormatters
+    });
+
+    useEffect(() => {
+        if (showPrefix) {
+            setMappedPrefixes(
+                props.items.map(item => ({
+                    ...item,
+                    sprite: `#adl-flag-${item.id.toLowerCase()}`
+                }))
+            );
+        }
+    }, [showPrefix]);
+
+    useEffect(() => {
+        setSchema(schema);
+    }, [schema.toString()]);
+
+    useEffect(() => {
+        props.onChange({ data, valid, errors, isValid });
+    }, [data, valid, errors, isValid]);
+
+    this.triggerValidation = triggerValidation;
+
+    /**
+     * The <Field> element assigns a uniqueId which it uses for the \<label for=\> attribute.
+     * This uniqueId is then passed as a prop to the first child of the field
+     *  (which is usually an element created by renderFormField) where it is assigned to the id attribute of that element.
+     * However here we have a different use case and the uniqueId is written to the <div class="adyen-kyc-input"> which in this case
+     *  is the first child of the <Field>.
+     * In order to retrieve this uniqueId and assign it to the phoneNumber input (to thus link <label> and <input> - we need this function.
+     */
+    const getRelatedUniqueId = () => {
+        const holder = document.querySelector('.adyen-kyc-phone-input [uniqueid]');
+        return holder ? holder.getAttribute('uniqueid') : null;
+    };
+
+    const getPhoneFieldError = useCallback(
+        field => {
+            const errMsg = i18n.get(errors[field]?.errorMessage);
+            return errMsg ? errMsg : null;
+        },
+        [errors]
+    );
+
+    const uniqueIDPhonePrefix = useMemo(() => {
+        return getUniqueId('adyen-kyc-phonePrefix');
+    }, []);
+
+    return (
+        <div className="adyen-kyc-phone-input">
+            <Field
+                name={'phoneNumber'}
+                label={i18n.get('mobileNumber')}
+                className={classNames({
+                    'adyen-kyc-phone-input__holder': true
+                })}
+                inputWrapperModifiers={['phoneInput']}
+                isValid={valid.phoneNumber}
+            >
+                <div
+                    className={classNames({
+                        'adyen-kyc-input': true,
+                        'adyen-kyc-input--invalid': !!errors.phoneNumber || !!errors.phonePrefix,
+                        'adyen-kyc-field--valid': (showPrefix ? valid.phonePrefix : true) && valid.phoneNumber,
+                        'adyen-kyc-input__phoneInput': true // Better BEM naming
+                    })}
+                >
+                    {showPrefix &&
+                        renderFormField('select', {
+                            className: 'adyen-kyc-countrycode-selector ',
+                            items: mappedPrefixes,
+                            onChange: handleChangeFor('phonePrefix'),
+                            // readonly: formUtils.isReadOnly('phonePrefix'),
+                            // placeholder: formUtils.getPlaceholder('phonePrefix', 'code'),
+                            selected: data.phonePrefix,
+                            isCollatingErrors,
+                            uniqueId: uniqueIDPhonePrefix
+                        })}
+
+                    {showNumber && (
+                        <div className="adyen-kyc-phone-number">
+                            <input
+                                id={getRelatedUniqueId()}
+                                type="tel"
+                                value={data.phoneNumber}
+                                onInput={handleChangeFor('phoneNumber', 'input')}
+                                onBlur={handleChangeFor('phoneNumber', 'blur')}
+                                // readOnly={formUtils.isReadOnly('phoneNumber')}
+                                // placeholder={formUtils.getPlaceholder('phoneNumber', '123456789')}
+                                className="adyen-kyc-input adyen-kyc-input__phone-number"
+                                autoCorrect="off"
+                                aria-required={true}
+                                aria-label={i18n.get('mobileNumber')}
+                                aria-invalid={!valid.phoneNumber}
+                                aria-describedby={`${getRelatedUniqueId()}${ARIA_ERROR_SUFFIX}`}
+                            />
+                        </div>
+                    )}
+                </div>
+            </Field>
+            {props.showInlineErrors && (
+                <div className="adyen-kyc-phone-input__error-holder">
+                    {showPrefix && getPhoneFieldError('phonePrefix') && (
+                        <span className={'adyen-kyc-error-text'} aria-live="polite" id={`${uniqueIDPhonePrefix}${ARIA_ERROR_SUFFIX}`}>
+                            {getPhoneFieldError('phonePrefix')}
+                        </span>
+                    )}
+                    {showNumber && getPhoneFieldError('phoneNumber') && (
+                        <span className={'adyen-kyc-error-text'} aria-live="polite" id={`${getRelatedUniqueId()}${ARIA_ERROR_SUFFIX}`}>
+                            {getPhoneFieldError('phoneNumber')}
+                        </span>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+PhoneInput.defaultProps = {
+    phoneLabel: 'telephoneNumber'
+};
+
+export default PhoneInput;

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -80,10 +80,16 @@ function PhoneInput(props) {
                 name={'phoneNumber'}
                 label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}
                 className={classNames({
-                    'adyen-checkout__input--phone-number': true
+                    'adyen-checkout-field--phone-input': true
                 })}
-                inputWrapperModifiers={['phoneInput']}
+                inputWrapperModifiers={['phone-input']}
                 isValid={valid.phoneNumber}
+                // Note we don't pass a string to the errorMessage prop because the phoneInput comp can potentially have 2 errors (one for prefix, one for number)
+                // - so we want to handle both those errors here in this comp rather than within the Field comp.
+                // However we do want to take advantage of the error icon that Field can provide - so we pass a boolean if errors exist
+                errorMessage={(errors.phoneNumber || errors.phonePrefix) && true}
+                // Avoids the situation where the phoneNumber is valid but the phonePrefix is not and we see the valid icon showing underneath the error icon
+                showValidIcon={errors.phonePrefix ? false : true}
             >
                 <div
                     className={classNames({
@@ -91,8 +97,8 @@ function PhoneInput(props) {
                         'adyen-checkout__input': true,
                         'adyen-checkout__input--invalid': !!errors.phoneNumber || !!errors.phonePrefix,
                         'adyen-checkout__input--valid': (showPrefix ? valid.phonePrefix : true) && valid.phoneNumber,
-                        // Style from local PhoneInput.scss with better BEM naming i.e. 'adyen-checkout-input' as the Base, 'phoneInput' as the Modifier
-                        'adyen-checkout-input--phoneInput': true
+                        // Style from local PhoneInput.scss with better BEM naming - see PhoneInput.scss
+                        'adyen-checkout-field__input-holder--phone-input': true
                     })}
                 >
                     {showPrefix &&
@@ -117,7 +123,7 @@ function PhoneInput(props) {
                                 onBlur={handleChangeFor('phoneNumber', 'blur')}
                                 // readOnly={props.phoneNumberIsReadonly}
                                 placeholder={props.placeholders.phoneNumber || '123456789'}
-                                className="adyen-checkout__input adyen-checkout-input__phone-number"
+                                className="adyen-checkout__input adyen-checkout-field__input--phone-number"
                                 autoCorrect="off"
                                 aria-required={true}
                                 aria-label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo } from 'preact/hooks';
 import classNames from 'classnames';
 import Field from '../FormFields/Field';
 import renderFormField from '../FormFields';
@@ -9,7 +9,6 @@ import './PhoneInput.scss';
 import { phoneFormatters, phoneValidationRules } from './validate';
 // import { PhoneInputProps, PhoneInputSchema } from './types';
 import { PhoneInputSchema } from './types';
-// import formUtilities from '../../../utils/formUtils';
 import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
 import { getUniqueId } from '../../../utils/idGenerator';
 
@@ -21,7 +20,6 @@ function PhoneInput(props) {
         i18n,
         commonProps: { isCollatingErrors }
     } = useCoreContext();
-    const [mappedPrefixes, setMappedPrefixes] = useState([]);
 
     const schema = props.requiredFields || [...(props?.items?.length ? ['phonePrefix'] : []), 'phoneNumber'];
     const showPrefix = schema.includes('phonePrefix') && !!props?.items?.length;
@@ -35,17 +33,6 @@ function PhoneInput(props) {
         rules: props.validators || phoneValidationRules,
         formatters: phoneFormatters
     });
-
-    useEffect(() => {
-        if (showPrefix) {
-            setMappedPrefixes(
-                props.items.map(item => ({
-                    ...item,
-                    sprite: `#adl-flag-${item.id.toLowerCase()}`
-                }))
-            );
-        }
-    }, [showPrefix]);
 
     useEffect(() => {
         setSchema(schema);
@@ -66,7 +53,7 @@ function PhoneInput(props) {
      * In order to retrieve this uniqueId and assign it to the phoneNumber input (to thus link <label> and <input> - we need this function.
      */
     const getRelatedUniqueId = () => {
-        const holder = document.querySelector('.adyen-checkout__phone-input [uniqueid]');
+        const holder = document.querySelector('.adyen-checkout__phone-input-new [uniqueid]');
         return holder ? holder.getAttribute('uniqueid') : null;
     };
 
@@ -83,10 +70,10 @@ function PhoneInput(props) {
     }, []);
 
     return (
-        <div className="adyen-checkout__phone-input">
+        <div className="adyen-checkout__phone-input-new">
             <Field
                 name={'phoneNumber'}
-                label={i18n.get('mobileNumber')}
+                label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}
                 className={classNames({
                     'adyen-checkout__input--phone-number': true
                 })}
@@ -104,10 +91,10 @@ function PhoneInput(props) {
                     {showPrefix &&
                         renderFormField('select', {
                             className: 'adyen-checkout-countrycode-selector ',
-                            items: mappedPrefixes,
+                            items: props.items,
                             onChange: handleChangeFor('phonePrefix'),
-                            // readonly: formUtils.isReadOnly('phonePrefix'),
-                            // placeholder: formUtils.getPlaceholder('phonePrefix', 'code'),
+                            // readonly: props.phonePrefixIsReadonly,
+                            placeholder: i18n.get('infix'),
                             selected: data.phonePrefix,
                             isCollatingErrors,
                             uniqueId: uniqueIDPhonePrefix
@@ -121,12 +108,12 @@ function PhoneInput(props) {
                                 value={data.phoneNumber}
                                 onInput={handleChangeFor('phoneNumber', 'input')}
                                 onBlur={handleChangeFor('phoneNumber', 'blur')}
-                                // readOnly={formUtils.isReadOnly('phoneNumber')}
-                                // placeholder={formUtils.getPlaceholder('phoneNumber', '123456789')}
+                                // readOnly={props.phoneNumberIsReadonly}
+                                placeholder={props.placeholders.phoneNumber || '123456789'}
                                 className="adyen-checkout__input adyen-checkout-input__phone-number"
                                 autoCorrect="off"
                                 aria-required={true}
-                                aria-label={i18n.get('mobileNumber')}
+                                aria-label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}
                                 aria-invalid={!valid.phoneNumber}
                                 aria-describedby={`${getRelatedUniqueId()}${ARIA_ERROR_SUFFIX}`}
                             />

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -80,6 +80,7 @@ function PhoneInput(props) {
                 name={'phoneNumber'}
                 label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}
                 className={classNames({
+                    'adyen-checkout-field': true,
                     'adyen-checkout-field--phone-input': true
                 })}
                 inputWrapperModifiers={['phone-input']}
@@ -95,6 +96,7 @@ function PhoneInput(props) {
                  A special situation exists here - normally the first element inside a Field comp is an <input> element which receives
                  'adyen-checkout__input' type styling (to set width, borders, valid and invalid styling etc).
                  Here it is a <div> - however we still need the "input-type" styling on this div for the same reasons (width, borders, showing validity etc)
+                 TODO - should probably have some specific 'adyen-checkout-input-holder' styling selectors
                  */}
                 <div
                     className={classNames({
@@ -102,13 +104,15 @@ function PhoneInput(props) {
                         'adyen-checkout__input': true,
                         'adyen-checkout__input--invalid': !!errors.phoneNumber || !!errors.phonePrefix,
                         'adyen-checkout__input--valid': (showPrefix ? valid.phonePrefix : true) && valid.phoneNumber,
+                        // Proposed renaming
+                        'adyen-checkout-input': true,
                         // Style from local PhoneInput.scss
                         'adyen-checkout-input-holder--phone-input': true
                     })}
                 >
                     {showPrefix &&
                         renderFormField('select', {
-                            className: 'adyen-checkout-dropdown--countrycode-selector',
+                            className: 'adyen-checkout-dropdown adyen-checkout-dropdown--countrycode-selector',
                             items: props.items,
                             onChange: handleChangeFor('phonePrefix'),
                             // readonly: props.phonePrefixIsReadonly,
@@ -128,7 +132,7 @@ function PhoneInput(props) {
                                 onBlur={handleChangeFor('phoneNumber', 'blur')}
                                 // readOnly={props.phoneNumberIsReadonly}
                                 placeholder={props.placeholders.phoneNumber || '123456789'}
-                                className="adyen-checkout__input adyen-checkout-input--phone-number"
+                                className="adyen-checkout__input adyen-checkout-input adyen-checkout-input--phone-number"
                                 autoCorrect="off"
                                 aria-required={true}
                                 aria-label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -91,14 +91,19 @@ function PhoneInput(props) {
                 // Avoids the situation where the phoneNumber is valid but the phonePrefix is not and we see the valid icon showing underneath the error icon
                 showValidIcon={errors.phonePrefix ? false : true}
             >
+                {/**
+                 A special situation exists here - normally the first element inside a Field comp is an <input> element which receives
+                 'adyen-checkout__input' type styling (to set width, borders, valid and invalid styling etc).
+                 Here it is a <div> - however we still need the "input-type" styling on this div for the same reasons (width, borders, showing validity etc)
+                 */}
                 <div
                     className={classNames({
                         // Styles from FormFields.scss
                         'adyen-checkout__input': true,
                         'adyen-checkout__input--invalid': !!errors.phoneNumber || !!errors.phonePrefix,
                         'adyen-checkout__input--valid': (showPrefix ? valid.phonePrefix : true) && valid.phoneNumber,
-                        // Style from local PhoneInput.scss with better BEM naming - see PhoneInput.scss
-                        'adyen-checkout-field__input-holder--phone-input': true
+                        // Style from local PhoneInput.scss
+                        'adyen-checkout-input-holder--phone-input': true
                     })}
                 >
                     {showPrefix &&
@@ -123,7 +128,7 @@ function PhoneInput(props) {
                                 onBlur={handleChangeFor('phoneNumber', 'blur')}
                                 // readOnly={props.phoneNumberIsReadonly}
                                 placeholder={props.placeholders.phoneNumber || '123456789'}
-                                className="adyen-checkout__input adyen-checkout-field__input--phone-number"
+                                className="adyen-checkout__input adyen-checkout-input--phone-number"
                                 autoCorrect="off"
                                 aria-required={true}
                                 aria-label={props.phoneNumberKey ? i18n.get(props.phoneNumberKey) : i18n.get('telephoneNumber')}

--- a/packages/lib/src/components/internal/PhoneInputNew/index.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PhoneInput';

--- a/packages/lib/src/components/internal/PhoneInputNew/types.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/types.ts
@@ -25,5 +25,4 @@ export interface PhoneInputProps {
 export interface PhonePrefixes {
     phonePrefixes: DataSetItem[];
     loadingStatus: string;
-    error?;
 }

--- a/packages/lib/src/components/internal/PhoneInputNew/types.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/types.ts
@@ -1,14 +1,23 @@
-// import { BaseInnerFormProps } from '../../../utils/useForm/types';
-//
-// export interface PhoneInputProps extends BaseInnerFormProps<PhoneInputSchema> {
-//     items: Array<{
-//         id: string;
-//         name: string;
-//     }>;
-//     showInlineErrors?: boolean;
-// }
+import { DataSet } from '../../../core/Services/data-set';
 
 export interface PhoneInputSchema {
     phoneNumber?: string;
     phonePrefix?: string;
+}
+
+export interface PhoneInputProps {
+    items: DataSet;
+    requiredFields?: string[];
+    data: {
+        phonePrefix?: string;
+        phoneNumber?: string;
+    };
+    onChange: (obj) => void;
+    phoneNumberKey?: string;
+    phonePrefixErrorKey?: string;
+    phoneNumberErrorKey?: string;
+    placeholders?: {
+        phoneNumber?: string;
+    };
+    ref?;
 }

--- a/packages/lib/src/components/internal/PhoneInputNew/types.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/types.ts
@@ -1,4 +1,4 @@
-import { DataSet } from '../../../core/Services/data-set';
+import { DataSet, DataSetItem } from '../../../core/Services/data-set';
 
 export interface PhoneInputSchema {
     phoneNumber?: string;
@@ -20,4 +20,10 @@ export interface PhoneInputProps {
         phoneNumber?: string;
     };
     ref?;
+}
+
+export interface PhonePrefixes {
+    phonePrefixes: DataSetItem[];
+    loadingStatus: string;
+    error?;
 }

--- a/packages/lib/src/components/internal/PhoneInputNew/types.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/types.ts
@@ -1,0 +1,14 @@
+// import { BaseInnerFormProps } from '../../../utils/useForm/types';
+//
+// export interface PhoneInputProps extends BaseInnerFormProps<PhoneInputSchema> {
+//     items: Array<{
+//         id: string;
+//         name: string;
+//     }>;
+//     showInlineErrors?: boolean;
+// }
+
+export interface PhoneInputSchema {
+    phoneNumber?: string;
+    phonePrefix?: string;
+}

--- a/packages/lib/src/components/internal/PhoneInputNew/usePhonePrefixes.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/usePhonePrefixes.ts
@@ -2,11 +2,11 @@ import { useLayoutEffect, useState } from 'preact/hooks';
 import getDataset from '../../../core/Services/get-dataset';
 import { DataSet } from '../../../core/Services/data-set';
 import { PhonePrefixes } from './types';
+import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 
-function usePhonePrefixes({ allowedCountries, loadingContext }): PhonePrefixes {
+function usePhonePrefixes({ allowedCountries, loadingContext, handleError }): PhonePrefixes {
     const [loadingStatus, setLoadingStatus] = useState<string>('loading');
     const [phonePrefixes, setPhonePrefixes] = useState<DataSet>([]);
-    const [error, setError] = useState(null);
 
     useLayoutEffect(() => {
         getDataset('phonenumbers', loadingContext)
@@ -32,11 +32,11 @@ function usePhonePrefixes({ allowedCountries, loadingContext }): PhonePrefixes {
             .catch(error => {
                 setPhonePrefixes([]);
                 setLoadingStatus('ready');
-                setError(error);
+                handleError?.(new AdyenCheckoutError('ERROR', error));
             });
     }, []);
 
-    return { phonePrefixes, loadingStatus, error };
+    return { phonePrefixes, loadingStatus };
 }
 
 export default usePhonePrefixes;

--- a/packages/lib/src/components/internal/PhoneInputNew/usePhonePrefixes.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/usePhonePrefixes.ts
@@ -1,0 +1,42 @@
+import { useLayoutEffect, useState } from 'preact/hooks';
+import getDataset from '../../../core/Services/get-dataset';
+import { DataSet } from '../../../core/Services/data-set';
+import { PhonePrefixes } from './types';
+
+function usePhonePrefixes({ allowedCountries, loadingContext }): PhonePrefixes {
+    const [loadingStatus, setLoadingStatus] = useState<string>('loading');
+    const [phonePrefixes, setPhonePrefixes] = useState<DataSet>([]);
+    const [error, setError] = useState(null);
+
+    useLayoutEffect(() => {
+        getDataset('phonenumbers', loadingContext)
+            .then(response => {
+                const countriesFilter = country => allowedCountries.includes(country.id);
+                const filteredCountries = allowedCountries.length ? response.filter(countriesFilter) : response;
+                const mappedCountries = filteredCountries.map(item => {
+                    // Get country flags (magic! - shifts the country code characters to the correct position of the emoji in the unicode space)
+                    const codePoints: number[] = item.id
+                        .toUpperCase()
+                        .split('')
+                        .map(char => 127397 + char.charCodeAt(0));
+
+                    // Get flag emoji + space at end (it doesn't work to add spaces in the template literal, below)
+                    const flag = String.fromCodePoint ? String.fromCodePoint(...codePoints) + '\u00A0\u00A0' : '';
+
+                    return { id: item.prefix, name: `${flag} ${item.prefix} (${item.id})`, selectedOptionName: `${flag} ${item.prefix}` };
+                });
+
+                setPhonePrefixes(mappedCountries || []);
+                setLoadingStatus('ready');
+            })
+            .catch(error => {
+                setPhonePrefixes([]);
+                setLoadingStatus('ready');
+                setError(error);
+            });
+    }, []);
+
+    return { phonePrefixes, loadingStatus, error };
+}
+
+export default usePhonePrefixes;

--- a/packages/lib/src/components/internal/PhoneInputNew/validate.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/validate.ts
@@ -1,13 +1,12 @@
 import { FormatRules, ValidatorRules } from '../../../utils/Validator/types';
-// import { getFormattingRegEx } from '../../../utils/validatorUtils';
-
-// Generates a regEx ideal for use in a String.replace call for use in a formatter
-export const getFormattingRegEx = (specChars: string, flags = 'g') => new RegExp(`[${specChars}]`, flags);
+import { isEmpty, getFormattingRegEx } from '../../../utils/validator-utils';
 
 export const phoneValidationRules: ValidatorRules = {
     phoneNumber: {
         modes: ['blur'],
-        validate: phoneNumber => /^(\d){4,12}$/.test(phoneNumber),
+        validate: value => {
+            return isEmpty(value) ? null : /^(\d){4,12}$/.test(value);
+        },
         errorMessage: 'invalidPhoneNumber'
     },
     phonePrefix: {

--- a/packages/lib/src/components/internal/PhoneInputNew/validate.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/validate.ts
@@ -1,11 +1,19 @@
 import { FormatRules, ValidatorRules } from '../../../utils/Validator/types';
 import { isEmpty, getFormattingRegEx } from '../../../utils/validator-utils';
 
+// ((+351|00351|351)?)(2\d{1}|(9(3|6|2|1)))\d{7} full portuguese phone num regex
+
+const portugueseRegex = /\b(2\d{1}|(9(3|6|2|1)))\d{7}\b/; // match 2 + any digit + 7 digits OR 9 + 3|6|2|1 + 7 digits
+const defaultRegex = /^(\d){4,}$/; // match >= 4 digits
+
 export const phoneValidationRules: ValidatorRules = {
     phoneNumber: {
         modes: ['blur'],
-        validate: value => {
-            return isEmpty(value) ? null : /^(\d){4,12}$/.test(value);
+        validate: (value, context) => {
+            // TODO improve this switching mechanism *if* we get any more country based regexs
+            const testRegex = context.state.data.phonePrefix === '+351' ? portugueseRegex : defaultRegex;
+
+            return isEmpty(value) ? null : testRegex.test(value);
         },
         errorMessage: 'invalidPhoneNumber'
     },

--- a/packages/lib/src/components/internal/PhoneInputNew/validate.ts
+++ b/packages/lib/src/components/internal/PhoneInputNew/validate.ts
@@ -1,0 +1,24 @@
+import { FormatRules, ValidatorRules } from '../../../utils/Validator/types';
+// import { getFormattingRegEx } from '../../../utils/validatorUtils';
+
+// Generates a regEx ideal for use in a String.replace call for use in a formatter
+export const getFormattingRegEx = (specChars: string, flags = 'g') => new RegExp(`[${specChars}]`, flags);
+
+export const phoneValidationRules: ValidatorRules = {
+    phoneNumber: {
+        modes: ['blur'],
+        validate: phoneNumber => /^(\d){4,12}$/.test(phoneNumber),
+        errorMessage: 'invalidPhoneNumber'
+    },
+    phonePrefix: {
+        modes: ['blur'],
+        validate: phonePrefix => !!phonePrefix,
+        errorMessage: 'invalidCountryCode'
+    }
+};
+
+export const phoneFormatters: FormatRules = {
+    phoneNumber: {
+        formatter: val => val.replace(getFormattingRegEx('^\\d', 'g'), '')
+    }
+};

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '3.10.1';
+export const SF_VERSION = '3.10.2';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/commonUtils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/commonUtils.ts
@@ -222,4 +222,4 @@ export function partial(...args) {
 }
 
 // Not null or undefined or only spaces
-export const isEmpty = input => !!(input == null || /^[\s]*$/.test(input));
+// export const isEmpty = input => !!(input == null || /^[\s]*$/.test(input));

--- a/packages/lib/src/components/internal/SecuredFields/lib/utilities/commonUtils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/utilities/commonUtils.ts
@@ -220,6 +220,3 @@ export function partial(...args) {
     }
     return partialFn;
 }
-
-// Not null or undefined or only spaces
-// export const isEmpty = input => !!(input == null || /^[\s]*$/.test(input));

--- a/packages/lib/src/core/Services/data-set.ts
+++ b/packages/lib/src/core/Services/data-set.ts
@@ -3,4 +3,5 @@ export type DataSet = DataSetItem[];
 export interface DataSetItem {
     id: string;
     name: string;
+    selectedOptionName?: string;
 }

--- a/packages/lib/src/core/Services/data-set.ts
+++ b/packages/lib/src/core/Services/data-set.ts
@@ -1,0 +1,6 @@
+export type DataSet = DataSetItem[];
+
+export interface DataSetItem {
+    id: string;
+    name: string;
+}

--- a/packages/lib/src/core/Services/get-dataset.ts
+++ b/packages/lib/src/core/Services/get-dataset.ts
@@ -1,11 +1,11 @@
 import { httpGet } from './http';
 
-export default function getDataset(name: string, loadingContext, locale) {
+export default function getDataset(name: string, loadingContext, locale?) {
     const options = {
         loadingContext,
         errorLevel: 'warn' as const,
         errorMessage: `Dataset ${name} is not available`,
-        path: `datasets/${name}/${locale}.json`
+        path: locale ? `datasets/${name}/${locale}.json` : `datasets/${name}.json`
     };
 
     return httpGet(options);

--- a/packages/lib/src/utils/validator-utils.ts
+++ b/packages/lib/src/utils/validator-utils.ts
@@ -16,10 +16,40 @@ export const getMaxLengthByFieldAndCountry = (
     return maxLength ? maxLength : MAX_LENGTH;
 };
 
+// Not null or undefined or only spaces
+export const isEmpty = input => !!(input == null || /^[\s]*$/.test(input));
+
+export const isString = input => typeof input === 'string' || input instanceof String;
+export const hasText = input => isString(input) && !isEmpty(input);
+
 export const SPECIAL_CHARS = '?\\-\\+_=!@#$%^&*(){}~<>\\[\\]\\/\\\\'; // N.B. difficulty escaping \
 
 // Generates a regEx ideal for use in a String.replace call for use in a formatter
+// e.g. getFormattingRegEx('^\\d', 'g') will generate: /[^\d]/g which is a regEx to match anything that is not a digit
 export const getFormattingRegEx = (specChars: string, flags = 'g') => new RegExp(`[${specChars}]`, flags);
+
+// Creates a regEx ideal for use in a RegExp.test call for use in a validator
+export const getValidatingRegEx = (specChars: string, exclude: boolean) => new RegExp(`^[${exclude ? '^' : ''}${specChars}]+$`);
+
+export const CHARACTER_PATTERNS: { [key: string]: RegExp } = {
+    digitsHyphen: /^[\d-]+$/,
+    noHtml: /^[^<>&]+$/,
+    alphaNum: /^\d[a-zA-Z0-9]{6,11}$/,
+    noSpecialChars: getValidatingRegEx(SPECIAL_CHARS, true)
+};
+
+export const exactLength = (input: string, length: number) => {
+    if (isEmpty(input)) {
+        return true;
+    }
+    return input.length === length;
+};
+
+export const validateForSpecialChars = name => {
+    const hasNoLength = !name.length;
+    // RegEx .test, if run against empty string, will return false
+    return CHARACTER_PATTERNS.noSpecialChars.test(name) || hasNoLength;
+};
 
 // Trim start and never allow more than 1 space on the end
 export const trimValWithOneSpace = (val: string) => val.trimStart().replace(/\s+/g, ' ');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adding an international phone prefix dropdown to the current phone number field to allow international phone numbers in the MBWay component.

Previously this component just had a single input into which the user was expected to type a Portuguese mobile phone number (either with or without the international "+351" prefix).

Now the component consists of 2 parts:
- an international country code selector (shows flags + international phone prefix + 2 character country code)
- an input into which to type the domestic part of the phone number

## Tested scenarios
All existing unit and e2e tests pass


**Fixed issue**:  COWEB-835 
Also resolves this [issue for the magento plugin](https://github.com/Adyen/adyen-magento2/issues/1438)