### PR TITLE
Removing 'onError' call when redirectToApp happens in QRLoader/Await components

### DIFF
--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -87,11 +87,7 @@ function Await(props: AwaitComponentProps) {
     };
 
     const redirectToApp = (url, fallback = (): void => {}): void => {
-        setTimeout((): void => {
-            // Redirect to the APP failed
-            props.onError(new AdyenCheckoutError('ERROR', `${props.type} App was not found`));
-            fallback();
-        }, 25);
+        setTimeout(fallback, 25);
         window.location.assign(url);
     };
 

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -87,7 +87,7 @@ function Await(props: AwaitComponentProps) {
     };
 
     const redirectToApp = (url, fallback = (): void => {}): void => {
-        setTimeout(fallback, 25);
+        setTimeout(fallback, 1000);
         window.location.assign(url);
     };
 

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -68,11 +68,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
     }
 
     public redirectToApp = (url, fallback = () => {}) => {
-        setTimeout(() => {
-            // Redirect to the APP failed
-            this.props.onError(new AdyenCheckoutError('ERROR', `${this.props.type} App was not found`));
-            fallback();
-        }, 25);
+        setTimeout(fallback, 25);
         window.location.assign(url);
     };
 

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -68,7 +68,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
     }
 
     public redirectToApp = (url, fallback = () => {}) => {
-        setTimeout(fallback, 25);
+        setTimeout(fallback, 1000);
         window.location.assign(url);
     };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Motivation:
currently, opening an app - in our case the Swish app - will always trigger an AdyenCheckoutError.

This behavior is described in issue #1712.

This PR aims to solve that by letting the (mobile) browser optimistically open the app (i.e. Swish). I haven't found a way to catch any failures. However, on iOS, it will display a popup (see screenshots) notifying the user about the missing app, and will not trigger any script errors in the browser.

## Tested scenarios
<!-- Description of tested scenarios -->
With a iPhone connected to a Desktop Mac OS X:
navigated a web page in the iPhone browser, run scripts from the desktop Safari (web developer tools, connect to device).

```javascript
// the url is grabbed from the Swish developer guide
let url = "swish://paymentrequest?token=c28a4061470f4af48973bd2a4642b4fa&callbackurl=merchant%253A%252F%252F";

addEventListener("myFakeEvent", () => window.location.assign(url));

dispatchEvent(new Event("myFakeEvent"));
```

**Fixed issue**: #1712   <!-- #-prefixed issue number -->

__Without the Swish app installed (message in Swedish)__
![without_the_swish_app_installed](https://user-images.githubusercontent.com/301286/192298178-acb4fa67-aaef-4164-9f3e-bb84ed77c30f.gif)


__With the app installed__
![with_swish_app_installed](https://user-images.githubusercontent.com/301286/192298300-dd2cbbff-fb94-426e-855c-1767c340094e.gif)
