### PR TITLE
Removing preact/compat imports

### DIFF
--- a/packages/lib/.eslintrc.js
+++ b/packages/lib/.eslintrc.js
@@ -33,6 +33,13 @@ module.exports = {
         }
     },
     rules: {
+        'no-restricted-imports': [
+            'error',
+            {
+                name: 'preact/compat',
+                message: 'preact/compat should be used to leverage a React app to start using Preact, which it is not the case for adyen-web SDK.'
+            }
+        ],
         'no-console': 0,
         'class-methods-use-this': 'off', // TODO
         'no-underscore-dangle': 'off', // TODO

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLogin.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLogin.tsx
@@ -13,7 +13,6 @@ const CtPLogin = (): h.JSX.Element => {
     const [isValid, setIsValid] = useState<boolean>(false);
     const [errorCode, setErrorCode] = useState<string>(null);
     const [isLoggingIn, setIsLoggingIn] = useState<boolean>(false);
-    // const inputRef = useRef<CtPLoginInputHandlers>(null);
     const [loginInputHandlers, setLoginInputHandlers] = useState<CtPLoginInputHandlers>(null);
 
     const onSetLoginInputHandlers = useCallback((handlers: CtPLoginInputHandlers) => {

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLogin.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLogin.tsx
@@ -3,7 +3,7 @@ import Button from '../../../../../internal/Button';
 import useClickToPayContext from '../../context/useClickToPayContext';
 import useCoreContext from '../../../../../../core/Context/useCoreContext';
 import CtPLoginInput, { CtPLoginInputHandlers } from './CtPLoginInput';
-import { useCallback, useRef, useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import './CtPLogin.scss';
 
 const CtPLogin = (): h.JSX.Element => {
@@ -13,7 +13,12 @@ const CtPLogin = (): h.JSX.Element => {
     const [isValid, setIsValid] = useState<boolean>(false);
     const [errorCode, setErrorCode] = useState<string>(null);
     const [isLoggingIn, setIsLoggingIn] = useState<boolean>(false);
-    const inputRef = useRef<CtPLoginInputHandlers>(null);
+    // const inputRef = useRef<CtPLoginInputHandlers>(null);
+    const [loginInputHandlers, setLoginInputHandlers] = useState<CtPLoginInputHandlers>(null);
+
+    const onSetLoginInputHandlers = useCallback((handlers: CtPLoginInputHandlers) => {
+        setLoginInputHandlers(handlers);
+    }, []);
 
     const handleOnLoginChange = useCallback(({ data, isValid }) => {
         setShopperLogin(data.shopperLogin);
@@ -29,7 +34,7 @@ const CtPLogin = (): h.JSX.Element => {
         setErrorCode(null);
 
         if (!isValid) {
-            inputRef.current.validateInput();
+            loginInputHandlers.validateInput();
             return;
         }
 
@@ -47,15 +52,15 @@ const CtPLogin = (): h.JSX.Element => {
             setErrorCode(error?.reason);
             setIsLoggingIn(false);
         }
-    }, [verifyIfShopperIsEnrolled, startIdentityValidation, shopperLogin, isValid, inputRef.current]);
+    }, [verifyIfShopperIsEnrolled, startIdentityValidation, shopperLogin, isValid, loginInputHandlers]);
 
     return (
         <Fragment>
             <div className="adyen-checkout-ctp__section-title">{i18n.get('ctp.login.title')}</div>
             <div className="adyen-checkout-ctp__section-subtitle">{i18n.get('ctp.login.subtitle')}</div>
             <CtPLoginInput
-                ref={inputRef}
                 onChange={handleOnLoginChange}
+                onSetInputHandlers={onSetLoginInputHandlers}
                 disabled={isLoggingIn}
                 errorMessage={errorCode && i18n.get(`ctp.errors.${errorCode}`)}
                 onPressEnter={handleOnLoginButtonClick}

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
@@ -1,6 +1,5 @@
 import { h } from 'preact';
-import { useCallback, useEffect, useImperativeHandle } from 'preact/hooks';
-import { forwardRef } from 'preact/compat';
+import { useCallback, useEffect, useRef } from 'preact/hooks';
 import { loginValidationRules } from './validate';
 import useCoreContext from '../../../../../../core/Context/useCoreContext';
 import useForm from '../../../../../../utils/useForm';
@@ -12,6 +11,7 @@ interface CtPLoginInputProps {
     errorMessage?: string;
     onPressEnter(): void;
     onChange({ data: CtPLoginInputDataState, valid, errors, isValid: boolean }): void;
+    onSetInputHandlers(handlers: CtPLoginInputHandlers): void;
 }
 
 interface CtPLoginInputDataState {
@@ -22,17 +22,23 @@ export type CtPLoginInputHandlers = {
     validateInput(): void;
 };
 
-const CtPLoginInput = forwardRef<CtPLoginInputHandlers, CtPLoginInputProps>((props, ref) => {
+const CtPLoginInput = (props: CtPLoginInputProps): h.JSX.Element => {
     const { i18n } = useCoreContext();
     const formSchema = ['shopperLogin'];
     const { handleChangeFor, data, triggerValidation, valid, errors, isValid } = useForm<CtPLoginInputDataState>({
         schema: formSchema,
         rules: loginValidationRules
     });
+    const loginInputHandlersRef = useRef<CtPLoginInputHandlers>({ validateInput: null });
 
     const validateInput = useCallback(() => {
         triggerValidation();
     }, [triggerValidation]);
+
+    useEffect(() => {
+        loginInputHandlersRef.current.validateInput = validateInput;
+        props.onSetInputHandlers(loginInputHandlersRef.current);
+    }, [validateInput, props.onSetInputHandlers]);
 
     const handleOnKeyUp = useCallback(
         (event: h.JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
@@ -42,8 +48,6 @@ const CtPLoginInput = forwardRef<CtPLoginInputHandlers, CtPLoginInputProps>((pro
         },
         [props.onPressEnter]
     );
-
-    useImperativeHandle(ref, () => ({ validateInput }));
 
     useEffect(() => {
         props.onChange({ data, valid, errors, isValid });
@@ -68,6 +72,6 @@ const CtPLoginInput = forwardRef<CtPLoginInputHandlers, CtPLoginInputProps>((pro
             })}
         </Field>
     );
-});
+};
 
 export default CtPLoginInput;

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.tsx
@@ -1,5 +1,5 @@
 import { Fragment, h } from 'preact';
-import { useCallback, useRef, useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import Button from '../../../../../internal/Button';
 import useClickToPayContext from '../../context/useClickToPayContext';
 import CtPOneTimePasswordInput from './CtPOneTimePasswordInput';
@@ -14,8 +14,12 @@ const CtPOneTimePassword = (): h.JSX.Element => {
     const [isValid, setIsValid] = useState<boolean>(false);
     const [isValidatingOtp, setIsValidatingOtp] = useState<boolean>(false);
     const [errorCode, setErrorCode] = useState<string>(null);
-    const inputRef = useRef<CtPOneTimePasswordInputHandlers>(null);
+    const [otpInputHandlers, setOtpInputHandlers] = useState<CtPOneTimePasswordInputHandlers>(null);
     const subtitleParts = i18n.get('ctp.otp.subtitle').split('%@');
+
+    const onSetOtpInputHandlers = useCallback((handlers: CtPOneTimePasswordInputHandlers) => {
+        setOtpInputHandlers(handlers);
+    }, []);
 
     const onChangeOtpInput = useCallback(({ data, isValid }) => {
         setOtp(data.otp);
@@ -26,7 +30,7 @@ const CtPOneTimePassword = (): h.JSX.Element => {
         setErrorCode(null);
 
         if (!isValid) {
-            inputRef.current.validateInput();
+            otpInputHandlers.validateInput();
             return;
         }
 
@@ -38,7 +42,7 @@ const CtPOneTimePassword = (): h.JSX.Element => {
             setErrorCode(error?.reason);
             setIsValidatingOtp(false);
         }
-    }, [otp, isValid, inputRef.current]);
+    }, [otp, isValid, otpInputHandlers]);
 
     return (
         <Fragment>
@@ -49,8 +53,8 @@ const CtPOneTimePassword = (): h.JSX.Element => {
                 {subtitleParts[1]}
             </div>
             <CtPOneTimePasswordInput
-                ref={inputRef}
                 onChange={onChangeOtpInput}
+                onSetInputHandlers={onSetOtpInputHandlers}
                 disabled={isValidatingOtp}
                 errorMessage={errorCode && i18n.get(`ctp.errors.${errorCode}`)}
                 onPressEnter={onSubmitPassword}

--- a/packages/lib/src/components/UPI/components/UPIComponent/UPIComponent.tsx
+++ b/packages/lib/src/components/UPI/components/UPIComponent/UPIComponent.tsx
@@ -1,5 +1,5 @@
 import { Fragment, h, RefObject } from 'preact';
-import { useCallback, useRef, useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import useCoreContext from '../../../../core/Context/useCoreContext';
 import { PayButtonFunctionProps, UIElementStatus } from '../../../types';
 import { VpaInputHandlers } from '../VpaInput/VpaInput';
@@ -32,7 +32,7 @@ const A11Y = {
 
 export default function UPIComponent({ defaultMode, onChange, onUpdateMode, payButton, showPayButton }: UPIComponentProps): h.JSX.Element {
     const { i18n, loadingContext } = useCoreContext();
-    const inputRef = useRef<VpaInputHandlers>(null);
+    const [vpaInputHandlers, setVpaInputHandlers] = useState<VpaInputHandlers>(null);
     const [status, setStatus] = useState<UIElementStatus>('ready');
     const [mode, setMode] = useState<UpiMode>(defaultMode);
 
@@ -41,8 +41,12 @@ export default function UPIComponent({ defaultMode, onChange, onUpdateMode, payB
     };
 
     this.showValidation = () => {
-        inputRef.current.validateInput();
+        vpaInputHandlers.validateInput();
     };
+
+    const onSetVpaInputHandlers = useCallback((handlers: VpaInputHandlers) => {
+        setVpaInputHandlers(handlers);
+    }, []);
 
     const onChangeUpiMode = useCallback(
         (newMode: UpiMode) => {
@@ -81,7 +85,7 @@ export default function UPIComponent({ defaultMode, onChange, onUpdateMode, payB
 
             {mode === UpiMode.Vpa ? (
                 <div id={A11Y.AreaId.VPA} aria-labelledby={A11Y.ButtonId.VPA} role="region">
-                    <VpaInput disabled={status === 'loading'} ref={inputRef} onChange={onChange} />
+                    <VpaInput disabled={status === 'loading'} onChange={onChange} onSetInputHandlers={onSetVpaInputHandlers} />
 
                     {showPayButton &&
                         payButton({

--- a/packages/lib/src/components/UPI/components/VpaInput/VpaInput.tsx
+++ b/packages/lib/src/components/UPI/components/VpaInput/VpaInput.tsx
@@ -1,6 +1,5 @@
 import { h } from 'preact';
-import { forwardRef } from 'preact/compat';
-import { useCallback, useEffect, useImperativeHandle } from 'preact/hooks';
+import { useCallback, useEffect, useRef } from 'preact/hooks';
 import Field from '../../../internal/FormFields/Field';
 import useForm from '../../../../utils/useForm';
 import renderFormField from '../../../internal/FormFields';
@@ -11,6 +10,7 @@ interface VpaInputProps {
     data?: {};
     disabled?: boolean;
     onChange({ data: VpaInputDataState, valid, errors, isValid: boolean }): void;
+    onSetInputHandlers(handlers: VpaInputHandlers): void;
 }
 
 interface VpaInputDataState {
@@ -21,21 +21,23 @@ export type VpaInputHandlers = {
     validateInput(): void;
 };
 
-const VpaInput = forwardRef<VpaInputHandlers, VpaInputProps>((props, ref) => {
+const VpaInput = (props: VpaInputProps): h.JSX.Element => {
     const formSchema = ['virtualPaymentAddress'];
     const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm<VpaInputDataState>({
         schema: formSchema,
         defaultData: props.data,
         rules: vpaValidationRules
     });
+    const vpaInputHandlersRef = useRef<VpaInputHandlers>({ validateInput: null });
 
     const validateInput = useCallback(() => {
         triggerValidation();
     }, [triggerValidation]);
 
-    useImperativeHandle(ref, () => ({
-        validateInput
-    }));
+    useEffect(() => {
+        vpaInputHandlersRef.current.validateInput = validateInput;
+        props.onSetInputHandlers(vpaInputHandlersRef.current);
+    }, [validateInput, props.onSetInputHandlers]);
 
     useEffect(() => {
         props.onChange({ data, valid, errors, isValid });
@@ -59,6 +61,6 @@ const VpaInput = forwardRef<VpaInputHandlers, VpaInputProps>((props, ref) => {
             })}
         </Field>
     );
-});
+};
 
 export default VpaInput;

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -10,7 +10,7 @@ export async function initSession() {
         returnUrl,
         shopperLocale,
         shopperReference,
-        shopperEmail: 'guilherme.ribeiro-ctp1@adyen.com',
+        shopperEmail: 'shopper-ctp1@adyen.com',
         countryCode
     });
 
@@ -34,8 +34,6 @@ export async function initSession() {
                 buttonType: 'plain'
             },
             card: {
-                useClickToPay: true,
-
                 hasHolderName: true,
                 holderNameRequired: true,
                 holderName: 'J. Smith',

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -10,7 +10,7 @@ export async function initSession() {
         returnUrl,
         shopperLocale,
         shopperReference,
-        shopperEmail: 'shopper-ctp1@adyen.com',
+        shopperEmail: 'guilherme.ribeiro-ctp1@adyen.com',
         countryCode
     });
 
@@ -34,6 +34,8 @@ export async function initSession() {
                 buttonType: 'plain'
             },
             card: {
+                useClickToPay: true,
+
                 hasHolderName: true,
                 holderNameRequired: true,
                 holderName: 'J. Smith',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The usage of `preact/compat` library leads to the misbehave of certain UI elements like input fields, event handlers, and focus mechanisms. Further more, [as described here](https://preactjs.com/guide/v10/switching-to-preact/), the library servers as a compatibility layer that allows you to leverage the many libraries of the React ecosystem and use them with Preact, which is not the case of this SDK.

This PR:
- Removes all the code that uses `preact/compat`
- Adds eslint rule to not let it be imported

