### PR TITLE
Fix/3DS2 challenge error handling

### DIFF
--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -64,7 +64,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                             const errorObject = handleErrorCode(challenge.result.errorCode, challenge.result.errorDescription);
                             this.props.onError(errorObject);
                             // Proceed with call to onAdditionalDetails
-                            this.setStatusComplete(challenge);
+                            this.setStatusComplete(challenge.result);
                             return;
                         }
 

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -59,9 +59,9 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                 <DoChallenge3DS2
                     onCompleteChallenge={(challenge: ThreeDS2FlowObject) => {
                         // Challenge has resulted in an error (no transStatus could be retrieved) - but we still treat this as a valid scenario
-                        if (hasOwnProperty(challenge.result, 'errorCode')) {
+                        if (hasOwnProperty(challenge.result, 'errorCode') && challenge.result.errorCode.length) {
                             // Tell the merchant there's been an error
-                            const errorObject = handleErrorCode(challenge.result.errorCode);
+                            const errorObject = handleErrorCode(challenge.result.errorCode, challenge.result.errorDescription);
                             this.props.onError(errorObject);
                             // Proceed with call to onAdditionalDetails
                             this.setStatusComplete(challenge);

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -145,9 +145,9 @@ export const createOldChallengeResolveData = (dataKey: string, transStatus: stri
     }
 });
 
-export const handleErrorCode = (errorCode: string): ErrorObject => {
+export const handleErrorCode = (errorCode: string, errorDescription?: string): ErrorObject => {
     const unknownMessage = ERROR_MESSAGES[ERRORS.UNKNOWN];
-    const message = ERROR_MESSAGES[errorCode] || unknownMessage;
+    const message = ERROR_MESSAGES[errorCode] || errorDescription || unknownMessage;
     return { errorCode, message };
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently when a shopper successfully completes a 3DS2 challenge - empty error fields (`errorCode` & `errorDescription`) are added to the response by the backend.
However the frontend only expects these fields to be present in the case of an actual error situation.
Upon seeing the presence of the `errorCode` property it treats the successful response as an erroneous one and the resulting call to the `/payments/details` endpoint gives a response with the message `"invalid transStatus"`

This situation is being remedied on the backend and patched.
However to be more defensive on the frontend we are now also checking if the `errorCode` prop is present _and_ has a value.
Plus we are also passing any `errorDescription` to the final error result object

## Tested scenarios
A credit card payment that leads to a 3DS2 challenge is once again successful.
If an `errorDescription` is present this is used as the error object `message` if there is no corresponding message already linked to the `errorCode`
