### PR TITLE
Accessibility: fixes bug where focus selects payment method item

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.test.tsx
@@ -29,26 +29,18 @@ describe('PaymentMethodItem', () => {
 
         wrapper.simulate('click');
         expect(onSelect.mock.calls.length).toBe(1);
+    });
+
+    test('Focus should NOT trigger select', () => {
+        const onSelect = jest.fn();
+        const wrapper = getWrapper({ paymentMethod, index, onSelect });
 
         wrapper.simulate('focus');
-        expect(onSelect.mock.calls.length).toBe(2);
+        expect(onSelect.mock.calls.length).toBe(0);
     });
 
     test('Defaults events', () => {
         const wrapper = getWrapper({ paymentMethod });
         wrapper.simulate('click');
-    });
-
-    test('Ignores focus during mouse down', () => {
-        const onSelect = jest.fn();
-        const wrapper = getWrapper({ paymentMethod, index, onSelect });
-
-        wrapper.simulate('mousedown');
-        wrapper.simulate('focus');
-        expect(onSelect.mock.calls.length).toBe(0);
-
-        wrapper.simulate('mouseup');
-        wrapper.simulate('focus');
-        expect(onSelect.mock.calls.length).toBe(1);
     });
 });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -37,25 +37,8 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         activeBrand: null
     };
 
-    public isMouseDown = false;
-    public onFocus = () => {
-        // Prevent a focus event when the user is clicking with a mouse.
-        // TODO find a solution where we can remove this if-clause (and just call this.props.onSelect()) so that the screenreader reads the same "stored card ends in..." message for clicking on a PM as it does when tabbing between them
-        if (!this.isMouseDown) {
-            this.props.onSelect();
-        }
-    };
-
     public onClick = () => {
         this.props.onSelect();
-    };
-
-    public onMouseDown = () => {
-        this.isMouseDown = true;
-    };
-
-    public onMouseUp = () => {
-        this.isMouseDown = false;
     };
 
     componentDidMount() {
@@ -113,10 +96,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
             <li
                 key={paymentMethod._id}
                 className={paymentMethodClassnames}
-                onFocus={this.onFocus}
                 onClick={onSelect}
-                onMouseDown={this.onMouseDown}
-                onMouseUp={this.onMouseUp}
                 aria-labelledby={buttonId}
             >
                 <div className="adyen-checkout__payment-method__header">


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

A bug was detect where we handle focus in a way that selects the payment method item. This is not the intended behaviour since payment methods should only be triggers on Click/Tap/Space (button pressed). 

## Tested scenarios
<!-- Description of tested scenarios -->

- So far only tested on Chrome on macOS

**Fixed issue**:  <!-- #-prefixed issue number -->
