### PR TITLE
ach - also allow forceCompat version of securedFields

### DIFF
--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
@@ -13,7 +13,7 @@ import useCoreContext from '../../../../core/Context/useCoreContext';
 import styles from './AchInput.module.scss';
 import './AchInput.scss';
 import { ACHInputDataState, ACHInputProps, ACHInputStateError, ACHInputStateValid } from './types';
-import StoreDetails from "../../../internal/StoreDetails";
+import StoreDetails from '../../../internal/StoreDetails';
 
 function validateHolderName(holderName, holderNameRequired = false) {
     if (holderNameRequired) {
@@ -177,11 +177,9 @@ function AchInput(props: ACHInputProps) {
                             )}
 
                             {props.enableStoreDetails && <StoreDetails onChange={setStorePaymentMethod} />}
-
                         </LoadingWrapper>
                     </div>
                 )}
-
             />
             {props.showPayButton && props.payButton({ status, label: i18n.get('confirmPurchase') })}
         </div>
@@ -209,6 +207,7 @@ const extractPropsForSFP = (props: ACHInputProps) => {
         onLoad: props.onLoad,
         showWarnings: props.showWarnings,
         styles: props.styles,
-        type: props.type
+        type: props.type,
+        forceCompat: props.forceCompat
     };
 };

--- a/packages/lib/src/components/Ach/components/AchInput/types.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/types.ts
@@ -1,6 +1,6 @@
 import Language from '../../../../language/Language';
 import { StylesObject } from '../../../internal/SecuredFields/lib/types';
-import UIElement from "../../../UIElement";
+import UIElement from '../../../UIElement';
 
 export interface ACHInputStateValid {
     holderName?: boolean;
@@ -52,9 +52,10 @@ export interface ACHInputProps {
     onLoad?: () => {};
     payButton?: (obj) => {};
     placeholders?: Placeholders;
-    ref? : any;
+    ref?: any;
     showPayButton?: boolean;
     showWarnings?: boolean;
     styles?: StylesObject;
     type?: string;
+    forceCompat?: boolean;
 }

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -44,8 +44,8 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
 
     const specifications = useMemo(() => new Specifications(props.specifications), [props.specifications]);
 
-    // Creates access to sfp so we can call functionality on it (like handleOnAutoComplete) directly from the console. Used for testing.
-    if (process.env.NODE_ENV === 'development') cardInputRef.current.sfp = sfp;
+    // Store ref to sfp (useful for 'deep' debugging)
+    cardInputRef.current.sfp = sfp;
 
     /**
      * STATE HOOKS


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Accept a config option for the ACH component, which is also securedFields based, to force it to use the JWE compat version of securedFields

**Related issue**:  In line with #1787, which allowed this config for the other securedField based components: Card & Giftcard
