### PR TITLE
Map Polish OnlineBanking component to match txVariant

### DIFF
--- a/packages/lib/src/components/OnlinebankingPL/index.ts
+++ b/packages/lib/src/components/OnlinebankingPL/index.ts
@@ -4,12 +4,9 @@ class OnlineBankingPL extends IssuerListContainer {
     public static type = 'onlineBanking_PL';
 
     formatProps(props) {
-        const type = 'onlineBanking_PL'
         return {
             ...super.formatProps(props),
-            showImage: false,
-            type,
-            issuers: props.paymentMethods.find(paymentMethod => paymentMethod.type === type)?.issuers
+            showImage: false
         };
     }
 }

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -134,7 +134,7 @@ const componentsMap = {
     molpay_ebanking_TH: MolPayEBankingTH,
     molpay_ebanking_VN: MolPayEBankingVN,
     onlinebanking_IN: OnlineBankingINElement,
-    onlinebanking_PL: OnlinebankingPL,
+    onlineBanking_PL: OnlinebankingPL,
     openbanking_UK: OpenBankingUK,
     paypal: PayPal,
     payu_IN_cashcard: PayuCashcard,

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.js
@@ -49,7 +49,7 @@ import '../../style.scss';
     window.dotpay = checkout.create('dotpay').mount('.dotpay-field');
 
     // Online banking PL
-    window.onlineBanking_PL = checkout.create('onlinebanking_PL').mount('.onlinebanking_PL-field');
+    window.onlineBanking_PL = checkout.create('onlineBanking_PL').mount('.onlinebanking_PL-field');
 
     // Entercash
     window.entercash = checkout.create('entercash').mount('.entercash-field');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
By mapping the name of the onlineBanking_PL component to match the case of its `txVariant` i.e. `onlinebanking_PL` => `onlineBanking_PL` (note the uppercase "B") - it is possible to avoid some unnecessary formatting of props, most notably having to "find" the `issuers` from the  corresponding paymentMethod object

## Tested scenarios
If the `/paymentMethods` response returns an "issuer" type payment method with the `type: "onlineBanking_PL"` - the issuer list is correctly populated by the default `IssuerListContainer` functionality

