### PR TITLE
Allow option to nullify this._node when unmounting

### DIFF
--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -126,10 +126,14 @@ class BaseElement<P extends BaseElementProps> {
 
     /**
      * Unmounts a payment element from the DOM
+     * @param nullifyNode - needs to be set to true if there is an intention to remount the component using mount() instead of remount()
+     *  (Mostly of use to merchants performing multiple mount & unmount actions on a component)
      */
-    public unmount(): this {
+    public unmount(nullifyNode?): this {
         if (this._node) {
             render(null, this._node);
+
+            if (nullifyNode) this._node = null;
         }
 
         return this;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Merchant issues like the one mentioned (#1638), and others; which are related to repeatedly mounting, unmounting and then (re)mounting components have all led to the conclusion that it would be useful when calling `unmount` on a component to be able to also set the reference to `component._node` to `null` without the merchant having to do it manually.

This PR allows the merchant to specify `true` when unmounting a component i.e. `component.unmount(true)` and this will cause the `BaseElement` to set its reference to `this._node` to `null`.

This seems to work to fix issues related to (re)mounting a component which then fails with the error `'Component is already mounted.'`

## Tested scenarios
All tests pass


**Relates to issue**:  #1638 
