### PR TITLE
[COWEB-1143] Move checkoutAttemptId field to paymentMethod object in state.data

### DIFF
--- a/packages/e2e/tests/analytics/checkoutAttemptId.test.js
+++ b/packages/e2e/tests/analytics/checkoutAttemptId.test.js
@@ -40,9 +40,9 @@ test('#1 - should save the checkoutAttemptId session in the sessionStorage and k
         .eql(1)
         .expect(
             paymentLogger.contains(record => {
-                const { checkoutAttemptId } = JSON.parse(record.request.body);
-                return checkoutAttemptId === id;
+                const body = JSON.parse(record.request.body);
+                return body.paymentMethod.checkoutAttemptId === id;
             })
         )
-        .ok('checkoutAttemptId is present in the /payments request');
+        .ok('checkoutAttemptId is present in the /payments request inside paymentMethod data');
 });

--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -34,7 +34,8 @@ class BaseElement<P extends BaseElementProps> {
      * Executed on the `data` getter.
      * Returns the component data necessary for the /payments request
      *
-     * TODO: Replace 'any' by type 'PaymentMethodData<T>'
+     * TODO: Replace 'any' by type PaymentMethodData<T> - this change requires updating all payment methods,
+     *       properly adding the type of the formatData function
      */
     protected formatData(): any {
         return {};
@@ -54,17 +55,14 @@ class BaseElement<P extends BaseElementProps> {
         const order = this.state.order || this.props.order;
 
         const componentData = this.formatData();
+        if (componentData.paymentMethod && checkoutAttemptId) {
+            componentData.paymentMethod.checkoutAttemptId = checkoutAttemptId;
+        }
 
         return {
             ...(clientData && { riskData: { clientData } }),
             ...(order && { order: { orderData: order.orderData, pspReference: order.pspReference } }),
             ...componentData,
-            ...(componentData.paymentMethod && {
-                paymentMethod: {
-                    ...componentData.paymentMethod,
-                    ...(checkoutAttemptId && { checkoutAttemptId })
-                }
-            }),
             clientStateDataIndicator: true
         };
     }

--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -4,6 +4,7 @@ import EventEmitter from './EventEmitter';
 import uuid from '../utils/uuid';
 import Core from '../core';
 import { BaseElementProps, PaymentData } from './types';
+import { RiskData } from '../core/RiskModule/RiskModule';
 
 class BaseElement<P extends BaseElementProps> {
     public readonly _id = `${this.constructor['type']}-${uuid()}`;
@@ -49,7 +50,7 @@ class BaseElement<P extends BaseElementProps> {
      * Returns the component payment data ready to submit to the Checkout API
      * Note: this does not ensure validity, check isValid first
      */
-    get data(): PaymentData {
+    get data(): PaymentData | RiskData {
         const clientData = getProp(this.props, 'modules.risk.data');
         const checkoutAttemptId = getProp(this.props, 'modules.analytics.checkoutAttemptId');
         const order = this.state.order || this.props.order;

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -57,7 +57,7 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     }
 
     updateWithAction(action: PaymentAction) {
-        if (action.paymentMethodType !== this.data.paymentMethod.type) throw new Error('Invalid Action');
+        if (action.paymentMethodType !== this.type) throw new Error('Invalid Action');
 
         if (action.paymentData) {
             this.paymentData = action.paymentData;

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -8,13 +8,11 @@ import RiskElement from '../core/RiskModule';
 import { PayButtonProps } from './internal/PayButton/PayButton';
 import Session from '../core/CheckoutSession';
 
-type DataWithCheckoutAttemptId = {
-    [key: string]: any;
-    checkoutAttemptId?: string;
-};
-
 export interface PaymentMethodData {
-    paymentMethod: DataWithCheckoutAttemptId;
+    paymentMethod: {
+        [key: string]: any;
+        checkoutAttemptId?: string;
+    };
     browserInfo?: {
         acceptHeader: string;
         colorDepth: number;

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -8,6 +8,41 @@ import RiskElement from '../core/RiskModule';
 import { PayButtonProps } from './internal/PayButton/PayButton';
 import Session from '../core/CheckoutSession';
 
+type DataWithCheckoutAttemptId = {
+    [key: string]: any;
+    checkoutAttemptId?: string;
+};
+
+export interface PaymentMethodData {
+    paymentMethod: DataWithCheckoutAttemptId;
+    browserInfo?: {
+        acceptHeader: string;
+        colorDepth: number;
+        javaEnabled: boolean;
+        language: string;
+        screenHeight: number;
+        screenWidth: number;
+        timeZoneOffset: number;
+        userAgent: string;
+    };
+}
+
+/**
+ * Represents the payment data that will be submitted to the /payments endpoint
+ */
+export interface PaymentData extends PaymentMethodData {
+    riskData?: {
+        clientData: string;
+    };
+    order?: {
+        orderData: string;
+        pspReference: string;
+    };
+    clientStateDataIndicator: boolean;
+    sessionData?: string;
+    storePaymentMethod?: boolean;
+}
+
 export interface PaymentResponse {
     action?: PaymentAction;
     resultCode: string;

--- a/packages/lib/src/core/RiskModule/RiskModule.tsx
+++ b/packages/lib/src/core/RiskModule/RiskModule.tsx
@@ -17,6 +17,8 @@ interface RiskModuleProps extends BaseElementProps {
     loadingContext: string;
 }
 
+export type RiskData = string | boolean;
+
 export default class RiskElement extends BaseElement<RiskModuleProps> {
     public static type = 'risk';
     public static defaultProps = {
@@ -77,7 +79,7 @@ export default class RiskElement extends BaseElement<RiskModuleProps> {
         return this.state.isValid;
     }
 
-    get data() {
+    get data(): RiskData {
         if (this.isValid) {
             const dataObj = { version: RISK_DATA_VERSION, ...this.state.data };
             return base64.encode(JSON.stringify(dataObj));


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Moving `checkoutAttemptId` to `paymentMethod` object in order to increase adoption of telemetry logic.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
- e2e test
- manual test
<!-- Description of tested scenarios -->


**Fixed issue**:  COWEB-1143
