### PR TITLE
Creating more informative errors 3DS2 errors

### DIFF
--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -1,17 +1,18 @@
 import { h } from 'preact';
 import UIElement from '../UIElement';
 import Challenge from './components/Challenge';
-import { ErrorObject } from './components/utils';
+import { ErrorCodeObject } from './components/utils';
 import { DEFAULT_CHALLENGE_WINDOW_SIZE } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import Language from '../../language';
+import { ThreeDS2ChallengeRejectObject } from './types';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;
     dataKey?: string;
     notificationURL?: string;
-    onError?: (error: string | ErrorObject) => void;
+    onError?: (error: string | ErrorCodeObject | ThreeDS2ChallengeRejectObject) => void;
     paymentData?: string;
     size?: string;
     challengeWindowSize?: '01' | '02' | '03' | '04' | '05';
@@ -19,7 +20,6 @@ export interface ThreeDS2ChallengeProps {
     loadingContext?: string;
     useOriginalFlow?: boolean;
     i18n?: Language;
-    threeDS2MDFlowUnloadListener?: any;
 }
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../UIElement';
 import DeviceFingerprint from './components/DeviceFingerprint';
-import { ErrorObject } from './components/utils';
+import { ErrorCodeObject } from './components/utils';
 import callSubmit3DS2Fingerprint from './callSubmit3DS2Fingerprint';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 
@@ -9,7 +9,7 @@ export interface ThreeDS2DeviceFingerprintProps {
     dataKey: string;
     token: string;
     notificationURL: string;
-    onError: (error?: string | ErrorObject) => void;
+    onError: (error?: string | ErrorCodeObject) => void;
     paymentData: string;
     showSpinner: boolean;
     type: string;

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -2,7 +2,7 @@ import { Component, h } from 'preact';
 import DoChallenge3DS2 from './DoChallenge3DS2';
 import { createChallengeResolveData, handleErrorCode, prepareChallengeData, createOldChallengeResolveData } from '../utils';
 import { PrepareChallenge3DS2Props, PrepareChallenge3DS2State } from './types';
-import { ThreeDS2FlowObject } from '../../types';
+import { ChallengeData, ThreeDS2ChallengeRejectObject, ThreeDS2FlowObject } from '../../types';
 import '../../ThreeDS2.scss';
 import Img from '../../../internal/Img';
 import { getImageUrl } from '../../../../utils/get-image';
@@ -19,25 +19,36 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
         super(props);
 
         if (this.props.token) {
-            const challengeData = prepareChallengeData({
+            const challengeData: ChallengeData = prepareChallengeData({
                 token: this.props.token,
                 size: this.props.challengeWindowSize || this.props.size
             });
 
+            /**
+             * Check the structure of the created challengeData
+             */
+            const { acsTransID, messageVersion, threeDSServerTransID } = challengeData.cReqData;
+
+            /** Missing props */
+            if (!challengeData.acsURL || !acsTransID || !messageVersion || !threeDSServerTransID) {
+                this.setStatusError({
+                    errorInfo:
+                        'Challenge Data missing one or more of the following properties (acsURL | acsTransID | messageVersion | threeDSServerTransID)',
+                    errorObj: challengeData
+                });
+                return;
+            }
+
+            /** All good */
             this.state = {
                 status: 'retrievingChallengeToken',
-                challengeData
+                challengeData,
+                errorInfo: null
             };
         } else {
-            this.state = { status: 'error' };
-            this.props.onError('Missing challengeToken parameter');
-        }
-    }
-
-    // For 3DS2InMDFlow - we need to remove the unload listener that has been set on the window
-    remove3DS2MDFlowUnloadListener() {
-        if (this.props.threeDS2MDFlowUnloadListener) {
-            window.removeEventListener('beforeunload', this.props.threeDS2MDFlowUnloadListener, { capture: true });
+            this.setStatusError({
+                errorInfo: 'Missing challengeToken parameter'
+            });
         }
     }
 
@@ -51,17 +62,13 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             const resolveDataFunction = this.props.useOriginalFlow ? createOldChallengeResolveData : createChallengeResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj.transStatus, this.props.paymentData);
 
-            this.remove3DS2MDFlowUnloadListener();
-
-            this.props.onComplete(data); // (equals onAdditionalDetails)
+            this.props.onComplete(data); // (equals onAdditionalDetails - except for 3DS2InMDFlow)
         });
     }
 
