### PR TITLE
Change onOrderCallback to not return promise

### DIFF
--- a/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
+++ b/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
@@ -37,9 +37,8 @@ const initCheckout = async () => {
         .create('giftcard', {
             type: 'giftcard',
             brand: 'valuelink',
-            onOrderCreated: async (resolve, reject, data) => {
+            onOrderCreated: (data) => {
                 window.onOrderCreatedTestData = data;
-                resolve();
             }
         })
         .mount('.card-field');

--- a/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.test.js
+++ b/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.test.js
@@ -52,7 +52,7 @@ test.requestHooks([mock])('Test if orderStatus is retrieved on success', async t
 });
 
 // set up request hooks for different scenarios
-test.requestHooks([noCallbackMock]).only('Test if onOrderCreated is not called if giftcard has enough balance for the payment', async t => {
+test.requestHooks([noCallbackMock])('Test if onOrderCreated is not called if giftcard has enough balance for the payment', async t => {
     await giftCard.cardUtils.fillCardNumber(t, GIFTCARD_NUMBER);
     await fillIFrame(t, giftCard.iframeSelector, 1, getInputSelector('encryptedSecurityCode'), GIFTCARD_PIN);
 

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -77,9 +77,7 @@ export class GiftcardElement extends UIElement {
     protected handleOrder = (order: Order) => {
         this.elementRef._parentInstance.update({ order });
         if (this.props.session && this.props.onOrderCreated) {
-            return new Promise((resolve, reject) => {
-                return this.props.onOrderCreated(resolve, reject, order);
-            });
+            return this.props.onOrderCreated(order);
         }
     };
 

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -76,14 +76,14 @@ import '../../style.scss';
         .create('giftcard', {
             type: 'giftcard',
             brand: 'svs',
-            onOrderCreated: async (data) => {
-                await afterGiftCard(data);
+            onOrderCreated: (data) => {
+                afterGiftCard(data);
             }
         })
         .mount('#giftcard-session-container');
 
 
-    const afterGiftCard = async (order) => {
+    const afterGiftCard = (order) => {
         sessionCheckout.create('card').mount('#payment-method-container');
     }
 })();

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -76,9 +76,8 @@ import '../../style.scss';
         .create('giftcard', {
             type: 'giftcard',
             brand: 'svs',
-            onOrderCreated: async (resolve, reject, data) => {
+            onOrderCreated: async (data) => {
                 await afterGiftCard(data);
-                resolve();
             }
         })
         .mount('#giftcard-session-container');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

We concluded that we don't need to use a promise for the onOrderCreated callback. This PR changes to normal function callback.

## Tested scenarios
<!-- Description of tested scenarios -->

- Ran e2e tests fro onOrderCreated
- Tested playground integration

**Fixed issue**:  <!-- #-prefixed issue number -->
