### PR TITLE
Boost sf version to v4.1.1 (fixes issue #1634)

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '4.1.0';
+export const SF_VERSION = '4.1.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Boost sf version to v4.1.1 - fixes issue whereby you could still enter a 4 digit cvc even when Amex is not a supported brand

## Tested scenarios
All tests pass


**Fixed issue**:  #1634