### PR TITLE
Fix for missing translation for QRLoader/Await

### DIFF
--- a/packages/lib/src/components/internal/Await/Await.scss
+++ b/packages/lib/src/components/internal/Await/Await.scss
@@ -81,36 +81,6 @@
     display: none;
 }
 
-.adyen-checkout__await__separator__label {
-    position: relative;
-    font-size: 13px;
-    color: $color-gray-darker;
-    overflow: hidden;
-    text-align: center;
-    z-index: 1;
-    display: block;
-}
-
-.adyen-checkout__await__separator__label:before,
-.adyen-checkout__await__separator__label:after {
-    position: absolute;
-    top: 51%;
-    overflow: hidden;
-    width: 50%;
-    height: 1px;
-    content: '\a0';
-    background-color: $color-gray-light;
-}
-
-.adyen-checkout__await__separator__label:before {
-    margin-left: -52%;
-    text-align: right;
-}
-
-.adyen-checkout__await__separator__label:after {
-    margin-left: 2%;
-}
-
 @media only screen and (max-device-width: 1200px) {
     .adyen-checkout__await__app-link {
         display: block;

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -11,6 +11,7 @@ import useCoreContext from '../../../core/Context/useCoreContext';
 import { AwaitComponentProps, StatusObject } from './types';
 import './Await.scss';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
+import ContentSeparator from '../ContentSeparator';
 
 function Await(props: AwaitComponentProps) {
     const { i18n, loadingContext } = useCoreContext();
@@ -199,7 +200,7 @@ function Await(props: AwaitComponentProps) {
 
             {props.url && (
                 <div className="adyen-checkout__await__app-link">
-                    <span className="adyen-checkout__await__separator__label">{i18n.get('or')}</span>
+                    <ContentSeparator />
                     <Button classNameModifiers={['await']} onClick={() => redirectToApp(props.url)} label={i18n.get('openApp')} />
                 </div>
             )}

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.scss
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.scss
@@ -82,36 +82,6 @@
     display: none;
 }
 
-.adyen-checkout__qr-loader__separator__label {
-    position: relative;
-    font-size: 13px;
-    color: $color-gray-darker;
-    overflow: hidden;
-    text-align: center;
-    z-index: 1;
-    display: block;
-}
-
-.adyen-checkout__qr-loader__separator__label:before,
-.adyen-checkout__qr-loader__separator__label:after {
-    position: absolute;
-    top: 51%;
-    overflow: hidden;
-    width: 50%;
-    height: 1px;
-    content: '\a0';
-    background-color: $color-gray-light;
-}
-
-.adyen-checkout__qr-loader__separator__label:before {
-    margin-left: -52%;
-    text-align: right;
-}
-
-.adyen-checkout__qr-loader__separator__label:after {
-    margin-left: 2%;
-}
-
 .adyen-checkout__button.adyen-checkout__button--qr-loader {
     text-decoration: none;
     margin-top: 24px;

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -10,6 +10,7 @@ import { QRLoaderProps, QRLoaderState } from './types';
 import copyToClipboard from '../../../utils/clipboard';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import useCoreContext from '../../../core/Context/useCoreContext';
+import ContentSeparator from '../ContentSeparator';
 const QRCODE_URL = 'barcode.shtml?barcodeType=qrCode&fileType=png&data=';
 
 class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
@@ -225,7 +226,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
 
                 {url && (
                     <div className="adyen-checkout__qr-loader__app-link">
-                        <span className="adyen-checkout__qr-loader__separator__label">{i18n.get('or')}</span>
+                        <ContentSeparator />
                         <Button classNameModifiers={['qr-loader']} onClick={() => this.redirectToApp(url)} label={i18n.get('openApp')} />
                     </div>
                 )}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`QRLoader` and `Await` components were using invalid translation key. 

This PR reuses the `<ContentSeparator />` component which has the proper translation in place for 'qrCodeOrApp' scenario

## Tested scenarios
- Manual testing checking that proper translation shows up


**Fixed issue**: #1769 
