### PR TITLE
Catching securedFields load and config failures

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -25,6 +25,7 @@ import {
 } from '../lib/configuration/constants';
 import { BinLookupResponse } from '../../../Card/types';
 import { getError } from '../../../../core/Errors/utils';
+import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
 
 /**
  * SecuredFieldsProvider:
@@ -194,7 +195,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
                 // Hide the spinner
                 this.setState({ status: 'csfLoadFailure' });
                 // Report the error
-                this.props.onError({ error: 'secured fields have failed to load', fieldType: 'csfLoadFailure' });
+                this.props.onError(new AdyenCheckoutError('ERROR', 'secured field iframes have failed to load'));
             }
         }, this.csfLoadFailTimeoutMS);
     }

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -21,6 +21,7 @@ import {
     CbObjOnLoad
 } from '../lib/types';
 import { existy } from '../lib/utilities/commonUtils';
+import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
 
 /**
  * Emits the onLoad event
@@ -46,7 +47,7 @@ function handleOnLoad(cbObj: CbObjOnLoad): void {
             // Hide the spinner
             this.setState({ status: 'csfConfigFailure' });
             // Report the error
-            this.props.onError({ error: 'secured fields have failed to configure', fieldType: 'csfConfigFailure' });
+            this.props.onError(new AdyenCheckoutError('ERROR', 'secured fields have failed to configure'));
         }
     }, this.csfConfigFailTimeoutMS);
 }

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -23,28 +23,32 @@ import {
 import { existy } from '../lib/utilities/commonUtils';
 
 /**
- * Emits the onLoad  event
- * Here we can assume CSF is loaded and ready to be used
+ * Emits the onLoad event
+ * Here we can assume all securedFields iframes have fired their 'load' event
  */
 function handleOnLoad(cbObj: CbObjOnLoad): void {
+    // Clear 'loading' timeout
+    clearTimeout(this.csfLoadFailTimeout);
+    this.csfLoadFailTimeout = null;
+
     // Propagate onLoad event
     this.props.onLoad(cbObj);
 
     /**
      * Having seen that the securedFields iframes have loaded some kind of content (we don't know what, yet)
      * - setTimeout since we expect to get a successful configuration message "within a reasonable time"
+     *
+     * Now we catch clientKey & environment mismatch in core.ts - this timeout being called indicates that the securedFields have not all configured
+     * - so we need to clear the loading spinner to see if the securedFields are reporting anything
      */
-    // eslint-disable-next-line
-    this.invalidOriginErrorTimeout = setTimeout(() => {
+    this.csfConfigFailTimeout = setTimeout(() => {
         if (this.state.status !== 'ready') {
             // Hide the spinner
-            this.setState({ status: 'invalidOriginError' });
-
-            // Now we catch clientKey & environment mismatch in core.ts - this error is indicative of a
-            // clientKey error: the requesting domain is not in the “Allowed origins” for the clientKey in the CA
-            this.props.onError({ error: 'invalidOriginError', fieldType: 'defaultError' });
+            this.setState({ status: 'csfConfigFailure' });
+            // Report the error
+            this.props.onError({ error: 'secured fields have failed to configure', fieldType: 'csfConfigFailure' });
         }
-    }, this.invalidOriginTimeoutMS);
+    }, this.csfConfigFailTimeoutMS);
 }
 
 /**
@@ -52,7 +56,9 @@ function handleOnLoad(cbObj: CbObjOnLoad): void {
  * Here we can assume CSF is loaded, configured and ready to be used
  */
 function handleOnConfigSuccess(cbObj: CbObjOnConfigSuccess): void {
-    clearTimeout(this.invalidOriginErrorTimeout);
+    // Clear 'config' timeout
+    clearTimeout(this.csfConfigFailTimeout);
+    this.csfConfigFailTimeout = null;
 
     this.setState({ status: 'ready' }, () => {
         // Propagate onConfigSuccess event

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -59,7 +59,9 @@ export function createSecuredFields(): number {
 export async function createNonCardSecuredFields(securedFields: HTMLElement[]): Promise<any> {
     for (let i = 0; i < securedFields.length; i++) {
         const securedField = securedFields[i];
-        await this.setupSecuredField(securedField);
+        await this.setupSecuredField(securedField).catch(e => {
+            if (window._b$dl) console.log('Secured fields setup failure. e=', e);
+        });
     }
 }
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '4.1.1';
+export const SF_VERSION = '4.2.0';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
@@ -85,10 +85,11 @@ export interface AriaConfigObject {
 
 abstract class AbstractSecuredField {
     public config: SFInternalConfig; // could be protected but needs to be public for tests to run
-    protected fieldType: string;
+    public fieldType: string;
     protected iframeSrc: string;
     protected loadingContext: string;
     protected holderEl: HTMLElement;
+    public loadToConfigTimeout: number;
     // From getters/setters with the same name
     protected _errorType: string;
     protected _hasError: boolean;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Extra functionality around detecting if securedField's iframe fails to call its 'load' event or if they fail to configure
In both cases calls the `onError` callback defined by the merchant when they configure the main Checkout instance.(https://docs.adyen.com/online-payments/web-components/optional-configuration#events)

## Tested scenarios
- Manually created scenarios forcing securedFields to fail to load and to fail to configure - saw that these situations were detected and reported as errors to the `onError` callback
- All unit & e2e tests pass

**Relates to issue:** #1369