### PR TITLE
Increasing deep link timeout for QrCode and Await components

### DIFF
--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -11,6 +11,7 @@ import useCoreContext from '../../../core/Context/useCoreContext';
 import { AwaitComponentProps, StatusObject } from './types';
 import './Await.scss';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
+import { DEEP_LINK_TIMEOUT } from '../../../utils/constants/deep-link-timeout';
 
 function Await(props: AwaitComponentProps) {
     const { i18n, loadingContext } = useCoreContext();
@@ -86,12 +87,13 @@ function Await(props: AwaitComponentProps) {
             });
     };
 
-    const redirectToApp = (url, fallback = (): void => {}): void => {
+    const redirectToApp = (url: string, fallback = (): void => {}): void => {
         setTimeout((): void => {
             // Redirect to the APP failed
             props.onError(new AdyenCheckoutError('ERROR', `${props.type} App was not found`));
             fallback();
-        }, 25);
+        }, DEEP_LINK_TIMEOUT);
+
         window.location.assign(url);
     };
 

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -10,6 +10,8 @@ import { QRLoaderProps, QRLoaderState } from './types';
 import copyToClipboard from '../../../utils/clipboard';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import useCoreContext from '../../../core/Context/useCoreContext';
+import { DEEP_LINK_TIMEOUT } from '../../../utils/constants/deep-link-timeout';
+
 const QRCODE_URL = 'barcode.shtml?barcodeType=qrCode&fileType=png&data=';
 
 class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
@@ -67,12 +69,13 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
         }
     }
 
-    public redirectToApp = (url, fallback = () => {}) => {
+    public redirectToApp = (url: string, fallback = (): void => {}) => {
         setTimeout(() => {
             // Redirect to the APP failed
             this.props.onError(new AdyenCheckoutError('ERROR', `${this.props.type} App was not found`));
             fallback();
-        }, 25);
+        }, DEEP_LINK_TIMEOUT);
+
         window.location.assign(url);
     };
 

--- a/packages/lib/src/utils/constants/deep-link-timeout.ts
+++ b/packages/lib/src/utils/constants/deep-link-timeout.ts
@@ -1,0 +1,3 @@
+const DEEP_LINK_TIMEOUT = 1000;
+
+export { DEEP_LINK_TIMEOUT };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Apparently some devices don't manage to open the respective payment method apps in time, therefore the library throws an Error. There is also differences between Android and iPhone, which seems that Android requires a higher timeout than iPhone.

To be on the safe side, this PR increases the deep link timeout from 25ms to 1 second for the QrCode and Await components.  If the payment method app doesn't open during this interval, then the fallback polling mechanism starts.
