### PR TITLE
Reduce CtP footprint in Card.tsx

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -11,7 +11,7 @@ import { reject } from '../internal/SecuredFields/utils';
 import { hasValidInstallmentsObject } from './components/CardInput/utils';
 import { createClickToPayService } from './components/ClickToPay/utils';
 import { ClickToPayCheckoutPayload, IClickToPayService } from './components/ClickToPay/services/types';
-import ClickToPayHolder from './ClickToPayHolder';
+import ClickToPayWrapper from './ClickToPayWrapper';
 import { UIElementStatus } from '../types';
 
 export class CardElement extends UIElement<CardElementProps> {
@@ -240,7 +240,7 @@ export class CardElement extends UIElement<CardElementProps> {
                 loadingContext={this.props.loadingContext}
                 commonProps={{ isCollatingErrors: this.props.SRConfig.collateErrors }}
             >
-                <ClickToPayHolder
+                <ClickToPayWrapper
                     amount={this.props.amount}
                     clickToPayService={this.clickToPayService}
                     setClickToPayRef={this.setClickToPayRef}
@@ -249,7 +249,7 @@ export class CardElement extends UIElement<CardElementProps> {
                     onError={this.handleError}
                 >
                     {isCardPrimaryInput => this.renderCardInput(isCardPrimaryInput)}
-                </ClickToPayHolder>
+                </ClickToPayWrapper>
             </CoreProvider>
         );
     }

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -9,10 +9,9 @@ import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLook
 import { CbObjOnBinLookup } from '../internal/SecuredFields/lib/types';
 import { reject } from '../internal/SecuredFields/utils';
 import { hasValidInstallmentsObject } from './components/CardInput/utils';
-import ClickToPayProvider from './components/ClickToPay/context/ClickToPayProvider';
 import { createClickToPayService } from './components/ClickToPay/utils';
 import { ClickToPayCheckoutPayload, IClickToPayService } from './components/ClickToPay/services/types';
-import ClickToPayWrapper from './ClickToPayWrapper';
+import ClickToPayHolder from './ClickToPayHolder';
 import { UIElementStatus } from '../types';
 
 export class CardElement extends UIElement<CardElementProps> {
@@ -241,7 +240,7 @@ export class CardElement extends UIElement<CardElementProps> {
                 loadingContext={this.props.loadingContext}
                 commonProps={{ isCollatingErrors: this.props.SRConfig.collateErrors }}
             >
-                <ClickToPayProvider
+                <ClickToPayHolder
                     amount={this.props.amount}
                     clickToPayService={this.clickToPayService}
                     setClickToPayRef={this.setClickToPayRef}
@@ -249,8 +248,8 @@ export class CardElement extends UIElement<CardElementProps> {
                     onSubmit={this.handleClickToPaySubmit}
                     onError={this.handleError}
                 >
-                    <ClickToPayWrapper>{isCardPrimaryInput => this.renderCardInput(isCardPrimaryInput)}</ClickToPayWrapper>
-                </ClickToPayProvider>
+                    {isCardPrimaryInput => this.renderCardInput(isCardPrimaryInput)}
+                </ClickToPayHolder>
             </CoreProvider>
         );
     }

--- a/packages/lib/src/components/Card/ClickToPayHolder.tsx
+++ b/packages/lib/src/components/Card/ClickToPayHolder.tsx
@@ -1,19 +1,67 @@
-import ClickToPayProvider from './components/ClickToPay/context/ClickToPayProvider';
-import ClickToPayWrapper from './ClickToPayWrapper';
-import { h } from 'preact';
+import { Fragment, h } from 'preact';
+import useClickToPayContext from './components/ClickToPay/context/useClickToPayContext';
+import { CtpState } from './components/ClickToPay/services/ClickToPayService';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import ClickToPayComponent from './components/ClickToPay';
+import ContentSeparator from '../internal/ContentSeparator';
+import Button from '../internal/Button';
+import useCoreContext from '../../core/Context/useCoreContext';
 
-const ClickToPayHolder = ({ amount, clickToPayService, setClickToPayRef, onSetStatus, onSubmit, onError, ...props }) => {
+type ClickToPayWrapperProps = {
+    children(isCardPrimaryInput?: boolean): h.JSX.Element;
+};
+
+const ClickToPayHolder = ({ children }: ClickToPayWrapperProps) => {
+    const { i18n } = useCoreContext();
+    const [isCardInputVisible, setIsCardInputVisible] = useState<boolean>(null);
+    const { ctpState, isCtpPrimaryPaymentMethod, setIsCtpPrimaryPaymentMethod, status } = useClickToPayContext();
+
+    const areFieldsNotSet = isCardInputVisible === null && isCtpPrimaryPaymentMethod === null;
+
+    useEffect(() => {
+        if (areFieldsNotSet) {
+            if (ctpState === CtpState.ShopperIdentified || ctpState === CtpState.Ready) {
+                setIsCardInputVisible(false);
+                setIsCtpPrimaryPaymentMethod(true);
+                return;
+            }
+            if (ctpState === CtpState.NotAvailable) {
+                setIsCardInputVisible(true);
+                setIsCtpPrimaryPaymentMethod(false);
+            }
+        }
+    }, [ctpState, areFieldsNotSet]);
+
+    const handleOnShowCardButtonClick = useCallback(() => {
+        setIsCardInputVisible(true);
+        setIsCtpPrimaryPaymentMethod(false);
+    }, []);
+
+    if (ctpState === CtpState.NotAvailable) {
+        return children();
+    }
+
+    if (ctpState === CtpState.Loading || ctpState === CtpState.ShopperIdentified) {
+        return <ClickToPayComponent />;
+    }
+
     return (
-        <ClickToPayProvider
-            amount={amount}
-            clickToPayService={clickToPayService}
-            setClickToPayRef={setClickToPayRef}
-            onSetStatus={onSetStatus}
-            onSubmit={onSubmit}
-            onError={onError}
-        >
-            <ClickToPayWrapper>{props.children}</ClickToPayWrapper>
-        </ClickToPayProvider>
+        <Fragment>
+            <ClickToPayComponent onShowCardButtonClick={handleOnShowCardButtonClick} />
+
+            <ContentSeparator classNames={['adyen-checkout-ctp__separator']} label={i18n.get('ctp.separatorText')} />
+
+            {isCardInputVisible ? (
+                children(!isCtpPrimaryPaymentMethod)
+            ) : (
+                <Button
+                    variant="secondary"
+                    disabled={status === 'loading'}
+                    label={i18n.get('ctp.manualCardEntry')}
+                    onClick={handleOnShowCardButtonClick}
+                />
+            )}
+        </Fragment>
     );
 };
 

--- a/packages/lib/src/components/Card/ClickToPayHolder.tsx
+++ b/packages/lib/src/components/Card/ClickToPayHolder.tsx
@@ -1,0 +1,20 @@
+import ClickToPayProvider from './components/ClickToPay/context/ClickToPayProvider';
+import ClickToPayWrapper from './ClickToPayWrapper';
+import { h } from 'preact';
+
+const ClickToPayHolder = ({ amount, clickToPayService, setClickToPayRef, onSetStatus, onSubmit, onError, ...props }) => {
+    return (
+        <ClickToPayProvider
+            amount={amount}
+            clickToPayService={clickToPayService}
+            setClickToPayRef={setClickToPayRef}
+            onSetStatus={onSetStatus}
+            onSubmit={onSubmit}
+            onError={onError}
+        >
+            <ClickToPayWrapper>{props.children}</ClickToPayWrapper>
+        </ClickToPayProvider>
+    );
+};
+
+export default ClickToPayHolder;

--- a/packages/lib/src/components/Card/ClickToPayWrapper.tsx
+++ b/packages/lib/src/components/Card/ClickToPayWrapper.tsx
@@ -1,67 +1,19 @@
-import { Fragment, h } from 'preact';
-import useClickToPayContext from './components/ClickToPay/context/useClickToPayContext';
-import { CtpState } from './components/ClickToPay/services/ClickToPayService';
-import { useCallback, useEffect, useState } from 'preact/hooks';
-import ClickToPayComponent from './components/ClickToPay';
-import ContentSeparator from '../internal/ContentSeparator';
-import Button from '../internal/Button';
-import useCoreContext from '../../core/Context/useCoreContext';
+import ClickToPayProvider, { ClickToPayProviderProps } from './components/ClickToPay/context/ClickToPayProvider';
+import ClickToPayHolder from './ClickToPayHolder';
+import { h } from 'preact';
 
-type ClickToPayWrapperProps = {
-    children(isCardPrimaryInput?: boolean): h.JSX.Element;
-};
-
-const ClickToPayWrapper = ({ children }: ClickToPayWrapperProps) => {
-    const { i18n } = useCoreContext();
-    const [isCardInputVisible, setIsCardInputVisible] = useState<boolean>(null);
-    const { ctpState, isCtpPrimaryPaymentMethod, setIsCtpPrimaryPaymentMethod, status } = useClickToPayContext();
-
-    const areFieldsNotSet = isCardInputVisible === null && isCtpPrimaryPaymentMethod === null;
-
-    useEffect(() => {
-        if (areFieldsNotSet) {
-            if (ctpState === CtpState.ShopperIdentified || ctpState === CtpState.Ready) {
-                setIsCardInputVisible(false);
-                setIsCtpPrimaryPaymentMethod(true);
-                return;
-            }
-            if (ctpState === CtpState.NotAvailable) {
-                setIsCardInputVisible(true);
-                setIsCtpPrimaryPaymentMethod(false);
-            }
-        }
-    }, [ctpState, areFieldsNotSet]);
-
-    const handleOnShowCardButtonClick = useCallback(() => {
-        setIsCardInputVisible(true);
-        setIsCtpPrimaryPaymentMethod(false);
-    }, []);
-
-    if (ctpState === CtpState.NotAvailable) {
-        return children();
-    }
-
-    if (ctpState === CtpState.Loading || ctpState === CtpState.ShopperIdentified) {
-        return <ClickToPayComponent />;
-    }
-
+const ClickToPayWrapper = ({ amount, clickToPayService, setClickToPayRef, onSetStatus, onSubmit, onError, ...props }: ClickToPayProviderProps) => {
     return (
-        <Fragment>
-            <ClickToPayComponent onShowCardButtonClick={handleOnShowCardButtonClick} />
-
-            <ContentSeparator classNames={['adyen-checkout-ctp__separator']} label={i18n.get('ctp.separatorText')} />
-
-            {isCardInputVisible ? (
-                children(!isCtpPrimaryPaymentMethod)
-            ) : (
-                <Button
-                    variant="secondary"
-                    disabled={status === 'loading'}
-                    label={i18n.get('ctp.manualCardEntry')}
-                    onClick={handleOnShowCardButtonClick}
-                />
-            )}
-        </Fragment>
+        <ClickToPayProvider
+            amount={amount}
+            clickToPayService={clickToPayService}
+            setClickToPayRef={setClickToPayRef}
+            onSetStatus={onSetStatus}
+            onSubmit={onSubmit}
+            onError={onError}
+        >
+            <ClickToPayHolder>{props.children}</ClickToPayHolder>
+        </ClickToPayProvider>
     );
 };
 

--- a/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayProvider.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayProvider.tsx
@@ -12,7 +12,7 @@ type ClickToPayProviderRef = {
     setStatus?(status: UIElementStatus): void;
 };
 
-type ClickToPayProviderProps = {
+export type ClickToPayProviderProps = {
     clickToPayService: IClickToPayService | null;
     amount: PaymentAmount;
     children: any;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
@ribeiroguilherme - this PR is what I was always talking about when I said that I wanted to reduce the footprint of Click-to-Pay in the actual Card component.

The whole CtP is wrapped inside one component `ClickToPayHolder` and it is this component that then unfolds the "complexity" of CtP - the `ClickToPayProvider` & the `ClickToPayWrapper`

I would actually like to rename the new `ClickToPayHolder` to `ClickToPayWrapper` and vice versa

## Tested scenarios
All unit & e2e tests pass


