### PR TITLE
Adds onOrderCreated callback to support GiftCard component in sessions flow

### DIFF
--- a/packages/e2e/app/config/webpack.config.js
+++ b/packages/e2e/app/config/webpack.config.js
@@ -17,6 +17,7 @@ const htmlPages = [
     { name: 'Issuer Lists', id: 'IssuerLists' },
     { name: 'Open Invoices', id: 'OpenInvoices' },
     { name: 'Drop-in Sessions', id: 'DropinSessions' },
+    { name: 'Gift Cards Sessions', id: 'GiftCardsSessions' },
     { name: 'Vouchers', id: 'Vouchers' }
 ];
 

--- a/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.html
+++ b/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class="no-js" lang="">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
+        <title>Adyen Web | Gift Cards</title>
+        <meta name="description" content="" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    </head>
+    <body>
+        <main>
+            <form class="merchant-checkout__form" method="post">
+                <div class="merchant-checkout__payment-method">
+                    <div class="merchant-checkout__payment-method__header">
+                        <h2>Gift Card</h2>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div class="card-field"></div>
+                    </div>
+                </div>
+            </form>
+        </main>
+
+        <script type="text/javascript">
+            window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' %>;
+        </script>
+    </body>
+</html>

--- a/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
+++ b/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
@@ -38,7 +38,6 @@ const initCheckout = async () => {
             type: 'giftcard',
             brand: 'valuelink',
             onOrderCreated: async (resolve, reject, data) => {
-                console.log(data);
                 window.onOrderCreatedTestData = data;
                 resolve();
             }

--- a/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
+++ b/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
@@ -1,0 +1,49 @@
+import AdyenCheckout from '@adyen/adyen-web';
+import '@adyen/adyen-web/dist/es/adyen.css';
+import { checkBalance, createOrder, createSession } from '../../services';
+import { amount, shopperLocale, countryCode, returnUrl, shopperReference } from '../../services/commonConfig';
+import '../../style.scss';
+
+const initCheckout = async () => {
+    const session = await createSession({
+        amount,
+        reference: 'ABC123',
+        returnUrl,
+        shopperLocale,
+        shopperReference,
+        countryCode,
+    });
+
+    const sessionCheckout = await AdyenCheckout({
+        environment: 'test',
+        clientKey: process.env.__CLIENT_KEY__,
+        showPayButton: true,
+        session,
+
+        // Events
+        beforeSubmit: (data, component, actions) => {
+            actions.resolve(data);
+        },
+        onPaymentCompleted: (result, component) => {
+            console.info(result, component);
+        },
+        onError: (error, component) => {
+            console.log('arg', error);
+            console.error(error.message, component);
+        },
+    });
+
+    window.card = sessionCheckout
+        .create('giftcard', {
+            type: 'giftcard',
+            brand: 'valuelink',
+            onOrderCreated: async (resolve, reject, data) => {
+                console.log(data);
+                window.onOrderCreatedTestData = data;
+                resolve();
+            }
+        })
+        .mount('.card-field');
+};
+
+initCheckout();

--- a/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
+++ b/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
@@ -1,6 +1,6 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/es/adyen.css';
-import { checkBalance, createOrder, createSession } from '../../services';
+import { createSession } from '../../services';
 import { amount, shopperLocale, countryCode, returnUrl, shopperReference } from '../../services/commonConfig';
 import '../../style.scss';
 

--- a/packages/e2e/tests/_models/GiftCardComponent.page.js
+++ b/packages/e2e/tests/_models/GiftCardComponent.page.js
@@ -46,3 +46,9 @@ export default class GiftCardPage extends BasePage {
         return splitPath.reduce(reducer, window.card.state);
     });
 }
+
+export class GiftCardSessionPage extends GiftCardPage {
+    constructor(baseEl = '.card-field') {
+        super();
+    }
+}

--- a/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.clientScripts.js
+++ b/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.clientScripts.js
@@ -1,0 +1,13 @@
+window.mainConfiguration = {
+    allowPaymentMethods: ['giftcard'],
+    paymentMethodsConfiguration: {
+        giftcard: {
+            brandsConfiguration: {
+                genericgiftcard: {
+                    icon: 'https://checkoutshopper-test.adyen.com/checkoutshopper/images/logos/mc.svg',
+                    name: 'Gifty mcGiftface'
+                }
+            }
+        }
+    }
+};

