### PR TITLE
Be more explicit in how we set a default securedFields type

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/initCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/initCSF.ts
@@ -13,12 +13,14 @@ const initCSF = (pSetupObj: CSFSetupObject): CSFReturnObject => {
 
     const setupObj: CSFSetupObject = { ...pSetupObj };
 
-    // Ensure there is always a default type
-    setupObj.type = setupObj.type || 'card';
-
-    // Map the generic types (i.e. 'card', 'scheme') to 'card'
-    const isGenericCardType: boolean = cardType.isGenericCardType(setupObj.type);
-    setupObj.type = isGenericCardType ? 'card' : setupObj.type;
+    try {
+        // Map the generic types (i.e. 'card', 'scheme') to 'card'
+        const isGenericCardType: boolean = cardType.isGenericCardType(setupObj.type);
+        setupObj.type = isGenericCardType ? 'card' : setupObj.type;
+    } catch (e) {
+        // If type has not been specified - ensure there is a default
+        setupObj.type = 'card';
+    }
 
     // //////// 1. Check passed config object has minimum expected properties //////////
     if (!hasOwnProperty(setupObj, 'rootNode')) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/initCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/initCSF.ts
@@ -13,7 +13,10 @@ const initCSF = (pSetupObj: CSFSetupObject): CSFReturnObject => {
 
     const setupObj: CSFSetupObject = { ...pSetupObj };
 
-    // Ensure there is always a default type & map the generic types (e.g. 'card', 'scheme') to 'card'
+    // Ensure there is always a default type
+    setupObj.type = setupObj.type || 'card';
+
+    // Map the generic types (i.e. 'card', 'scheme') to 'card'
     const isGenericCardType: boolean = cardType.isGenericCardType(setupObj.type);
     setupObj.type = isGenericCardType ? 'card' : setupObj.type;
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType-tests/cardType-otherFns.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType-tests/cardType-otherFns.test.ts
@@ -33,9 +33,11 @@ describe('Tests for cardType.getShortestPermittedCardLength & getCardByBrand fun
         expect(isGenericCardType).toBe(true);
     });
 
-    test('Should recognise undefined as being of "generic" type (since it is force to the default, "card")', () => {
-        const isGenericCardType = CardType.isGenericCardType();
-        expect(isGenericCardType).toBe(true);
+    test('Should throw error since a type argument has not been passed', () => {
+        expect(() => {
+            /* @ts-ignore */
+            CardType.isGenericCardType();
+        }).toThrow('Error: isGenericCardType type param has not been specified');
     });
 
     test('Should not recognise "visa" as being of "generic" type', () => {

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType-tests/cardType-otherFns.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType-tests/cardType-otherFns.test.ts
@@ -37,7 +37,7 @@ describe('Tests for cardType.getShortestPermittedCardLength & getCardByBrand fun
         expect(() => {
             /* @ts-ignore */
             CardType.isGenericCardType();
-        }).toThrow('Error: isGenericCardType type param has not been specified');
+        }).toThrow('Error: isGenericCardType: type param has not been specified');
     });
 
     test('Should not recognise "visa" as being of "generic" type', () => {

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType.ts
@@ -285,7 +285,7 @@ const getCardByBrand = pBrand => {
     return cardType[0];
 };
 
-const isGenericCardType = (type = 'card') => type === 'card' || type === 'scheme';
+const isGenericCardType = type => type === 'card' || type === 'scheme';
 
 export default {
     detectCard,

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType.ts
@@ -285,7 +285,10 @@ const getCardByBrand = pBrand => {
     return cardType[0];
 };
 
-const isGenericCardType = type => type === 'card' || type === 'scheme';
+const isGenericCardType = type => {
+    if (!type) throw new Error('Error: isGenericCardType: type param has not been specified');
+    return type === 'card' || type === 'scheme';
+};
 
 export default {
     detectCard,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A small change to be more explicit in how we set a default securedFields type if one has not been defined.
Previously it was being caught because we set a default value for a parameter on a util function - now we are being clearer as to our intentions

## Tested scenarios
All tests pass

