### PR TITLE
Improving contrast on main colors

### DIFF
--- a/packages/lib/src/components/Ach/components/AchInput/defaultStyles.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/defaultStyles.ts
@@ -1,5 +1,5 @@
 export default {
     base: {
-        caretColor: '#0066FF'
+        caretColor: '#0075FF'
     }
 };

--- a/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
@@ -26,7 +26,7 @@ export default function CVCHint({ frontCVC = false }: CVCHintProps) {
                 />
                 <rect x="4" y="12" width="19" height="2" fill="#B9C4C9" />
                 <rect x="4" y="4" width="4" height="4" rx="1" fill="white" />
-                <rect className={'adyen-checkout__card__cvc__hint__location'} x="16.5" y="4.5" width="7" height="5" rx="2.5" stroke="#D10244" />
+                <rect className={'adyen-checkout__card__cvc__hint__location'} x="16.5" y="4.5" width="7" height="5" rx="2.5" stroke="#C12424" />
             </svg>
 
             <svg
@@ -50,7 +50,7 @@ export default function CVCHint({ frontCVC = false }: CVCHintProps) {
                     d="M4 11C4 10.4477 4.44772 10 5 10H21C22.1046 10 23 10.8954 23 12C23 13.1046 22.1046 14 21 14H5C4.44771 14 4 13.5523 4 13V11Z"
                     fill="white"
                 />
-                <rect className={'adyen-checkout__card__cvc__hint__location'} x="16.5" y="9.5" width="7" height="5" rx="2.5" stroke="#D10244" />
+                <rect className={'adyen-checkout__card__cvc__hint__location'} x="16.5" y="9.5" width="7" height="5" rx="2.5" stroke="#C12424" />
             </svg>
         </div>
     );

--- a/packages/lib/src/components/Card/components/CardInput/defaultStyles.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultStyles.ts
@@ -1,5 +1,5 @@
 export default {
     base: {
-        caretColor: '#0066FF'
+        caretColor: '#0075FF'
     }
 };

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.scss
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.scss
@@ -3,7 +3,7 @@
 .adyen-checkout-ctp__otp-resend-code {
     font-size: 13px;
     font-weight: 400;
-    color: #0066FF;
+    color: #0075FF;
     margin-left: auto;
     cursor: pointer;
 }

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPSection/CtPLogoutLink.scss
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPSection/CtPLogoutLink.scss
@@ -4,7 +4,7 @@
   font-size: 13px;
   line-height: 19px;
   font-weight: 400;
-  color: #0066FF;
+  color: #0075FF;
   margin-left: auto;
   cursor: pointer;
 }

--- a/packages/lib/src/components/internal/PhoneInput/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInput/PhoneInput.scss
@@ -9,7 +9,7 @@
             height: auto;
 
             &:focus {
-                border: 1px solid #06f;
+                border: 1px solid #0075FF;
                 box-shadow: 0 0 0 2px #99c2ff;
             }
         }
@@ -40,7 +40,7 @@
             align-items: center;
 
             &:focus {
-                border: 1px solid #06f;
+                border: 1px solid #0075FF;
                 box-shadow: 0 0 0 2px #99c2ff;
             }
         }

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.scss
@@ -11,10 +11,10 @@
             height: auto;
 
             &:focus-within {
-                 border: 1px solid #06f;
+                 border: 1px solid #0075FF;
 
                  .adyen-checkout-dropdown--countrycode-selector {
-                     border-right: 1px solid #06f;
+                     border-right: 1px solid #0075FF;
                  }
              }
         }
@@ -53,7 +53,7 @@
             padding-left: 15px;
 
             &:focus-within {
-                border: 1px solid #06f;
+                border: 1px solid #0075FF;
                 box-shadow: 0 0 0 2px #99c2ff;
             }
         }

--- a/packages/lib/src/style/colors.scss
+++ b/packages/lib/src/style/colors.scss
@@ -9,14 +9,14 @@ $color-white: #fff;
 
 $color-new-gray-darker: #707070;
 
-$color-blue: #06f;
+$color-blue: #0075FF;
 $color-blue-light: #99c2ff;
 $color-blue-lighter: #e5efff;
-$color-green: #0abf53;
+$color-green: #089A43;
 $color-orange: #ffae42;
 $color-orange-light: #ffeacc;
 $color-orange-dark: #7f4a00;
-$color-red: #d10244;
+$color-red: #C12424;
 $color-red-light: #fbe6ed;
 
 // Application

--- a/packages/playground/src/pages/SecuredFields/securedFields.style.scss
+++ b/packages/playground/src/pages/SecuredFields/securedFields.style.scss
@@ -357,7 +357,7 @@
 }
 
 .material-input-label--error {
-    color: #d10244;
+    color: #C12424;
 }
 
 .material-input-label--focus,
@@ -368,16 +368,16 @@
 }
 
 .pm-input-field-mat--focus {
-    border: 1px solid #0066ff;
+    border: 1px solid #0075FF;
 }
 
 .pm-input-field-mat--valid {
     border: 1px solid #b9c4c9;
-    border-bottom: 1px solid #0abf53;
+    border-bottom: 1px solid #089A43;
 }
 
 .pm-input-field-mat--error {
-    border: 1px solid #d10244;
+    border: 1px solid #C12424;
 }
 
 .pm-input-field-mat .js-iframe {
@@ -393,11 +393,11 @@
 }
 
 .valid-icon {
-    fill: #0abf53;
+    fill: #089A43;
 }
 
 .error-icon {
-    fill: #d10244;
+    fill: #C12424;
 }
 
 .pm-input-field-mat--valid .valid-icon {

--- a/packages/playground/src/style/colors.scss
+++ b/packages/playground/src/style/colors.scss
@@ -7,12 +7,12 @@ $color-gray-light: #e6e9eb;
 $color-gray-lighter: #f7f8f9;
 $color-white: #fff;
 
-$color-blue: #06f;
+$color-blue: #0075FF;
 $color-blue-light: #99c2ff;
 $color-blue-lighter: #e5efff;
-$color-green: #0abf53;
+$color-green: #089A43;
 $color-orange: #ffae42;
-$color-red: #d10244;
+$color-red: #C12424;
 
 // Application
 $color-primary: $color-blue;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Improving contrast on main colors re. a11y guidelines - namely the red, green & blue colours that we use for borders etc for focus, error & valid states

NOTE: follow up work needs to be done to change the colours in the error & valid icons - but that is a separate issue in a separate repo


**Fixed issue**:  COWEB-1140