-    setStatusError(errorObj) {
-        this.setState({ status: 'error' }, () => {
-            this.remove3DS2MDFlowUnloadListener();
-            this.props.onError(errorObj);
-        });
+    setStatusError(errorInfoObj) {
+        this.setState({ status: 'error', errorInfo: errorInfoObj.errorInfo });
+        this.props.onError(errorInfoObj); // For some reason this doesn't fire if it's in a callback passed to the setState function
     }
 
     render(props, { challengeData }) {
@@ -72,27 +79,30 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                         // Challenge has resulted in an error (no transStatus could be retrieved) - but we still treat this as a valid scenario
                         if (hasOwnProperty(challenge.result, 'errorCode') && challenge.result.errorCode.length) {
                             // Tell the merchant there's been an error
-                            const errorObject = handleErrorCode(challenge.result.errorCode, challenge.result.errorDescription);
-                            this.props.onError(errorObject);
-                            // Proceed with call to onAdditionalDetails
-                            this.setStatusComplete(challenge.result);
-                            return;
+                            const errorCodeObject = handleErrorCode(challenge.result.errorCode, challenge.result.errorDescription);
+                            this.props.onError(errorCodeObject);
                         }
 
-                        // A valid result (w. transStatus)
+                        // Proceed with call to onAdditionalDetails
                         this.setStatusComplete(challenge.result);
                     }}
-                    onErrorChallenge={(challenge: ThreeDS2FlowObject) => {
-                        // Called when challenge times-out (which is still a valid scenario)
-                        if (hasOwnProperty(challenge, 'errorCode')) {
-                            const errorObject = handleErrorCode(challenge.errorCode);
-                            this.props.onError(errorObject);
+                    onErrorChallenge={(challenge: ThreeDS2FlowObject | ThreeDS2ChallengeRejectObject) => {
+                        /**
+                         * Called when challenge times-out (which is still a valid scenario)...
+                         */
+                        // first part of if-clause checks errorCode isn't undefined or null, second part keeps typescript happy
+                        if (hasOwnProperty(challenge, 'errorCode') && 'errorCode' in challenge) {
+                            const errorCodeObject = handleErrorCode(challenge.errorCode);
+                            this.props.onError(errorCodeObject);
                             this.setStatusComplete(challenge.result);
                             return;
                         }
 
-                        // or, when the challenge response is un-parseable JSON - in which case something unknown has gone wrong
-                        this.setStatusError(challenge);
+                        /**
+                         * ...OR, when the challenge response is un-parseable JSON - in which case something unknown has gone wrong
+                         * - So pass this on to the defined error handler *without* blocking the flow
+                         */
+                        this.props.onError(challenge as ThreeDS2ChallengeRejectObject);
                     }}
                     {...challengeData}
                 />
@@ -107,7 +117,9 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                         src={getImageUrl({ loadingContext: this.props.loadingContext, imageFolder: 'components/' })('error')}
                         alt={''}
                     />
-                    <div className="adyen-checkout__status__text">{this.props.i18n.get('error.message.unknown')}</div>
+                    <div className="adyen-checkout__status__text">
+                        {this.state.errorInfo ? this.state.errorInfo : this.props.i18n.get('error.message.unknown')}
+                    </div>
                 </div>
             );
         }

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
@@ -5,7 +5,6 @@ import { ThreeDS2ChallengeProps } from '../../ThreeDS2Challenge';
 export interface DoChallenge3DS2Props extends ChallengeData {
     onCompleteChallenge: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorChallenge: (rejectObject: ThreeDS2FlowObject) => void;
-    threeDS2MDFlowUnloadListener?: (event: any) => any;
 }
 
 export interface DoChallenge3DS2State {
@@ -20,4 +19,5 @@ export interface PrepareChallenge3DS2Props extends ThreeDS2ChallengeProps {
 export interface PrepareChallenge3DS2State {
     challengeData?: ChallengeData;
     status?: string;
+    errorInfo?: string;
 }

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -2,7 +2,7 @@ import { Component, h } from 'preact';
 import DoFingerprint3DS2 from './DoFingerprint3DS2';
 import { createFingerprintResolveData, createOldFingerprintResolveData, handleErrorCode, prepareFingerPrintData } from '../utils';
 import { PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State } from './types';
-import { ResultObject } from '../../types';
+import { FingerPrintData, ResultObject } from '../../types';
 
 class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State> {
     public static type = 'scheme';
@@ -13,7 +13,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
         const { token, notificationURL } = this.props; // See comments on prepareFingerPrintData regarding notificationURL
 
         if (token) {
-            const fingerPrintData = prepareFingerPrintData({ token, notificationURL });
+            const fingerPrintData: FingerPrintData = prepareFingerPrintData({ token, notificationURL });
 
             this.state = {
                 status: 'init',
@@ -34,7 +34,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
 
     componentDidMount() {
         // If no fingerPrintData or no threeDSMethodURL - don't render component. Instead exit with threeDSCompInd: 'U'
-        if (!this.state.fingerPrintData || !this.state.fingerPrintData.threeDSMethodURL || !this.state.fingerPrintData.threeDSMethodURL.length) {
+        if (!this.state.fingerPrintData || !this.state.fingerPrintData.threeDSMethodURL) {
             this.setStatusComplete({ threeDSCompInd: 'U' });
             return;
         }
@@ -52,6 +52,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
              */
             const resolveDataFunction = this.props.useOriginalFlow ? createOldFingerprintResolveData : createFingerprintResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj, this.props.paymentData);
+
             this.props.onComplete(data);
         });
     }
@@ -64,8 +65,8 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
                         this.setStatusComplete(fingerprint.result);
                     }}
                     onErrorFingerprint={fingerprint => {
-                        const errorObject = handleErrorCode(fingerprint.errorCode);
-                        this.props.onError(errorObject);
+                        const errorCodeObject = handleErrorCode(fingerprint.errorCode);
+                        this.props.onError(errorCodeObject);
                         this.setStatusComplete(fingerprint.result);
                     }}
                     showSpinner={this.props.showSpinner}

--- a/packages/lib/src/components/ThreeDS2/components/utils.ts
+++ b/packages/lib/src/components/ThreeDS2/components/utils.ts
@@ -19,7 +19,7 @@ export interface ChallengeResolveData {
     };
 }
 
-export interface ErrorObject {
+export interface ErrorCodeObject {
     errorCode: string;
     message: string;
 }
@@ -145,7 +145,7 @@ export const createOldChallengeResolveData = (dataKey: string, transStatus: stri
     }
 });
 
