### PR TITLE
fix checkbox nanocss bug

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Checkbox/Checkbox.scss
+++ b/packages/lib/src/components/internal/FormFields/Checkbox/Checkbox.scss
@@ -56,7 +56,8 @@
 
     /* Check */
     + .adyen-checkout__checkbox__label:before {
-        border: 1px solid transparent;
+        border-left: 1px solid transparent;
+        border-top: 1px solid transparent;
         border-bottom: 2px solid $color-white;
         border-right: 2px solid $color-white;
         border-radius: 0 2px 1px 2px;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This fixes the bug where the checkbox tick was only showing one of the lines. I was unable to find when this bug started, and what was causing it, besides seems to be a bug in `nanocss`.

Might be useful in the future further investigation on this, because `nanocss` version has not been change for more than a year.

## Tested scenarios
<!-- Description of tested scenarios -->

- Check the CSS generated in the inspector
- Checked visually the checkbox 

**Fixed issue**:  <!-- #-prefixed issue number -->
