### PR TITLE
Adding proper button 'type' for PaymentMethodItem button

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -127,6 +127,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
                         aria-expanded={isSelected}
                         aria-controls={containerId}
                         onClick={onSelect}
+                        type="button"
                     >
                         <span
                             className={classNames({


### PR DESCRIPTION

## Summary
- Default  button `type` attribute is `submit`. Not set explicitly to `type=button` breaks the Drop-in flow when Drop-in is within `<form>` markup
 
## Tested scenarios
- Tested on playground that redirect does not occur anymore


**Fixed issue**:  COWEB-1112