-export const handleErrorCode = (errorCode: string, errorDescription?: string): ErrorObject => {
+export const handleErrorCode = (errorCode: string, errorDescription?: string): ErrorCodeObject => {
     const unknownMessage = ERROR_MESSAGES[ERRORS.UNKNOWN];
     const message = ERROR_MESSAGES[errorCode] || errorDescription || unknownMessage;
     return { errorCode, message };

--- a/packages/lib/src/components/ThreeDS2/config.ts
+++ b/packages/lib/src/components/ThreeDS2/config.ts
@@ -1,18 +1,17 @@
-import { ThreeDS2FlowObject } from './types';
+import { ThreeDS2FlowObject, ThreeDS2ChallengeRejectObject } from './types';
 
 export const DEFAULT_CHALLENGE_WINDOW_SIZE = '02';
 
 export const THREEDS_METHOD_TIMEOUT = 10000;
 export const CHALLENGE_TIMEOUT = 600000;
 
-export const UNKNOWN_CHALLENGE_RESOLVE_OBJECT: ThreeDS2FlowObject = {
-    result: {
-        transStatus: 'U'
-    },
-    type: 'challengeResult'
+export const CHALLENGE_UNKNOWN_ERROR_REJECT_OBJECT: ThreeDS2ChallengeRejectObject = {
+    type: 'challengeError',
+    comment: 'something unexpected happened',
+    extraInfo: 'any info about what happened'
 };
 
-export const UNKNOWN_CHALLENGE_RESOLVE_OBJECT_TIMEOUT: ThreeDS2FlowObject = {
+export const CHALLENGE_TIMEOUT_REJECT_OBJECT: ThreeDS2FlowObject = {
     result: {
         transStatus: 'U'
     },

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -35,6 +35,13 @@ export interface ThreeDS2FlowObject {
     threeDSServerTransID?: string;
 }
 
+export interface ThreeDS2ChallengeRejectObject {
+    type: 'challengeError';
+    comment?: string;
+    extraInfo?: string;
+    eventDataRaw?: string;
+}
+
 // One token fits all - Fingerprint & Challenge
 export interface ThreeDS2Token {
     acsTransID?: string;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Creating more informative errors from the 3DS2 process and stopping the "dead-end" that was possible from an un-parseable postMessage that came from a legitimate source.

- We now have extra checks on the data that is passed in to 3DS2 in order to create a challenge - these lead to more informative errors, presented in the component itself.

- There was also a situation that emerged in the MDFlow where a postMessage came from a legitimate, expected adyen url but with un-parseable data. This was leading to an "unknown error" message & icon, and a "dead-end" within the component itself - past which it was not possible to proceed.
Now we create an informative message about this event that we pass to the `onError` callback but _don't_ block the flow.

- Have also removed the code that dealt with the config prop from the MDFlow (`threeDS2MDFlowUnloadListener`) - since this is no longer required

## Tested scenarios
All existing tests pass


**Relates to issue**:  FOC-67614
