### PR TITLE
Storing the checkoutAttemptId on sessionStorage

### DIFF
--- a/packages/e2e/app/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/e2e/app/src/pages/IssuerLists/IssuerLists.js
@@ -12,6 +12,9 @@ const initCheckout = async () => {
     });
 
     const checkout = await AdyenCheckout({
+        analytics: {
+            enabled: false
+        },
         amount,
         paymentMethodsResponse,
         clientKey: process.env.__CLIENT_KEY__,

--- a/packages/e2e/tests/analytics/checkoutAttemptId.clientScripts.js
+++ b/packages/e2e/tests/analytics/checkoutAttemptId.clientScripts.js
@@ -1,0 +1,5 @@
+import { ClientFunction } from 'testcafe';
+
+const getCheckoutAttemptIdFromSessionStorage = ClientFunction(() => JSON.parse(sessionStorage.getItem('adyen-checkout__checkout-attempt-id')));
+
+export { getCheckoutAttemptIdFromSessionStorage };

--- a/packages/e2e/tests/analytics/checkoutAttemptId.mocks.js
+++ b/packages/e2e/tests/analytics/checkoutAttemptId.mocks.js
@@ -1,0 +1,16 @@
+import { RequestLogger, RequestMock } from 'testcafe';
+import { BASE_URL } from '../pages';
+
+const paymentUrl = `http://localhost:3024/payments`;
+
+const paymentResponse = {
+    resultCode: 'Authorised'
+};
+
+const paymentLogger = RequestLogger({ url: paymentUrl, method: 'post' }, { logRequestBody: true });
+
+const mock = RequestMock()
+    .onRequestTo(request => request.url === paymentUrl && request.method === 'post')
+    .respond(paymentResponse, 200, { 'Access-Control-Allow-Origin': BASE_URL });
+
+export { paymentLogger, mock };

--- a/packages/e2e/tests/analytics/checkoutAttemptId.test.js
+++ b/packages/e2e/tests/analytics/checkoutAttemptId.test.js
@@ -1,0 +1,48 @@
+import { CARDS_URL } from '../pages';
+import { REGULAR_TEST_CARD } from '../cards/utils/constants';
+import CardComponentPage from '../_models/CardComponent.page';
+import { mock, paymentLogger } from './checkoutAttemptId.mocks';
+import { getCheckoutAttemptIdFromSessionStorage } from './checkoutAttemptId.clientScripts';
+
+let cardPage;
+
+fixture`Analytics - checkoutAttemptId on sessionStorage`
+    .page(CARDS_URL)
+    .requestHooks([mock, paymentLogger])
+    .beforeEach(() => {
+        cardPage = new CardComponentPage();
+    });
+
+test('#1 - should save the checkoutAttemptId session in the sessionStorage and keep it there if page refreshes', async t => {
+    await t.setNativeDialogHandler(() => true);
+
+    const { id, timestamp } = await getCheckoutAttemptIdFromSessionStorage();
+
+    await t.expect(id).ok();
+    await t.expect(timestamp).ok();
+
+    /**
+     * Refreshes the page - ex: shopper decided to add another product to the basket
+     */
+    await t.eval(() => location.reload(true));
+
+    const { id: storedId, timestamp: storedTimestamp } = await getCheckoutAttemptIdFromSessionStorage();
+
+    await t.expect(storedId).eql(id);
+    await t.expect(storedTimestamp).eql(timestamp);
+
+    await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+    await cardPage.cardUtils.fillDateAndCVC(t);
+
+    await t
+        .click(cardPage.payButton)
+        .expect(paymentLogger.count(() => true))
+        .eql(1)
+        .expect(
+            paymentLogger.contains(record => {
+                const { checkoutAttemptId } = JSON.parse(record.request.body);
+                return checkoutAttemptId === id;
+            })
+        )
+        .ok('checkoutAttemptId is present in the /payments request');
+});

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -1,4 +1,4 @@
-interface Experiment {
+export interface Experiment {
     controlGroup: boolean;
     experimentId: string;
     experimentName?: string;

--- a/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
+++ b/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
@@ -12,14 +12,14 @@ import {
     CheckoutSessionOrdersResponse,
     CheckoutSessionPaymentResponse,
     CheckoutSessionSetupResponse,
-    SessionConfiguration,
+    SessionConfiguration
 } from '../../types';
 import cancelOrder from '../Services/sessions/cancel-order';
-import {onOrderCancelData} from "../../components/Dropin/types";
+import { onOrderCancelData } from '../../components/Dropin/types';
 
 class Session {
     private readonly session: CheckoutSession;
-    private readonly storage: Storage;
+    private readonly storage: Storage<CheckoutSession>;
     public readonly clientKey: string;
     public readonly loadingContext: string;
     public configuration: SessionConfiguration;
@@ -133,7 +133,6 @@ class Session {
             return response;
         });
     }
-
 
     /**
      * Gets the stored session but only if the current id and the stored id match

--- a/packages/lib/src/core/Services/analytics/collect-id.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.ts
@@ -1,11 +1,25 @@
 import { httpPost } from '../http';
+import Storage from '../../../utils/Storage';
+import { CheckoutAttemptIdSession, CollectIdProps } from './types';
+
+/**
+ * If the checkout attempt ID was stored more than fifteen minutes ago, then we should request a new ID.
+ * More here: COWEB-1099
+ */
+function confirmSessionDurationIsMaxFifteenMinutes(checkoutAttemptIdSession: CheckoutAttemptIdSession): boolean {
+    if (!checkoutAttemptIdSession?.id) return false;
+
+    const fifteenMinInMs = 1000 * 60 * 15;
+    const fifteenMinAgoTimestamp = Date.now() - fifteenMinInMs;
+    return checkoutAttemptIdSession.timestamp > fifteenMinAgoTimestamp;
+}
 
 /**
  * Log event to Adyen
  * @param config - ready to be serialized and included in the body of request
  * @returns a function returning a promise containing the response of the call
  */
-const collectId = ({ loadingContext, clientKey, experiments }) => {
+const collectId = ({ loadingContext, clientKey, experiments }: CollectIdProps) => {
     let promise;
 
     const options = {
@@ -14,12 +28,25 @@ const collectId = ({ loadingContext, clientKey, experiments }) => {
         path: `v2/analytics/id?clientKey=${clientKey}`
     };
 
-    return () => {
+    return (): Promise<string> => {
         if (promise) return promise;
         if (!clientKey) return Promise.reject();
 
+        const storage = new Storage<CheckoutAttemptIdSession>('checkout-attempt-id', window.sessionStorage);
+        const checkoutAttemptIdSession = storage.get();
+
+        if (confirmSessionDurationIsMaxFifteenMinutes(checkoutAttemptIdSession)) {
+            return Promise.resolve(checkoutAttemptIdSession.id);
+        }
+
         promise = httpPost(options, { experiments })
-            .then(conversion => conversion?.id)
+            .then(conversion => {
+                if (conversion.id) {
+                    storage.set({ id: conversion.id, timestamp: Date.now() });
+                    return conversion.id;
+                }
+                return undefined;
+            })
             .catch(() => {});
 
         return promise;

--- a/packages/lib/src/core/Services/analytics/types.ts
+++ b/packages/lib/src/core/Services/analytics/types.ts
@@ -1,0 +1,14 @@
+import { Experiment } from '../../Analytics/types';
+
+type CheckoutAttemptIdSession = {
+    id: string;
+    timestamp: number;
+};
+
+type CollectIdProps = {
+    clientKey: string;
+    loadingContext: string;
+    experiments: Experiment[];
+};
+
+export { CheckoutAttemptIdSession, CollectIdProps };

--- a/packages/lib/src/utils/Storage.ts
+++ b/packages/lib/src/utils/Storage.ts
@@ -1,14 +1,14 @@
-class Storage {
+class Storage<T> {
     private readonly prefix = 'adyen-checkout__';
     private readonly key: string;
-    private storage;
+    private storage: globalThis.Storage;
 
     constructor(key: string, storage = window.localStorage) {
         this.storage = storage;
         this.key = this.prefix + key;
     }
 
-    public get() {
+    public get(): T {
         try {
             return JSON.parse(this.storage.getItem(this.key));
         } catch (err) {
@@ -16,7 +16,7 @@ class Storage {
         }
     }
 
-    public set(value: any) {
+    public set(value: T) {
         this.storage.setItem(this.key, JSON.stringify(value));
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR handles the storage and usage of the `checkoutAttemptId` on the `sessionStorage`. This change aims to improve the calculation of the conversion rates, in scenarios like the shopper reloads the checkout page or comes back from a redirect payment method.

Highlights on how it works:

- If `checkoutAttemptId` is passed during the initialization of `AdyenCheckout`, then we don't handle the storage of the ID - the PBL app or the merchant itself is handling it in this scenario
- In case that there is no `checkoutAttemptId` passed, the SDK will request it and save on the sessionStorage along with a timestamp of 15 minutes - so if a redirect happens, or if the shopper decides to move out from the checkout and add another extra item to the cart, we would still use the same checkoutAttemptId if the timespan is within the 15 minutes.

## Tested scenarios
- Passing `checkoutAttemptId` to `AdyenCheckout` doesn't trigger a request to get new ID, neither use the one on the session storage
- After saving the value in the session storage and refreshing the page, the UI will sill use the same ID
- After 15 min passed, the UI requests another ID


**Fixed issue**:  COWEB-1099
