### PR TITLE
Fixes AmazonPay settings loading region from wrong defaultProp

### DIFF
--- a/packages/lib/src/components/AmazonPay/defaultProps.ts
+++ b/packages/lib/src/components/AmazonPay/defaultProps.ts
@@ -1,11 +1,12 @@
-export default {
+import { AmazonPayElementProps } from './types';
+
+const defautProps: Partial<AmazonPayElementProps> = {
     cancelUrl: typeof window !== 'undefined' ? window.location.href : '',
     configuration: {},
     environment: 'TEST',
     locale: 'en_GB',
     placement: 'Cart',
     productType: 'PayAndShip',
-    region: 'EU',
     returnUrl: typeof window !== 'undefined' ? window.location.href : '',
     showOrderButton: true,
     showChangePaymentDetailsButton: false,
@@ -14,3 +15,5 @@ export default {
     onClick: resolve => resolve(),
     onSignOut: resolve => resolve()
 };
+
+export default defautProps;

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -48,7 +48,6 @@ export interface AmazonPayElementProps {
     configuration?: AmazonPayConfiguration;
     currency?: Currency;
     deliverySpecifications?: DeliverySpecifications;
-    design?: string;
     environment?: string;
     i18n: Language;
     loadingContext?: string;
@@ -84,6 +83,7 @@ export interface AmazonPayButtonProps {
     configuration?: AmazonPayConfiguration;
     currency?: Currency;
     deliverySpecifications?: DeliverySpecifications;
+    design?: string;
     environment?: string;
     locale?: string;
     onClick: (resolve, reject) => Promise<void>;
@@ -92,7 +92,6 @@ export interface AmazonPayButtonProps {
     productType?: ProductType;
     recurringMetadata?: RecurringMetadata;
     ref: any;
-    region?: Region;
     returnUrl?: string;
     showPayButton: boolean;
 }

--- a/packages/lib/src/components/AmazonPay/utils.ts
+++ b/packages/lib/src/components/AmazonPay/utils.ts
@@ -7,7 +7,15 @@ import {
     SUPPORTED_LOCALES_EU,
     SUPPORTED_LOCALES_US
 } from './config';
-import { AmazonPayButtonSettings, ChargeAmount, Currency, PayloadJSON, Region, SupportedLocale } from './types';
+import {
+    AmazonPayButtonProps,
+    AmazonPayButtonSettings,
+    ChargeAmount,
+    Currency,
+    PayloadJSON,
+    Region,
+    SupportedLocale
+} from './types';
 import { PaymentAmount } from '../../types';
 import { getDecimalAmount } from '../../utils/amount-util';
 
@@ -25,11 +33,11 @@ export function getAmazonPayUrl(region: Region): string {
  * @param props -
  * @returns the AmazonPay button settings
  */
-export function getAmazonPaySettings(props): AmazonPayButtonSettings {
+export function getAmazonPaySettings(props: AmazonPayButtonProps): AmazonPayButtonSettings {
     return {
         ...(props.buttonColor && { buttonColor: props.buttonColor }),
         ...(props.design && { design: getDesignCode(props.design) }),
-        checkoutLanguage: getCheckoutLocale(props.locale, props.region),
+        checkoutLanguage: getCheckoutLocale(props.locale, props.configuration.region),
         ledgerCurrency: LEDGER_CURRENCIES_PER_REGION[props.configuration.region] || props.currency || (props.amount?.currency as Currency),
         merchantId: props.configuration.merchantId,
         productType: props.productType,

--- a/packages/lib/src/core/core.component.props.test.ts
+++ b/packages/lib/src/core/core.component.props.test.ts
@@ -355,7 +355,6 @@ describe('Core - tests ensuring props reach components', () => {
             // expect props from AmazonPay.formatProps()
             expect(aPay.props.type).toEqual('amazonpay');
             expect(aPay.props.productType).toEqual('PayOnly');
-            expect(aPay.props.region).toEqual('EU'); // should have reformatted region to upperCase
         });
 
         test('Redirect PM in Dropin receives correct props ', async () => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
There was a bug found where amazon would always load locale `en_GB` even when in the US. This would cause the script to fail when instantiating if no `region: US` prop would be passed.
This property has been deprecated and only `configuration.region` should be used.

Further more a generalised bug was detected where almost none of the components default pros are actually typed.

In this PR was also cleanup an unused property `design`. Since it cannot be found anywhere in amazon documentation.

## Tested scenarios
<!-- Description of tested scenarios -->

Tested AmazonPay loading in the US and AmazonPay loading in EU.


**Fixed issue**:  <!-- #-prefixed issue number -->
