### PR TITLE
Adds new callback and method to fix giftcard without submit button

### DIFF
--- a/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
+++ b/packages/e2e/app/src/pages/GiftCardsSessions/GiftCardsSessions.js
@@ -39,6 +39,9 @@ const initCheckout = async () => {
             brand: 'valuelink',
             onOrderCreated: (data) => {
                 window.onOrderCreatedTestData = data;
+            },
+            onRequiringConfirmation: () => {
+                window.onRequiringConfirmationTestData = true;
             }
         })
         .mount('.card-field');

--- a/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.mocks.js
+++ b/packages/e2e/tests/giftcards/onOrderCreated/onOrderCreated.mocks.js
@@ -94,7 +94,8 @@ const noCallbackPaymentResponse = {
 const loggers = {
     setupLogger: RequestLogger({ url: setupUrl, method: 'post' }, { logRequestBody: true }),
     balanceLogger: RequestLogger({ url: balanceUrl, method: 'post' }, { logRequestBody: true }),
-    ordersLogger: RequestLogger({ url: ordersUrl, method: 'post' }, { logRequestBody: true })
+    ordersLogger: RequestLogger({ url: ordersUrl, method: 'post' }, { logRequestBody: true }),
+    paymentLogger: RequestLogger({ url: paymentsUrl, method: 'post' }, { logRequestBody: true })
 };
 
 const mock = RequestMock()

--- a/packages/e2e/tests/giftcards/onRequiringConfirmation/onRequiringConfirmation.clientScripts.js
+++ b/packages/e2e/tests/giftcards/onRequiringConfirmation/onRequiringConfirmation.clientScripts.js
@@ -1,0 +1,13 @@
+window.mainConfiguration = {
+    allowPaymentMethods: ['giftcard'],
+    paymentMethodsConfiguration: {
+        giftcard: {
+            brandsConfiguration: {
+                genericgiftcard: {
+                    icon: 'https://checkoutshopper-test.adyen.com/checkoutshopper/images/logos/mc.svg',
+                    name: 'Gifty mcGiftface'
+                }
+            }
+        }
+    }
+};

--- a/packages/e2e/tests/giftcards/onRequiringConfirmation/onRequiringConfirmation.mocks.js
+++ b/packages/e2e/tests/giftcards/onRequiringConfirmation/onRequiringConfirmation.mocks.js
@@ -1,0 +1,28 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import { BASE_URL } from '../../pages';
+
+import { mock, loggers } from '../onOrderCreated/onOrderCreated.mocks';
+
+const path = require('path');
+require('dotenv').config({ path: path.resolve('../../', '.env') });
+
+const MOCK_SESSION_ID = 'CS616D08FC28573F9C';
+const MOCK_SESSION_DATA = 'Ab02b4c0!BQABAgChW9EQ6U';
+
+const balanceUrl = `https://checkoutshopper-test.adyen.com/checkoutshopper/v1/sessions/${MOCK_SESSION_ID}/paymentMethodBalance?clientKey=${process.env.CLIENT_KEY}`;
+
+const balanceResponse = {
+    balance: {
+        currency: 'USD',
+        value: 1000000
+    },
+    sessionData: MOCK_SESSION_DATA
+};
+
+const balanceMock = RequestMock()
+    .onRequestTo(request => request.url === balanceUrl && request.method === 'post')
+    .respond(balanceResponse, 200, {
+        'Access-Control-Allow-Origin': BASE_URL
+    });
+
+export { mock, balanceMock, loggers, MOCK_SESSION_DATA };

--- a/packages/e2e/tests/giftcards/onRequiringConfirmation/onRequiringConfirmation.test.js
+++ b/packages/e2e/tests/giftcards/onRequiringConfirmation/onRequiringConfirmation.test.js
@@ -1,0 +1,47 @@
+import { ClientFunction } from 'testcafe';
+
+import { fillIFrame, getInputSelector } from '../../utils/commonUtils';
+import { GIFTCARD_NUMBER, GIFTCARD_PIN } from '../utils/constants';
+import { GIFTCARDS_SESSIONS_URL } from '../../pages';
+import {mock, loggers, MOCK_SESSION_DATA, balanceMock} from './onRequiringConfirmation.mocks';
+
+import { GiftCardSessionPage } from '../../_models/GiftCardComponent.page';
+
+const giftCard = new GiftCardSessionPage();
+const { balanceLogger, ordersLogger, paymentLogger } = loggers;
+
+const getCallBackData = ClientFunction(() => window.onRequiringConfirmationTestData);
+
+// only setup the loggers for the endpoints so we can setup different responses for different scenarios
+fixture`Testing gift cards`.page(GIFTCARDS_SESSIONS_URL).requestHooks([balanceLogger, ordersLogger, paymentLogger]);
+
+// set up request hooks for different scenarios
+test.requestHooks([balanceMock, mock])('Test if onRequiringConfirmation is retrieved on success', async t => {
+
+    await giftCard.pmHolder();
+    await giftCard.cardUtils.fillCardNumber(t, GIFTCARD_NUMBER);
+    await fillIFrame(t, giftCard.iframeSelector, 1, getInputSelector('encryptedSecurityCode'), GIFTCARD_PIN);
+
+    // first step, request confirmation (.balanceCheck())
+    await t
+        .click(giftCard.payButton)
+        .expect(balanceLogger.count(() => true))
+        .eql(1)
+        .expect(
+            balanceLogger.contains(record => {
+                const { sessionData } = JSON.parse(record.request.body);
+                return sessionData === MOCK_SESSION_DATA;
+            })
+        )
+        .ok()
+        .expect(ordersLogger.count(() => true))
+        .eql(0)
+        .expect(getCallBackData())
+        .ok();
+
+    // second step, make payment (.submit())
+    await t
+        .click(giftCard.payButton)
+        .expect(paymentLogger.count(() => true))
+        .eql(1)
+});

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -81,6 +81,11 @@ export class GiftcardElement extends UIElement {
         }
     };
 
