### PR TITLE
Click to Pay - Adding missing property for 'payments' call and 'merchantDisplayName' new config

### DIFF
--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/AbstractSrcInitiator.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/AbstractSrcInitiator.ts
@@ -1,6 +1,7 @@
 import { IdentityLookupParams } from '../types';
 import Script from '../../../../../../utils/Script';
 import {
+    CustomSdkConfiguration,
     SrcCheckoutParams,
     SrciCheckoutResponse,
     SrciCompleteIdentityValidationResponse,
@@ -33,15 +34,16 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
     public schemeSdk: any;
     public abstract readonly schemeName: ClickToPayScheme;
 
-    protected readonly dpaLocale: string;
+    protected readonly customSdkConfiguration: CustomSdkConfiguration;
 
     private readonly sdkUrl: string;
     private scriptElement: Script | null = null;
 
-    protected constructor(sdkUrl: string, dpaLocale: string) {
+    protected constructor(sdkUrl: string, customSdkConfiguration: CustomSdkConfiguration) {
         if (!sdkUrl) throw Error('AbstractSrcInitiator: Invalid SDK URL');
+
         this.sdkUrl = sdkUrl;
-        this.dpaLocale = dpaLocale;
+        this.customSdkConfiguration = customSdkConfiguration;
     }
 
     public async loadSdkScript() {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/MastercardSdk.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/MastercardSdk.ts
@@ -2,7 +2,7 @@ import { getMastercardSettings, MC_SDK_PROD, MC_SDK_TEST } from './config';
 import { IdentityLookupParams } from '../types';
 import AbstractSrcInitiator from './AbstractSrcInitiator';
 import SrciError from './SrciError';
-import { SrciCompleteIdentityValidationResponse, SrciIdentityLookupResponse, SrcInitParams } from './types';
+import { CustomSdkConfiguration, SrciCompleteIdentityValidationResponse, SrciIdentityLookupResponse, SrcInitParams } from './types';
 
 const IdentityTypeMap = {
     email: 'EMAIL_ADDRESS',
@@ -12,8 +12,8 @@ const IdentityTypeMap = {
 class MastercardSdk extends AbstractSrcInitiator {
     public readonly schemeName = 'mc';
 
-    constructor(environment: string, locale: string) {
-        super(environment.toLowerCase().includes('live') ? MC_SDK_PROD : MC_SDK_TEST, locale);
+    constructor(environment: string, customSdkConfig: CustomSdkConfiguration) {
+        super(environment.toLowerCase().includes('live') ? MC_SDK_PROD : MC_SDK_TEST, customSdkConfig);
     }
 
     protected isSdkIsAvailableOnWindow(): boolean {
@@ -28,7 +28,11 @@ class MastercardSdk extends AbstractSrcInitiator {
     }
 
     public async init(params: SrcInitParams, srciTransactionId: string): Promise<void> {
-        const sdkProps = { ...params, ...getMastercardSettings({ dpaLocale: this.dpaLocale }), srciTransactionId };
+        const sdkProps = {
+            ...params,
+            ...getMastercardSettings(this.customSdkConfiguration),
+            srciTransactionId
+        };
         await this.schemeSdk.init(sdkProps);
     }
 

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/VisaSdk.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/VisaSdk.ts
@@ -2,7 +2,7 @@ import { getVisaSetttings, VISA_SDK_PROD, VISA_SDK_TEST } from './config';
 import { IdentityLookupParams } from '../types';
 import AbstractSrcInitiator from './AbstractSrcInitiator';
 import SrciError from './SrciError';
-import { SrciCompleteIdentityValidationResponse, SrciIdentityLookupResponse, SrcInitParams } from './types';
+import { CustomSdkConfiguration, SrciCompleteIdentityValidationResponse, SrciIdentityLookupResponse, SrcInitParams } from './types';
 
 const IdentityTypeMap = {
     email: 'EMAIL',
@@ -12,8 +12,8 @@ const IdentityTypeMap = {
 class VisaSdk extends AbstractSrcInitiator {
     public readonly schemeName = 'visa';
 
-    constructor(environment: string, locale: string) {
-        super(environment.toLowerCase().includes('live') ? VISA_SDK_PROD : VISA_SDK_TEST, locale);
+    constructor(environment: string, customSdkConfig: CustomSdkConfiguration) {
+        super(environment.toLowerCase().includes('live') ? VISA_SDK_PROD : VISA_SDK_TEST, customSdkConfig);
     }
 
     protected isSdkIsAvailableOnWindow(): boolean {
@@ -28,7 +28,12 @@ class VisaSdk extends AbstractSrcInitiator {
     }
 
     public async init(params: SrcInitParams, srciTransactionId: string): Promise<void> {
-        const sdkProps = { ...params, ...getVisaSetttings({ dpaLocale: this.dpaLocale }), srciTransactionId };
+        const sdkProps = {
+            ...params,
+            ...getVisaSetttings(this.customSdkConfiguration),
+            srciTransactionId
+        };
+
         await this.schemeSdk.init(sdkProps);
     }
 

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/config.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/config.ts
@@ -1,17 +1,22 @@
+import { CustomSdkConfiguration } from './types';
+
 const VISA_SDK_TEST = 'https://sandbox-assets.secure.checkout.visa.com/checkout-widget/resources/js/src-i-adapter/visaSdk.js';
 const VISA_SDK_PROD = 'https://assets.secure.checkout.visa.com/checkout-widget/resources/js/src-i-adapter/visaSdk.js';
 
 const MC_SDK_TEST = 'https://sandbox.src.mastercard.com/sdk/srcsdk.mastercard.js';
 const MC_SDK_PROD = 'https://src.mastercard.com/sdk/srcsdk.mastercard.js';
 
-const getVisaSetttings = ({ dpaLocale = 'en_US' }) => ({
+const getVisaSetttings = ({ dpaLocale = 'en_US', dpaPresentationName = '' }: CustomSdkConfiguration) => ({
     dpaTransactionOptions: {
         dpaLocale: dpaLocale,
         payloadTypeIndicator: 'NON_PAYMENT'
+    },
+    dpaData: {
+        dpaPresentationName
     }
 });
 
-const getMastercardSettings = ({ dpaLocale = 'en_US' }) => ({
+const getMastercardSettings = ({ dpaLocale = 'en_US', dpaPresentationName = '' }: CustomSdkConfiguration) => ({
     dpaTransactionOptions: {
         dpaLocale: dpaLocale,
         paymentOptions: {
@@ -22,6 +27,9 @@ const getMastercardSettings = ({ dpaLocale = 'en_US' }) => ({
             'com.mastercard.dcfExperience': 'PAYMENT_SETTINGS'
         },
         confirmPayment: false
+    },
+    dpaData: {
+        dpaPresentationName
     }
 });
 

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/types.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/types.ts
@@ -1,4 +1,12 @@
 /**
+ * Type that represent the object which contains the customizable properties of the SDK initialization
+ */
+export type CustomSdkConfiguration = {
+    dpaLocale: string;
+    dpaPresentationName: string;
+};
+
+/**
  * Types used to define the interface with the SRCi SDK
  */
 export type SrciInitiateIdentityValidationResponse = {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
@@ -33,6 +33,7 @@ type MastercardCheckout = {
 type VisaCheckout = {
     srcCheckoutPayload?: string;
     srcTokenReference?: string;
+    srcCorrelationId: string;
     srcScheme: string;
 };
 

--- a/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
@@ -2,6 +2,9 @@ import { ClickToPayCheckoutPayload, SrcProfileWithScheme } from './types';
 import { SrciCheckoutResponse } from './sdks/types';
 import ShopperCard from '../models/ShopperCard';
 
+/**
+ * Creates the payload for the /payments call
+ */
 function createCheckoutPayloadBasedOnScheme(
     card: ShopperCard,
     checkoutResponse: SrciCheckoutResponse,
@@ -15,8 +18,12 @@ function createCheckoutPayloadBasedOnScheme(
              * For test environment, we are using hardcoded tokenId
              */
             return tokenId
-                ? { srcScheme: scheme, srcTokenReference: environment.toLowerCase().includes('live') ? tokenId : '987654321' }
-                : { srcScheme: scheme, srcCheckoutPayload: checkoutResponse.encryptedPayload };
+                ? {
+                      srcScheme: scheme,
+                      srcCorrelationId,
+                      srcTokenReference: environment.toLowerCase().includes('live') ? tokenId : '987654321'
+                  }
+                : { srcScheme: scheme, srcCheckoutPayload: checkoutResponse.encryptedPayload, srcCorrelationId };
         case 'mc':
         default:
             return { srcScheme: scheme, srcDigitalCardId, srcCorrelationId };

--- a/packages/lib/src/components/Card/components/ClickToPay/utils.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/utils.ts
@@ -21,7 +21,10 @@ function createClickToPayService(
     const shopperIdentity = createShopperIdentityObject(clickToPayConfiguration?.shopperIdentityValue, clickToPayConfiguration?.shopperIdentityType);
 
     const schemeNames = Object.keys(schemesConfig);
-    const srcSdkLoader = new SrcSdkLoader(schemeNames, clickToPayConfiguration?.locale);
+    const srcSdkLoader = new SrcSdkLoader(schemeNames, {
+        dpaLocale: clickToPayConfiguration?.locale,
+        dpaPresentationName: clickToPayConfiguration?.merchantDisplayName
+    });
     return new ClickToPayService(schemesConfig, srcSdkLoader, environment, shopperIdentity);
 }
 

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -128,6 +128,10 @@ export type ClickToPayConfiguration = {
     shopperIdentityValue: string;
     shopperIdentityType?: 'email' | 'mobilePhone';
     /**
+     * Used to display the merchant name in case the DCF appears (ex: first time doing transaction in the device),
+     */
+    merchantDisplayName: string;
+    /**
      * Used to ensure the correct language and user experience if DCF screen is displayed. As a fallback, it uses the main locale
      * defined during the creation of the Checkout.
      * Format: ISO language_country pair (e.g., en_US )

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -153,7 +153,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                 brands: ['mc', 'visa'],
                 useClickToPay: true,
                 clickToPayConfiguration: {
-                    shopperIdentityValue: 'shopper.email@domain.com'
+                    shopperIdentityValue: 'shopper-ctp1@adyen.com',
+                    merchantDisplayName: 'Adyen Merchant Name '
                 }
             })
             .mount('.card-ctp-field');

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -10,7 +10,7 @@ export async function initSession() {
         returnUrl,
         shopperLocale,
         shopperReference,
-        shopperEmail: 'shopper@domain.com',
+        shopperEmail: 'shopper-ctp1@adyen.com',
         countryCode
     });
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added `srcCorrelationId` property as part of the payload that is submitted in the `/payments` call
- Added new configuration property for Click to Pay named `merchantDisplayName` , which will be used to display the merchant name within the DCF (in case the DCF pops up during the checkout step)

## Tested scenarios
- Manual test verifying the new property is sent
- Manual test verifying the merchant name shows up inside the DCF pop-up