### PR TITLE
Add Google Pay authJwt to initiate payment request

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -60,5 +60,10 @@ describe('GooglePay', () => {
             });
             expect(gpay.props.configuration.merchantOrigin).toEqual('example.com');
         });
+
+        test('Retrieves authJwt from configuration', () => {
+            const gpay = new GooglePay({ configuration: { merchantId: 'abcdef', gatewayMerchantId: 'TestMerchant', authJwt: 'jwt.code' } });
+            expect(gpay.props.configuration.authJwt).toEqual('jwt.code');
+        });
     });
 });

--- a/packages/lib/src/components/GooglePay/requests.ts
+++ b/packages/lib/src/components/GooglePay/requests.ts
@@ -64,7 +64,8 @@ export function initiatePaymentRequest({ configuration, ...props }: GooglePayPro
         merchantInfo: {
             merchantId: configuration.merchantId,
             merchantName: configuration.merchantName,
-            ...(configuration.merchantOrigin ? { merchantOrigin: configuration.merchantOrigin } : {})
+            ...(configuration.merchantOrigin ? { merchantOrigin: configuration.merchantOrigin } : {}),
+            ...(configuration.authJwt ? { authJwt: configuration.authJwt } : {})
         },
         allowedPaymentMethods: [
             {

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -20,11 +20,16 @@ export interface GooglePayPropsConfiguration {
      */
     merchantName?: string;
 
-
     /**
      * Merchant fully qualified domain name.
      */
     merchantOrigin?: string;
+
+    /**
+     * Google JWT solution for platforms
+     * To request Google Pay credentials, you can enable platforms to send requests that are authenticated with the platform credentials. You don't need to register individual domain names to call Google Pay APIs.
+     */
+     authJwt?: string;
 }
 
 export interface GooglePayProps extends UIElementProps {


### PR DESCRIPTION
Add Google Pay authJwt to initiate payment request

## Summary
- To request Google Pay credentials, you can enable platforms to send requests that are authenticated with the platform credentials. You don't need to register individual domain names to call Google Pay APIs.

## Tested scenarios
- Test retrieve authJwt from configuration


