### PR TITLE
fixes payment errors on order flow not triggering any callback

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -144,8 +144,8 @@ class DropinElement extends UIElement<DropinElementProps> {
      * handleOrder is implemented so we don't trigger a callback like in the components
      * @param response - PaymentResponse
      */
-    protected handleOrder = (response: PaymentResponse): void => {
-        this.updateParent({ order: response.order });
+    protected handleOrder = ({ order }: PaymentResponse): void => {
+        this.updateParent({ order });
     };
 
     closeActivePaymentMethod() {

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -9,6 +9,7 @@ import { getCommonProps } from './components/utils';
 import { createElements, createStoredElements } from './elements';
 import createInstantPaymentElements from './elements/createInstantPaymentElements';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
+import { PaymentResponse } from '../types';
 
 const SUPPORTED_INSTANT_PAYMENTS = ['paywithgoogle', 'applepay'];
 
@@ -138,6 +139,14 @@ class DropinElement extends UIElement<DropinElementProps> {
 
         return null;
     }
+
+    /**
+     * handleOrder is implemented so we don't trigger a callback like in the components
+     * @param response - PaymentResponse
+     */
+    protected handleOrder = (response: PaymentResponse): void => {
+        this.updateParent({ order: response.order });
+    };
 
     closeActivePaymentMethod() {
         this.dropinRef.closeActivePaymentMethod();

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -6,6 +6,7 @@ import getImage from '../../utils/get-image';
 import PayButton from '../internal/PayButton';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { Order, PaymentAmount } from '../../types';
+import { PaymentResponse } from '../types';
 
 export class GiftcardElement extends UIElement {
     public static type = 'giftcard';
@@ -74,8 +75,9 @@ export class GiftcardElement extends UIElement {
         }
     };
 
-    protected handleOrder = (order: Order) => {
-        this.elementRef._parentInstance.update({ order });
+    protected handleOrder = (response: PaymentResponse) => {
+        const order: Order = response.order;
+        this._parentInstance.update({ order });
         if (this.props.session && this.props.onOrderCreated) {
             return this.props.onOrderCreated(order);
         }
@@ -84,7 +86,6 @@ export class GiftcardElement extends UIElement {
     public balanceCheck() {
         return this.onBalanceCheck();
     }
-
 
     public onBalanceCheck = () => {
         // skip balance check if no onBalanceCheck event has been defined
@@ -115,8 +116,7 @@ export class GiftcardElement extends UIElement {
                         this.setState({ order: { orderData: order.orderData, pspReference: order.pspReference } });
                         this.submit();
                     });
-                }
-                else {
+                } else {
                     if (this.props.onRequiringConfirmation) {
                         this.props.onRequiringConfirmation();
                     }

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -77,7 +77,7 @@ export class GiftcardElement extends UIElement {
 
     protected handleOrder = (response: PaymentResponse) => {
         const order: Order = response.order;
-        this._parentInstance.update({ order });
+        this.updateParent({ order });
         if (this.props.session && this.props.onOrderCreated) {
             return this.props.onOrderCreated(order);
         }

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -77,7 +77,6 @@ export class GiftcardElement extends UIElement {
 
     protected handleOrder = (response: PaymentResponse) => {
         const order: Order = response.order;
-        debugger;
         this._parentInstance.update({ order });
         if (this.props.session && this.props.onOrderCreated) {
             return this.props.onOrderCreated(order);

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -77,6 +77,7 @@ export class GiftcardElement extends UIElement {
 
     protected handleOrder = (response: PaymentResponse) => {
         const order: Order = response.order;
+        debugger;
         this._parentInstance.update({ order });
         if (this.props.session && this.props.onOrderCreated) {
             return this.props.onOrderCreated(order);

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -75,8 +75,7 @@ export class GiftcardElement extends UIElement {
         }
     };
 
-    protected handleOrder = (response: PaymentResponse) => {
-        const order: Order = response.order;
+    protected handleOrder = ({ order }: PaymentResponse) => {
         this.updateParent({ order });
         if (this.props.session && this.props.onOrderCreated) {
             return this.props.onOrderCreated(order);

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -5,7 +5,7 @@ import CoreProvider from '../../core/Context/CoreProvider';
 import getImage from '../../utils/get-image';
 import PayButton from '../internal/PayButton';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
-import { Order, PaymentAmount } from '../../types';
+import { PaymentAmount } from '../../types';
 import { PaymentResponse } from '../types';
 
 export class GiftcardElement extends UIElement {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -1,17 +1,19 @@
 import { h } from 'preact';
 import BaseElement from './BaseElement';
-import { Order, PaymentAction } from '../types';
+import { PaymentAction } from '../types';
+import { PaymentResponse } from './types';
 import getImage from '../utils/get-image';
 import PayButton from './internal/PayButton';
-import { IUIElement, PayButtonFunctionProps, UIElementProps } from './types';
+import { IUIElement, PayButtonFunctionProps, RawPaymentResponse, UIElementProps } from './types';
 import { getSanitizedResponse, resolveFinalResult } from './utils';
 import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
 import { UIElementStatus } from './types';
 import { hasOwnProperty } from '../utils/hasOwnProperty';
+import DropinElement from './Dropin';
 
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
     protected componentRef: any;
-    public elementRef: any;
+    public elementRef: UIElement;
 
     constructor(props: P) {
         super({ setStatusAutomatically: true, ...props });
@@ -43,8 +45,10 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     }
 
     private onSubmit(): void {
+        //TODO: refactor this, instant payment methods are part of Dropin logic not UIElement
         if (this.props.isInstantPayment) {
-            this.elementRef.closeActivePaymentMethod();
+            const dropinElementRef = this.elementRef as DropinElement;
+            dropinElementRef.closeActivePaymentMethod();
         }
 
         if (this.props.setStatusAutomatically) {
@@ -58,7 +62,12 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
             // Session flow
             // wrap beforeSubmit callback in a promise
             const beforeSubmitEvent = this.props.beforeSubmit
-                ? new Promise((resolve, reject) => this.props.beforeSubmit(this.data, this.elementRef, { resolve, reject }))
+                ? new Promise((resolve, reject) =>
+                      this.props.beforeSubmit(this.data, this.elementRef, {
+                          resolve,
+                          reject
+                      })
+                  )
                 : Promise.resolve(this.data);
 
             beforeSubmitEvent
@@ -172,11 +181,13 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         return null;
     }
 
-    protected handleOrder = (order: Order): void => {
-        this.elementRef._parentInstance.update({ order });
+    protected handleOrder = (response: PaymentResponse): void => {
+        this.elementRef._parentInstance.update({ order: response.order });
+        // in case we receive an order in any other component then a GiftCard trigger handleFinalResult
+        this.handleFinalResult(response);
     };
 
-    protected handleFinalResult = result => {
+    protected handleFinalResult = (result: PaymentResponse) => {
         if (this.props.setStatusAutomatically) {
             const [status, statusProps] = resolveFinalResult(result);
             if (status) this.setElementStatus(status, statusProps);
@@ -191,13 +202,13 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
      * The component will handle automatically actions, orders, and final results.
      * @param rawResponse -
      */
-    protected handleResponse(rawResponse): void {
+    protected handleResponse(rawResponse: RawPaymentResponse): void {
         const response = getSanitizedResponse(rawResponse);
 
         if (response.action) {
             this.elementRef.handleAction(response.action);
         } else if (response.order?.remainingAmount?.value > 0) {
-            this.elementRef.handleOrder(response.order);
+            this.elementRef.handleOrder(response);
         } else {
             this.elementRef.handleFinalResult(response);
         }

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -184,7 +184,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     }
 
     protected handleOrder = (response: PaymentResponse): void => {
-        this.elementRef._parentInstance.update({ order: response.order });
+        this.updateParent({ order: response.order });
         // in case we receive an order in any other component then a GiftCard trigger handleFinalResult
         if (this.props.onPaymentCompleted) this.props.onPaymentCompleted(response, this.elementRef);
     };

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -184,7 +184,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     protected handleOrder = (response: PaymentResponse): void => {
         this.elementRef._parentInstance.update({ order: response.order });
         // in case we receive an order in any other component then a GiftCard trigger handleFinalResult
-        this.handleFinalResult(response);
+        if (this.props.onPaymentCompleted) this.props.onPaymentCompleted(response, this.elementRef);
     };
 
     protected handleFinalResult = (result: PaymentResponse) => {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -10,6 +10,8 @@ import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
 import { UIElementStatus } from './types';
 import { hasOwnProperty } from '../utils/hasOwnProperty';
 import DropinElement from './Dropin';
+import { CoreOptions } from '../core/types';
+import Core from '../core';
 
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
     protected componentRef: any;
@@ -208,10 +210,21 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         if (response.action) {
             this.elementRef.handleAction(response.action);
         } else if (response.order?.remainingAmount?.value > 0) {
-            this.elementRef.handleOrder(response);
+            // we don't want to call elementRef here, use the component handler
+            // we do this way so the logic on handlingOrder is associated with payment method
+            this.handleOrder(response);
         } else {
             this.elementRef.handleFinalResult(response);
         }
+    }
+
+    /**
+     * Call update on parent instance
+     * This function exist to make safe access to the protect _parentInstance
+     * @param options - CoreOptions
+     */
+    public updateParent(options: CoreOptions = {}): Promise<Core> {
+        return this.elementRef._parentInstance.update(options);
     }
 
     /**

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -1,5 +1,5 @@
 import { CustomTranslations, Locales } from '../language/types';
-import { PaymentMethods, PaymentMethodOptions, PaymentActionsType, PaymentAmountExtended } from '../types';
+import { PaymentMethods, PaymentMethodOptions, PaymentActionsType, PaymentAmountExtended, Order } from '../types';
 import { AnalyticsOptions } from './Analytics/types';
 import { PaymentMethodsResponseObject } from './ProcessResponse/PaymentMethodsResponse/types';
 import { RiskModuleOptions } from './RiskModule/RiskModule';
@@ -74,6 +74,9 @@ export interface CoreOptions {
 
     risk?: RiskModuleOptions;
 
+    order?: Order;
+
+    //TODO: discuss if can remove this
     [key: string]: any;
 }
 

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -292,14 +292,14 @@ export type CheckoutSessionSetupResponse = {
 export type CheckoutSessionPaymentResponse = {
     sessionData: string;
     status?: string;
-    resultCode?: string;
+    resultCode: string;
     action?: PaymentAction;
 };
 
 export type CheckoutSessionDetailsResponse = {
     sessionData: string;
     status?: string;
-    resultCode?: string;
+    resultCode: string;
     action?: PaymentAction;
 };
 

--- a/packages/playground/src/pages/GiftCards/GiftCards.html
+++ b/packages/playground/src/pages/GiftCards/GiftCards.html
@@ -45,8 +45,16 @@
                 <div id="payment-method-container"></div>
             </div>
             <div class="merchant-checkout__payment-method__details">
-                <button class="adyen-checkout__button adyen-checkout__button--pay" id="custom-checkout-button">Custom
-                    Checkout Button
+                <button class="adyen-checkout__button adyen-checkout__button--pay" id="custom-checkout-add-button">
+                    Custom Add Gift Card
+                </button>
+
+                <button class="adyen-checkout__button adyen-checkout__button--pay" id="custom-checkout-confirm-button">
+                    Custom Confirm Gift Card
+                </button>
+
+                <button class="adyen-checkout__button adyen-checkout__button--pay" id="custom-checkout-card-button">
+                    Custom Card Button
                 </button>
             </div>
         </div>

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -95,8 +95,8 @@ import '../../style.scss';
             },
             onRequiringConfirmation: () => {
                 console.log('onRequiringConfirmation');
-                checkoutConfirmButton.style.display = 'none';
-                checkoutAddButton.style.display = '';
+                checkoutConfirmButton.style.display = '';
+                checkoutAddButton.style.display = 'none';
             }
         })
         .mount('#giftcard-session-container');

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -47,7 +47,7 @@ import '../../style.scss';
 
     const session = await createSession({
         amount,
-        reference: 'ABC123',
+        reference: 'antonio_giftcard_test',
         returnUrl,
         shopperLocale,
         shopperReference,
@@ -58,7 +58,7 @@ import '../../style.scss';
         environment: process.env.__CLIENT_ENV__,
         clientKey: process.env.__CLIENT_KEY__,
         session,
-        showPayButton: false,
+        showPayButton: true,
 
         // Events
         beforeSubmit: (data, component, actions) => {
@@ -72,41 +72,34 @@ import '../../style.scss';
         }
     });
 
-    const checkoutButton = document.querySelector('#custom-checkout-button');
+    const checkoutAddButton = document.querySelector('#custom-checkout-add-button');
+    const checkoutConfirmButton = document.querySelector('#custom-checkout-confirm-button');
+    const checkoutCardButton = document.querySelector('#custom-checkout-card-button');
+
+    checkoutConfirmButton.style.display = 'none';
 
     const giftcardCheckBalance = () => window.giftcard.balanceCheck();
     const giftcardSubmit = () => window.giftcard.submit();
     const cardSubmit = () => window.card.submit();
 
-    checkoutButton.addEventListener('click', giftcardCheckBalance);
-
-    const setupGiftCardSubmit = () => {
-        checkoutButton.removeEventListener('click', giftcardCheckBalance);
-        checkoutButton.addEventListener('click', giftcardSubmit);
-    };
-    const setupCardSubmit = () => {
-        checkoutButton.removeEventListener('click', setupGiftCardSubmit);
-        checkoutButton.addEventListener('click', cardSubmit);
-    };
+    checkoutAddButton.addEventListener('click', giftcardCheckBalance);
+    checkoutConfirmButton.addEventListener('click', giftcardSubmit);
+    checkoutCardButton.addEventListener('click', cardSubmit);
 
     window.giftcard = sessionCheckout
         .create('giftcard', {
             type: 'giftcard',
             brand: 'svs',
-            onSubmit: () => {
-                afterGiftCard();
-            },
             onOrderCreated: () => {
-                afterGiftCard();
+                console.log('onOrderCreated');
             },
             onRequiringConfirmation: () => {
-                setupGiftCardSubmit();
+                console.log('onRequiringConfirmation');
+                checkoutConfirmButton.style.display = 'none';
+                checkoutAddButton.style.display = '';
             }
         })
         .mount('#giftcard-session-container');
 
-    const afterGiftCard = () => {
-        window.card = sessionCheckout.create('card').mount('#payment-method-container');
-        setupCardSubmit();
-    };
+    window.card = sessionCheckout.create('card').mount('#payment-method-container');
 })();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

In this change we fix a bug where no callback was called when a `payment/` error was received. 
This would happen because of the order object in the response would trigger `handleOrder`, which would just update the component state but not trigger anything.
This change moves the responsibility of handling an order to the payment method. This means, that `Giftcard` is the only payment method capable of triggering `onOrderCreated`. A fallback is created in `UIElement` so handle a response with "order" has `onPaymentCompleted`. This last scenario should only happen when a payment fails since other payment methods always pay full remaining amount. 

## Tested scenarios
<!-- Description of tested scenarios -->

  | Dropin | Comp | Custom Button
-- | -- | -- | --
Giftcard -> Authorization | ✅ | ✅ | ✅
Giftcard -> Success | ✅ | ✅ | ✅
Giftcard -> Fail | ✅ | ✅ | ✅
Card -> Success | ✅ | ✅ |  
Card -> Fail | ✅ | ✅ |  
Giftcard -> Card -> Fail | ✅ | ✅ | ✅
Giftcard -> Card -> Success | ✅ | ✅ | ✅
Giftcard -> Giftcard -> Card -> Fail | ✅ | ✅ |  
Giftcard -> Giftcard -> Card -> Success | ✅ | ✅ |  



**Fixed issue**:  <!-- #-prefixed issue number -->
