### PR TITLE
Release 5.27.0

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -44,6 +44,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "5.26.0"
+        "@adyen/adyen-web": "5.27.0"
     }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -23,7 +23,7 @@
         "./dist/adyen.css": "./dist/adyen.css",
         "./package.json": "./package.json"
     },
-    "version": "5.26.0",
+    "version": "5.27.0",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -46,6 +46,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "5.26.0"
+        "@adyen/adyen-web": "5.27.0"
     }
 }


### PR DESCRIPTION
## New

- Payment method: PayByBank #1751 
- Adds support for `enableStoreDetails` #1706 

## Improved

- The mount function now mounts a Component after it has been unmounted. Previously, only remount could remount a Component. #1772 

## Fixed

- For Google Pay, payment submission errors now trigger the `onError` callback instead of throwing an exception. #1774 
- On mobile, redirecting the shopper to another app no longer triggers the `onError` callback with an `AdyenCheckoutError`. #1764 
- For UPI, changing the payment mode to **QR code** now triggers the `onChange` callback. Previously, only changing the payment mode to **VPA** triggered the callback. #1776 

