### PR TITLE
Change level to silent

### DIFF
--- a/packages/lib/src/core/Services/payment-status.ts
+++ b/packages/lib/src/core/Services/payment-status.ts
@@ -12,10 +12,9 @@ export default function checkPaymentStatus(paymentData, clientKey, loadingContex
         throw new Error('Could not check the payment status');
     }
 
-    const options = {
+    return httpPost({
         loadingContext,
-        path: `services/PaymentInitiation/v1/status?clientKey=${clientKey}`
-    };
-
-    return httpPost(options, { paymentData });
+        path: `services/PaymentInitiation/v1/status?clientKey=${clientKey}`,
+        errorLevel: 'silent'
+    }, { paymentData });
 }


### PR DESCRIPTION
## Summary

In our case for Blik integration sometimes (rare but it exists) we got message in JS console log (we used some mechanism to wrap up that logging and put into our Kibana, it logged with warning level and visible to alerts):
```
Call to https://checkoutshopper-live.adyen.com/checkoutshopper/services/PaymentInitiation/v1/status?
clientKey=live_<reducted> failed. Error= TypeError: Load failed
```

## Tested scenarios

 - Initialise component on slow or bad network, see on JS console

**Fixed issue**:  <!-- #-prefixed issue number -->
