### PR TITLE
Populating the alt tags for the valid & invalid icons

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -62,6 +62,7 @@ export default function CVC(props: CVCProps) {
             dir={'ltr'}
             name={ENCRYPTED_SECURITY_CODE}
             isCollatingErrors={isCollatingErrors}
+            i18n={i18n}
         >
             <DataSfSpan encryptedFieldType={ENCRYPTED_SECURITY_CODE} className={cvcClassnames} />
 

--- a/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
@@ -19,6 +19,7 @@ export default function CardHolderName({ onBlur, onInput, placeholder, value, re
             isValid={!!isValid}
             name={'holderName'}
             isCollatingErrors={isCollatingErrors}
+            i18n={i18n}
         >
             {renderFormField('text', {
                 name: 'holderName',

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -29,6 +29,7 @@ export default function CardNumber(props: CardNumberProps) {
             name={'encryptedCardNumber'}
             isCollatingErrors={isCollatingErrors}
             showValidIcon={false}
+            i18n={i18n}
         >
             <DataSfSpan
                 encryptedFieldType={ENCRYPTED_CARD_NUMBER}

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -35,6 +35,7 @@ export default function ExpirationDate(props: ExpirationDateProps) {
             dir={'ltr'}
             name={'encryptedExpiryDate'}
             isCollatingErrors={isCollatingErrors}
+            i18n={i18n}
         >
             <DataSfSpan
                 encryptedFieldType={'encryptedExpiryDate'}

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -33,7 +33,8 @@ const Field: FunctionalComponent<FieldProps> = props => {
         useLabelElement,
         // Redeclare prop names to avoid internal clashes
         filled: propsFilled,
-        focused: propsFocused
+        focused: propsFocused,
+        i18n
     } = props;
 
     const uniqueId = useRef(getUniqueId(`adyen-checkout-${name}`));
@@ -112,13 +113,13 @@ const Field: FunctionalComponent<FieldProps> = props => {
 
                     {isValid && showValidIcon !== false && (
                         <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--valid">
-                            <Icon type="checkmark" />
+                            <Icon type="checkmark" alt={i18n?.get('field.valid')} />
                         </span>
                     )}
 
                     {errorMessage && (
                         <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--invalid">
-                            <Icon type="field_error" />
+                            <Icon type="field_error" alt={i18n?.get('field.invalid')} />
                         </span>
                     )}
                 </div>

--- a/packages/lib/src/components/internal/FormFields/Field/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Field/types.ts
@@ -1,4 +1,5 @@
 import { h, Component, ComponentChildren } from 'preact';
+import Language from '../../../../language';
 
 export interface FieldProps {
     className?: string;
@@ -23,6 +24,7 @@ export interface FieldProps {
     showValidIcon?: boolean;
     isCollatingErrors?: boolean;
     useLabelElement?: boolean;
+    i18n?: Language;
 }
 
 export interface FieldState {

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -156,6 +156,8 @@
     "blik.code": "6-digit code",
     "blik.help": "Get the code from your banking app.",
     "swish.pendingMessage": "After you scan, the status can be pending for up to 10 minutes. Attempting to pay again within this time may result in multiple charges.",
+    "field.valid": "Field valid",
+    "field.invalid": "Field not valid",
     "error.va.gen.01": "Incomplete field",
     "error.va.gen.02": "Field not valid",
     "error.va.sf-cc-num.01": "Invalid card number",

--- a/packages/lib/src/language/locales/no-NO.json
+++ b/packages/lib/src/language/locales/no-NO.json
@@ -154,6 +154,8 @@
     "blik.code": "6-sifret kode",
     "blik.help": "Hent koden fra bank-appen din.",
     "swish.pendingMessage": "Etter at du har skannet koden kan det ta opptil 10 minutter før betalingen vises som bekreftet. Forsøk på å betale igjen kan føre til flere innbetalinger.",
+    "field.valid": "Feltet er gyldig",
+    "field.invalid": "Feltet er ikke gyldig",
     "error.va.gen.01": "Ufullstendig felt",
     "error.va.gen.02": "Feltet er ikke gyldig",
     "error.va.sf-cc-num.01": "Ugyldig kortnummer",


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For accessibility reasons we are now populating the alt tags for the valid & invalid icons with translatable text

TODO - ensure these translations are available in all languages, for now they are just in Norwegian (with a fallback to English)

## Tested scenarios
All tests pass


**Fixed issue**:  #1622
