### PR TITLE
Create securedFields sequentially not simultaneously

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/AbstractCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/AbstractCSF.ts
@@ -14,8 +14,8 @@ abstract class AbstractCSF {
     protected handleBrandFromBinLookup: typeof handleBrandFromBinLookup;
     protected callbacksHandler: (callbacksObj: object) => void;
     protected configHandler: () => void;
-    protected createCardSecuredFields: (securedFields: HTMLElement[]) => number;
-    protected createNonCardSecuredFields: (securedFields: HTMLElement[]) => number;
+    protected createCardSecuredFields: (securedFields: HTMLElement[]) => Promise<any>;
+    protected createNonCardSecuredFields: (securedFields: HTMLElement[]) => Promise<any>;
     protected createSecuredFields: typeof createSecuredFields;
     protected destroySecuredFields: () => void;
     protected handleIOSTouchEvents: () => void;

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/handleIframeConfigFeedback.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/handleIframeConfigFeedback.ts
@@ -13,34 +13,21 @@ import { CbObjOnAdditionalSF } from '../../types';
 export function handleIframeConfigFeedback({ csfState, csfCallbacks }, isConfigured, pFeedbackObj): boolean {
     csfState.iframeConfigCount += 1;
 
-    if (!csfState.isConfigured) {
-        if (process.env.NODE_ENV === 'development' && window._b$dl) {
-            console.log('\n### handleIframeConfigFeedback:: csfState.type=', csfState.type);
-            console.log('### handleIframeConfigFeedback:: pFeedbackObj=', pFeedbackObj);
-            console.log('### handleIframeConfigFeedback:: csfState.iframeConfigCount=', csfState.iframeConfigCount);
-            console.log('### handleIframeConfigFeedback:: csfState.originalNumIframes=', csfState.originalNumIframes);
-        }
+    if (window._b$dl)
+        console.log('### handleIframeConfigFeedback::csfState.iframeConfigCount:: ', csfState.iframeConfigCount, 'who=', pFeedbackObj.fieldType);
 
+    if (!csfState.isConfigured) {
         if (csfState.iframeConfigCount === csfState.originalNumIframes) {
             if (process.env.NODE_ENV === 'development' && window._b$dl) {
                 console.log('\n### handleIframeConfigFeedback::handleIframeConfigFeedback:: ALL IFRAMES CONFIG DO CALLBACK type=', csfState.type);
             }
 
             // Announce we're configured to the rest of the system
-            // this.isConfigured();
             isConfigured();
 
             return true;
         }
     } else {
-        if (process.env.NODE_ENV === 'development' && window._b$dl) {
-            console.log('### handleIframeConfigFeedback:: State is already configured so MUST BE ADDING IFRAMES');
-            console.log('### handleIframeConfigFeedback:: csfState.iframeConfigCount=', csfState.iframeConfigCount);
-            console.log('### handleIframeConfigFeedback:: csfState.originalNumIframes=', csfState.originalNumIframes);
-            console.log('### handleIframeConfigFeedback:: current csfState.numIframes=', csfState.numIframes);
-            console.log('### handleIframeConfigFeedback:: pFeedbackObj=', pFeedbackObj);
-        }
-
         const callbackObj: CbObjOnAdditionalSF = { additionalIframeConfigured: true, fieldType: pFeedbackObj.fieldType, type: csfState.type };
         csfCallbacks.onAdditionalSFConfig(callbackObj);
     }

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
@@ -111,10 +111,6 @@ class SecuredField extends AbstractSecuredField {
     }
 
     iframeOnLoadListenerFn(): void {
-        if (process.env.NODE_ENV === 'development' && window._b$dl) {
-            logger.log('\n### SecuredField:::: onIframeLoaded:: this type=', this.config.txVariant);
-        }
-
         off(window, 'load', this.iframeOnLoadListener, false);
 
         // Create reference to bound fn (see getters/setters for binding)
@@ -145,9 +141,7 @@ class SecuredField extends AbstractSecuredField {
             isCollatingErrors: this.config.isCollatingErrors
         };
 
-        if (process.env.NODE_ENV === 'development' && window._b$dl) {
-            logger.log('### SecuredField:::: onIframeLoaded:: created configObj=', configObj);
-        }
+        if (window._b$dl) console.log('### SecuredField:::: onIframeLoaded:: created configObj=', configObj);
 
         postMessageToIframe(configObj, this.iframeContentWindow, this.loadingContext);
         //--
@@ -238,6 +232,8 @@ class SecuredField extends AbstractSecuredField {
                 break;
 
             case 'config':
+                if (window._b$dl)
+                    console.log('### SecuredField::postMessageListenerFn:: configured - calling onConfigCallback', feedbackObj.fieldType);
                 this.onConfigCallback(feedbackObj);
                 break;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We now create the securedFields in sequence rather than trying to create them all at the same time.

This seems to mitigate against the "iframe interruption bug" whereby if _something_ interrupts the loading of an iframe then the listener we have for its `load` event never fires; which means the iframe never configures.

## Tested scenarios
Tested by adding a breakpoint to the line where we declare the `setupSecuredField` function in `createSecuredFields.ts`
With the old, simultaneous creation, solution this re-created the error and some of the iframes never configured.
With the new, sequential creation, solution this no longer happens and everything configures.

Also all unit & e2e test still pass
