### PR TITLE
Add support for installmentOptions for Sessions

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -50,7 +50,9 @@ export class CardElement extends UIElement<CardElementProps> {
                 collateErrors,
                 moveFocus,
                 showPanel
-            }
+            },
+            // installmentOptions of a session should be used before falling back to the merchant configuration
+            installmentOptions: props.session?.configuration?.installmentOptions || props.installmentOptions ,
         };
     }
 

--- a/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
+++ b/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
@@ -60,7 +60,13 @@ class Session {
      * Fetches data from a session
      */
     setupSession(options): Promise<CheckoutSessionSetupResponse> {
-        return setupSession(this, options);
+        return setupSession(this, options).then(response => {
+            if (response.configuration) {
+                this.configuration = { ...response.configuration };
+            }
+
+            return response;
+        });
     }
 
     /**

--- a/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
+++ b/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
@@ -12,6 +12,7 @@ import {
     CheckoutSessionOrdersResponse,
     CheckoutSessionPaymentResponse,
     CheckoutSessionSetupResponse,
+    SessionConfiguration,
 } from '../../types';
 import cancelOrder from '../Services/sessions/cancel-order';
 import {onOrderCancelData} from "../../components/Dropin/types";
@@ -21,6 +22,7 @@ class Session {
     private readonly storage: Storage;
     public readonly clientKey: string;
     public readonly loadingContext: string;
+    public configuration: SessionConfiguration;
 
     constructor(rawSession: CheckoutSession, clientKey: string, loadingContext: string) {
         const session = sanitizeSession(rawSession) as CheckoutSession;

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -42,6 +42,7 @@ class Core {
                 .setupSession(this.options)
                 .then(sessionResponse => {
                     const amount = this.options.order ? this.options.order.remainingAmount : sessionResponse.amount;
+                    this.session.configuration = sessionResponse.configuration
                     this.setOptions({ ...sessionResponse, amount });
                     return this;
                 })

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -42,7 +42,6 @@ class Core {
                 .setupSession(this.options)
                 .then(sessionResponse => {
                     const amount = this.options.order ? this.options.order.remainingAmount : sessionResponse.amount;
-                    this.session.configuration = sessionResponse.configuration
                     this.setOptions({ ...sessionResponse, amount });
                     return this;
                 })

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -1,7 +1,7 @@
 import paymentMethods from '../components';
 import { ADDRESS_SCHEMA } from '../components/internal/Address/constants';
 import actionTypes from '../core/ProcessResponse/PaymentAction/actionTypes';
-import {InstallmentOptions} from "../components/Card/components/CardInput/components/types";
+import { InstallmentOptions } from '../components/Card/components/CardInput/components/types';
 
 export type PaymentActionsType = keyof typeof actionTypes;
 

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -1,6 +1,7 @@
 import paymentMethods from '../components';
 import { ADDRESS_SCHEMA } from '../components/internal/Address/constants';
 import actionTypes from '../core/ProcessResponse/PaymentAction/actionTypes';
+import {InstallmentOptions} from "../components/Card/components/CardInput/components/types";
 
 export type PaymentActionsType = keyof typeof actionTypes;
 
@@ -263,6 +264,10 @@ export type CheckoutSession = {
     sessionData: string;
 };
 
+export type SessionConfiguration = {
+    installmentOptions: InstallmentOptions;
+}
+
 export type CheckoutSessionSetupResponse = {
     id: string;
     sessionData: string;
@@ -271,6 +276,7 @@ export type CheckoutSessionSetupResponse = {
     expiresAt: string;
     paymentMethods: any;
     returnUrl: string;
+    configuration: SessionConfiguration;
 };
 
 export type CheckoutSessionPaymentResponse = {


### PR DESCRIPTION
## Summary
This PR covers the handling of configuration.installmentOptions returned on the internal `/setup` call of `/sessions`. 

## Tested scenarios
- When installmentOptions are provided in the `/sessions` call, they are correctly shown on the card component.
- When installmentOptions are provided both in the config and the `/sessions` call, `/sessions` takes precedence. 
- When installmentOptions are provided only in the config, they are correctly shown on the card component.

**Fixed issue**: COWEB-1122
