### PR TITLE
Import from relative path instead of src/ dir for AdyenCheckout's Cor…

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -5,7 +5,7 @@ if (process.env.NODE_ENV === 'development') {
     // require('preact/debug');
 }
 
-import { CoreOptions } from 'src/core/types';
+import { CoreOptions } from './core/types';
 import Checkout from './core';
 /* eslint-enable */
 


### PR DESCRIPTION
…eOptions parameter

This import breaks when creating a dist/ version for typescript.
Instead, import as a relative path like is done for the Checkout itself.

fixes https://github.com/Adyen/adyen-web/issues/1697 