### PR TITLE
Fix absolute path breaking stuff in typescript

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -5,7 +5,7 @@ if (process.env.NODE_ENV === 'development') {
     // require('preact/debug');
 }
 
-import { CoreOptions } from 'src/core/types';
+import { CoreOptions } from './core/types';
 import Checkout from './core';
 /* eslint-enable */
 


### PR DESCRIPTION
## Summary
the following commit breaks stuff in typescript:
https://github.com/Adyen/adyen-web/commit/c5ecf2d10c4f282d071c0df2849abd8d2e624cd3

```
Error: node_modules/@adyen/adyen-web/dist/types/index.d.ts:1:29 - error TS2307: Cannot find module 'src/core/types' or its corresponding type declarations.

1 import { CoreOptions } from 'src/core/types';

```

steps to reproduce:
follow the steps in: https://angular.io/guide/setup-local
till you can do the `yarn ng server --open`

then `yarn add @adyen/adyen-web`
then add `import AdyenCheckout from '@adyen/adyen-web';` to  `main.ts` and things break

the released version code of that file looked a little different then this file but changes 
```
import { CoreOptions } from 'src/core/types';
import Checkout from './core';
declare function AdyenCheckout(props: CoreOptions): Promise<Checkout>;
export default AdyenCheckout;
```
to
```
import Checkout from './core';
import {CoreOptions} from './core/types';
declare function AdyenCheckout(props: CoreOptions): Promise<Checkout>;
export default AdyenCheckout;
```
made the errors go away and my IDE (phpstorm) happy


i did no further tests
