### PR TITLE
Pay button shows Croatian kuna and converted EUR amount

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -52,7 +52,7 @@ export class CardElement extends UIElement<CardElementProps> {
                 showPanel
             },
             // installmentOptions of a session should be used before falling back to the merchant configuration
-            installmentOptions: props.session?.configuration?.installmentOptions || props.installmentOptions ,
+            installmentOptions: props.session?.configuration?.installmentOptions || props.installmentOptions
         };
     }
 

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -235,7 +235,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
      * Get the payButton component for the current element
      */
     protected payButton = (props: PayButtonFunctionProps) => {
-        return <PayButton {...props} amount={this.props.amount} onClick={this.submit} />;
+        return <PayButton {...props} amount={this.props.amount} secondaryAmount={this.props.secondaryAmount} onClick={this.submit} />;
     };
 }
 

--- a/packages/lib/src/components/internal/Button/Button.scss
+++ b/packages/lib/src/components/internal/Button/Button.scss
@@ -55,6 +55,8 @@
         &:disabled {
             opacity: 1;
         }
+        display: flex;
+        justify-content: center;
     }
 
     &.adyen-checkout__button--standalone {
@@ -189,11 +191,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-
-        &--secondary{
-            margin-left: 5px;
-            font-size: 0.85em;
-        }
     }
 
     .adyen-checkout__spinner {

--- a/packages/lib/src/components/internal/Button/Button.scss
+++ b/packages/lib/src/components/internal/Button/Button.scss
@@ -189,6 +189,11 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+
+        &--secondary{
+            margin-left: 5px;
+            font-size: 0.85em;
+        }
     }
 
     .adyen-checkout__spinner {

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, Component, ComponentChild, h, toChildArray, VNode } from 'preact';
+import { Component, h } from 'preact';
 import classNames from 'classnames';
 import Spinner from '../Spinner';
 import useCoreContext from '../../../core/Context/useCoreContext';

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -31,7 +31,7 @@ class Button extends Component<ButtonProps, ButtonState> {
         }, delay);
     };
 
-    render({ classNameModifiers = [], disabled, href, icon, inline, label, status, variant }, { completed }) {
+    render({ classNameModifiers = [], disabled, href, icon, inline, label, secondaryLabel, status, variant }, { completed }) {
         const { i18n } = useCoreContext();
 
         const buttonIcon = icon ? <img className="adyen-checkout__button__icon" src={icon} alt="" aria-hidden="true" /> : '';
@@ -58,6 +58,7 @@ class Button extends Component<ButtonProps, ButtonState> {
                 <span className="adyen-checkout__button__content">
                     {buttonIcon}
                     <span className="adyen-checkout__button__text">{label}</span>
+                    {secondaryLabel && <span className="adyen-checkout__button__text adyen-checkout__button__text--secondary">{secondaryLabel}</span>}
                 </span>
             )
         };

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from 'preact';
+import { cloneElement, Component, ComponentChild, h, toChildArray, VNode } from 'preact';
 import classNames from 'classnames';
 import Spinner from '../Spinner';
 import useCoreContext from '../../../core/Context/useCoreContext';
@@ -31,7 +31,7 @@ class Button extends Component<ButtonProps, ButtonState> {
         }, delay);
     };
 
