### PR TITLE
UPI - Fix for uncaught exception after timeout

### DIFF
--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -37,7 +37,7 @@ class UPI extends UIElement {
     }
 
     public setStatus(status: UIElementStatus): this {
-        this.componentRef?.setStatus(status, this.state.data.isQrCodeFlow);
+        this.componentRef?.setStatus?.(status, this.state.data?.isQrCodeFlow);
         return this;
     }
 
@@ -69,9 +69,9 @@ class UPI extends UIElement {
                         ref={ref => {
                             this.componentRef = ref;
                         }}
+                        onError={this.props.onError}
                         clientKey={this.props.clientKey}
                         paymentData={this.props.paymentData}
-                        onError={this.handleError}
                         onComplete={this.onComplete}
                         brandLogo={this.icon}
                         type={UPI_COLLECT}

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -17,7 +17,7 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         onSubmit: handleSubmit,
         onAdditionalDetails: handleAdditionalDetails,
         onError: (error, component) => {
-            console.log(error, component);
+            console.info(error, component);
         },
         showPayButton: true
     });

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -16,7 +16,9 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         //        onChange: handleChange,
         onSubmit: handleSubmit,
         onAdditionalDetails: handleAdditionalDetails,
-        onError: console.error,
+        onError: (error, component) => {
+            console.log(error, component);
+        },
         showPayButton: true
     });
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -59,7 +59,7 @@ export async function initManual() {
             checkout.update({ paymentMethodsResponse: await getPaymentMethods({ amount, shopperLocale }), order: null, amount });
         },
         onError: (error, component) => {
-            console.error(error.name, error.message, error.stack, component);
+            console.info(error.name, error.message, error.stack, component);
         },
         paymentMethodsConfiguration: {
             card: {

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -26,7 +26,7 @@ export async function initSession() {
             console.info(result, component);
         },
         onError: (error, component) => {
-            console.error(error.message, component);
+            console.info(error, component);
         },
         paymentMethodsConfiguration: {
             paywithgoogle: {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`onError` callback wasn't being triggered UPI payment method when used as Component. This happened only for the Collect flow, when the shopper needs to input the VPA.

*Fix:*  Adjusted Await component to use the same error callback as the QRLoader

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**: COWEB-1335