--- a/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.mocks.js
+++ b/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.mocks.js
@@ -1,0 +1,124 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import { BASE_URL } from '../../pages';
+
+const path = require('path');
+require('dotenv').config({ path: path.resolve('../../', '.env') });
+
+const MOCK_SESSION_ID = 'CS616D08FC28573F9C';
+const MOCK_SESSION_DATA = 'Ab02b4c0!BQABAgChW9EQ6U';
+
+const sessionsUrl = 'http://localhost:3024/sessions';
+const setupUrl = `https://checkoutshopper-test.adyen.com/checkoutshopper/v1/sessions/${MOCK_SESSION_ID}/setup?clientKey=${process.env.CLIENT_KEY}`;
+const balanceUrl = `https://checkoutshopper-test.adyen.com/checkoutshopper/v1/sessions/${MOCK_SESSION_ID}/paymentMethodBalance?clientKey=${process.env.CLIENT_KEY}`;
+const ordersUrl = `https://checkoutshopper-test.adyen.com/checkoutshopper/v1/sessions/${MOCK_SESSION_ID}/orders?clientKey=${process.env.CLIENT_KEY}`;
+const paymentsUrl = `https://checkoutshopper-test.adyen.com/checkoutshopper/v1/sessions/${MOCK_SESSION_ID}/payments?clientKey=${process.env.CLIENT_KEY}`;
+
+const sessionsResponse = {
+    amount: {
+        currency: 'USD',
+        value: 25900
+    },
+    countryCode: 'US',
+    expiresAt: '2021-10-15T13:02:27+02:00',
+    id: MOCK_SESSION_ID,
+    merchantAccount: 'TestMerchantCheckout',
+    reference: 'ABC123',
+    returnUrl: 'http://localhost:3024/result',
+    shopperLocale: 'en-US',
+    shopperReference: 'newshoppert',
+    sessionData: MOCK_SESSION_DATA
+};
+
+const setupResponse = {
+    amount: {
+        currency: 'USD',
+        value: 25900
+    },
+    countryCode: 'US',
+    expiresAt: '2021-10-15T13:02:27+02:00',
+    id: MOCK_SESSION_ID,
+    returnUrl: 'http://localhost:3024/result',
+    shopperLocale: 'en-US',
+    paymentMethods: {
+        storedPaymentMethods: [
+            {
+                brand: 'visa',
+                expiryMonth: '03',
+                expiryYear: '2030',
+                holderName: 'Checkout Shopper PlaceHolder',
+                id: '8415611088427239',
+                lastFour: '1111',
+                name: 'VISA',
+                supportedShopperInteractions: ['Ecommerce', 'ContAuth'],
+                type: 'scheme'
+            }
+        ]
+    },
+    sessionData: MOCK_SESSION_DATA
+};
+
+const balanceResponse = {
+    balance: {
+        currency: 'USD',
+        value: 6000
+    },
+    sessionData: MOCK_SESSION_DATA
+};
+
+const ordersResponse = {
+    orderData: '',
+    sessionData: MOCK_SESSION_DATA
+};
+
+const paymentResponse = {
+    order: {
+        amount: {
+            currency: 'USD',
+            value: 25900
+        },
+        reference: 'ABC123',
+        remainingAmount: {
+            currency: 'USD',
+            value: 19900
+        }
+    },
+    resultCode: 'Authorised',
+    sessionData: MOCK_SESSION_DATA
+};
+
+const noCallbackPaymentResponse = {
+    resultCode: 'Authorised',
+    sessionData: MOCK_SESSION_DATA
+};
+
+const loggers = {
+    setupLogger: RequestLogger({ url: setupUrl, method: 'post' }, { logRequestBody: true }),
+    balanceLogger: RequestLogger({ url: balanceUrl, method: 'post' }, { logRequestBody: true }),
+    ordersLogger: RequestLogger({ url: ordersUrl, method: 'post' }, { logRequestBody: true })
+};
+
+const mock = RequestMock()
+    .onRequestTo(request => request.url === sessionsUrl)
+    .respond(sessionsResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === setupUrl && request.method === 'post')
+    .respond(setupResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === balanceUrl && request.method === 'post')
+    .respond(balanceResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === ordersUrl && request.method === 'post')
+    .respond(ordersResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === paymentsUrl && request.method === 'post')
+    .respond(paymentResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL });
+
+const noCallbackMock = RequestMock()
+    .onRequestTo(request => request.url === sessionsUrl)
+    .respond(sessionsResponse, 500, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === setupUrl && request.method === 'post')
+    .respond(setupResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === balanceUrl && request.method === 'post')
+    .respond(balanceResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === ordersUrl && request.method === 'post')
+    .respond(ordersResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL })
+    .onRequestTo(request => request.url === paymentsUrl && request.method === 'post')
+    .respond(noCallbackPaymentResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL });
+
+export { mock, noCallbackMock, loggers, MOCK_SESSION_DATA };

