### PR TITLE
More specific credit card error messages

### DIFF
--- a/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.v2.test.js
+++ b/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.v2.test.js
@@ -119,7 +119,7 @@ test('#3 Enter number of unsupported card, ' + 'then inspect response body for e
         .expect(errorLabel.exists)
         .ok()
         // with text
-        .expect(errorLabel.withExactText('Unsupported card entered').exists)
+        .expect(errorLabel.withExactText('Card number: Unsupported card entered').exists)
         .ok();
 });
 

--- a/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.test.js
@@ -28,7 +28,7 @@ test('#1 Enter number of unsupported card, ' + 'then check UI shows an error ' +
         .expect(cardPage.numErrorText.exists)
         .ok()
         // with text
-        .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+        .expect(cardPage.numErrorText.withExactText('Card number: Unsupported card entered').exists)
         .ok();
 
     // Past card field with supported number
@@ -56,7 +56,7 @@ test(
             .expect(cardPage.numErrorText.exists)
             .ok()
             // with text
-            .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+            .expect(cardPage.numErrorText.withExactText('Card number: Unsupported card entered').exists)
             .ok();
 
         // Click Pay (which will call showValidation on all fields)
@@ -99,7 +99,7 @@ test('#3 Enter number of unsupported card, ' + 'then check UI shows an error ' +
         .expect(cardPage.numErrorText.exists)
         .ok()
         // with text
-        .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+        .expect(cardPage.numErrorText.withExactText('Card number: Unsupported card entered').exists)
         .ok();
 
     // Past card field with supported number
@@ -121,7 +121,7 @@ test('#4 Enter number of unsupported card, ' + 'then check UI shows an error ' +
         .expect(cardPage.numErrorText.exists)
         .ok()
         // with text
-        .expect(cardPage.numErrorText.withExactText('Unsupported card entered').exists)
+        .expect(cardPage.numErrorText.withExactText('Card number: Unsupported card entered').exists)
         .ok();
 
     // Past card field with supported number

--- a/packages/e2e/tests/cards/expiryDate/minimumExpiryDate.test.js
+++ b/packages/e2e/tests/cards/expiryDate/minimumExpiryDate.test.js
@@ -7,6 +7,7 @@ import LANG from '../../../../lib/src/language/locales/en-US.json';
 const errorHolder = Selector('.card-field .adyen-checkout__field--error');
 const errorLabel = Selector('.card-field .adyen-checkout__error-text');
 
+const ARIA_LABEL = LANG['creditCard.encryptedExpiryDate.aria.label'];
 const CARD_TOO_OLD = LANG['error.va.sf-cc-dat.01'];
 const CARD_TOO_FAR = LANG['error.va.sf-cc-dat.02'];
 const CARD_EXPIRES_BEFORE = LANG['error.va.sf-cc-dat.03'];
@@ -36,7 +37,7 @@ test('With minimumExpiryDate set - input an expiry date that is too old & expect
         .expect(errorLabel.exists)
         .ok()
         // with text
-        .expect(errorLabel.withExactText(CARD_TOO_OLD).exists)
+        .expect(errorLabel.withExactText(`${ARIA_LABEL}: ${CARD_TOO_OLD}`).exists)
         .ok();
 });
 
@@ -55,7 +56,7 @@ test('With minimumExpiryDate set - input an expiry date that is 1 month before i
         .expect(errorLabel.exists)
         .ok()
         // with text
-        .expect(errorLabel.withExactText(CARD_EXPIRES_BEFORE).exists)
+        .expect(errorLabel.withExactText(`${ARIA_LABEL}: ${CARD_EXPIRES_BEFORE}`).exists)
         .ok();
 });
 
@@ -102,7 +103,7 @@ test('With minimumExpiryDate set - input an expiry date that is too far in the f
         .expect(errorLabel.exists)
         .ok()
         // with text
-        .expect(errorLabel.withExactText(CARD_TOO_FAR).exists)
+        .expect(errorLabel.withExactText(`${ARIA_LABEL}: ${CARD_TOO_FAR}`).exists)
         .ok();
 });
 
@@ -133,7 +134,7 @@ test(
             .expect(errorLabel.exists)
             .ok()
             // with text
-            .expect(errorLabel.withExactText(CARD_EXPIRES_BEFORE).exists)
+            .expect(errorLabel.withExactText(`${ARIA_LABEL}: ${CARD_EXPIRES_BEFORE}`).exists)
             .ok();
     }
 );
