### PR TITLE
FIX: Adjust credit card brand animation in card component

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -78,7 +78,7 @@ describe('CardInput - Brands beneath Card Number field', () => {
         expect(wrapper.find('.adyen-checkout__card__brands__brand-wrapper--disabled')).toHaveLength(0);
     });
 
-    test('should disable the brands icons that are not detected', () => {
+    test('should hide all brand icons when brand is detected', () => {
         const detectedBrand = 'visa';
         const brandsIcons = [
             { name: 'visa', icon: 'visa.png' },
@@ -86,11 +86,19 @@ describe('CardInput - Brands beneath Card Number field', () => {
             { name: 'amex', icon: 'amex.png' }
         ];
         const wrapper = mount(<CardInput i18n={i18n} brand={detectedBrand} brandsIcons={brandsIcons} />);
-        const brands = wrapper.find('.adyen-checkout__card__brands__brand-wrapper');
+        expect(wrapper.find('.adyen-checkout__card__brands--hidden')).toHaveLength(1);
+    });
 
-        expect(brands.at(0).is('.adyen-checkout__card__brands__brand-wrapper--disabled')).toBeFalsy();
-        expect(brands.at(1).is('.adyen-checkout__card__brands__brand-wrapper--disabled')).toBeTruthy();
-        expect(brands.at(2).is('.adyen-checkout__card__brands__brand-wrapper--disabled')).toBeTruthy();
+    test('should show all brand icons when no brand is detected', () => {
+        const detectedBrand = 'card';
+        const brandsIcons = [
+            { name: 'visa', icon: 'visa.png' },
+            { name: 'mc', icon: 'mc.png' },
+            { name: 'amex', icon: 'amex.png' }
+        ];
+        const wrapper = mount(<CardInput i18n={i18n} brand={detectedBrand} brandsIcons={brandsIcons} />);
+        const brandWrapper = wrapper.find('.checkout__card__brands');
+        expect(wrapper.find('.adyen-checkout__card__brands--hidden')).toHaveLength(0);
     });
 });
 

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
@@ -6,23 +6,28 @@
   flex-shrink: 1;
   flex-wrap: wrap;
   gap: 4px;
+  height: 16px;
+  overflow: hidden;
   margin-top: -8px;
   margin-bottom: 16px;
+  will-change: height;
+  transition: all .2s ease-out;
 }
+.adyen-checkout__card__brands--hidden {
+  opacity: 0;
+  height: 0;
+}
+
 .adyen-checkout__card__brands img {
   border-radius: 3px;
   height: 16px;
   width: 24px;
 }
 
-.adyen-checkout__card__brands__brand-wrapper--disabled {
-  opacity: 0.25;
-}
 
 .adyen-checkout__card__brands__brand-wrapper {
   display: inline-block;
   height: 16px;
-  transition: opacity .2s ease-out;
   width: 24px;
   position: relative;
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
@@ -10,7 +10,6 @@
   overflow: hidden;
   margin-top: -8px;
   margin-bottom: 16px;
-  will-change: height;
   transition: all .2s ease-out;
 }
 .adyen-checkout__card__brands--hidden {

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
@@ -18,13 +18,15 @@ const AvailableBrands = ({ brands, activeBrand }: PaymentMethodBrandsProps) => {
 
     const isValidBrand = activeBrand !== 'card';
     return (
-        <span className="adyen-checkout__card__brands">
+        <span
+            className={classNames('adyen-checkout__card__brands', {
+                'adyen-checkout__card__brands--hidden': isValidBrand
+            })}
+        >
             {brands.map(({ name, icon }) => (
                 <span
                     key={name}
-                    className={classNames('adyen-checkout__card__brands__brand-wrapper', {
-                        'adyen-checkout__card__brands__brand-wrapper--disabled': isValidBrand && activeBrand !== name
-                    })}
+                    className="adyen-checkout__card__brands__brand-wrapper"
                 >
                     <Img src={icon} alt="" />
                 </span>


### PR DESCRIPTION
## Summary
See title. The credit card brands now slide out when the first two numbers of the card are recognised as a brand.
