### PR TITLE
Loading securedFields file that now uses JWE

### DIFF
--- a/packages/e2e/app/src/pages/Cards/Cards.js
+++ b/packages/e2e/app/src/pages/Cards/Cards.js
@@ -5,6 +5,7 @@ import { amount, shopperLocale, countryCode } from '../../services/commonConfig'
 import '../../style.scss';
 
 const initCheckout = async () => {
+    // window.TextEncoder = null; // Comment in to force use of "compat" version
     window.checkout = await AdyenCheckout({
         amount,
         clientKey: process.env.__CLIENT_KEY__,

--- a/packages/e2e/app/src/pages/CustomCards/CustomCards.js
+++ b/packages/e2e/app/src/pages/CustomCards/CustomCards.js
@@ -7,6 +7,7 @@ import './customcards.style.scss';
 import { setFocus, onBrand, onConfigSuccess, onBinLookup, onChange } from './customCards.config';
 
 const initCheckout = async () => {
+    // window.TextEncoder = null; // Comment in to force use of "compat" version
     window.checkout = await AdyenCheckout({
         amount,
         clientKey: process.env.__CLIENT_KEY__,

--- a/packages/e2e/tests/_models/BasePage.js
+++ b/packages/e2e/tests/_models/BasePage.js
@@ -22,4 +22,8 @@ export default class BasePage {
     setForceClick = ClientFunction(val => {
         window.testCafeForceClick = val;
     });
+
+    decodeBase64 = ClientFunction(val => {
+        return window.atob(val);
+    });
 }

--- a/packages/e2e/tests/cards/installments/cards.installments.test.js
+++ b/packages/e2e/tests/cards/installments/cards.installments.test.js
@@ -16,7 +16,7 @@ fixture`Cards (Installments)`
         cardComponent = new CardComponentPage('.card-field', { installments: new InstallmentsComponent() });
     });
 
-test('should not add installments property to payload if one-time payment is selected', async t => {
+test('#1 should not add installments property to payload if one-time payment is selected', async t => {
     await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
     await cardComponent.cardUtils.fillDateAndCVC(t);
 
@@ -33,7 +33,7 @@ test('should not add installments property to payload if one-time payment is sel
         .ok('payment payload has the expected payload');
 });
 
-test('should not add installments property to payload if 1x installment is selected', async t => {
+test('#2 should not add installments property to payload if 1x installment is selected', async t => {
     await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
     await cardComponent.cardUtils.fillDateAndCVC(t);
     await cardComponent.installments.selectInstallment(1);
@@ -51,7 +51,7 @@ test('should not add installments property to payload if 1x installment is selec
         .ok('payment payload has the expected payload');
 });
 
-test('should add revolving plan to payload if selected', async t => {
+test('#3 should add revolving plan to payload if selected', async t => {
     await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
     await cardComponent.cardUtils.fillDateAndCVC(t);
     await cardComponent.installments.selectRevolving();
@@ -69,7 +69,7 @@ test('should add revolving plan to payload if selected', async t => {
         .ok('payment payload has the expected payload');
 });
 
-test('should add installments value property if regular installment > 1 is selected', async t => {
+test('#4 should add installments value property if regular installment > 1 is selected', async t => {
     await cardComponent.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
     await cardComponent.cardUtils.fillDateAndCVC(t);
     await cardComponent.installments.selectInstallment(2);

--- a/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
+++ b/packages/e2e/tests/cards/kcp/startWithoutKCP/startWithoutKCP.test.js
@@ -1,4 +1,12 @@
-import { KOREAN_TEST_CARD, REGULAR_TEST_CARD, TEST_PWD_VALUE, TEST_TAX_NUMBER_VALUE } from '../../utils/constants';
+import {
+    JWE_ALG,
+    JWE_CONTENT_ALG,
+    JWE_VERSION,
+    KOREAN_TEST_CARD,
+    REGULAR_TEST_CARD,
+    TEST_PWD_VALUE,
+    TEST_TAX_NUMBER_VALUE
+} from '../../utils/constants';
 import CardComponentPage from '../../../_models/CardComponent.page';
 import { turnOffSDKMocking } from '../../../_common/cardMocks';
 
@@ -70,7 +78,26 @@ test(
 
         // Expect card state to have tax and pwd elements
         await t.expect(cardPage.getFromState('data.taxNumber')).eql(TEST_TAX_NUMBER_VALUE);
-        await t.expect(cardPage.getFromState('data.encryptedPassword')).contains('adyenjs_0_1_');
+
+        // Extract & decode JWE header
+        const JWEToken = await cardPage.getFromState('data.encryptedPassword');
+        const JWETokenArr = JWEToken.split('.');
+        const blobHeader = JWETokenArr[0];
+        const base64Decoded = await cardPage.decodeBase64(blobHeader);
+        const headerObj = JSON.parse(base64Decoded);
+
+        // Look for expected properties
+        await t.expect(JWETokenArr.length).eql(5); // Expected number of components in the JWE token
+
+        await t
+            .expect(headerObj.alg)
+            .eql(JWE_ALG)
+            .expect(headerObj.enc)
+            .eql(JWE_CONTENT_ALG)
+            .expect(headerObj.version)
+            .eql(JWE_VERSION);
+
+        // await t.expect(cardPage.getFromState('data.encryptedPassword')).contains('adyenjs_0_1_');
 
         await t.expect(cardPage.getFromState('valid.taxNumber')).eql(true);
         await t.expect(cardPage.getFromState('valid.encryptedPassword')).eql(true);

--- a/packages/e2e/tests/cards/utils/constants.js
+++ b/packages/e2e/tests/cards/utils/constants.js
@@ -28,3 +28,7 @@ export const TEST_CVC_VALUE = '737';
 export const TEST_PWD_VALUE = '12';
 export const TEST_TAX_NUMBER_VALUE = '123456';
 export const TEST_CPF_VALUE = '22936094488';
+
+export const JWE_VERSION = '1';
+export const JWE_CONTENT_ALG = 'A256CBC-HS512';
+export const JWE_ALG = 'RSA-OAEP';

--- a/packages/e2e/tests/customcard/branding/customcard.unsupportedCard.test.js
+++ b/packages/e2e/tests/customcard/branding/customcard.unsupportedCard.test.js
@@ -1,5 +1,5 @@
 import { start, getAriaErrorField, checkIframeElHasExactText } from '../../utils/commonUtils';
-import { REGULAR_TEST_CARD, MAESTRO_CARD } from '../../cards/utils/constants';
+import { REGULAR_TEST_CARD, MAESTRO_CARD, JWE_ALG, JWE_CONTENT_ALG, JWE_VERSION } from '../../cards/utils/constants';
 import LANG from '../../../../lib/src/language/locales/en-US.json';
 
 import CustomCardComponentPage from '../../_models/CustomCardComponent.page';
@@ -113,7 +113,26 @@ test(
         await t.expect(cardPage.getFromState(BASE_REF, 'valid.encryptedCardNumber')).eql(true);
 
         // ...with encrypted blob
-        await t.expect(cardPage.getFromState(BASE_REF, 'data.encryptedCardNumber')).contains('adyenjs_0_1_');
+
+        // Extract & decode JWE header
+        const JWEToken = await cardPage.getFromState(BASE_REF, 'data.encryptedCardNumber');
+        const JWETokenArr = JWEToken.split('.');
+        const blobHeader = JWETokenArr[0];
+        const base64Decoded = await cardPage.decodeBase64(blobHeader);
+        const headerObj = JSON.parse(base64Decoded);
+
+        // Look for expected properties
+        await t.expect(JWETokenArr.length).eql(5); // Expected number of components in the JWE token
+
+        await t
+            .expect(headerObj.alg)
+            .eql(JWE_ALG)
+            .expect(headerObj.enc)
+            .eql(JWE_CONTENT_ALG)
+            .expect(headerObj.version)
+            .eql(JWE_VERSION);
+
+        // await t.expect(cardPage.getFromState(BASE_REF, 'data.encryptedCardNumber')).contains('adyenjs_0_1_');
 
         /**
          * Validity received & processed at SF level
@@ -169,7 +188,26 @@ test(
         await t.expect(cardPage.getFromState(BASE_REF, 'valid.encryptedCardNumber')).eql(true);
 
         // ...with encrypted blob
-        await t.expect(cardPage.getFromState(BASE_REF, 'data.encryptedCardNumber')).contains('adyenjs_0_1_');
+
+        // Extract & decode JWE header
+        const JWEToken = await cardPage.getFromState(BASE_REF, 'data.encryptedCardNumber');
+        const JWETokenArr = JWEToken.split('.');
+        const blobHeader = JWETokenArr[0];
+        const base64Decoded = await cardPage.decodeBase64(blobHeader);
+        const headerObj = JSON.parse(base64Decoded);
+
+        // Look for expected properties
+        await t.expect(JWETokenArr.length).eql(5); // Expected number of components in the JWE token
+
+        await t
+            .expect(headerObj.alg)
+            .eql(JWE_ALG)
+            .expect(headerObj.enc)
+            .eql(JWE_CONTENT_ALG)
+            .expect(headerObj.version)
+            .eql(JWE_VERSION);
+
+        // await t.expect(cardPage.getFromState(BASE_REF, 'data.encryptedCardNumber')).contains('adyenjs_0_1_');
 
         /**
          * Validity received & processed at SF level

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
@@ -152,6 +152,8 @@ class CSF extends AbstractCSF {
             setFocusOnFrame: (pFieldType: string): void => {
                 if (this.state.isConfigured) {
                     this.setFocusOnFrame(pFieldType);
+                    // Comment in a quick way to test destroying secured fields (also see comment in destroySecuredFields)
+                    // this.destroySecuredFields();
                 } else {
                     notConfiguredWarning('You cannot set focus on any secured field');
                 }

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
@@ -73,8 +73,6 @@ export function handleConfig(): void {
     const d = btoa(window.location.origin);
 
     /** Detect Edge vn \<= 18 & IE11 - who don't support TextEncoder; and use this as an indicator to load a different, compatible, version of SF */
-    // const sfVersion = typeof window.TextEncoder === 'function' ? SF_VERSION : SF_VERSION_CSE_DOWNGRADE;
-
     const needsJWECompatVersion = !(typeof window.TextEncoder === 'function');
     const bundleType = `${sfBundleType}${needsJWECompatVersion ? 'Compat' : ''}`; // e.g. 'card' or 'cardCompat'
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
@@ -71,7 +71,14 @@ export function handleConfig(): void {
 
     // Add a hash of the origin to ensure urls are different across domains
     const d = btoa(window.location.origin);
-    this.config.iframeSrc = `${this.config.loadingContext}securedfields/${this.props.clientKey}/${SF_VERSION}/securedFields.html?type=${sfBundleType}&d=${d}`;
+
+    /** Detect Edge vn \<= 18 & IE11 - who don't support TextEncoder; and use this as an indicator to load a different, compatible, version of SF */
+    // const sfVersion = typeof window.TextEncoder === 'function' ? SF_VERSION : SF_VERSION_CSE_DOWNGRADE;
+
+    const needsJWECompatVersion = !(typeof window.TextEncoder === 'function');
+    const bundleType = `${sfBundleType}${needsJWECompatVersion ? 'Compat' : ''}`; // e.g. 'card' or 'cardCompat'
+
+    this.config.iframeSrc = `${this.config.loadingContext}securedfields/${this.props.clientKey}/${SF_VERSION}/securedFields.html?type=${bundleType}&d=${d}`;
 
     // TODO###### FOR QUICK LOCAL TESTING of sf
     if (process.env.NODE_ENV === 'development' && process.env.__SF_ENV__ !== 'build') {

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/destroySecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/destroySecuredFields.ts
@@ -12,7 +12,7 @@ export function destroySecuredFields(): void {
     // Then remove ref to SecuredField instance
     securedFieldKeys.forEach(pFieldType => {
         const sf: SecuredField = this.state.securedFields[pFieldType];
-        if (sf) sf.destroy();
+        if (sf) sf.destroy();// Comment out if you want to test the 'destroy' effects in the actual SF
         this.state.securedFields[pFieldType] = null;
     });
     // --

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -16,7 +16,6 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 export const GIFT_CARD = 'giftcard';
 
 export const SF_VERSION = '4.0.0';
-export const SF_VERSION_CSE_DOWNGRADE = '3.10.2'; // Edge >= 18 & IE11 can't handle...the truth, I mean, JWE
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '4.0.0';
+export const SF_VERSION = '4.1.0';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -15,7 +15,8 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '3.10.2';
+export const SF_VERSION = '4.0.0';
+export const SF_VERSION_CSE_DOWNGRADE = '3.10.2'; // Edge >= 18 & IE11 can't handle...the truth, I mean, JWE
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Loading securedFields version (`4.0.0`) that now uses JWE, rather than CSE, to encrypt data.

For Edge <= 18 & IE11 we fall back to a bulkier, "Compat", version of the file with the necessary polyfills.

## Tested scenarios
Tested in (Browserstack):
- Windows 10, Chrome 45
- Windows 10, Firefox 40
- Safari 11.1
- Edge 15
- IE11

Tested on desktop:
-  latest versions of Chrome(102.0.5005), Firefox (90.0.2), Safari (15.5) on Mac OS Monterey

All tests, unit & e2e, pass for both the "regular" and the "compat" version

**Fixed issue**:  COWEB-1062

**Update**: latest version is `4.1.0` which is smaller in size and which also restores the "event logging" i.e. the tracking of the user behaviour within the PAN & cvc fields. All tests still pass.