--- a/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.test.js
+++ b/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.test.js
@@ -1,0 +1,63 @@
+import { ClientFunction } from 'testcafe';
+
+import { fillIFrame, getInputSelector } from '../../utils/commonUtils';
+import { GIFTCARD_NUMBER, GIFTCARD_PIN } from '../utils/constants';
+import { GIFTCARDS_SESSIONS_URL } from '../../pages';
+import { mock, noCallbackMock, loggers, MOCK_SESSION_DATA } from './onOrderCreated.mocks';
+
+import { GiftCardSessionPage } from '../../_models/GiftCardComponent.page';
+
+const giftCard = new GiftCardSessionPage();
+const { setupLogger, balanceLogger, ordersLogger } = loggers;
+
+const getCallBackData = ClientFunction(() => window.onOrderCreatedTestData);
+
+// only setup the loggers for the endpoints so we can setup different responses for different scenarios
+fixture`Testing gift cards`.page(GIFTCARDS_SESSIONS_URL).requestHooks([setupLogger, balanceLogger, ordersLogger]);
+
+// set up request hooks for different scenarios
+test.requestHooks([mock])('Test if orderStatus is retrieved on success', async t => {
+    // Wait for el to appear in DOM
+    await t
+        .expect(setupLogger.count(() => true))
+        .eql(1)
+        .expect(
+            setupLogger.contains(record => {
+                const { sessionData } = JSON.parse(record.request.body);
+                return sessionData === MOCK_SESSION_DATA;
+            })
+        )
+        .ok('setup API call has the expected sessionData value');
+
+    await giftCard.pmHolder();
+
+    await giftCard.cardUtils.fillCardNumber(t, GIFTCARD_NUMBER);
+    await fillIFrame(t, giftCard.iframeSelector, 1, getInputSelector('encryptedSecurityCode'), GIFTCARD_PIN);
+
+    await t
+        .click(giftCard.payButton)
+        .expect(balanceLogger.count(() => true))
+        .eql(1)
+        .expect(
+            balanceLogger.contains(record => {
+                const { sessionData } = JSON.parse(record.request.body);
+                return sessionData === MOCK_SESSION_DATA;
+            })
+        )
+        .ok()
+        .expect(ordersLogger.count(() => true))
+        .eql(1)
+        .expect(getCallBackData())
+        .ok();
+});
+
+// set up request hooks for different scenarios
+test.requestHooks([noCallbackMock]).only('Test if onOrderCreated is not called if giftcard has enough balance for the payment', async t => {
+    await giftCard.cardUtils.fillCardNumber(t, GIFTCARD_NUMBER);
+    await fillIFrame(t, giftCard.iframeSelector, 1, getInputSelector('encryptedSecurityCode'), GIFTCARD_PIN);
+
+    await t
+        .click(giftCard.payButton)
+        .expect(getCallBackData())
+        .notOk();
+});

--- a/packages/e2e/tests/pages.js
+++ b/packages/e2e/tests/pages.js
@@ -14,4 +14,6 @@ export const VOUCHERS_URL = `${BASE_URL}/vouchers/`;
 
 export const DROPIN_SESSIONS_URL = `${BASE_URL}/dropinsessions`;
 
+export const GIFTCARDS_SESSIONS_URL = `${BASE_URL}/giftcardssessions`;
+
 export const ADDRESS_URL = `${BASE_URL}/address`;

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -5,7 +5,7 @@ import CoreProvider from '../../core/Context/CoreProvider';
 import getImage from '../../utils/get-image';
 import PayButton from '../internal/PayButton';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
-import { PaymentAmount } from '../../types';
+import { Order, PaymentAmount } from '../../types';
 
 export class GiftcardElement extends UIElement {
     public static type = 'giftcard';
@@ -71,6 +71,15 @@ export class GiftcardElement extends UIElement {
 
         if (this.props.session) {
             return this.props.session.createOrder();
+        }
+    };
+
+    protected handleOrder = (order: Order) => {
+        this.elementRef._parentInstance.update({ order });
+        if (this.props.session && this.props.onOrderCreated) {
+            return new Promise((resolve, reject) => {
+                return this.props.onOrderCreated(resolve, reject, order);
+            });
         }
     };
 

--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -27,6 +27,7 @@ export const GENERIC_OPTIONS = [
     'onError',
     'onBalanceCheck',
     'onOrderRequest',
+    'onOrderCreated',
     'setStatusAutomatically'
 ];
 

--- a/packages/playground/src/pages/GiftCards/GiftCards.html
+++ b/packages/playground/src/pages/GiftCards/GiftCards.html
@@ -33,6 +33,20 @@
                 </div>
             </div>
 
+            <div class="merchant-checkout__form">
+                <div class="merchant-checkout__payment-method">
+                    <div class="merchant-checkout__payment-method__header">
+                        <h2>Gift Card Component (w/ Sessions)</h2>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div id="giftcard-session-container"></div>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div id="payment-method-container"></div>
+                    </div>
+                </div>
+            </div>
+
             <div class="info">
                 <table>
                     <caption>

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -1,8 +1,8 @@
 import AdyenCheckout from '@adyen/adyen-web';
 import '@adyen/adyen-web/dist/es/adyen.css';
 import { handleChange, handleSubmit } from '../../handlers';
-import { amount, shopperLocale, countryCode } from '../../config/commonConfig';
-import { checkBalance, createOrder } from '../../services';
+import { amount, shopperLocale, countryCode, returnUrl, shopperReference } from '../../config/commonConfig';
+import { checkBalance, createOrder, createSession } from '../../services';
 import '../../../config/polyfills';
 import '../../utils';
 import '../../style.scss';
@@ -44,4 +44,41 @@ import '../../style.scss';
             }
         })
         .mount('#mealvoucher-fr-container');
