### PR TITLE
Feature/expanding core mount fny

### DIFF
--- a/packages/playground/src/Script.js
+++ b/packages/playground/src/Script.js
@@ -1,0 +1,43 @@
+class Script {
+    constructor(src, node = 'body', attributes = {}, dataAttributes = {}) {
+        this.script = document.createElement('script');
+        this.src = src;
+        this.node = node;
+        this.attributes = attributes;
+        this.dataAttributes = dataAttributes;
+    }
+
+    load = () =>
+        new Promise((resolve, reject) => {
+            Object.assign(this.script, this.attributes);
+            Object.assign(this.script.dataset, this.dataAttributes);
+
+            this.script.src = this.src;
+            this.script.async = true;
+            this.script.onload = event => {
+                this.script.setAttribute('data-script-loaded', 'true');
+                resolve(event);
+            };
+            this.script.onerror = () => {
+                this.remove();
+                reject(new Error(`Unable to load script ${this.src}`));
+            };
+
+            const container = document.querySelector(this.node);
+            const addedScript = container.querySelector(`script[src="${this.src}"]`);
+
+            if (addedScript) {
+                const isLoaded = addedScript.getAttribute('data-script-loaded');
+                if (isLoaded) resolve(true);
+                else addedScript.addEventListener('load', resolve);
+            } else {
+                container.appendChild(this.script);
+            }
+        });
+
+    remove = () => {
+        return this.script.parentNode && this.script.parentNode.removeChild(this.script);
+    };
+}
+
+export default Script;

--- a/packages/playground/src/pages/Cards/Cards.html
+++ b/packages/playground/src/pages/Cards/Cards.html
@@ -40,6 +40,15 @@
 
                 <div class="merchant-checkout__payment-method">
                     <div class="merchant-checkout__payment-method__header">
+                        <h2>Card in React</h2>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div class="react-card-field"></div>
+                    </div>
+                </div>
+
+                <div class="merchant-checkout__payment-method">
+                    <div class="merchant-checkout__payment-method__header">
                         <h2>Bancontact</h2>
                     </div>
                     <div class="merchant-checkout__payment-method__details">

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -5,15 +5,17 @@ import { handleSubmit, handleAdditionalDetails, handleError, handleChange } from
 import { amount, shopperLocale } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
+import { MockReactApp } from './MockReactApp';
 
 const showComps = {
+    clickToPay: true,
     storedCard: true,
     card: true,
+    cardInReact: true,
     bcmcCard: true,
     avsCard: true,
     avsPartialCard: true,
-    kcpCard: true,
-    clickToPay: true
+    kcpCard: true
 };
 
 getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse => {
@@ -68,6 +70,12 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                 }
             })
             .mount('.card-field');
+    }
+
+    // Card mounted in a React app
+    if (showComps.cardInReact) {
+        window.cardReact = checkout.create('card', {});
+        MockReactApp(window, 'cardReact', document.querySelector('.react-card-field'), false);
     }
 
     // Bancontact card
