### PR TITLE
Checks in PayButton to stop the secondaryAmount being rendered unnecessarily

### DIFF
--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -46,7 +46,17 @@ const PayButton = ({ amount, secondaryAmount, classNameModifiers = [], label, ..
     const isZeroAuth = amount && {}.hasOwnProperty.call(amount, 'value') && amount.value === 0;
     const defaultLabel = isZeroAuth ? i18n.get('confirmPreauthorization') : payAmountLabel(i18n, amount);
 
-    const secondaryLabel = secondaryAmount && Object.keys(secondaryAmount).length ? secondaryAmountLabel(i18n, secondaryAmount) : null;
+    /**
+     * Show the secondaryLabel if:
+     *  - it's not zero auth, and
+     *  - we don't have a predefined label (i.e. redirect, qrcode, await based comps...), and
+     *  - we do have an amount object (merchant might not be passing this in order to not show the amount on the button), and
+     *  - we have a secondaryAmount object with some properties
+     */
+    const secondaryLabel =
+        !isZeroAuth && !label && amount && secondaryAmount && Object.keys(secondaryAmount).length
+            ? secondaryAmountLabel(i18n, secondaryAmount)
+            : null;
 
     return (
         <Button


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added checks in `PayButton` to stop the `secondaryAmount` being rendered in situations when it shouldn't be present 
i.e if the merchant inadvertently defines and passes a `secondaryAmount` object - it should _not_ be shown when:
- we have a zero auth transaction
- it is a `Redirect` component
- it is a component based around the `Await` component e.g. MBWay
- it is a QR code component
- it is a Voucher
- if there is no primary `amount` passed in (i.e. merchant doesn't want the amount on the button at all)

## Tested scenarios
Tested above scenarios
