### PR TITLE
Add proper typing for `AdyenCheckout` function

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -9,7 +9,7 @@ import { CoreOptions } from 'src/core/types';
 import Checkout from './core';
 /* eslint-enable */
 
-async function AdyenCheckout(props: CoreOptions) {
+async function AdyenCheckout(props: CoreOptions): Promise<Checkout> {
     const checkout = new Checkout(props);
     return await checkout.initialize();
 }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -5,10 +5,11 @@ if (process.env.NODE_ENV === 'development') {
     // require('preact/debug');
 }
 
+import { CoreOptions } from 'src/core/types';
 import Checkout from './core';
 /* eslint-enable */
 
-async function AdyenCheckout(props) {
+async function AdyenCheckout(props: CoreOptions) {
     const checkout = new Checkout(props);
     return await checkout.initialize();
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

We are in the process of upgrading from `3.23.0` to `5.21.0` and were a bit surprised that there was no more typing when creating the `AdyenCheckout` object. 

Adding the typing to the function makes it easier to see what  options are actually available.

## Tested scenarios

