### PR TITLE
Add Card config property to force the use of the JWE compat version

### DIFF
--- a/packages/e2e/tests/customcard/branding/customcard.unsupportedCard.test.js
+++ b/packages/e2e/tests/customcard/branding/customcard.unsupportedCard.test.js
@@ -101,7 +101,7 @@ test(
          * Expect error clearing received & processed at SF level
          */
         // Expect input in iframe to have aria-invalid set to true
-        await cardPage.cardUtils.checkIframeForAttrVal(t, 0, 'encryptedCardNumber', 'aria-invalid', 'true');
+        await cardPage.cardUtils.checkIframeForAttrVal(t, 0, 'encryptedCardNumber', 'aria-invalid', 'false');
 
         // Expect error field in iframe to be unfilled
         await checkIframeElHasExactText(t, cardPage.iframeSelector, 0, getAriaErrorField('encryptedCardNumber'), '');

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -68,6 +68,7 @@ export interface CardInputProps {
     enableStoreDetails?: boolean;
     expiryMonth?: string;
     expiryYear?: string;
+    forceCompat?: boolean;
     fundingSource?: string;
     hasCVC?: boolean;
     hasHolderName?: boolean;

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -170,6 +170,7 @@ export const extractPropsForSFP = (props: CardInputProps) => {
         brandsConfiguration: props.brandsConfiguration,
         clientKey: props.clientKey,
         countryCode: props.countryCode,
+        forceCompat: props.forceCompat,
         i18n: props.i18n,
         implementationType: props.implementationType,
         keypadFix: props.keypadFix,

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -179,7 +179,8 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             legacyInputMode: this.props.legacyInputMode,
             minimumExpiryDate: this.props.minimumExpiryDate,
             implementationType: this.props.implementationType || 'components', // to distinguish between 'regular' and 'custom' card component
-            isCollatingErrors: this.props.isCollatingErrors
+            isCollatingErrors: this.props.isCollatingErrors,
+            forceCompat: this.props.forceCompat
         };
 
         this.csf = initCSF(csfSetupObj);

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -13,6 +13,7 @@ export interface SFPProps {
     brandsConfiguration?: CardBrandsConfiguration;
     clientKey: string;
     countryCode?: string;
+    forceCompat?: boolean;
     hasKoreanFields?: boolean;
     i18n: Language;
     implementationType?: string;

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
@@ -72,8 +72,12 @@ export function handleConfig(): void {
     // Add a hash of the origin to ensure urls are different across domains
     const d = btoa(window.location.origin);
 
-    /** Detect Edge vn \<= 18 & IE11 - who don't support TextEncoder; and use this as an indicator to load a different, compatible, version of SF */
-    const needsJWECompatVersion = !(typeof window.TextEncoder === 'function');
+    /**
+     * Unless we are forcing the use of the compat version via card config
+     * - detect Edge vn \<= 18 & IE11 - who don't support TextEncoder; and use this as an indicator to load a different, compatible, version of SF
+     */
+    const needsJWECompatVersion = this.props.forceCompat ? true : !(typeof window.TextEncoder === 'function');
+
     const bundleType = `${sfBundleType}${needsJWECompatVersion ? 'Compat' : ''}`; // e.g. 'card' or 'cardCompat'
 
     this.config.iframeSrc = `${this.config.loadingContext}securedfields/${this.props.clientKey}/${SF_VERSION}/securedFields.html?type=${bundleType}&d=${d}`;

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
@@ -46,6 +46,7 @@ export interface CSFSetupObject extends CSFCommonProps {
     rootNode: string | HTMLElement;
     callbacks?: object;
     i18n?: Language;
+    forceCompat: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adding a new property, `forceCompat`, to Card config which will allow the merchant to force the use of the JWE compat version of securedFields.
This allows Checkout to work on older models of Samsung TV's and older versions of Chrome (45 - 53)
(From Chrome version >= 54 no problems were found)

## Tested scenarios
Browserstack testing of Chrome 45 - 53 on Windows 10 & Mac High Sierra
Manual testing on a Samsung SmartTV
All existing tests pass

**Fixed issue**:  #1775 