### PR TITLE
adds ach as stored payment method

### DIFF
--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import UIElement from '../UIElement';
 import AchInput from './components/AchInput';
 import CoreProvider from '../../core/Context/CoreProvider';
+import RedirectButton from '../internal/RedirectButton';
 
 export class AchElement extends UIElement {
     public static type = 'ach';
@@ -21,11 +22,14 @@ export class AchElement extends UIElement {
      * Formats the component data output
      */
     formatData() {
+        const recurringPayment = !!this.props.storedPaymentMethodId;
+
         // Map holderName to ownerName
         const paymentMethod = {
             type: AchElement.type,
             ...this.state.data,
-            ownerName: this.state.data?.holderName
+            ownerName: this.state.data?.holderName,
+            ...(recurringPayment && { storedPaymentMethodId: this.props.storedPaymentMethodId })
         };
 
         delete paymentMethod.holderName;
@@ -47,6 +51,10 @@ export class AchElement extends UIElement {
     }
 
     get isValid() {
+        if (this.props.storedPaymentMethodId) {
+            return true;
+        }
+
         return !!this.state.isValid;
     }
 
@@ -57,15 +65,27 @@ export class AchElement extends UIElement {
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
-                <AchInput
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
-                    {...this.props}
-                    onChange={this.setState}
-                    onSubmit={this.submit}
-                    payButton={this.payButton}
-                />
+                {this.props.storedPaymentMethodId ? (
+                    <RedirectButton
+                        name={this.displayName}
+                        amount={this.props.amount}
+                        payButton={this.payButton}
+                        onSubmit={this.submit}
+                        ref={ref => {
+                            this.componentRef = ref;
+                        }}
+                    />
+                ) : (
+                    <AchInput
+                        ref={ref => {
+                            this.componentRef = ref;
+                        }}
+                        {...this.props}
+                        onChange={this.setState}
+                        onSubmit={this.submit}
+                        payButton={this.payButton}
+                    />
+                )}
             </CoreProvider>
         );
     }

--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -36,7 +36,8 @@ export class AchElement extends UIElement {
 
         return {
             paymentMethod,
-            ...(this.state.billingAddress && { billingAddress: this.state.billingAddress })
+            ...(this.state.billingAddress && { billingAddress: this.state.billingAddress }),
+            ...(this.state.storePaymentMethod && { storePaymentMethod: this.state.storePaymentMethod  })
         };
     }
 

--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -3,11 +3,12 @@ import UIElement from '../UIElement';
 import AchInput from './components/AchInput';
 import CoreProvider from '../../core/Context/CoreProvider';
 import RedirectButton from '../internal/RedirectButton';
+import { AchElementProps } from './types';
 
-export class AchElement extends UIElement {
+export class AchElement extends UIElement<AchElementProps> {
     public static type = 'ach';
 
-    formatProps(props) {
+    formatProps(props: AchElementProps) {
         return {
             ...props,
             // Fix mismatch between passed hasHolderName & holderNameRequired props
@@ -37,7 +38,7 @@ export class AchElement extends UIElement {
         return {
             paymentMethod,
             ...(this.state.billingAddress && { billingAddress: this.state.billingAddress }),
-            ...(this.state.storePaymentMethod && { storePaymentMethod: this.state.storePaymentMethod  })
+            ...(this.state.storePaymentMethod && { storePaymentMethod: this.state.storePaymentMethod })
         };
     }
 

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
@@ -13,6 +13,7 @@ import useCoreContext from '../../../../core/Context/useCoreContext';
 import styles from './AchInput.module.scss';
 import './AchInput.scss';
 import { ACHInputDataState, ACHInputProps, ACHInputStateError, ACHInputStateValid } from './types';
+import StoreDetails from "../../../internal/StoreDetails";
 
 function validateHolderName(holderName, holderNameRequired = false) {
     if (holderNameRequired) {
@@ -37,6 +38,8 @@ function AchInput(props: ACHInputProps) {
     const [billingAddress, setBillingAddress] = useState(props.billingAddressRequired ? props.data.billingAddress : null);
     const [isSfpValid, setIsSfpValid] = useState(false);
     const [focusedElement, setFocusedElement] = useState('');
+    const [storePaymentMethod, setStorePaymentMethod] = useState(false);
+
 
     const handleFocus = e => {
         const isFocused = e.focus === true;
@@ -120,8 +123,8 @@ function AchInput(props: ACHInputProps) {
 
         const isValid = sfpValid && holderNameValid && billingAddressValid;
 
-        props.onChange({ data, isValid, billingAddress });
-    }, [data, valid, errors]);
+        props.onChange({ data, isValid, billingAddress, storePaymentMethod });
+    }, [data, valid, errors, storePaymentMethod]);
 
     return (
         <div className="adyen-checkout__ach">
@@ -173,9 +176,13 @@ function AchInput(props: ACHInputProps) {
                                     ref={billingAddressRef}
                                 />
                             )}
+
+                            {props.enableStoreDetails && <StoreDetails onChange={setStorePaymentMethod} />}
+
                         </LoadingWrapper>
                     </div>
                 )}
+
             />
             {props.showPayButton && props.payButton({ status, label: i18n.get('confirmPurchase') })}
         </div>

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
@@ -40,7 +40,6 @@ function AchInput(props: ACHInputProps) {
     const [focusedElement, setFocusedElement] = useState('');
     const [storePaymentMethod, setStorePaymentMethod] = useState(false);
 
-
     const handleFocus = e => {
         const isFocused = e.focus === true;
 

--- a/packages/lib/src/components/Ach/components/AchInput/types.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/types.ts
@@ -32,6 +32,7 @@ export interface ACHInputProps {
     billingAddressRequiredFields?: string[];
     clientKey: string;
     data?: ACHInputDataState;
+    enableStoreDetails: boolean;
     hasHolderName?: boolean;
     holderName?: string;
     holderNameRequired?: boolean;

--- a/packages/lib/src/components/Ach/components/AchInput/types.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/types.ts
@@ -1,5 +1,6 @@
 import Language from '../../../../language/Language';
 import { StylesObject } from '../../../internal/SecuredFields/lib/types';
+import UIElement from "../../../UIElement";
 
 export interface ACHInputStateValid {
     holderName?: boolean;
@@ -30,7 +31,7 @@ export interface ACHInputProps {
     billingAddressAllowedCountries?: string[];
     billingAddressRequired?: boolean;
     billingAddressRequiredFields?: string[];
-    clientKey: string;
+    clientKey?: string;
     data?: ACHInputDataState;
     enableStoreDetails: boolean;
     hasHolderName?: boolean;
@@ -39,17 +40,19 @@ export interface ACHInputProps {
     i18n?: Language;
     keypadFix?: boolean;
     legacyInputMode?: boolean;
-    loadingContext: string;
+    loadingContext?: string;
     onAllValid?: () => {};
     onBlur?: (e) => {};
-    onChange?: (obj) => {};
+    onChange?: (obj) => void;
+    onSubmit?: (obj) => void;
     onConfigSuccess?: () => {};
-    onError?: () => {};
+    onError?: (error: any, element?: UIElement<any>) => void;
     onFieldValid?: () => {};
     onFocus?: (e) => {};
     onLoad?: () => {};
     payButton?: (obj) => {};
     placeholders?: Placeholders;
+    ref? : any;
     showPayButton?: boolean;
     showWarnings?: boolean;
     styles?: StylesObject;

--- a/packages/lib/src/components/Ach/types.ts
+++ b/packages/lib/src/components/Ach/types.ts
@@ -1,0 +1,8 @@
+import { UIElementProps } from '../types';
+
+export interface AchElementProps extends UIElementProps {
+    storedPaymentMethodId?: string;
+    holderNameRequired?: boolean;
+    hasHolderName?: boolean;
+    enableStoreDetails: boolean;
+}

--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/filters.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/filters.ts
@@ -10,7 +10,7 @@ export function filterEcomStoredPaymentMethods(pm) {
     return !!pm && !!pm.supportedShopperInteractions && pm.supportedShopperInteractions.includes('Ecommerce');
 }
 
-const supportedStoredPaymentMethods = ['scheme', 'blik', 'twint'];
+const supportedStoredPaymentMethods = ['scheme', 'blik', 'twint', 'ach'];
 
 export function filterSupportedStoredPaymentMethods(pm) {
     return !!pm && !!pm.type && supportedStoredPaymentMethods.includes(pm.type);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This ticket creates the ability to use ACH as a stored payment method. As well it creates a configuration that allows merchants to enable a checkbox for the user to consent storing their payment details to be used as part of the stored payment.

## Tested scenarios
<!-- Description of tested scenarios -->

- ACH payment was saved
- Payment was successfully made with ACH stored payment method


**Fixed issue**:  <!-- #-prefixed issue number -->
