### PR TITLE
fixing bug in 5.25.0 - storedCard error is not translated

### DIFF
--- a/packages/e2e/app/config/webpack.config.js
+++ b/packages/e2e/app/config/webpack.config.js
@@ -18,7 +18,8 @@ const htmlPages = [
     { name: 'Open Invoices', id: 'OpenInvoices' },
     { name: 'Drop-in Sessions', id: 'DropinSessions' },
     { name: 'Gift Cards Sessions', id: 'GiftCardsSessions' },
-    { name: 'Vouchers', id: 'Vouchers' }
+    { name: 'Vouchers', id: 'Vouchers' },
+    { name: 'StoredCards', id: 'StoredCards' }
 ];
 
 const htmlPageGenerator = ({ id }, index) =>

--- a/packages/e2e/app/src/pages/StoredCards/StoredCards.html
+++ b/packages/e2e/app/src/pages/StoredCards/StoredCards.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class="no-js" lang="">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
+        <title>Adyen Web | StoredCards</title>
+        <meta name="description" content="" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    </head>
+    <body>
+        <main>
+            <form class="merchant-checkout__form" method="post">
+                <div class="merchant-checkout__payment-method">
+                    <div class="merchant-checkout__payment-method__header">
+                        <h2>StoredCard</h2>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div class="stored-card-field"></div>
+                    </div>
+                </div>
+            </form>
+        </main>
+
+        <script type="text/javascript">
+            window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' %>;
+        </script>
+    </body>
+</html>

--- a/packages/e2e/app/src/pages/StoredCards/StoredCards.js
+++ b/packages/e2e/app/src/pages/StoredCards/StoredCards.js
@@ -1,0 +1,40 @@
+import AdyenCheckout from '@adyen/adyen-web/dist/es/index.js';
+import '@adyen/adyen-web/dist/es/adyen.css';
+import { handleSubmit, handleAdditionalDetails, handleError } from '../../handlers';
+import { amount, shopperLocale, countryCode } from '../../services/commonConfig';
+import '../../style.scss';
+
+const initCheckout = async () => {
+    window.checkout = await AdyenCheckout({
+        amount,
+        clientKey: process.env.__CLIENT_KEY__,
+        locale: shopperLocale,
+        countryCode,
+        environment: 'test',
+        showPayButton: true,
+        onSubmit: handleSubmit,
+        onAdditionalDetails: handleAdditionalDetails,
+        onError: handleError,
+        ...window.mainConfiguration
+    });
+
+    const storedCardData = {
+        brand: 'visa',
+        expiryMonth: '03',
+        expiryYear: '2030',
+        holderName: 'Checkout Shopper PlaceHolder',
+        id: '8415611088427239',
+        lastFour: '1111',
+        name: 'VISA',
+        networkTxReference: '059172561886790',
+        supportedShopperInteractions: ['Ecommerce', 'ContAuth'],
+        type: 'scheme',
+        storedPaymentMethodId: '8415611088427239',
+        ...window.cardConfig
+    };
+
+    // Credit card with installments
+    window.storedCard = checkout.create('card', storedCardData).mount('.stored-card-field');
+};
+
+initCheckout();

