### PR TITLE
Click to Pay - Checkout flow

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -11,13 +11,19 @@ import { reject } from '../internal/SecuredFields/utils';
 import { hasValidInstallmentsObject } from './components/CardInput/utils';
 import ClickToPayProvider from './components/ClickToPay/context/ClickToPayProvider';
 import { createClickToPayService } from './components/ClickToPay/utils';
-import { CheckoutPayload, IClickToPayService } from './components/ClickToPay/services/types';
+import { ClickToPayCheckoutPayload, IClickToPayService } from './components/ClickToPay/services/types';
 import ClickToPayWrapper from './ClickToPayWrapper';
+import { UIElementStatus } from '../types';
 
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
 
     private readonly clickToPayService: IClickToPayService | null;
+
+    /**
+     * Reference to the 'ClickToPayComponent'
+     */
+    private clickToPayRef = null;
 
     constructor(props) {
         super(props);
@@ -32,8 +38,22 @@ export class CardElement extends UIElement<CardElementProps> {
         SRConfig: {}
     };
 
+    public setStatus(status: UIElementStatus, props?): this {
+        if (this.componentRef?.setStatus) {
+            this.componentRef.setStatus(status, props);
+        }
+        if (this.clickToPayRef?.setStatus) {
+            this.clickToPayRef.setStatus(status, props);
+        }
+        return this;
+    }
+
     public setComponentRef = ref => {
         this.componentRef = ref;
+    };
+
+    private setClickToPayRef = ref => {
+        this.clickToPayRef = ref;
     };
 
     formatProps(props: CardElementProps) {
@@ -121,10 +141,10 @@ export class CardElement extends UIElement<CardElementProps> {
         return this;
     }
 
-    handleClickToPaySubmit(payload: CheckoutPayload) {
-        // TODO
-        console.log(payload);
-    }
+    private handleClickToPaySubmit = (payload: ClickToPayCheckoutPayload) => {
+        this.setState({ data: { ...payload }, valid: {}, errors: {}, isValid: true });
+        this.submit();
+    };
 
     onBinLookup(obj: CbObjOnBinLookup) {
         // Handler for regular card comp doesn't need this 'raw' data or to know about 'resets'
@@ -207,10 +227,15 @@ export class CardElement extends UIElement<CardElementProps> {
                 loadingContext={this.props.loadingContext}
                 commonProps={{ isCollatingErrors: this.props.SRConfig.collateErrors }}
             >
-                <ClickToPayProvider amount={this.props.amount} clickToPayService={this.clickToPayService}>
-                    <ClickToPayWrapper onSubmit={this.handleClickToPaySubmit}>
-                        {isCardPrimaryInput => this.renderCardInput(isCardPrimaryInput)}
-                    </ClickToPayWrapper>
+                <ClickToPayProvider
+                    amount={this.props.amount}
+                    clickToPayService={this.clickToPayService}
+                    setClickToPayRef={this.setClickToPayRef}
+                    onSetStatus={this.setElementStatus}
+                    onSubmit={this.handleClickToPaySubmit}
+                    onError={this.handleError}
+                >
+                    <ClickToPayWrapper>{isCardPrimaryInput => this.renderCardInput(isCardPrimaryInput)}</ClickToPayWrapper>
                 </ClickToPayProvider>
             </CoreProvider>
         );

--- a/packages/lib/src/components/Card/ClickToPayWrapper.tsx
+++ b/packages/lib/src/components/Card/ClickToPayWrapper.tsx
@@ -8,14 +8,13 @@ import Button from '../internal/Button';
 import useCoreContext from '../../core/Context/useCoreContext';
 
 type ClickToPayWrapperProps = {
-    onSubmit(payload: any): void;
     children(isCardPrimaryInput?: boolean): h.JSX.Element;
 };
 
-const ClickToPayWrapper = ({ onSubmit, children }: ClickToPayWrapperProps) => {
+const ClickToPayWrapper = ({ children }: ClickToPayWrapperProps) => {
     const { i18n } = useCoreContext();
     const [isCardInputVisible, setIsCardInputVisible] = useState<boolean>(null);
-    const { ctpState, isCtpPrimaryPaymentMethod, setIsCtpPrimaryPaymentMethod } = useClickToPayContext();
+    const { ctpState, isCtpPrimaryPaymentMethod, setIsCtpPrimaryPaymentMethod, status } = useClickToPayContext();
 
     const areFieldsNotSet = isCardInputVisible === null && isCtpPrimaryPaymentMethod === null;
 
@@ -48,7 +47,8 @@ const ClickToPayWrapper = ({ onSubmit, children }: ClickToPayWrapperProps) => {
 
     return (
         <Fragment>
-            <ClickToPayComponent onSubmit={onSubmit} />
+            <ClickToPayComponent />
+
             <ContentSeparator classNames={['adyen-checkout-ctp__separator']} label={i18n.get('qrCodeOrApp')} />
 
             {isCardInputVisible ? (
@@ -56,6 +56,7 @@ const ClickToPayWrapper = ({ onSubmit, children }: ClickToPayWrapperProps) => {
             ) : (
                 <Button
                     variant="secondary"
+                    disabled={status === 'loading'}
                     label={ctpState === CtpState.Ready ? i18n.get('ctp.useAnotherCard') : i18n.get('ctp.manualCardEntry')}
                     onClick={handleOnShowCardButtonClick}
                 />

--- a/packages/lib/src/components/Card/components/ClickToPay/ClickToPayComponent.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/ClickToPayComponent.tsx
@@ -7,13 +7,8 @@ import CtPCards from './components/CtPCards';
 import CtPSection from './components/CtPSection';
 import CtPLoader from './components/CtPLoader';
 import CtPLogin from './components/CtPLogin';
-import { CheckoutPayload } from './services/types';
 
-type ClickToPayComponentProps = {
-    onSubmit?(payload: CheckoutPayload): void;
-};
-
-const ClickToPayComponent = ({ onSubmit }: ClickToPayComponentProps): h.JSX.Element => {
+const ClickToPayComponent = (): h.JSX.Element => {
     const { ctpState, startIdentityValidation, logoutShopper } = useClickToPayContext();
 
     useEffect(() => {
@@ -39,7 +34,7 @@ const ClickToPayComponent = ({ onSubmit }: ClickToPayComponentProps): h.JSX.Elem
             <CtPSection>
                 {[CtpState.Loading, CtpState.ShopperIdentified].includes(ctpState) && <CtPLoader />}
                 {ctpState === CtpState.OneTimePassword && <CtPOneTimePassword />}
-                {ctpState === CtpState.Ready && <CtPCards onSubmit={onSubmit} />}
+                {ctpState === CtpState.Ready && <CtPCards />}
                 {ctpState === CtpState.Login && <CtPLogin />}
             </CtPSection>
         </Fragment>

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPCards/CtPCards.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPCards/CtPCards.tsx
@@ -45,7 +45,7 @@ const CtPCards = () => {
                 })}
                 status={status}
                 variant={isCtpPrimaryPaymentMethod ? 'primary' : 'secondary'}
-                icon={getImage({ loadingContext: loadingContext, imageFolder: 'components/' })(isCtpPrimaryPaymentMethod ? 'lock' : 'lock_dark')}
+                icon={getImage({ loadingContext: loadingContext, imageFolder: 'components/' })(isCtpPrimaryPaymentMethod ? 'lock' : 'lock_black')}
                 onClick={doCheckout}
             />
         </Fragment>

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPCards/CtPCards.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPCards/CtPCards.tsx
@@ -1,7 +1,6 @@
 import { Fragment, h } from 'preact';
 import { useCallback, useState } from 'preact/hooks';
 import useClickToPayContext from '../../context/useClickToPayContext';
-import { CheckoutPayload } from '../../services/types';
 import CtPSingleCard from './CtPSingleCard/CtPSingleCard';
 import getImage from '../../../../../../utils/get-image';
 import useCoreContext from '../../../../../../core/Context/useCoreContext';
@@ -11,29 +10,21 @@ import CtPCardsList from './CtPCardsList';
 import ShopperCard from '../../models/ShopperCard';
 import './CtPCards.scss';
 
-/**
- * TODO:
- * - Do payments call
- * - Add new text to i18n
- */
-
-type CtPCardsProps = {
-    onSubmit(payload: CheckoutPayload): void;
-};
-
-const CtPCards = ({ onSubmit }: CtPCardsProps) => {
+const CtPCards = () => {
     const { loadingContext, i18n } = useCoreContext();
-    const { amount, cards, checkout, isCtpPrimaryPaymentMethod } = useClickToPayContext();
-    const [isDoingCheckout, setIsDoingCheckout] = useState<boolean>(false);
+    const { amount, cards, checkout, isCtpPrimaryPaymentMethod, status, onSubmit, onSetStatus, onError } = useClickToPayContext();
     const [checkoutCard, setCheckoutCard] = useState<ShopperCard>(cards[0]);
 
     const doCheckout = useCallback(async () => {
         if (!checkoutCard) return;
 
-        setIsDoingCheckout(true);
-        const payload = await checkout(checkoutCard);
-        setIsDoingCheckout(false);
-        onSubmit(payload);
+        try {
+            onSetStatus('loading');
+            const payload = await checkout(checkoutCard);
+            onSubmit(payload);
+        } catch (error) {
+            onError(error);
+        }
     }, [checkout, checkoutCard]);
 
     const handleOnChangeCard = useCallback((card: ShopperCard) => {
@@ -52,7 +43,7 @@ const CtPCards = ({ onSubmit }: CtPCardsProps) => {
                 label={i18n.get('payButton.with', {
                     values: { value: amountLabel(i18n, amount), maskedData: `•••• ${checkoutCard?.panLastFour}` }
                 })}
-                status={isDoingCheckout && 'loading'}
+                status={status}
                 variant={isCtpPrimaryPaymentMethod ? 'primary' : 'secondary'}
                 icon={getImage({ loadingContext: loadingContext, imageFolder: 'components/' })(isCtpPrimaryPaymentMethod ? 'lock' : 'lock_dark')}
                 onClick={doCheckout}

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPCards/CtPCardsList/CtPCardsList.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPCards/CtPCardsList/CtPCardsList.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo } from 'preact/hooks';
 import useCoreContext from '../../../../../../../core/Context/useCoreContext';
 import useForm from '../../../../../../../utils/useForm';
 import ShopperCard from '../../../models/ShopperCard';
+import useClickToPayContext from '../../../context/useClickToPayContext';
 
 type CtPCardsListProps = {
     cards: ShopperCard[];
@@ -19,6 +20,7 @@ const schema = ['srcDigitalCardId'];
 
 const CtPCardsList = ({ cards, onChangeCard }: CtPCardsListProps) => {
     const { i18n } = useCoreContext();
+    const { status } = useClickToPayContext();
     const { handleChangeFor, data } = useForm<CardsSelectorDataState>({
         schema,
         defaultData: { srcDigitalCardId: cards[0].srcDigitalCardId }
@@ -46,6 +48,7 @@ const CtPCardsList = ({ cards, onChangeCard }: CtPCardsListProps) => {
                 name: 'cards',
                 filterable: false,
                 isIconOnLeftSide: true,
+                readonly: status === 'loading',
                 onChange: handleChangeFor('srcDigitalCardId')
             })}
         </Field>

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPSection/CtPLogoutLink.scss
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPSection/CtPLogoutLink.scss
@@ -1,3 +1,5 @@
+@import '../../../../../../style/index';
+
 .adyen-checkout-ctp__section-logout-button {
   font-size: 13px;
   line-height: 19px;
@@ -5,4 +7,9 @@
   color: #0066FF;
   margin-left: auto;
   cursor: pointer;
+}
+
+.adyen-checkout-ctp__section-logout-button--disabled {
+  pointer-events: none;
+  color: $color-gray-darker;
 }

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPSection/CtPLogoutLink.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPSection/CtPLogoutLink.tsx
@@ -2,10 +2,11 @@ import { h } from 'preact';
 import useClickToPayContext from '../../context/useClickToPayContext';
 import useCoreContext from '../../../../../../core/Context/useCoreContext';
 import { CtpState } from '../../services/ClickToPayService';
+import classnames from 'classnames';
 import './CtPLogoutLink.scss';
 
 const CtPLogoutLink = (): h.JSX.Element => {
-    const { ctpState, logoutShopper } = useClickToPayContext();
+    const { ctpState, logoutShopper, status } = useClickToPayContext();
     const { i18n } = useCoreContext();
 
     if ([CtpState.Ready, CtpState.OneTimePassword].includes(ctpState) === false) {
@@ -13,7 +14,14 @@ const CtPLogoutLink = (): h.JSX.Element => {
     }
 
     return (
-        <span role="button" tabIndex={0} className="adyen-checkout-ctp__section-logout-button" onClick={logoutShopper}>
+        <span
+            role="button"
+            tabIndex={0}
+            className={classnames('adyen-checkout-ctp__section-logout-button', {
+                'adyen-checkout-ctp__section-logout-button--disabled': status === 'loading'
+            })}
+            onClick={logoutShopper}
+        >
             {ctpState === CtpState.Ready ? i18n.get('ctp.logout.notYouCards') : i18n.get('ctp.logout.notYou')}
         </span>
     );

--- a/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayContext.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayContext.ts
@@ -1,8 +1,10 @@
 import { createContext } from 'preact';
 import { CtpState } from '../services/ClickToPayService';
-import { IClickToPayService } from '../services/types';
+import { ClickToPayCheckoutPayload, IClickToPayService } from '../services/types';
 import { PaymentAmount } from '../../../../../types';
 import ShopperCard from '../models/ShopperCard';
+import { UIElementStatus } from '../../../../types';
+import AdyenCheckoutError from '../../../../../core/Errors/AdyenCheckoutError';
 
 export interface ClickToPayContextInterface
     extends Pick<IClickToPayService, 'checkout' | 'startIdentityValidation' | 'finishIdentityValidation' | 'verifyIfShopperIsEnrolled'> {
@@ -13,9 +15,17 @@ export interface ClickToPayContextInterface
     cards: ShopperCard[];
     otpMaskedContact: string;
     amount: PaymentAmount;
+    status: UIElementStatus;
+    onSubmit(payload: ClickToPayCheckoutPayload): void;
+    onSetStatus(status: UIElementStatus): void;
+    onError(error: AdyenCheckoutError): void;
 }
 
 const ClickToPayContext = createContext<ClickToPayContextInterface>({
+    status: null,
+    onSubmit: null,
+    onSetStatus: null,
+    onError: null,
     amount: null,
     isCtpPrimaryPaymentMethod: null,
     setIsCtpPrimaryPaymentMethod: null,

--- a/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.ts
@@ -128,8 +128,6 @@ class ClickToPayService implements IClickToPayService {
             );
         }
 
-        console.log(checkoutResponse);
-
         return createCheckoutPayloadBasedOnScheme(card, checkoutResponse);
     }
 
@@ -211,15 +209,11 @@ class ClickToPayService implements IClickToPayService {
         return new Promise((resolve, reject) => {
             const promises = this.sdks.map(sdk => {
                 const isRecognizedPromise = sdk.isRecognized();
-                isRecognizedPromise.then(response => response.recognized && resolve(response));
+                isRecognizedPromise.then(response => response.recognized && resolve(response)).catch(error => reject(error));
                 return isRecognizedPromise;
             });
 
-            Promise.all(promises)
-                .then(() => resolve({ recognized: false }))
-                .catch(error => {
-                    reject(error);
-                });
+            Promise.allSettled(promises).then(() => resolve({ recognized: false }));
         });
     }
 

--- a/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.ts
@@ -5,7 +5,6 @@ import { createCheckoutPayloadBasedOnScheme, createShopperCardsList } from './ut
 import { SrciIsRecognizedResponse, SrcInitParams } from './sdks/types';
 import { ClickToPayScheme } from '../../../types';
 import ShopperCard from '../models/ShopperCard';
-import SrciError from './sdks/SrciError';
 import AdyenCheckoutError from '../../../../../core/Errors/AdyenCheckoutError';
 
 export enum CtpState {
@@ -218,7 +217,9 @@ class ClickToPayService implements IClickToPayService {
 
             Promise.all(promises)
                 .then(() => resolve({ recognized: false }))
-                .catch(error => reject(error));
+                .catch(error => {
+                    reject(error);
+                });
         });
     }
 

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/MastercardSdk.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/MastercardSdk.ts
@@ -13,7 +13,7 @@ class MastercardSdk extends AbstractSrcInitiator {
     public readonly schemeName = 'mc';
 
     constructor(environment: string) {
-        super(environment.toLowerCase() === 'test' ? MC_SDK_TEST : MC_SDK_PROD);
+        super(environment.toLowerCase().includes('live') ? MC_SDK_PROD : MC_SDK_TEST);
     }
 
     protected isSdkIsAvailableOnWindow(): boolean {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/VisaSdk.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/VisaSdk.ts
@@ -13,7 +13,7 @@ class VisaSdk extends AbstractSrcInitiator {
     public readonly schemeName = 'visa';
 
     constructor(environment: string) {
-        super(environment.toLowerCase() === 'test' ? VISA_SDK_TEST : VISA_SDK_PROD);
+        super(environment.toLowerCase().includes('live') ? VISA_SDK_PROD : VISA_SDK_TEST);
     }
 
     protected isSdkIsAvailableOnWindow(): boolean {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
@@ -8,7 +8,7 @@ export interface IClickToPayService {
     shopperCards: ShopperCard[];
     shopperValidationContact: string;
     initialize(): Promise<void>;
-    checkout(card: ShopperCard): Promise<CheckoutPayload>;
+    checkout(card: ShopperCard): Promise<ClickToPayCheckoutPayload>;
     logout(): Promise<void>;
     verifyIfShopperIsEnrolled(value: string, type?: string): Promise<{ isEnrolled: boolean }>;
     subscribeOnStateChange(callback: CallbackStateSubscriber): void;
@@ -39,4 +39,4 @@ export interface SrcProfileWithScheme extends SrcProfile {
     scheme: ClickToPayScheme;
 }
 
-export type CheckoutPayload = VisaCheckout | MastercardCheckout;
+export type ClickToPayCheckoutPayload = VisaCheckout | MastercardCheckout;

--- a/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
@@ -24,15 +24,15 @@ export interface IdentityLookupParams {
 }
 
 type MastercardCheckout = {
-    digitalCardId: string;
-    correlationId: string;
-    scheme: string;
+    srcDigitalCardId: string;
+    srcCorrelationId: string;
+    srcScheme: string;
 };
 
 type VisaCheckout = {
-    tokenId?: string;
-    checkoutPayload?: string;
-    scheme: string;
+    srcCheckoutPayload?: string;
+    srcTokenReference?: string;
+    srcScheme: string;
 };
 
 export interface SrcProfileWithScheme extends SrcProfile {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
@@ -1,8 +1,8 @@
-import { CheckoutPayload, SrcProfileWithScheme } from './types';
+import { ClickToPayCheckoutPayload, SrcProfileWithScheme } from './types';
 import { SrciCheckoutResponse } from './sdks/types';
 import ShopperCard from '../models/ShopperCard';
 
-function createCheckoutPayloadBasedOnScheme(card: ShopperCard, checkoutResponse: SrciCheckoutResponse): CheckoutPayload {
+function createCheckoutPayloadBasedOnScheme(card: ShopperCard, checkoutResponse: SrciCheckoutResponse): ClickToPayCheckoutPayload {
     const { scheme, tokenId, srcDigitalCardId, srcCorrelationId } = card;
 
     switch (scheme) {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
@@ -7,10 +7,13 @@ function createCheckoutPayloadBasedOnScheme(card: ShopperCard, checkoutResponse:
 
     switch (scheme) {
         case 'visa':
-            return tokenId ? { scheme, tokenId } : { scheme, checkoutPayload: checkoutResponse.encryptedPayload };
+            // For testing, using hardcoded value for tokenId: 987654321
+            return tokenId
+                ? { srcScheme: scheme, srcTokenReference: '987654321' } //  TODO: srcTokenReference: tokenId
+                : { srcScheme: scheme, srcCheckoutPayload: checkoutResponse.encryptedPayload };
         case 'mc':
         default:
-            return { scheme, digitalCardId: srcDigitalCardId, correlationId: srcCorrelationId };
+            return { srcScheme: scheme, srcDigitalCardId, srcCorrelationId };
     }
 }
 

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -23,6 +23,8 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         this.handleAction = this.handleAction.bind(this);
         this.handleOrder = this.handleOrder.bind(this);
         this.handleResponse = this.handleResponse.bind(this);
+        this.setElementStatus = this.setElementStatus.bind(this);
+
         this.elementRef = (props && props.elementRef) || this;
     }
 
@@ -91,6 +93,11 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         return this;
     }
 
+    public setElementStatus(status: UIElementStatus, props?: any): this {
+        this.elementRef?.setStatus(status, props);
+        return this;
+    }
+
     public setStatus(status: UIElementStatus, props?): this {
         if (this.componentRef?.setStatus) {
             this.componentRef.setStatus(status, props);
@@ -99,6 +106,8 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     }
 
     private submitPayment(data): Promise<void> {
+        console.log(data);
+
         return this._parentInstance.session
             .submitPayment(data)
             .then(this.handleResponse)

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -48,7 +48,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         }
 
         if (this.props.setStatusAutomatically) {
-            this.elementRef.setStatus('loading');
+            this.setElementStatus('loading');
         }
 
         if (this.props.onSubmit) {
@@ -106,8 +106,6 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     }
 
     private submitPayment(data): Promise<void> {
-        console.log(data);
-
         return this._parentInstance.session
             .submitPayment(data)
             .then(this.handleResponse)
@@ -127,7 +125,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
          * - If Drop-in, will set status for Dropin component, and then it will propagate the new status for the active payment method component
          * - If Component, it will set its own status
          */
-        this.elementRef.setStatus('ready');
+        this.setElementStatus('ready');
 
         if (this.props.onError) {
             this.props.onError(error, this.elementRef);
@@ -175,7 +173,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     protected handleFinalResult = result => {
         if (this.props.setStatusAutomatically) {
             const [status, statusProps] = resolveFinalResult(result);
-            if (status) this.elementRef.setStatus(status, statusProps);
+            if (status) this.setElementStatus(status, statusProps);
         }
 
         if (this.props.onPaymentCompleted) this.props.onPaymentCompleted(result, this.elementRef);

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -4,7 +4,7 @@ import UIElement from './UIElement';
 import Core from '../core';
 import Analytics from '../core/Analytics';
 import RiskElement from '../core/RiskModule';
-import Session from "../core/CheckoutSession";
+import Session from '../core/CheckoutSession';
 
 export interface PaymentResponse {
     action?: PaymentAction;
@@ -34,6 +34,7 @@ export interface IUIElement {
     type: string;
     elementRef: any;
     submit(): void;
+    setElementStatus(status: UIElementStatus, props: any): UIElement;
     setStatus(status: UIElementStatus, props?: { message?: string; [key: string]: any }): UIElement;
     handleAction(action: PaymentAction): UIElement | null;
     showValidation(): void;

--- a/packages/lib/src/components/utils.ts
+++ b/packages/lib/src/components/utils.ts
@@ -1,4 +1,4 @@
-import { PaymentResponse, RawPaymentResponse } from './types';
+import {PaymentResponse, RawPaymentResponse, UIElementStatus} from './types';
 
 const ALLOWED_PROPERTIES = ['action', 'resultCode', 'sessionData', 'order'];
 
@@ -19,7 +19,7 @@ export function getSanitizedResponse(response: RawPaymentResponse): PaymentRespo
     return sanitizedObject as PaymentResponse;
 }
 
-export function resolveFinalResult(result: PaymentResponse) {
+export function resolveFinalResult(result: PaymentResponse): [status: UIElementStatus, statusProps?: any] {
     switch (result.resultCode) {
         case 'Authorised':
         case 'Received':

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -239,6 +239,7 @@
     "ctp.useAnotherCard": "Use a different card",
     "ctp.manualCardEntry": "Manual card entry",
 
+    "ctp.errors.AUTH_INVALID": "Authentication Invalid ",
     "ctp.errors.NOT_FOUND": "User not found",
     "ctp.errors.ID_FORMAT_UNSUPPORTED": "Format not supported",
     "ctp.errors.FRAUD": "The user account was locked or disabled",

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -157,7 +157,11 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                                 paymentOptions: {
                                     dynamicDataType: 'CARD_APPLICATION_CRYPTOGRAM_SHORT_FORM'
                                 },
-                                consumerNameRequested: true
+                                consumerNameRequested: true,
+                                customInputData: {
+                                    'com.mastercard.dcfExperience': 'PAYMENT_SETTINGS'
+                                },
+                                confirmPayment: false
                             }
                         },
                         visa: {

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -157,11 +157,11 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                                 paymentOptions: {
                                     dynamicDataType: 'CARD_APPLICATION_CRYPTOGRAM_SHORT_FORM'
                                 },
-                                consumerNameRequested: true,
-                                customInputData: {
-                                    'com.mastercard.dcfExperience': 'PAYMENT_SETTINGS'
-                                },
-                                confirmPayment: false
+                                consumerNameRequested: true
+                                // customInputData: {
+                                //     'com.mastercard.dcfExperience': 'PAYMENT_SETTINGS'
+                                // },
+                                // confirmPayment: false
                             }
                         },
                         visa: {

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -10,7 +10,7 @@ export async function initSession() {
         returnUrl,
         shopperLocale,
         shopperReference,
-        countryCode,
+        countryCode
     });
 
     const checkout = await AdyenCheckout({
@@ -46,9 +46,11 @@ export async function initSession() {
                     schemes: {
                         discovery: '',
                         visa: {
-                            srciTransactionId: 'adyen-id-' + new Date().getTime(),
                             srcInitiatorId: 'B9SECVKIQX2SOBQ6J9X721dVBBKHhJJl1nxxVbemHGn5oB6S8',
                             srciDpaId: '8e6e347c-254e-863f-0e6a-196bf2d9df02',
+
+                            srciTransactionId: 'adyen-id-' + new Date().getTime(),
+
                             dpaTransactionOptions: {
                                 dpaLocale: 'en_US',
                                 payloadTypeIndicator: 'NON_PAYMENT'
@@ -57,13 +59,19 @@ export async function initSession() {
                         mc: {
                             srcInitiatorId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1',
                             srciDpaId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1_dpa2',
+
                             srciTransactionId: 'adyen-id-' + new Date().getTime(),
+
                             dpaTransactionOptions: {
-                                dpaLocale: 'en_US',
+                                dpaLocale: 'pt_BR',
                                 paymentOptions: {
                                     dynamicDataType: 'CARD_APPLICATION_CRYPTOGRAM_SHORT_FORM'
                                 },
-                                consumerNameRequested: true
+                                consumerNameRequested: true,
+                                customInputData: {
+                                    'com.mastercard.dcfExperience': 'PAYMENT_SETTINGS'
+                                },
+                                confirmPayment: false
                             }
                         }
                     },

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -63,7 +63,7 @@ export async function initSession() {
                             srciTransactionId: 'adyen-id-' + new Date().getTime(),
 
                             dpaTransactionOptions: {
-                                dpaLocale: 'pt_BR',
+                                dpaLocale: 'en_US',
                                 paymentOptions: {
                                     dynamicDataType: 'CARD_APPLICATION_CRYPTOGRAM_SHORT_FORM'
                                 },


### PR DESCRIPTION
## Summary

This PR covers the payment flow doing `/payments` call using a Shopper card from CtP system.

PR highlights:
- Introduced the `setElementStatus` function in the `UIElement` . This function was created in order to allow a Preact component to set the status of the whole UIElement. 
  - In this specific scenario of this PR, when the Shopper starts the checkout flow within the `<CtPCards />` component, we need to trigger the 'loading' in the whole UiElement from the Preact component. 

- `Card.tsx` now has two components references: `this.componentRef` and `this.clickToPayRef`
  - `this.clickToPayRef` is introduced in order to make the `this.elementRef.setStatus` work for Card and Click to Pay - once the status is set to 'loading' for example (during a `this.submit` call) , the UiElement can properly set the status of the Preact components

## Tested scenarios
- Manual testing:
  - Selecting shopper card and clicking on Pay, triggering the `/payments` and receiving 'Authorized' as response

## Note
- This PR is part of the umbrella branch `feature/click-to-pay`, meaning that it is not the final PR.