+    public balanceCheck() {
+        return this.onBalanceCheck();
+    }
+
+
     public onBalanceCheck = () => {
         // skip balance check if no onBalanceCheck event has been defined
         const hasBalanceCheck = this.props.session || this.props.onBalanceCheck;
@@ -110,6 +115,11 @@ export class GiftcardElement extends UIElement {
                         this.setState({ order: { orderData: order.orderData, pspReference: order.pspReference } });
                         this.submit();
                     });
+                }
+                else {
+                    if (this.props.onRequiringConfirmation) {
+                        this.props.onRequiringConfirmation();
+                    }
                 }
             })
             .catch(error => {

--- a/packages/playground/src/pages/GiftCards/GiftCards.html
+++ b/packages/playground/src/pages/GiftCards/GiftCards.html
@@ -1,131 +1,136 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge" />
-        <title>Adyen Web | Gift Cards</title>
-        <meta name="description" content="" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    </head>
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <title>Adyen Web | Gift Cards</title>
+    <meta name="description" content=""/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+</head>
 
-    <body class="giftcard-demo">
-        <header></header>
-        <main>
-            <div class="merchant-checkout__form">
-                <div class="merchant-checkout__payment-method">
-                    <div class="merchant-checkout__payment-method__header">
-                        <h2>Giftcard</h2>
-                    </div>
-                    <div class="merchant-checkout__payment-method__details">
-                        <div id="genericgiftcard-container"></div>
-                    </div>
-                </div>
+<body class="giftcard-demo">
+<header></header>
+<main>
+    <div class="merchant-checkout__form">
+        <div class="merchant-checkout__payment-method">
+            <div class="merchant-checkout__payment-method__header">
+                <h2>Giftcard</h2>
             </div>
-
-            <div class="merchant-checkout__form">
-                <div class="merchant-checkout__payment-method">
-                    <div class="merchant-checkout__payment-method__header">
-                        <h2>Mealvoucher</h2>
-                    </div>
-                    <div class="merchant-checkout__payment-method__details">
-                        <div id="mealvoucher-fr-container"></div>
-                    </div>
-                </div>
+            <div class="merchant-checkout__payment-method__details">
+                <div id="genericgiftcard-container"></div>
             </div>
+        </div>
+    </div>
 
-            <div class="merchant-checkout__form">
-                <div class="merchant-checkout__payment-method">
-                    <div class="merchant-checkout__payment-method__header">
-                        <h2>Gift Card Component (w/ Sessions)</h2>
-                    </div>
-                    <div class="merchant-checkout__payment-method__details">
-                        <div id="giftcard-session-container"></div>
-                    </div>
-                    <div class="merchant-checkout__payment-method__details">
-                        <div id="payment-method-container"></div>
-                    </div>
-                </div>
+    <div class="merchant-checkout__form">
+        <div class="merchant-checkout__payment-method">
+            <div class="merchant-checkout__payment-method__header">
+                <h2>Mealvoucher</h2>
             </div>
-
-            <div class="info">
-                <table>
-                    <caption>
-                        Test gift cards
-                    </caption>
-                    <thead>
-                        <tr>
-                            <th scope="col">Card Type</th>
-                            <th scope="col">Card Number</th>
-                            <th scope="col">PIN</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>Gall & Gall Card</td>
-                            <td>60643650100000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>Baby Gift Card</td>
-                            <td>60643622000000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>Gift Card</td>
-                            <td>62805011000000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>Kado Wereld</td>
-                            <td>60643625100000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>Entertainment Card</td>
-                            <td>60643611000000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>Plastix</td>
-                            <td>4010100000000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>Webshop Giftcard</td>
-                            <td>60643620700000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>Leasure Giftcard</td>
-                            <td>60643622800000000000</td>
-                            <td>73737</td>
-                        </tr>
-                        <tr>
-                            <td>VVV Giftcard</td>
-                            <td>6064364240000000000</td>
-                            <td>737373</td>
-                        </tr>
-                        <tr>
-                            <td>GiftForYou (Bloemen)</td>
-                            <td>60643647103300000000</td>
-                            <td>737373</td>
-                        </tr>
-                    </tbody>
-                </table>
-
-                <p>
-                    <a
-                        href="https://docs.adyen.com/development-resources/test-cards/test-card-numbers#gift-cards"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        More information →
-                    </a>
-                </p>
+            <div class="merchant-checkout__payment-method__details">
+                <div id="mealvoucher-fr-container"></div>
             </div>
-        </main>
-        <script type="text/javascript">
-            window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' %>;
-        </script>
-    </body>
+        </div>
+    </div>
+
+    <div class="merchant-checkout__form">
+        <div class="merchant-checkout__payment-method">
+            <div class="merchant-checkout__payment-method__header">
+                <h2>Gift Card Component (w/ Sessions)</h2>
+            </div>
+            <div class="merchant-checkout__payment-method__details">
+                <div id="giftcard-session-container"></div>
+            </div>
+            <div class="merchant-checkout__payment-method__details">
+                <div id="payment-method-container"></div>
+            </div>
+            <div class="merchant-checkout__payment-method__details">
+                <button class="adyen-checkout__button adyen-checkout__button--pay" id="custom-checkout-button">Custom
+                    Checkout Button
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="info">
+        <table>
+            <caption>
+                Test gift cards
+            </caption>
+            <thead>
+            <tr>
+                <th scope="col">Card Type</th>
+                <th scope="col">Card Number</th>
+                <th scope="col">PIN</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>Gall & Gall Card</td>
+                <td>60643650100000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>Baby Gift Card</td>
+                <td>60643622000000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>Gift Card</td>
+                <td>62805011000000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>Kado Wereld</td>
+                <td>60643625100000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>Entertainment Card</td>
+                <td>60643611000000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>Plastix</td>
+                <td>4010100000000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>Webshop Giftcard</td>
+                <td>60643620700000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>Leasure Giftcard</td>
+                <td>60643622800000000000</td>
+                <td>73737</td>
+            </tr>
+            <tr>
+                <td>VVV Giftcard</td>
+                <td>6064364240000000000</td>
+                <td>737373</td>
+            </tr>
+            <tr>
+                <td>GiftForYou (Bloemen)</td>
+                <td>60643647103300000000</td>
+                <td>737373</td>
+            </tr>
+            </tbody>
+        </table>
+
+        <p>
+            <a
+                    href="https://docs.adyen.com/development-resources/test-cards/test-card-numbers#gift-cards"
+                    target="_blank"
+                    rel="noopener noreferrer"
+            >
+                More information →
+            </a>
+        </p>
+    </div>
+</main>
+<script type="text/javascript">
+    window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' % >;
+</script>
+</body>
 </html>

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -74,14 +74,14 @@ import '../../style.scss';
 
     const checkoutButton = document.querySelector('#custom-checkout-button');
 
-    const checkBalance = () => window.giftcard.balanceCheck();
+    const giftcardCheckBalance = () => window.giftcard.balanceCheck();
     const giftcardSubmit = () => window.giftcard.submit();
     const cardSubmit = () => window.card.submit();
 
-    checkoutButton.addEventListener('click', checkBalance);
+    checkoutButton.addEventListener('click', giftcardCheckBalance);
 
     const setupGiftCardSubmit = () => {
-        checkoutButton.removeEventListener('click', checkBalance);
+        checkoutButton.removeEventListener('click', giftcardCheckBalance);
         checkoutButton.addEventListener('click', giftcardSubmit);
     };
     const setupCardSubmit = () => {

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -58,7 +58,7 @@ import '../../style.scss';
         environment: process.env.__CLIENT_ENV__,
         clientKey: process.env.__CLIENT_KEY__,
         session,
-        showPayButton: true,
+        showPayButton: false,
 
         // Events
         beforeSubmit: (data, component, actions) => {
@@ -72,18 +72,41 @@ import '../../style.scss';
         }
     });
 
+    const checkoutButton = document.querySelector('#custom-checkout-button');
+
+    const checkBalance = () => window.giftcard.balanceCheck();
+    const giftcardSubmit = () => window.giftcard.submit();
+    const cardSubmit = () => window.card.submit();
+
+    checkoutButton.addEventListener('click', checkBalance);
+
+    const setupGiftCardSubmit = () => {
+        checkoutButton.removeEventListener('click', checkBalance);
+        checkoutButton.addEventListener('click', giftcardSubmit);
+    };
+    const setupCardSubmit = () => {
+        checkoutButton.removeEventListener('click', setupGiftCardSubmit);
+        checkoutButton.addEventListener('click', cardSubmit);
+    };
+
     window.giftcard = sessionCheckout
         .create('giftcard', {
             type: 'giftcard',
             brand: 'svs',
-            onOrderCreated: (data) => {
-                afterGiftCard(data);
+            onSubmit: () => {
+                afterGiftCard();
+            },
+            onOrderCreated: () => {
+                afterGiftCard();
+            },
+            onRequiringConfirmation: () => {
+                setupGiftCardSubmit();
             }
         })
         .mount('#giftcard-session-container');
 
-
-    const afterGiftCard = (order) => {
-        sessionCheckout.create('card').mount('#payment-method-container');
-    }
+    const afterGiftCard = () => {
+        window.card = sessionCheckout.create('card').mount('#payment-method-container');
+        setupCardSubmit();
+    };
 })();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

The motivation for this PR is to enable the session gift card flow when using a custom submit button (`showPayButton: false`). 

The problem with current setup is that merchants don't have feedback and a gift card can fulfil the total amount in the checkout, and since this is usually managed by the submit button present in GC component a new mechanism needs to be implemented.

### Solution:

Introduced a new callback `onRequiringConfirmation` was added this callback is triggered to provide inform that the gif card can be used for the total payment amount, and confirmation should be given.

This confirmation can be done by using `.submit()` method. This will trigger the payment call with the current gift card.

Also it was exposed the `.balanceCheck()` method. The merchant needs to use this to check if a gift card is valid and in turn start the gif card flow. 
This flow can result in one of 3 results `onOrderCreated` is called if an additional payment method is required to complete the checkout. `onRequiringConfirmation` is trigger to confirm that the payment should be done using only the gift card. Or finally an error, if the gift card has no balance or the request failed.

## Tested scenarios
<!-- Description of tested scenarios -->

Manual testing:
- All there above scenarios where tested in the playground
E2E:
- Implemented E2E to check if onRequiringConfirmation was triggered, and order was not created

**Fixed issue**:  <!-- #-prefixed issue number -->
