### PR TITLE
Fixing bug with clearing unsupported card when Pay button press…

### DIFF
--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
@@ -25,12 +25,12 @@ test('#1 Check Bancontact comp is correctly presented at startup', async t => {
     // Expect 3 card brand logos to be displayed (not concerned about order)
     await t.expect(images.count).eql(3);
     await t
-        .expect(images.nth(0).withAttribute('alt', 'bcmc').exists)
-        .ok()
-        .expect(images.nth(1).withAttribute('alt', 'visa').exists)
-        .ok()
-        .expect(images.nth(2).withAttribute('alt', 'maestro').exists)
-        .ok();
+        .expect(images.nth(0).getAttribute('src'))
+        .contains('bcmc.svg')
+        .expect(images.nth(1).getAttribute('src'))
+        .contains('visa.svg')
+        .expect(images.nth(2).getAttribute('src'))
+        .contains('maestro.svg');
 
     // Hidden cvc field
     await t.expect(dropinPage.cc.cvcHolder.filterHidden().exists).ok();

--- a/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.v2.test.js
+++ b/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.v2.test.js
@@ -30,7 +30,7 @@ fixture`Testing binLookup v2 response`
     .clientScripts('binLookup.clientScripts.js')
     .requestHooks(logger);
 
-test('Enter number of known dual branded card, ' + 'then inspect response body for expected properties ', async t => {
+test('#1 Enter number of known dual branded card, ' + 'then inspect response body for expected properties ', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
@@ -59,7 +59,7 @@ test('Enter number of known dual branded card, ' + 'then inspect response body f
         .notEql(0);
 });
 
-test('Enter number of regular, non dual branded, card, ' + 'then inspect response body for expected properties ', async t => {
+test('#2 Enter number of regular, non dual branded, card, ' + 'then inspect response body for expected properties ', async t => {
     logger.clear();
 
     await start(t, 2000, TEST_SPEED);
@@ -87,7 +87,7 @@ test('Enter number of regular, non dual branded, card, ' + 'then inspect respons
         .notEql(0);
 });
 
-test('Enter number of unsupported card, ' + 'then inspect response body for expected properties ' + 'then check UI shows an error', async t => {
+test('#3 Enter number of unsupported card, ' + 'then inspect response body for expected properties ' + 'then check UI shows an error', async t => {
     logger.clear();
 
     await start(t, 2000, TEST_SPEED);
@@ -123,7 +123,7 @@ test('Enter number of unsupported card, ' + 'then inspect response body for expe
         .ok();
 });
 
-test('Enter number of card that is not in the test Dbs, ' + 'then inspect response body for expected properties ', async t => {
+test('#4 Enter number of card that is not in the test Dbs, ' + 'then inspect response body for expected properties ', async t => {
     logger.clear();
 
     await start(t, 2000, TEST_SPEED);
@@ -152,7 +152,7 @@ test('Enter number of card that is not in the test Dbs, ' + 'then inspect respon
 /**
  * TEST CALLBACKS
  */
-test('Enter number of dual branded card, ' + 'then inspect callback for expected properties ', async t => {
+test('#5 Enter number of dual branded card, ' + 'then inspect callback for expected properties ', async t => {
     logger.clear();
 
     await start(t, 2000, TEST_SPEED);
@@ -176,7 +176,7 @@ test('Enter number of dual branded card, ' + 'then inspect callback for expected
         .eql(['mc', 'visa', 'amex', 'cartebancaire']);
 });
 
-test('Enter number of regular, non dual branded, card, ' + 'then inspect callback for expected properties ', async t => {
+test('#6 Enter number of regular, non dual branded, card, ' + 'then inspect callback for expected properties ', async t => {
     logger.clear();
 
     await start(t, 2000, TEST_SPEED);
@@ -200,7 +200,7 @@ test('Enter number of regular, non dual branded, card, ' + 'then inspect callbac
         .eql(['mc', 'visa', 'amex', 'cartebancaire']);
 });
 
-test('Enter number of unsupported card, ' + 'then inspect callbacks for expected properties ', async t => {
+test('#7 Enter number of unsupported card, ' + 'then inspect callbacks for expected properties ', async t => {
     logger.clear();
 
     await start(t, 2000, TEST_SPEED);
@@ -227,7 +227,7 @@ test('Enter number of unsupported card, ' + 'then inspect callbacks for expected
     await t.expect(cardError.errorMessage).eql('Unsupported card entered');
 });
 
-test('Enter number of card that is not in the test Dbs, ' + 'then inspect callbacks for expected properties ', async t => {
+test('#8 Enter number of card that is not in the test Dbs, ' + 'then inspect callbacks for expected properties ', async t => {
     logger.clear();
 
     await start(t, 2000, TEST_SPEED);

--- a/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.clientScripts.js
+++ b/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.clientScripts.js
@@ -1,0 +1,26 @@
+/**
+ * Set cartebancaire as a brand since the test dual brand card is visa/cb
+ */
+window.cardConfig = {
+    type: 'scheme',
+    brands: ['mc', 'visa', 'amex', 'cartebancaire'],
+    onBinLookup: obj => {
+        window.binLookupObj = obj;
+    },
+    onChange: state => {
+        // Needed now that, for v5, we enhance the securedFields state.errors object with a rootNode prop
+        // - Testcafe doesn't like a ClientFunction retrieving an object with a DOM node in it!?
+        if (state.errors.encryptedCardNumber) {
+            state.errors.encryptedCardNumber.rootNode = '';
+        }
+
+        window.errorObj = state.errors;
+    }
+};
+
+window.dropinConfig = {
+    showStoredPaymentMethods: false, // hide stored PMs so credit card is first on list
+    paymentMethodsConfiguration: {
+        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire'] }
+    }
+};

--- a/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.test.js
@@ -1,0 +1,132 @@
+import { turnOffSDKMocking } from '../../../../_common/cardMocks';
+import CardComponentPage from '../../../../_models/CardComponent.page';
+import { REGULAR_TEST_CARD, MAESTRO_CARD, UNKNOWN_VISA_CARD } from '../../../utils/constants';
+
+const path = require('path');
+require('dotenv').config({ path: path.resolve('../../', '.env') }); // 2 dirs up
+
+const cardPage = new CardComponentPage();
+
+fixture`Testing error handling related to binLookup v2 response`
+    .beforeEach(async t => {
+        await t.navigateTo(cardPage.pageUrl);
+        // For individual test suites (that rely on binLookup & perhaps are being run in isolation)
+        // - provide a way to ensure SDK bin mocking is turned off
+        await turnOffSDKMocking();
+    })
+    .clientScripts('./unsupportedCardErrors.clientScripts.js');
+
+test('#1 Enter number of unsupported card, ' + 'then check UI shows an error ' + 'then PASTE supported card & check UI error is cleared', async t => {
+    // Wait for field to appear in DOM
+    await cardPage.numHolder();
+
+    // Fill card field with unsupported number
+    await cardPage.cardUtils.fillCardNumber(t, MAESTRO_CARD);
+
+    // Test UI shows "Unsupported card" error
+    await t
+        .expect(cardPage.numErrorText.exists)
+        .ok()
+        // with text
+        .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+        .ok();
+
+    // Past card field with supported number
+    await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, 'paste');
+
+    // Test UI shows "Unsupported card" error has gone
+    await t.expect(cardPage.numErrorText.exists).notOk();
+});
+
+test(
+    '#2 Enter number of unsupported card, ' +
+        'then check UI shows an error ' +
+        'then press the Pay button ' +
+        'then check UI shows more errors ' +
+        'then PASTE supported card & check PAN UI errors are cleared whilst others persist',
+    async t => {
+        // Wait for field to appear in DOM
+        await cardPage.numHolder();
+
+        // Fill card field with unsupported number
+        await cardPage.cardUtils.fillCardNumber(t, MAESTRO_CARD);
+
+        // Test UI shows "Unsupported card" error
+        await t
+            .expect(cardPage.numErrorText.exists)
+            .ok()
+            // with text
+            .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+            .ok();
+
+        // Click Pay (which will call showValidation on all fields)
+        await t
+            .click(cardPage.payButton)
+            // More visible errors
+            .expect(cardPage.numLabelTextError.exists)
+            .ok()
+            .expect(cardPage.dateLabelTextError.exists)
+            .ok()
+            .expect(cardPage.cvcLabelTextError.exists)
+            .ok();
+
+        // Past card field with supported number
+        await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, 'paste');
+
+        // Test UI shows "Unsupported card" error has gone
+        await t.expect(cardPage.numErrorText.exists).notOk();
+
+        // PAN error cleared but other errors persist
+        await t
+            .expect(cardPage.numLabelTextError.exists)
+            .notOk()
+            .expect(cardPage.dateLabelTextError.exists)
+            .ok()
+            .expect(cardPage.cvcLabelTextError.exists)
+            .ok();
+    }
+);
+
+test('#3 Enter number of unsupported card, ' + 'then check UI shows an error ' + 'then PASTE card not in db check UI error is cleared', async t => {
+    // Wait for field to appear in DOM
+    await cardPage.numHolder();
+
+    // Fill card field with unsupported number
+    await cardPage.cardUtils.fillCardNumber(t, MAESTRO_CARD);
+
+    // Test UI shows "Unsupported card" error
+    await t
+        .expect(cardPage.numErrorText.exists)
+        .ok()
+        // with text
+        .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+        .ok();
+
+    // Past card field with supported number
+    await cardPage.cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste');
+
+    // Test UI shows "Unsupported card" error has gone
+    await t.expect(cardPage.numErrorText.exists).notOk();
+});
+
+test('#4 Enter number of unsupported card, ' + 'then check UI shows an error ' + 'then delete PAN & check UI error is cleared', async t => {
+    // Wait for field to appear in DOM
+    await cardPage.numHolder();
+
+    // Fill card field with unsupported number
+    await cardPage.cardUtils.fillCardNumber(t, MAESTRO_CARD);
+
+    // Test UI shows "Unsupported card" error
+    await t
+        .expect(cardPage.numErrorText.exists)
+        .ok()
+        // with text
+        .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+        .ok();
+
+    // Past card field with supported number
+    await cardPage.cardUtils.deleteCardNumber(t);
+
+    // Test UI shows "Unsupported card" error has gone
+    await t.expect(cardPage.numErrorText.exists).notOk();
+});

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -220,6 +220,12 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
 
     public handleUnsupportedCard(errObj: CbObjOnError): boolean {
         const hasUnsupportedCard = !!errObj.error;
+
+        // Store the brand(s) we detected and which we don't support
+        if (hasUnsupportedCard) {
+            this.setState({ detectedUnsupportedBrands: errObj.detectedBrands });
+        }
+
         errObj.rootNode = this.rootNode; // Needed for CustomCard
         this.handleOnError(errObj, hasUnsupportedCard);
         // Inform CSF that the number field has an unsupportedCard error (or that it has been cleared)
@@ -262,7 +268,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
     }
 
     /**
-     * Map SF errors to ValidationRuleResult like objects, for CardInput component
+     * Map SF errors to ValidationRuleResult-like objects, for CardInput component
      */
     public mapErrorsToValidationRuleResult(): object {
         const errorKeys = Object.keys(this.state.errors);
@@ -287,7 +293,8 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
     }
 
     public processBinLookupResponse(binLookupResponse: BinLookupResponse, resetObject: SingleBrandResetObject): void {
-        // If we were dealing with an unsupported card and now we have a valid /binLookup response - reset state and inform CSF
+        // If we were dealing with an unsupported card & now we have a valid /binLookup response (or a response triggering a reset of the UI),
+        // - reset state to clear the error & the stored unsupportedBrands and, in the case of a valid /binLookup response, inform CSF (via handleUnsupportedCard)
         // (Scenario: from an unsupportedCard state the shopper has pasted another number long enough to trigger a /binLookup)
         if (this.state.detectedUnsupportedBrands) {
             this.setState(prevState => ({

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -181,7 +181,6 @@ function handleOnError(cbObj: CbObjOnError, hasUnsupportedCard: boolean = null):
     this.setState(
         prevState => ({
             errors: { ...prevState.errors, [cbObj.fieldType]: errorCode || false },
-            detectedUnsupportedBrands: !hasUnsupportedCard ? null : cbObj.detectedBrands,
             // If dealing with an unsupported card ensure these card number related fields are reset re. pasting a full, unsupported card straight in
             ...(hasUnsupportedCard && { data: { ...prevState.data, [ENCRYPTED_CARD_NUMBER]: undefined } }),
             ...(hasUnsupportedCard && { valid: { ...prevState.valid, [ENCRYPTED_CARD_NUMBER]: false } }),


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixing bug with clearing unsupported card error when Pay button press & paste action took place.
- A bug had crept in whereby entering an unsupported card (as decided by /binLookup) then pressing the "Pay" button, then _pasting_ a supported card led to the "unsupported card error" not being removed.
- The cause (the `showValidation` call from the Pay button accidentally clearing the fact that we were in an "unsupported card" scenario) has been identified and a more robust solution put in place

## Tested scenarios
Added new e2e test to catch this scenario
Fixed existing unit tests
All tests now pass and run
Also fixed test that was failing due to PR #1611

**Fixed issue**:  #1612
