### PR TITLE
Connecting email validation to fields

### DIFF
--- a/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
+++ b/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
@@ -5,6 +5,7 @@ import SendCopyToEmail from '../../../internal/SendCopyToEmail/SendCopyToEmail';
 import { useEffect, useState } from 'preact/hooks';
 import useForm from '../../../../utils/useForm';
 import { BankTransferSchema } from '../../types';
+import { personalDetailsValidationRules } from '../../../internal/PersonalDetails/validate';
 
 function BankTransferInput(props) {
     const { i18n } = useCoreContext();
@@ -12,7 +13,10 @@ function BankTransferInput(props) {
 
     const { handleChangeFor, triggerValidation, data, valid, errors, isValid, setSchema } = useForm<BankTransferSchema>({
         schema: [],
-        defaultData: props.data
+        defaultData: props.data,
+        rules: {
+            shopperEmail: personalDetailsValidationRules.shopperEmail
+        }
     });
 
     const toggleEmailField = () => setShowingEmail(!showingEmail);
@@ -26,6 +30,8 @@ function BankTransferInput(props) {
 
     useEffect(() => {
         props.onChange({ data, errors, valid, isValid });
+        console.log('### BankTransferInput::data:: ', data);
+        console.log('### BankTransferInput::errors:: ', errors);
     }, [data, valid, errors, showingEmail, isValid]);
 
     return (

--- a/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
+++ b/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
@@ -30,8 +30,6 @@ function BankTransferInput(props) {
 
     useEffect(() => {
         props.onChange({ data, errors, valid, isValid });
-        console.log('### BankTransferInput::data:: ', data);
-        console.log('### BankTransferInput::errors:: ', errors);
     }, [data, valid, errors, showingEmail, isValid]);
 
     return (

--- a/packages/lib/src/components/Boleto/components/BoletoInput/validate.ts
+++ b/packages/lib/src/components/Boleto/components/BoletoInput/validate.ts
@@ -1,11 +1,14 @@
 import { ValidatorRules } from '../../../../utils/Validator/types';
 import validateSSN from '../../../internal/SocialSecurityNumberBrazil/validate';
+import { personalDetailsValidationRules } from '../../../internal/PersonalDetails/validate';
+
 export const boletoValidationRules: ValidatorRules = {
     socialSecurityNumber: {
         validate: validateSSN,
         errorMessage: '',
         modes: ['blur']
     },
+    shopperEmail: personalDetailsValidationRules.shopperEmail,
     default: {
         validate: value => !!value && value.length > 0,
         errorMessage: '',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The shopper email fields in the `BankTransfer` & `Boleto` components were not validating.
This PR connects those fields to the same email validation rule as used in the `PersonalDetails` component

## Tested scenarios
Fields now validate using a email regEx
All tests pass
