### PR TITLE
Bancontact card resets internal CSF state when PAN is deleted

### DIFF
--- a/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.visa.test.js
@@ -144,3 +144,31 @@ test(
         await t.expect(dropinPage.getFromWindow('dropin.isValid')).eql(true);
     }
 );
+
+test(
+    '#6 Enter Visa card number ' +
+        'then delete it' +
+        'then re-add it' +
+        'and expect Visa logo to be shown a second time (showing CSF has reset state)',
+    async t => {
+        // Wait for field to appear in DOM
+        await dropinPage.cc.numSpan();
+
+        // Add Visa num (dual branded, but with Carte Bancaire, so only recognised as Visa)
+        await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+
+        // Expect Visa logo in number field
+        await t.expect(dropinPage.cc.brandingIcon.withAttribute('alt', 'visa').exists).ok();
+
+        await dropinPage.cc.cardUtils.deleteCardNumber(t);
+
+        // Expect BCMC logo in number field
+        await t.expect(dropinPage.cc.brandingIcon.withAttribute('alt', 'bcmc').exists).ok();
+
+        // Re-add Visa num
+        await dropinPage.cc.cardUtils.fillCardNumber(t, DUAL_BRANDED_CARD);
+
+        // Expect Visa logo in number field again
+        await t.expect(dropinPage.cc.brandingIcon.withAttribute('alt', 'visa').exists).ok();
+    }
+);

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
@@ -27,6 +27,7 @@ import { on, selectOne } from '../utilities/dom';
 import { partial } from '../utilities/commonUtils';
 import { hasOwnProperty } from '../../../../../utils/hasOwnProperty';
 import ua from './utils/userAgent';
+import { SingleBrandResetObject } from '../../SFP/types';
 
 const notConfiguredWarning = (str = 'You cannot use secured fields') => {
     logger.warn(`${str} - they are not yet configured. Use the 'onConfigSuccess' callback to know when this has happened.`);
@@ -214,11 +215,11 @@ class CSF extends AbstractCSF {
                     notConfiguredWarning('You cannot destroy secured fields');
                 }
             },
-            brandsFromBinLookup: (binLookupResponse: BinLookupResponse): void => {
+            brandsFromBinLookup: (binLookupResponse: BinLookupResponse, resetObj: SingleBrandResetObject): void => {
                 if (!this.config.isCreditCardType) return null;
 
                 if (this.state.isConfigured) {
-                    this.handleBrandFromBinLookup(binLookupResponse);
+                    this.handleBrandFromBinLookup(binLookupResponse, resetObj);
                 } else {
                     notConfiguredWarning('You cannot set pass brands to secured fields');
                 }

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -19,7 +19,8 @@ export const SF_VERSION = '4.1.0';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 
-export const NON_CREDIT_CARD_TYPE_SECURED_FIELDS = ['sepa', 'sepadirectdebit', 'ach', GIFT_CARD];
+// export const NON_CREDIT_CARD_TYPE_SECURED_FIELDS = ['ach', GIFT_CARD, 'sepa', 'sepadirectdebit']; //Maybe, sometime in the future
+export const NON_CREDIT_CARD_TYPE_SECURED_FIELDS = ['ach', GIFT_CARD];
 
 // Credit card (CardInput) related securedFields
 export const CREDIT_CARD_SF_FIELDS = [
@@ -32,11 +33,15 @@ export const CREDIT_CARD_SF_FIELDS = [
     // ENCRYPTED_PIN_FIELD,// probably redundant - it was an alt. name for KCP's encryptedPassword. But maybe has a role to play if we ever encrypt ibans.
 ];
 
-export const OTHER_SF_FIELDS = [ENCRYPTED_BANK_ACCNT_NUMBER_FIELD, ENCRYPTED_BANK_LOCATION_FIELD];
+export const OTHER_SF_FIELDS = [ENCRYPTED_BANK_ACCNT_NUMBER_FIELD, ENCRYPTED_BANK_LOCATION_FIELD]; // ACH fields
 
 export const ALL_SECURED_FIELDS = CREDIT_CARD_SF_FIELDS.concat(OTHER_SF_FIELDS);
 
 // export const ALL_RELATED_SECURED_FIELDS = ALL_SECURED_FIELDS.concat(NON_CREDIT_CARD_TYPE_SECURED_FIELDS);
+
+// Card components created as: checkout.create({BRAND}) e.g. checkout.create('bcmc')
+// - which are dedicated to a single, core, brand e.g. 'bcmc' BUT which can in effect handle multiple brands e.g. "bcmc", "maestro", "visa"
+export const DEDICATED_CARD_COMPONENTS = ['bcmc'];
 
 export const REQUIRED = 'required';
 export const OPTIONAL = 'optional';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The Bancontact card component wasn't resetting its internal state when one of the other card numbers this component supports, e.g. maestro, was entered and then deleted.
Although the UI reset, and the BCMC logo was shown again, internally the component stayed as "maestro" - so when _re-entering_ a maestro number nothing was seen to have changed and the UI didn't reflect the  maestro "state" second time round

## Tested scenarios
All tests pass.
New e2e test added for this specific scenario

