### PR TITLE
Ensure side menu shows on Gift card playground page & other small fixes

### DIFF
--- a/packages/e2e/tests/customcard/expiryDate/expiryDatePolicies.optional.regular.test.js
+++ b/packages/e2e/tests/customcard/expiryDate/expiryDatePolicies.optional.regular.test.js
@@ -66,7 +66,7 @@ test('#1 Testing optional expiryDatePolicy - how UI & state respond', async t =>
         .eql(false);
 });
 
-test('#2 Testing optional expiryDatePolicy - how securedField responds', async t => {
+test('#2 Testing optional expiryDatePolicy, in regular Custom Card - how securedField responds', async t => {
     // Wait for field to appear in DOM
     await cardPage.numHolder();
 

--- a/packages/e2e/tests/customcard/expiryDate/expiryDatePolicies.optional.separate.test.js
+++ b/packages/e2e/tests/customcard/expiryDate/expiryDatePolicies.optional.separate.test.js
@@ -76,7 +76,7 @@ test('#1 Testing optional expiryDatePolicy - how UI & state respond', async t =>
         .eql(false);
 });
 
-test('#2 Testing optional expiryDatePolicy - how securedFields respond', async t => {
+test('#2 Testing optional expiryDatePolicy, in Custom Card w. separate date fields - how securedFields respond', async t => {
     // Wait for field to appear in DOM
     await cardPage.numHolder();
 

--- a/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
@@ -24,7 +24,7 @@ describe('PayButton', () => {
             secondaryAmount: { currency: 'HRK', value: 7534 }
         });
         // secondary amount indicators
-        expect(wrapper.text()).toContain('/');
+        expect(wrapper.text()).toContain(PAY_BTN_DIVIDER);
         expect(wrapper.text()).toContain('75.34');
 
         expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');

--- a/packages/playground/src/pages/GiftCards/GiftCards.html
+++ b/packages/playground/src/pages/GiftCards/GiftCards.html
@@ -129,8 +129,9 @@
         </p>
     </div>
 </main>
+
 <script type="text/javascript">
-    window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' % >;
+    window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' %>;
 </script>
 </body>
 </html>


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Ensure side menu shows on Gift card playground page
- Change the names of some e2e tests for clarity
- Use the correct constant instead of a string PayButton unit test

