### PR TITLE
UPI - Triggering onChange callback when selecting QR code mode

### DIFF
--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -41,6 +41,10 @@ class UPI extends UIElement<UPIElementProps> {
     private onUpdateMode = (mode: UpiMode): void => {
         if (mode === UpiMode.QrCode) {
             this.useQrCodeVariant = true;
+            /**
+             * When selecting QR code mode, we need to clear the state data and trigger the 'onChange'.
+             */
+            this.setState({ data: {}, valid: {}, errors: {}, isValid: true });
         } else {
             this.useQrCodeVariant = false;
         }

--- a/packages/lib/src/components/UPI/components/VpaInput/VpaInput.tsx
+++ b/packages/lib/src/components/UPI/components/VpaInput/VpaInput.tsx
@@ -41,7 +41,7 @@ const VpaInput = (props: VpaInputProps): h.JSX.Element => {
 
     useEffect(() => {
         props.onChange({ data, valid, errors, isValid });
-    }, [data, valid, errors]);
+    }, [data, valid, errors, isValid]);
 
     return (
         <Field

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -39,6 +39,9 @@ export async function initManual() {
                 handleFinalState(result.resultCode, component);
             }
         },
+        onChange: state => {
+            console.log('onChange', state);
+        },
         onAdditionalDetails: async (state, component) => {
             const result = await makeDetailsCall(state.data);
 

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -29,6 +29,9 @@ export async function initSession() {
         onError: (error, component) => {
             console.info(error, component);
         },
+        onChange: (state, component) => {
+            console.log('onChange', state);
+        },
         paymentMethodsConfiguration: {
             paywithgoogle: {
                 buttonType: 'plain'


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When tweaking the payment modes on UPI, `onChange` callback was being called only when switching to 'VPA' but not when switching to 'QR code'. 

This behavior doesn't work on integrations that rely on the `onChange` callback as a way to get the payment method data (Example: SFCC plugin).

## Tested scenarios
- `onChange` callback is triggered with the expected data on 'advanced flow' and 'sessions' flow