--- a/packages/e2e/tests/_models/CardComponent.page.js
+++ b/packages/e2e/tests/_models/CardComponent.page.js
@@ -14,8 +14,8 @@ export default class CardPage extends BasePage {
      */
     installments = null;
 
-    constructor(baseEl = '.card-field', internalComponents = {}) {
-        super('cards');
+    constructor(baseEl = '.card-field', internalComponents = {}, url = 'cards') {
+        super(url);
 
         Object.assign(this, internalComponents);
 

--- a/packages/e2e/tests/storedCard/general.test.js
+++ b/packages/e2e/tests/storedCard/general.test.js
@@ -1,0 +1,59 @@
+import { TEST_CVC_VALUE } from '../cards/utils/constants';
+import CardComponentPage from '../_models/CardComponent.page';
+import LANG from '../../../lib/src/language/locales/en-US.json';
+
+const cardPage = new CardComponentPage('.stored-card-field', {}, 'storedcards');
+
+const ARIA_LABEL = LANG['creditCard.encryptedSecurityCode.aria.label'];
+const INCOMPLETE_FIELD = LANG['error.va.gen.01'];
+
+// KEEP for changes in upcoming version
+// const EMPTY_FIELD = LANG['error.va.sf-cc-cvc.01'];
+// const INCORRECTLY_FILLED_FIELD = LANG['error.va.sf-cc-cvc.02'];
+
+fixture`Testing some general functionality and UI on the stored card component`.beforeEach(async t => {
+    await t.navigateTo(cardPage.pageUrl);
+});
+
+test('#1 Can fill out the cvc fields in the stored card and make a successful payment', async t => {
+    // Wait for field to appear in DOM
+    await cardPage.cvcHolder();
+
+    // handler for alert that's triggered on successful payment
+    await t.setNativeDialogHandler(() => true);
+
+    await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
+
+    // click pay
+    await t
+        .click(cardPage.payButton)
+        .expect(cardPage.cvcLabelTextError.exists)
+        .notOk()
+        .wait(1000);
+
+    // Check the value of the alert text
+    const history = await t.getNativeDialogHistory();
+    await t.expect(history[0].text).eql('Authorised');
+});
+
+test('#2 Pressing pay without filling the cvc should generate a translated error', async t => {
+    // Wait for field to appear in DOM
+    await cardPage.cvcHolder();
+
+    // click pay
+    await t
+        .click(cardPage.payButton)
+        .expect(cardPage.cvcLabelTextError.exists)
+        .ok()
+        // with text
+        .expect(cardPage.cvcErrorText.withExactText(`${ARIA_LABEL}: ${INCOMPLETE_FIELD}`).exists)
+        .ok();
+});
+
+test("#3 Value of label's 'for' attr should match value of corresponding securedField input's 'id' attr", async t => {
+    // Wait for field to appear in DOM
+    await cardPage.cvcHolder();
+
+    const cvcAttrVal = await cardPage.cvcLabel.getAttribute('for');
+    await cardPage.cardUtils.checkIframeForAttrVal(t, 0, 'encryptedSecurityCode', 'id', cvcAttrVal);
+});

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
@@ -3,6 +3,7 @@ import CVC from './CVC';
 import Field from '../../../../internal/FormFields/Field';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { StoredCardFieldsProps } from './types';
+import { ENCRYPTED_SECURITY_CODE } from '../../../../internal/SecuredFields/lib/configuration/constants';
 
 export default function StoredCardFields({
     brand,
@@ -19,6 +20,17 @@ export default function StoredCardFields({
     const { i18n } = useCoreContext();
     const storedCardDescription = i18n.get('creditCard.storedCard.description.ariaLabel').replace('%@', lastFour);
     const ariaLabel = `${storedCardDescription} ${i18n.get('creditCard.expiryDateField.title')} ${expiryMonth}/${expiryYear}`;
+
+    const getErrorWithLabel = (errors, fieldType) => {
+        let errorMessage = errors[fieldType] ? i18n.get(errors[fieldType]) : null;
+
+        if (errorMessage) {
+            const label = i18n.get(`creditCard.${fieldType}.aria.label`);
+            errorMessage = `${label}: ${errorMessage}`;
+        }
+
+        return errorMessage;
+    };
 
     return (
         <div className="adyen-checkout__card__form adyen-checkout__card__form--oneClick" aria-label={ariaLabel}>
@@ -40,7 +52,7 @@ export default function StoredCardFields({
                 {hasCVC && (
                     <CVC
                         cvcPolicy={cvcPolicy}
-                        error={errors.encryptedSecurityCode}
+                        error={getErrorWithLabel(errors, ENCRYPTED_SECURITY_CODE)}
                         focused={focusedElement === 'encryptedSecurityCode'}
                         filled={!!valid.encryptedSecurityCode || !!errors.encryptedSecurityCode}
                         isValid={!!valid.encryptedSecurityCode}


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixing bug in 5.25.0 - where errors on the `storedCard` component are not translated & instead show as an error code

## Tested scenarios
New e2e tests added for this scenario
All previous tests, unit & e2e, pass

