### PR TITLE
Add class to disable CardInput whilst in a 'loading' state

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.scss
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.scss
@@ -36,6 +36,10 @@
     margin-top: $spacing-medium;
 }
 
+.adyen-checkout__card-input.adyen-checkout__card-input--loading{
+    pointer-events: none;
+}
+
 .adyen-checkout__card__holderName:first-child {
     margin: 0 0 $spacing-medium;
 }

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -22,6 +22,7 @@ import styles from './CardInput.module.scss';
 import { getAddressHandler, getAutoJumpHandler, getErrorPanelHandler, getFocusHandler } from './handlers';
 import { InstallmentsObj } from './components/Installments/Installments';
 import { TouchStartEventObj } from './components/types';
+import classNames from 'classnames';
 
 const CardInput: FunctionalComponent<CardInputProps> = props => {
     const sfp = useRef(null);
@@ -376,8 +377,12 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
                 render={({ setRootNode, setFocusOn }, sfpState) => (
                     <div
                         ref={setRootNode}
-                        className={`adyen-checkout__card-input ${styles['card-input__wrapper']} adyen-checkout__card-input--${props.fundingSource ??
-                            'credit'}`}
+                        className={classNames({
+                            'adyen-checkout__card-input': true,
+                            [styles['card-input__wrapper']]: true,
+                            [`adyen-checkout__card-input--${props.fundingSource ?? 'credit'}`]: true,
+                            'adyen-checkout__card-input--loading': status === 'loading'
+                        })}
                         role={collateErrors && 'form'}
                         aria-describedby={collateErrors ? errorFieldId : null}
                     >


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When the shopper presses "Pay" the `CardInput` goes into a "loading" state.
This should also disable the `CardInput` so in the case of a slow internet connection the shopper cannot interact with the input fields.
Similarly to what we do with the Dropin, when in this "loading" state a class is added to the wrapping `<div>` to disable `pointer-events`

## Tested scenarios
Throttling the network connect - the user can no longer interact with the inputs as we wait for the `/payments` call to be successful
