### PR TITLE
Upgrade Preact to 10.11.2

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -105,7 +105,7 @@
         "@types/googlepay": "^0.6.2",
         "classnames": "^2.3.1",
         "core-js-pure": "^3.25.3",
-        "preact": "10.7.3"
+        "preact": "10.11.2"
     },
     "files": [
         "dist",

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectListItem.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectListItem.tsx
@@ -17,7 +17,10 @@ const SelectListItem = ({ item, selected, isIconOnLeftSide, ...props }: SelectIt
                 'adyen-checkout__dropdown__element-icon--left': isIconOnLeftSide
             }
         ])}
-        data-disabled={!!item.disabled}
+        // A change in Preact v10.11.1 means that all falsy values are assessed and set on data attributes.
+        // In the case of data-disabled we only ever want it set if item.disabled is actually true, since the presence of the data-disabled attr,
+        // regardless of its value, will disable the select list item
+        data-disabled={item.disabled === true ? true : null}
         data-value={item.id}
         onClick={props.onSelect}
         onKeyDown={props.onKeyDown}

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -211,7 +211,7 @@ function handleOnTouchstartIOS(cbObj): void {
     this.props.onTouchstartIOS(cbObj);
 }
 
-// Only called for holder name
+// Only called for holder name (from CSF>partials>processAutoComplete)
 function handleOnAutoComplete(cbObj: CbObjOnAutoComplete): void {
     this.setState({ autoCompleteName: cbObj.value }, () => {
         this.props.onChange(this.state, { event: 'handleOnAutoComplete', fieldType: cbObj.fieldType });

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/processAutoComplete.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/processAutoComplete.ts
@@ -13,6 +13,11 @@ import getIframeContentWin from '../utils/iframes/getIframeContentWin';
  * @param pFeedbackObj -
  */
 export function processAutoComplete({ csfState, csfConfig, csfCallbacks }, pFeedbackObj: SFFeedbackObj): void {
+    /**
+     * NOTE: It seems Chrome has started autofilling across cross-origin iframes. Have tested as far back as v104 but have no resources to test further back
+     * So, in theory for Chrome \>= v104 we don't need to do any of this, including having special listeners in the securedFields
+     */
+
     // Specifically for cc-name (but no reason not to propagate all AC objects to the merchant)
     if (pFeedbackObj.name === 'cc-name') {
         const feedbackObj: SFFeedbackObj = { ...pFeedbackObj };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9706,10 +9706,10 @@ postcss@^8.2.15, postcss@^8.4.7:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-preact@10.7.3:
-  version "10.7.3"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.7.3.tgz#f98c09a29cb8dbb22e5fc824a1edcc377fc42b5a"
-  integrity sha512-giqJXP8VbtA1tyGa3f1n9wiN7PrHtONrDyE3T+ifjr/tTkg+2N4d/6sjC9WyJKv8wM7rOYDveqy5ZoFmYlwo4w==
+preact@10.11.2:
+  version "10.11.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.11.2.tgz#e43f2a2f2985dedb426bb4c765b7bb037734f8a8"
+  integrity sha512-skAwGDFmgxhq1DCBHke/9e12ewkhc7WYwjuhHB8HHS8zkdtITXLRmUMTeol2ldxvLwYtwbFeifZ9uDDWuyL4Iw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Upgrade `Preact` to `v10.11.2` and fix it at this version in `package.json`.
This fixes the Chrome autofill issue caused by `Preact 10.11.1`
Have also included the necessary change for `SelectListItem` (also caused by a change in `Preact 10.11.1`) - so dropdowns and Issuer Lists keep working.

## Tested scenarios
All tests, unit & e2e, pass.
Selecting an item in a dropdown works
Autofilling in Chrome works