@@ -165,7 +166,7 @@ test(
             .expect(errorLabel.exists)
             .ok()
             // with text
-            .expect(errorLabel.withExactText(CARD_TOO_OLD).exists)
+            .expect(errorLabel.withExactText(`${ARIA_LABEL}: ${CARD_TOO_OLD}`).exists)
             .ok();
     }
 );

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -57,7 +57,7 @@ export default function CVC(props: CVCProps) {
             classNameModifiers={[...classNameModifiers, 'securityCode']}
             onFocusField={() => onFocusField(ENCRYPTED_SECURITY_CODE)}
             className={fieldClassnames}
-            errorMessage={error && i18n.get(error)}
+            errorMessage={error}
             isValid={isValid}
             dir={'ltr'}
             name={ENCRYPTED_SECURITY_CODE}

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
@@ -33,12 +33,24 @@ export default function CardFields({
 }: CardFieldsProps) {
     const { i18n } = useCoreContext();
 
+    // Prepend a label to the errorMessage so that it matches the error read by the screenreader
+    const getErrorWithLabel = (errors, fieldType) => {
+        let errorMessage = errors[fieldType] ? i18n.get(errors[fieldType]) : null;
+
+        if (errorMessage) {
+            const label = i18n.get(`creditCard.${fieldType}.aria.label`);
+            errorMessage = `${label}: ${errorMessage}`;
+        }
+
+        return errorMessage;
+    };
+
     return (
         <div className="adyen-checkout__card__form">
             <CardNumber
                 brand={brand}
                 brandsConfiguration={brandsConfiguration}
-                error={errors.encryptedCardNumber}
+                error={getErrorWithLabel(errors, ENCRYPTED_CARD_NUMBER)}
                 focused={focusedElement === ENCRYPTED_CARD_NUMBER}
                 isValid={!!valid.encryptedCardNumber}
                 label={i18n.get('creditCard.numberField.title')}
@@ -58,7 +70,8 @@ export default function CardFields({
                 })}
             >
                 <ExpirationDate
-                    error={errors.encryptedExpiryDate || errors.encryptedExpiryYear || errors.encryptedExpiryMonth}
+                    // error={errors.encryptedExpiryDate || errors.encryptedExpiryYear || errors.encryptedExpiryMonth}
+                    error={getErrorWithLabel(errors, ENCRYPTED_EXPIRY_DATE)}
                     focused={focusedElement === ENCRYPTED_EXPIRY_DATE}
                     isValid={!!valid.encryptedExpiryMonth && !!valid.encryptedExpiryYear}
                     filled={!!errors.encryptedExpiryDate || !!valid.encryptedExpiryYear}
@@ -70,7 +83,7 @@ export default function CardFields({
 
                 {hasCVC && (
                     <CVC
-                        error={errors.encryptedSecurityCode}
+                        error={getErrorWithLabel(errors, ENCRYPTED_SECURITY_CODE)}
                         focused={focusedElement === ENCRYPTED_SECURITY_CODE}
                         cvcPolicy={cvcPolicy}
                         isValid={!!valid.encryptedSecurityCode}

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
@@ -70,7 +70,6 @@ export default function CardFields({
                 })}
             >
                 <ExpirationDate
-                    // error={errors.encryptedExpiryDate || errors.encryptedExpiryYear || errors.encryptedExpiryMonth}
                     error={getErrorWithLabel(errors, ENCRYPTED_EXPIRY_DATE)}
                     focused={focusedElement === ENCRYPTED_EXPIRY_DATE}
                     isValid={!!valid.encryptedExpiryMonth && !!valid.encryptedExpiryYear}

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -23,10 +23,10 @@ export default function CardNumber(props: CardNumberProps) {
             filled={props.filled}
             classNameModifiers={['cardNumber']}
             onFocusField={() => onFocusField(ENCRYPTED_CARD_NUMBER)}
-            errorMessage={error && i18n.get(error)}
+            errorMessage={error}
             isValid={isValid}
             dir={'ltr'}
-            name={'encryptedCardNumber'}
+            name={ENCRYPTED_CARD_NUMBER}
             isCollatingErrors={isCollatingErrors}
             showValidIcon={false}
         >

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -11,7 +11,6 @@ import { ENCRYPTED_CARD_NUMBER } from '../../../../internal/SecuredFields/lib/co
 
 export default function CardNumber(props: CardNumberProps) {
     const {
-        i18n,
         commonProps: { isCollatingErrors }
     } = useCoreContext();
     const { error = '', isValid = false, onFocusField = () => {}, dualBrandingElements, dualBrandingChangeHandler, dualBrandingSelected } = props;

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -5,7 +5,12 @@ import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { ExpirationDateProps } from './types';
 import styles from '../CardInput.module.scss';
 import DataSfSpan from './DataSfSpan';
-import { DATE_POLICY_HIDDEN, DATE_POLICY_OPTIONAL, DATE_POLICY_REQUIRED } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import {
+    DATE_POLICY_HIDDEN,
+    DATE_POLICY_OPTIONAL,
+    DATE_POLICY_REQUIRED,
+    ENCRYPTED_EXPIRY_DATE
+} from '../../../../internal/SecuredFields/lib/configuration/constants';
 
 export default function ExpirationDate(props: ExpirationDateProps) {
     const { label, focused, filled, onFocusField, className = '', error = '', isValid = false, expiryDatePolicy = DATE_POLICY_REQUIRED } = props;
@@ -29,15 +34,15 @@ export default function ExpirationDate(props: ExpirationDateProps) {
             className={fieldClassnames}
             focused={focused}
             filled={filled}
-            onFocusField={() => onFocusField('encryptedExpiryDate')}
-            errorMessage={error && i18n.get(error)}
+            onFocusField={() => onFocusField(ENCRYPTED_EXPIRY_DATE)}
+            errorMessage={error}
             isValid={isValid}
             dir={'ltr'}
             name={'encryptedExpiryDate'}
             isCollatingErrors={isCollatingErrors}
         >
             <DataSfSpan
-                encryptedFieldType={'encryptedExpiryDate'}
+                encryptedFieldType={ENCRYPTED_EXPIRY_DATE}
                 className={classNames(
                     'adyen-checkout__input',
                     'adyen-checkout__input--small',

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/processAriaConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/processAriaConfig.ts
@@ -7,9 +7,6 @@ import Language from '../../../../../../language/Language';
  * If the ariaConfig object doesn't exist at all we create one with these 2 properties.
  * The iframeTitle and label properties, where they don't previously exist are populated with values read from the translation file.
  * In both cases we then add an error object containing the possible errors for any securedField read from the translation file and stored under error-codes
- *
- * NOTE: whilst we allow the merchant to overwrite the translated strings with their own iframeTitle and label we currently don't support this for the error object
- * since this is a more complex object involving special, specific codes
  */
 export function processAriaConfig(configObj: SFInternalConfig, fieldType: string, i18n: Language): AriaConfig {
     // txVariant can be the scheme name (VISA, Mastercard...) so we put all of them under creditCard


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For the credit card component which uses a generic "Incomplete field" message we are now prefixing the field name to error messages to make them more accessible for the cognitively impaired.
This also aligns the visual error messages with those that are read by the screenreader

## Tested scenarios
All tests pass

