### PR TITLE
Blik (Await) Don't call /details endpoint when payload is missing

### DIFF
--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -36,6 +36,11 @@ class BlikElement extends UIElement {
         return !!this.state.isValid;
     }
 
+    /**
+     * NOTE: for future reference:
+     *  this.props.onComplete (which is called from this.onComplete) equates to the merchant defined onAdditionalDetails callback
+     *  (the initial /payments response defines an "await" action, actionTypes.ts translates this to "onComplete: props.onAdditionalDetails")
+     */
     render() {
         if (this.props.paymentData) {
             return (

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -80,7 +80,7 @@ function Await(props: AwaitComponentProps) {
             .catch(({ message, ...response }) => ({
                 type: 'network-error',
                 props: {
-                    ...(message && { message: props.getI18n(message) }),
+                    ...(message && { message: i18n.get(message) }),
                     ...response
                 }
             }))

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -44,7 +44,7 @@ function Await(props: AwaitComponentProps) {
                     paymentData: props.paymentData
                 }
             };
-
+            // Send success response to onAdditionalDetails
             return props.onComplete(state, this);
         }
 
@@ -64,7 +64,6 @@ function Await(props: AwaitComponentProps) {
                     paymentData: props.paymentData
                 }
             };
-
             // Send error response to onAdditionalDetails
             return props.onComplete(state, this);
         }

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -132,6 +132,7 @@ function Await(props: AwaitComponentProps) {
                 checkStatus();
 
                 const actualTimePassed = timePassed + delay;
+                // timePassed is the value that is the main "engine" that drives this useEffect/polling
                 setTimePassed(actualTimePassed);
 
                 if (actualTimePassed >= props.throttleTime && !hasAdjustedTime) {
@@ -140,13 +141,10 @@ function Await(props: AwaitComponentProps) {
                 }
             };
 
-            // Reset 'loading' to ensure that it is changes to this value that are the main "engine" that drives this useEffect
-            setLoading(true);
-
             // Create (another) interval to poll for a result
             setStoredTimeout(setTimeout(statusInterval, delay));
         }
-    }, [loading, expired, completed]);
+    }, [loading, expired, completed, timePassed]);
 
     const finalState = (image, message) => (
         <div className="adyen-checkout__await adyen-checkout__await--result">

--- a/packages/lib/src/components/internal/Await/types.ts
+++ b/packages/lib/src/components/internal/Await/types.ts
@@ -27,4 +27,5 @@ export interface AwaitComponentProps {
     messageText: string;
     awaitText: string;
     ref: any;
+    getI18n?: (key: string, options?) => string; // Should equate to the Language.get method
 }

--- a/packages/lib/src/components/internal/Await/types.ts
+++ b/packages/lib/src/components/internal/Await/types.ts
@@ -27,5 +27,4 @@ export interface AwaitComponentProps {
     messageText: string;
     awaitText: string;
     ref: any;
-    getI18n?: (key: string, options?) => string; // Should equate to the Language.get method
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Don't make "final state" calls (leading to a call to `onAdditionalDetails`) when `payload` is missing. 
Instead show an error state in the component.

## Tested scenarios
Mocked responses with `resultCode:"authorised"` and an empty &/or missing 'payload' to ensure an error is shown and no `/details` call is made.
Mocked responses with `resultCode:"pending"` to confirm that the regular polling to the `/status` endpoint continues until the timeout (there were some concerns, expressed in the ticket) that it switched off after three attempts

**Relates to issue**:  DEV-54329