### PR TITLE
Passing type to binLookup

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
@@ -31,6 +31,7 @@ export default parent => {
                     path: `v3/bin/binLookup?token=${parent.props.clientKey}`
                 },
                 {
+                    type: parent.props.type,
                     supportedBrands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES,
                     encryptedBin: callbackObj.encryptedBin,
                     requestId: callbackObj.uuid // Pass id of request


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
To help with the move to sorting binLookup results on the backend rather than the front end this PR passes the card `'type'` prop to the `/binLookup` API so it can distinguish, for example, between the generic `'card'` version of the credit card and the specific `'bcmc'` version



**Relates to issue**:  DEV-45761
