### PR TITLE
Locks Preact version to the same as yarn.lock

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -105,7 +105,7 @@
         "@types/googlepay": "^0.6.2",
         "classnames": "^2.3.1",
         "core-js-pure": "^3.25.3",
-        "preact": "^10.5.13"
+        "preact": "~10.7.3"
     },
     "files": [
         "dist",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -105,7 +105,7 @@
         "@types/googlepay": "^0.6.2",
         "classnames": "^2.3.1",
         "core-js-pure": "^3.25.3",
-        "preact": "~10.7.3"
+        "preact": "10.7.3"
     },
     "files": [
         "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9706,7 +9706,7 @@ postcss@^8.2.15, postcss@^8.4.7:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-preact@~10.7.3:
+preact@10.7.3:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.7.3.tgz#f98c09a29cb8dbb22e5fc824a1edcc377fc42b5a"
   integrity sha512-giqJXP8VbtA1tyGa3f1n9wiN7PrHtONrDyE3T+ifjr/tTkg+2N4d/6sjC9WyJKv8wM7rOYDveqy5ZoFmYlwo4w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9706,10 +9706,10 @@ postcss@^8.2.15, postcss@^8.4.7:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-preact@^10.5.13:
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.7.1.tgz#bdd2b2dce91a5842c3b9b34dfe050e5401068c9e"
-  integrity sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==
+preact@~10.7.3:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.7.3.tgz#f98c09a29cb8dbb22e5fc824a1edcc377fc42b5a"
+  integrity sha512-giqJXP8VbtA1tyGa3f1n9wiN7PrHtONrDyE3T+ifjr/tTkg+2N4d/6sjC9WyJKv8wM7rOYDveqy5ZoFmYlwo4w==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Attempts to fix the bug reported in #1794 by restricting which preact version can be used.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