-    render({ classNameModifiers = [], disabled, href, icon, inline, label, secondaryLabel, status, variant }, { completed }) {
+    render({ classNameModifiers = [], disabled, href, icon, inline, label, status, variant }, { completed }) {
         const { i18n } = useCoreContext();
 
         const buttonIcon = icon ? <img className="adyen-checkout__button__icon" src={icon} alt="" aria-hidden="true" /> : '';
@@ -58,7 +58,6 @@ class Button extends Component<ButtonProps, ButtonState> {
                 <span className="adyen-checkout__button__content">
                     {buttonIcon}
                     <span className="adyen-checkout__button__text">{label}</span>
-                    {secondaryLabel && <span className="adyen-checkout__button__text adyen-checkout__button__text--secondary">{secondaryLabel}</span>}
                 </span>
             )
         };
@@ -76,6 +75,11 @@ class Button extends Component<ButtonProps, ButtonState> {
         return (
             <button className={buttonClasses} type="button" disabled={disabled} onClick={this.onClick}>
                 {buttonText}
+                {toChildArray(this.props.children).map(
+                    (child: ComponentChild): ComponentChild => {
+                        return cloneElement(child as VNode);
+                    }
+                )}
             </button>
         );
     }

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -75,11 +75,7 @@ class Button extends Component<ButtonProps, ButtonState> {
         return (
             <button className={buttonClasses} type="button" disabled={disabled} onClick={this.onClick}>
                 {buttonText}
-                {toChildArray(this.props.children).map(
-                    (child: ComponentChild): ComponentChild => {
-                        return cloneElement(child as VNode);
-                    }
-                )}
+                {this.props.children}
             </button>
         );
     }

--- a/packages/lib/src/components/internal/Button/types.ts
+++ b/packages/lib/src/components/internal/Button/types.ts
@@ -7,6 +7,7 @@ export interface ButtonProps {
     variant: 'primary' | 'secondary' | 'ghost' | 'action';
     disabled?: boolean;
     label?: string;
+    secondaryLabel?: string;
     icon?: string;
     inline?: boolean;
     href?: string;

--- a/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
@@ -17,6 +17,24 @@ describe('PayButton', () => {
         expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
     });
 
+    test('Renders a pay button with a secondary amount', () => {
+        const wrapper = getWrapper({
+            amount: { currency: 'EUR', value: 1000 },
+            secondaryAmount: { currency: 'HRK', value: 7534 }
+        });
+        // secondary amount indicators
+        expect(wrapper.text()).toContain('/');
+        expect(wrapper.text()).toContain('75.34');
+
+        expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
+    });
+
+    test('Renders a pay button with an amount and no secondary amount', () => {
+        const wrapper = getWrapper({ amount: { currency: 'USD', value: 1000 }, secondaryAmount: undefined });
+        expect(wrapper.text()).not.toContain('/');
+        expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
+    });
+
     test('Renders a zero auth pay button', () => {
         const wrapper = getWrapper({ amount: { currency: 'USD', value: 0 } });
         expect(wrapper.text()).toContain('Confirm preauthorization');

--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -11,7 +11,7 @@ export interface PayButtonProps {
     classNameModifiers?: string[];
     label?: string;
     amount: PaymentAmountExtended;
-    secondaryAmount: PaymentAmountExtended;
+    secondaryAmount?: PaymentAmountExtended;
     status?: string;
     disabled?: boolean;
     icon?: string;

--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -18,7 +18,7 @@ export interface PayButtonProps {
     onClick?(): void;
 }
 
-const payAmountLabel = (i18n: Language, amount) => {
+const payAmountLabel = (i18n: Language, amount: PaymentAmountExtended) => {
     const payStr = `${i18n.get('payButton')}`;
 
     const primaryAmount =
@@ -29,7 +29,7 @@ const payAmountLabel = (i18n: Language, amount) => {
     return `${payStr} ${primaryAmount}`;
 };
 
-const secondaryAmountLabel = (i18n: Language, secondaryAmount) => {
+const secondaryAmountLabel = (i18n: Language, secondaryAmount: PaymentAmountExtended) => {
     const convertedSecondaryAmount =
         secondaryAmount && !!secondaryAmount?.value && !!secondaryAmount?.currency
             ? i18n.amount(secondaryAmount.value, secondaryAmount.currency, { currencyDisplay: secondaryAmount.currencyDisplay || 'symbol' })

--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -3,6 +3,7 @@ import Button from '../Button';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import { PaymentAmountExtended } from '../../../types';
 import Language from '../../../language/Language';
+import SecondaryButtonLabel from './components/SecondaryButtonLabel';
 
 export interface PayButtonProps {
     /**
@@ -53,8 +54,9 @@ const PayButton = ({ amount, secondaryAmount, classNameModifiers = [], label, ..
             disabled={props.disabled || props.status === 'loading'}
             classNameModifiers={[...classNameModifiers, 'pay']}
             label={label || defaultLabel}
-            secondaryLabel={secondaryLabel}
-        />
+        >
+            {secondaryLabel && <SecondaryButtonLabel label={secondaryLabel} />}
+        </Button>
     );
 };
 

--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Button from '../Button';
 import useCoreContext from '../../../core/Context/useCoreContext';
-import { PaymentAmount } from '../../../types';
+import { PaymentAmountExtended } from '../../../types';
 import Language from '../../../language/Language';
 
 export interface PayButtonProps {
@@ -10,20 +10,42 @@ export interface PayButtonProps {
      */
     classNameModifiers?: string[];
     label?: string;
-    amount: PaymentAmount;
+    amount: PaymentAmountExtended;
+    secondaryAmount: PaymentAmountExtended;
     status?: string;
     disabled?: boolean;
     icon?: string;
     onClick?(): void;
 }
 
-const payAmountLabel = (i18n: Language, amount) =>
-    `${i18n.get('payButton')} ${!!amount?.value && !!amount?.currency ? i18n.amount(amount.value, amount.currency) : ''}`;
+const payAmountLabel = (i18n: Language, amount) => {
+    const payStr = `${i18n.get('payButton')}`;
 
-const PayButton = ({ amount, classNameModifiers = [], label, ...props }: PayButtonProps) => {
+    const primaryAmount =
+        !!amount?.value && !!amount?.currency
+            ? i18n.amount(amount.value, amount.currency, { currencyDisplay: amount.currencyDisplay || 'symbol' })
+            : '';
+
+    return `${payStr} ${primaryAmount}`;
+};
+
+const secondaryAmountLabel = (i18n: Language, secondaryAmount) => {
+    const convertedSecondaryAmount =
+        secondaryAmount && !!secondaryAmount?.value && !!secondaryAmount?.currency
+            ? i18n.amount(secondaryAmount.value, secondaryAmount.currency, { currencyDisplay: secondaryAmount.currencyDisplay || 'symbol' })
+            : '';
+
+    const divider = convertedSecondaryAmount.length ? '/ ' : '';
+
+    return `${divider}${convertedSecondaryAmount}`;
+};
+
+const PayButton = ({ amount, secondaryAmount, classNameModifiers = [], label, ...props }: PayButtonProps) => {
     const { i18n } = useCoreContext();
     const isZeroAuth = amount && {}.hasOwnProperty.call(amount, 'value') && amount.value === 0;
     const defaultLabel = isZeroAuth ? i18n.get('confirmPreauthorization') : payAmountLabel(i18n, amount);
+
+    const secondaryLabel = secondaryAmount && Object.keys(secondaryAmount).length ? secondaryAmountLabel(i18n, secondaryAmount) : null;
 
     return (
         <Button
@@ -31,6 +53,7 @@ const PayButton = ({ amount, classNameModifiers = [], label, ...props }: PayButt
             disabled={props.disabled || props.status === 'loading'}
             classNameModifiers={[...classNameModifiers, 'pay']}
             label={label || defaultLabel}
+            secondaryLabel={secondaryLabel}
         />
     );
 };

--- a/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.scss
+++ b/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.scss
@@ -1,0 +1,5 @@
+.checkout-secondary-button__text{
+  font-size: .85em;
+  margin-left: 5px;
+  margin-top: 1px
+}

--- a/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.tsx
+++ b/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.tsx
@@ -1,0 +1,8 @@
+import { h } from 'preact';
+import './SecondaryButtonLabel.scss';
+
+const SecondaryButtonLabel = ({ label }) => {
+    return <span className={'checkout-secondary-button__text'}>{label}</span>;
+};
+
+export default SecondaryButtonLabel;

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -63,8 +63,8 @@ export interface UIElementProps extends BaseElementProps {
     type?: string;
     name?: string;
     icon?: string;
-    amount?: PaymentAmount | PaymentAmountExtended;
-    secondaryAmount?: PaymentAmount | PaymentAmountExtended;
+    amount?: PaymentAmount;
+    secondaryAmount?: PaymentAmountExtended;
 
     /**
      * Show/Hide pay button

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { Order, PaymentAction, PaymentAmountExtended } from '../types';
+import { Order, PaymentAction, PaymentAmount, PaymentAmountExtended } from '../types';
 import Language from '../language/Language';
 import UIElement from './UIElement';
 import Core from '../core';
@@ -63,8 +63,8 @@ export interface UIElementProps extends BaseElementProps {
     type?: string;
     name?: string;
     icon?: string;
-    amount?: PaymentAmountExtended;
-    secondaryAmount?: PaymentAmountExtended;
+    amount?: PaymentAmount | PaymentAmountExtended;
+    secondaryAmount?: PaymentAmount | PaymentAmountExtended;
 
     /**
      * Show/Hide pay button

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { Order, PaymentAction, PaymentAmount } from '../types';
+import { Order, PaymentAction, PaymentAmountExtended } from '../types';
 import Language from '../language/Language';
 import UIElement from './UIElement';
 import Core from '../core';
@@ -63,7 +63,8 @@ export interface UIElementProps extends BaseElementProps {
     type?: string;
     name?: string;
     icon?: string;
-    amount?: PaymentAmount;
+    amount?: PaymentAmountExtended;
+    secondaryAmount?: PaymentAmountExtended;
 
     /**
      * Show/Hide pay button

--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -5,6 +5,7 @@ export const FALLBACK_CONTEXT = 'https://checkoutshopper-live.adyen.com/checkout
 
 export const GENERIC_OPTIONS = [
     'amount',
+    'secondaryAmount',
     'countryCode',
     'environment',
     'loadingContext',

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -1,5 +1,5 @@
 import { CustomTranslations, Locales } from '../language/types';
-import { PaymentAmount, PaymentMethods, PaymentMethodOptions, PaymentActionsType } from '../types';
+import { PaymentMethods, PaymentMethodOptions, PaymentActionsType, PaymentAmountExtended } from '../types';
 import { AnalyticsOptions } from './Analytics/types';
 import { PaymentMethodsResponseObject } from './ProcessResponse/PaymentMethodsResponse/types';
 import { RiskModuleOptions } from './RiskModule/RiskModule';
@@ -38,7 +38,12 @@ export interface CoreOptions {
     /**
      * Amount of the payment
      */
-    amount?: PaymentAmount;
+    amount?: PaymentAmountExtended;
+
+    /**
+     * Secondary amount of the payment - alternative currency & value converted according to rate
+     */
+    secondaryAmount?: PaymentAmountExtended;
 
     /**
      * The shopper's country code. A valid value is an ISO two-character country code (e.g. 'NL').

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -187,6 +187,15 @@ export interface PaymentAmount {
     currency: string;
 }
 
+export interface PaymentAmountExtended extends PaymentAmount {
+    /**
+     * Adds currencyDisplay prop - as a way for the merchant to influence the final display of the amount on the pay button.
+     * Defaults to 'symbol'.
+     * see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currencydisplay
+     */
+    currencyDisplay?: string;
+}
+
 export type AddressField = typeof ADDRESS_SCHEMA[number];
 
 export type AddressData = {
@@ -266,7 +275,7 @@ export type CheckoutSession = {
 
 export type SessionConfiguration = {
     installmentOptions: InstallmentOptions;
-}
+};
 
 export type CheckoutSessionSetupResponse = {
     id: string;

--- a/packages/playground/src/config/getCurrency.js
+++ b/packages/playground/src/config/getCurrency.js
@@ -9,6 +9,7 @@ const currencies = {
     DK: 'DKK',
     GB: 'GBP',
     HK: 'HKD',
+    HR: 'HRK',
     HU: 'HUN',
     ID: 'IDR',
     IN: 'INR',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
From the ticket (COWEB-1139): 
> Add secondaryAmount config to Drop-in/Components to allow merchants to display dual prices on the Pay button (HRK to EUR migration) 

TL;DR - since Croatia is converting to the Euro they need to display 2 prices on the Pay button from 05/09/2022 to end 2023

The merchant can now pass in a `secondaryAmount` config object in the form:
```
{ 
currency: 'HRK', 
value: {convertedValue: 1 EUR = 7.53450 kuna}, 
currencyDisplay: 'code' 
}
```
This represents the secondary currency and the value (converted from the original amount).
It is up to the merchant to perform this calculation themselves.
A third property `currencyDisplay` gives the merchant _some_ control over how that converted value is then displayed (e.g. whether a currency symbol is used or whether the currency type appears before the value or after; see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currencydisplay)

Although exactly how this secondary currency is displayed ultimately depends on the rules defined within the browser for `.toLocaleString` for the primary language (`shopperLocale`)


## Tested scenarios
When countryCode (& currency) is Croatia (HR) we show the HRK amount first and then the converted EUR amount
When countryCode (& currency) is European (NL)  we show the EUR amount first and then the converted HRK amount

Added unit tests
All tests pass


**Fixed issue**:  COWEB-1139