+
+    const session = await createSession({
+        amount,
+        reference: 'ABC123',
+        returnUrl,
+        shopperLocale,
+        shopperReference,
+        countryCode
+    });
+
+    const sessionCheckout = await AdyenCheckout({
+        environment: process.env.__CLIENT_ENV__,
+        clientKey: process.env.__CLIENT_KEY__,
+        session,
+        showPayButton: true,
+
+        // Events
+        beforeSubmit: (data, component, actions) => {
+            actions.resolve(data);
+        },
+        onPaymentCompleted: (result, component) => {
+            console.info(result, component);
+        },
+        onError: (error, component) => {
+            console.error(error.message, component);
+        }
+    });
+
+    window.giftcard = sessionCheckout
+        .create('giftcard', {
+            type: 'giftcard',
+            brand: 'svs',
+            onOrderCreated: async (resolve, reject, data) => {
+                resolve(console.log('onOrderCreated', data));
+            }
+        })
+        .mount('#giftcard-session-container');
 })();

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -85,24 +85,6 @@ import '../../style.scss';
 
 
     const afterGiftCard = async (order) => {
-        const checkout = await AdyenCheckout({
-            environment: process.env.__CLIENT_ENV__,
-            clientKey: process.env.__CLIENT_KEY__,
-            session,
-            showPayButton: true,
-            order,
-
-            // Events
-            beforeSubmit: (data, component, actions) => {
-                actions.resolve(data);
-            },
-            onPaymentCompleted: (result, component) => {
-                console.info(result, component);
-            },
-            onError: (error, component) => {
-                console.error(error.message, component);
-            }
-        });
-        checkout.create('card').mount('#payment-method-container');
+        sessionCheckout.create('card').mount('#payment-method-container');
     }
 })();

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -77,8 +77,32 @@ import '../../style.scss';
             type: 'giftcard',
             brand: 'svs',
             onOrderCreated: async (resolve, reject, data) => {
-                resolve(console.log('onOrderCreated', data));
+                await afterGiftCard(data);
+                resolve();
             }
         })
         .mount('#giftcard-session-container');
+
+
+    const afterGiftCard = async (order) => {
+        const checkout = await AdyenCheckout({
+            environment: process.env.__CLIENT_ENV__,
+            clientKey: process.env.__CLIENT_KEY__,
+            session,
+            showPayButton: true,
+            order,
+
+            // Events
+            beforeSubmit: (data, component, actions) => {
+                actions.resolve(data);
+            },
+            onPaymentCompleted: (result, component) => {
+                console.info(result, component);
+            },
+            onError: (error, component) => {
+                console.error(error.message, component);
+            }
+        });
+        checkout.create('card').mount('#payment-method-container');
+    }
 })();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This ticket is meant to add onOrderCreated callback. This callback tries to solve the following:

> While trying to make partial payments using gift cards on checkout sessions + web components, there is no way to inform the merchant and the shopper of a successful gift card payment and the remaining amount to be paid, after a part of the payment is successfully paid using a giftcard.

We solve this by creating this new callback, it should only get triggered when an order is created, because there was not enough balance in the giftcard to cover the full amount. If the gifcard can cover the full amount we still use the normal flow of asking for confirmation.

This callback will allow merchants to retrieve the `order` object, this should have the `remainingAmount` as well as informations of the payment methods already used. This `order` object can then be used while setting up the new payment method component, together with the old session.

## Tested scenarios
<!-- Description of tested scenarios -->
* Created E2E scenario to test when the callback is trigger and when it's not
* Playground as been updated with an example 


**Fixed issue**:  <!-- #-prefixed issue number -->