@@ -134,6 +142,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
             .create('card', {
                 type: 'scheme',
                 brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro', 'korean_local_card'],
+                // Set koreanAuthenticationRequired AND countryCode so KCP fields show at start
+                // Just set koreanAuthenticationRequired if KCP fields should only show if korean_local_card entered
                 configuration: {
                     koreanAuthenticationRequired: true
                 },

--- a/packages/playground/src/pages/Cards/MockReactApp.js
+++ b/packages/playground/src/pages/Cards/MockReactApp.js
@@ -54,12 +54,12 @@ function MockReactComp(props) {
         if (props.mountAtStart) {
             setIsMounted(true);
             // New mount/unmount/mount fny
-            props.docWindow[props.type].mount(ref.current); //  = window.card.mount(ref.current)
+            props.docWindow[props.type].mount(ref.current); // = window.card.mount(ref.current)
         }
     }, []);
 
     React.useEffect(() => {
-        console.log('### MockReactComp:::: RENDERING isMounted=', isMounted);
+        // console.log('### MockReactComp:::: RENDERING isMounted=', isMounted);
     }, [isMounted]);
 
     return [

--- a/packages/playground/src/pages/Cards/MockReactApp.js
+++ b/packages/playground/src/pages/Cards/MockReactApp.js
@@ -1,0 +1,85 @@
+import Script from '../../Script';
+
+function MountButton(props) {
+    const e = React.createElement;
+
+    const [isMounted, setIsMounted] = React.useState(props.mountAtStart);
+    return e(
+        'button',
+        {
+            type: 'button',
+            onClick: () => {
+                setIsMounted(!isMounted);
+                props.onClick();
+            },
+            className: 'adyen-checkout__button adyen-checkout__button--secondary'
+        },
+        isMounted ? 'Unmount' : 'Mount'
+    );
+}
+
+function MockReactComp(props) {
+    const e = React.createElement;
+
+    const ref = React.createRef();
+
+    const [isMounted, setIsMounted] = React.useState(false);
+
+    const listenerFn = React.useCallback(
+        e => {
+            // console.log('### MockReactComp:::: isMounted=', isMounted, 'so...', isMounted ? 'unmount it' : 'mount it');
+            if (!isMounted) {
+                setIsMounted(true);
+                // New mount/unmount/mount fny
+                props.docWindow[props.type].mount(ref.current);
+
+                // Old mount/unmount/remount fny
+                // if (!props.docWindow[props.type]._node) {
+                //     console.log('### MockReactComp:::: first mount');
+                //     props.docWindow[props.type].mount(ref.current);
+                // } else {
+                //     console.log('### MockReactComp:::: second & sub remount');
+                //     props.docWindow[props.type].remount();
+                // }
+            } else {
+                setIsMounted(false);
+                props.docWindow[props.type].unmount();
+                // props.docWindow[props.type]._node = null;
+            }
+        },
+        [isMounted]
+    );
+
+    React.useEffect(() => {
+        if (props.mountAtStart) {
+            setIsMounted(true);
+            // New mount/unmount/mount fny
+            props.docWindow[props.type].mount(ref.current); //  = window.card.mount(ref.current)
+        }
+    }, []);
+
+    React.useEffect(() => {
+        console.log('### MockReactComp:::: RENDERING isMounted=', isMounted);
+    }, [isMounted]);
+
+    return [
+        e(MountButton, {
+            key: 'mountBtn',
+            onClick: listenerFn,
+            mountAtStart: props.mountAtStart
+        }),
+        e('div', { ref, id: 'myReactDiv', key: 'holder', style: { marginTop: '20px' } })
+    ];
+}
+
+export async function MockReactApp(docWindow, type, domContainer, mountAtStart = true) {
+    const script1 = new Script('https://unpkg.com/react@18/umd/react.development.js');
+    await script1.load();
+
+    const script2 = new Script('https://unpkg.com/react-dom@18/umd/react-dom.development.js');
+    await script2.load();
+
+    const e = React.createElement;
+    const root = ReactDOM.createRoot(domContainer);
+    root.render(e(MockReactComp, { docWindow, type, mountAtStart }));
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently in order to mount/unmount and then mount a component again the user has to call:
`mount` -> `unmount` and then `remount` for any second and subsequent "mounting"

Following our discussions around this, this PR expands the core `mount` functionality to also incorporate a "remount" operation. 
So now the user would call: `mount` -> `unmount` -> `mount`

The public `remount` function has been left in for legacy reasons but is no longer expected to be used

## Tested scenarios
Extensive manual testing has taken place both of mounting/unmounting/mounting in a "regular" environment where the node on which to be mounted is passed as a selector e.g. `'.card-field'`;
and also in a (re-rendering) React environment where the node is passed as a React `ref` 
The tests were conducted for both the Credit card comp and the PayPal component.

Following these latter tests a new element has been added to the Cards Playground: "Card in React" which adds a React environment in which we implement our Card component and which allows testing of the mounting & unmounting of the Card component

**Relates to issue**:  #1638
