### PR TITLE
3DS2 handling challenge error

### DIFF
--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -5,6 +5,7 @@ import { ErrorObject } from './components/utils';
 import { DEFAULT_CHALLENGE_WINDOW_SIZE } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
+import Language from '../../language';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;
@@ -15,7 +16,9 @@ export interface ThreeDS2ChallengeProps {
     size?: string;
     challengeWindowSize?: '01' | '02' | '03' | '04' | '05';
     type?: string;
+    loadingContext?: string;
     useOriginalFlow?: boolean;
+    i18n?: Language;
 }
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -4,6 +4,10 @@ import { createChallengeResolveData, handleErrorCode, prepareChallengeData, crea
 import { PrepareChallenge3DS2Props, PrepareChallenge3DS2State } from './types';
 import { ThreeDS2FlowObject } from '../../types';
 import '../../ThreeDS2.scss';
+import Img from '../../../internal/Img';
+import { getImageUrl } from '../../../../utils/get-image';
+import './challenge.scss';
+import { hasOwnProperty } from '../../../../utils/hasOwnProperty';
 
 class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareChallenge3DS2State> {
     public static defaultProps = {
@@ -35,11 +39,17 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             /**
              * Create the data in the way that the /details endpoint expects.
              *  This is different for the 'old',v66, flow triggered by a 'threeDS2Challenge' action (which includes the threeds2InMDFlow)
-             *  than for the the new, v67, 'threeDS2' action
+             *  than for the new, v67, 'threeDS2' action
              */
             const resolveDataFunction = this.props.useOriginalFlow ? createOldChallengeResolveData : createChallengeResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj.transStatus, this.props.paymentData);
-            this.props.onComplete(data);
+            this.props.onComplete(data); // (equals onAdditionalDetails)
+        });
+    }
+
+    setStatusError(errorObj) {
+        this.setState({ status: 'error' }, () => {
+            this.props.onError(errorObj);
         });
     }
 
@@ -48,15 +58,46 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             return (
                 <DoChallenge3DS2
                     onCompleteChallenge={(challenge: ThreeDS2FlowObject) => {
+                        // Challenge has resulted in an error (no transStatus could be retrieved) - but we still treat this as a valid scenario
+                        if (hasOwnProperty(challenge.result, 'errorCode')) {
+                            // Tell the merchant there's been an error
+                            const errorObject = handleErrorCode(challenge.result.errorCode);
+                            this.props.onError(errorObject);
+                            // Proceed with call to onAdditionalDetails
+                            this.setStatusComplete(challenge);
+                            return;
+                        }
+
+                        // A valid result (w. transStatus)
                         this.setStatusComplete(challenge.result);
                     }}
                     onErrorChallenge={(challenge: ThreeDS2FlowObject) => {
-                        const errorObject = handleErrorCode(challenge.errorCode);
-                        this.props.onError(errorObject);
-                        this.setStatusComplete(challenge.result);
+                        // Called when challenge times-out (which is still a valid scenario)
+                        if (hasOwnProperty(challenge, 'errorCode')) {
+                            const errorObject = handleErrorCode(challenge.errorCode);
+                            this.props.onError(errorObject);
+                            this.setStatusComplete(challenge.result);
+                            return;
+                        }
+
+                        // or, when the challenge response is un-parseable JSON - in which case something unknown has gone wrong
+                        this.setStatusError(challenge);
                     }}
                     {...challengeData}
                 />
+            );
+        }
+
+        if (this.state.status === 'error') {
+            return (
+                <div className="adyen-checkout__threeds2-challenge-error">
+                    <Img
+                        className="adyen-checkout__status__icon adyen-checkout__status__icon--error"
+                        src={getImageUrl({ loadingContext: this.props.loadingContext, imageFolder: 'components/' })('error')}
+                        alt={this.props.i18n.get('error.message.unknown')}
+                    />
+                    <div className="adyen-checkout__status__text">{this.props.i18n.get('error.message.unknown')}</div>
+                </div>
             );
         }
 

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -94,7 +94,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                     <Img
                         className="adyen-checkout__status__icon adyen-checkout__status__icon--error"
                         src={getImageUrl({ loadingContext: this.props.loadingContext, imageFolder: 'components/' })('error')}
-                        alt={this.props.i18n.get('error.message.unknown')}
+                        alt={''}
                     />
                     <div className="adyen-checkout__status__text">{this.props.i18n.get('error.message.unknown')}</div>
                 </div>

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/challenge.scss
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/challenge.scss
@@ -1,0 +1,14 @@
+@import '../../../../style/index';
+
+.adyen-checkout__threeds2-challenge-error {
+  .adyen-checkout__status__icon {
+    display: block;
+    margin: $spacing-xxxlarge auto $spacing-xlarge;
+  }
+
+  .adyen-checkout__status__text {
+    color: $color-red;
+    margin-bottom: $spacing-xxxlarge;
+    text-align: center;
+  }
+}

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -203,6 +203,7 @@ export const get3DS2FlowProps = (actionSubtype, props) => {
 
     // Challenge
     return {
-        statusType: 'custom'
+        statusType: 'custom',
+        i18n: props.i18n
     };
 };

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -21,14 +21,18 @@ export interface ChallengeData {
 }
 
 export interface ResultObject {
+    threeDSCompInd?: ResultValue; // Fingerprint
+    // Challenge
     transStatus?: ResultValue;
-    threeDSCompInd?: ResultValue;
+    errorCode?: string;
+    errorDescription?: string;
 }
 
 export interface ThreeDS2FlowObject {
     result: ResultObject;
     type: 'ChallengeShopper' | 'IdentifyShopper' | 'challengeResult' | 'fingerPrintResult';
     errorCode?: string;
+    threeDSServerTransID?: string;
 }
 
 // One token fits all - Fingerprint & Challenge

--- a/packages/lib/src/utils/get-process-message-handler.ts
+++ b/packages/lib/src/utils/get-process-message-handler.ts
@@ -1,5 +1,7 @@
 /**
- * Centralised window.postMessage processing function used in 3DS2 components
+ * Centralised window.postMessage processing function used in 3DS2 components and also by the deviceFingerprinting process
+ * NOTE: this latter use case means that while the deviceFingerprinting is still completing this component is also listening to
+ *  securedFields related postMessaging
  *
  * @param domain - expected domain for the postMesssage to have originated from
  * @param resolve - the resolve function from the Promise that called this function
@@ -7,6 +9,8 @@
  * @param rejectObj - an object to reject the promise with if origins don't match
  * @param expectedType - string to check that the passed data has the expected type
  */
+import { hasOwnProperty } from './hasOwnProperty';
+
 const getProcessMessageHandler = (
     domain: string,
     resolve: Function,
@@ -32,7 +36,7 @@ const getProcessMessageHandler = (
     // Try to parse the data
     try {
         const feedbackObj = JSON.parse(event.data);
-        if (Object.prototype.hasOwnProperty.call(feedbackObj, 'type') && feedbackObj.type === expectedType) {
+        if (hasOwnProperty(feedbackObj, 'type') && feedbackObj.type === expectedType) {
             resolve(feedbackObj);
         } else {
             return 'Event data was not of expected type';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A scenario exists, described in when it is not possible to retrieve a `transStatus` result for a 3DS2 challenge.
In this scenario an "error" object is sent (with `errorCode` & `errorDescription` properties).
The frontend 3DS2 component should treat this response as a valid outcome and handle it accordingly (show error icon, call merchant defined `onError` callback)

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  COWEB-1113
