### PR TITLE
Remove 3ds2InMDFlow listener

### DIFF
--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -19,6 +19,7 @@ export interface ThreeDS2ChallengeProps {
     loadingContext?: string;
     useOriginalFlow?: boolean;
     i18n?: Language;
+    threeDS2MDFlowUnloadListener?: any;
 }
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -43,6 +43,12 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
              */
             const resolveDataFunction = this.props.useOriginalFlow ? createOldChallengeResolveData : createChallengeResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj.transStatus, this.props.paymentData);
+
+            // For 3DS2InMDFlow - we need to remove the unload listener that has been set on the window
+            if (this.props.threeDS2MDFlowUnloadListener) {
+                window.removeEventListener('beforeunload', this.props.threeDS2MDFlowUnloadListener, { capture: true });
+            }
+
             this.props.onComplete(data); // (equals onAdditionalDetails)
         });
     }

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -34,6 +34,13 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
         }
     }
 
+    // For 3DS2InMDFlow - we need to remove the unload listener that has been set on the window
+    remove3DS2MDFlowUnloadListener() {
+        if (this.props.threeDS2MDFlowUnloadListener) {
+            window.removeEventListener('beforeunload', this.props.threeDS2MDFlowUnloadListener, { capture: true });
+        }
+    }
+
     setStatusComplete(resultObj) {
         this.setState({ status: 'complete' }, () => {
             /**
@@ -44,10 +51,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             const resolveDataFunction = this.props.useOriginalFlow ? createOldChallengeResolveData : createChallengeResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj.transStatus, this.props.paymentData);
 
-            // For 3DS2InMDFlow - we need to remove the unload listener that has been set on the window
-            if (this.props.threeDS2MDFlowUnloadListener) {
-                window.removeEventListener('beforeunload', this.props.threeDS2MDFlowUnloadListener, { capture: true });
-            }
+            this.remove3DS2MDFlowUnloadListener();
 
             this.props.onComplete(data); // (equals onAdditionalDetails)
         });
@@ -55,6 +59,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
 
     setStatusError(errorObj) {
         this.setState({ status: 'error' }, () => {
+            this.remove3DS2MDFlowUnloadListener();
             this.props.onError(errorObj);
         });
     }

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
@@ -5,6 +5,7 @@ import { ThreeDS2ChallengeProps } from '../../ThreeDS2Challenge';
 export interface DoChallenge3DS2Props extends ChallengeData {
     onCompleteChallenge: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorChallenge: (rejectObject: ThreeDS2FlowObject) => void;
+    threeDS2MDFlowUnloadListener?: (event: any) => any;
 }
 
 export interface DoChallenge3DS2State {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
There is an issue with the `3DS2InMDFlow` when the challenge page getting reloaded/refreshed. When this happens the process fails. So now the `3DS2InMDFlow` redirect page adds a `beforeunload` listener to the page. 
So, _for this flow only,_ we need to remove this listener so the redirect back from the challenge page can go unimpeded

## Tested scenarios
Regular and new 3DS2InMDFlow both work as expected


**Relates to issue**:  FOC-66295
