### PR TITLE
Added maskSecurityCode config prop

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -110,6 +110,7 @@ export interface CardInputProps {
     styles?: StylesObject;
     trimTrailingSeparator?: boolean;
     type?: string;
+    maskSecurityCode?: boolean;
 }
 
 export interface CardInputState {

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -200,7 +200,8 @@ export const extractPropsForSFP = (props: CardInputProps) => {
         onFieldValid: props.onFieldValid,
         onLoad: props.onLoad,
         showWarnings: props.showWarnings,
-        trimTrailingSeparator: props.trimTrailingSeparator
+        trimTrailingSeparator: props.trimTrailingSeparator,
+        maskSecurityCode: props.maskSecurityCode
     } as SFPProps; // Can't set as return type on fn or it will complain about missing, mandatory, props
 };
 

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -180,7 +180,8 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             minimumExpiryDate: this.props.minimumExpiryDate,
             implementationType: this.props.implementationType || 'components', // to distinguish between 'regular' and 'custom' card component
             isCollatingErrors: this.props.isCollatingErrors,
-            forceCompat: this.props.forceCompat
+            forceCompat: this.props.forceCompat,
+            maskSecurityCode: this.props.maskSecurityCode
         };
 
         this.csf = initCSF(csfSetupObj);

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -41,6 +41,7 @@ export interface SFPProps {
     trimTrailingSeparator?: boolean;
     type: string;
     render: () => {};
+    maskSecurityCode: boolean;
 }
 
 export interface SFPState {

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/AbstractCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/AbstractCSF.ts
@@ -13,7 +13,7 @@ abstract class AbstractCSF {
     protected validateForm: () => void;
     protected handleBrandFromBinLookup: typeof handleBrandFromBinLookup;
     protected callbacksHandler: (callbacksObj: object) => void;
-    protected configHandler: () => void;
+    protected configHandler: (props: CSFSetupObject) => void;
     protected createCardSecuredFields: (securedFields: HTMLElement[]) => Promise<any>;
     protected createNonCardSecuredFields: (securedFields: HTMLElement[]) => Promise<any>;
     protected createSecuredFields: typeof createSecuredFields;

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
@@ -36,6 +36,15 @@ const notConfiguredWarning = (str = 'You cannot use secured fields') => {
 class CSF extends AbstractCSF {
     // --
     constructor(setupObj: CSFSetupObject) {
+        /**
+         * Initialises:
+         *  - this.props = setupObj: CSFSetupObject
+         *
+         * and empty objects for:
+         *  - this.config: CSFConfigObject (populated in handleConfig.ts)
+         *  - this.callbacks: CSFCallbacksConfig (populated in configureCallbacks.ts
+         *  - this.state: CSFStateObject (populated below)
+         */
         super(setupObj);
 
         this.state = {
@@ -114,7 +123,7 @@ class CSF extends AbstractCSF {
     }
 
     private init(): void {
-        this.configHandler();
+        this.configHandler(this.props);
         this.callbacksHandler(this.props.callbacks);
 
         /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -9,7 +9,7 @@ import {
 } from '../../configuration/constants';
 import { existy } from '../../utilities/commonUtils';
 import cardType from '../utils/cardType';
-import { SFSetupObject } from '../../securedField/AbstractSecuredField';
+import { SecuredFieldInitObj } from '../../securedField/AbstractSecuredField';
 import SecuredField from '../../securedField/SecuredField';
 import { CardObject, CbObjOnBrand, SFFeedbackObj, CbObjOnLoad, CVCPolicyType } from '../../types';
 import AdyenCheckoutError from '../../../../../../core/Errors/AdyenCheckoutError';
@@ -169,30 +169,30 @@ export function setupSecuredField(pItem: HTMLElement): Promise<any> {
         const uid = getAttribute(pItem, DATA_UID);
 
         // ////// CREATE SecuredField passing in configObject of props that will be set on the SecuredField instance
-        const setupObj: SFSetupObject = {
+        const sfInitObj: SecuredFieldInitObj = {
             fieldType,
             extraFieldData,
             uid,
+            cvcPolicy,
+            holderEl: pItem,
+            expiryDatePolicy: DATE_POLICY_REQUIRED,
             txVariant: this.state.type,
             cardGroupTypes: this.config.cardGroupTypes,
             iframeUIConfig: this.config.iframeUIConfig ? this.config.iframeUIConfig : {},
             sfLogAtStart: this.config.sfLogAtStart,
             trimTrailingSeparator: this.config.trimTrailingSeparator,
-            cvcPolicy,
-            expiryDatePolicy: DATE_POLICY_REQUIRED,
             isCreditCardType: this.config.isCreditCardType,
             iframeSrc: this.config.iframeSrc,
             loadingContext: this.config.loadingContext,
             showWarnings: this.config.showWarnings,
-            holderEl: pItem,
             legacyInputMode: this.config.legacyInputMode,
             minimumExpiryDate: this.config.minimumExpiryDate,
             implementationType: this.config.implementationType,
-            bundleType: this.config.bundleType,
-            isCollatingErrors: this.config.isCollatingErrors
+            isCollatingErrors: this.config.isCollatingErrors,
+            maskSecurityCode: this.config.maskSecurityCode
         };
 
-        const sf: SecuredField = new SecuredField(setupObj, this.props.i18n)
+        const sf: SecuredField = new SecuredField(sfInitObj, this.props.i18n)
             .onIframeLoaded((): void => {
                 // Count
                 this.state.iframeCount += 1;

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleConfig.ts
@@ -1,6 +1,7 @@
 import { getCardGroupTypes } from '../utils/getCardGroupTypes';
 import { NON_CREDIT_CARD_TYPE_SECURED_FIELDS, SF_VERSION } from '../../configuration/constants';
 import * as logger from '../../utilities/logger';
+import { CSFSetupObject } from '../types';
 
 /**
  * Parses this.props to set 'config' type vars on this (CSFComp)
@@ -8,66 +9,63 @@ import * as logger from '../../utilities/logger';
  *
  * See interface ConfigObject in types.ts
  */
-export function handleConfig(): void {
+export function handleConfig(props: CSFSetupObject): void {
     // --
-    this.config.cardGroupTypes = getCardGroupTypes(this.props.cardGroupTypes);
+    this.config.cardGroupTypes = getCardGroupTypes(props.cardGroupTypes);
 
     if (process.env.NODE_ENV === 'development' && window._b$dl) {
         logger.log('### StoreCls::init:: this.config.cardGroupTypes=', this.config.cardGroupTypes);
     }
 
-    const loadingContext: string = this.props.loadingContext;
+    const loadingContext: string = props.loadingContext;
 
     if (!loadingContext) {
         logger.warn('WARNING Config :: no loadingContext has been specified!');
         return;
     }
 
-    const lastChar = str => str.charAt(str.length - 1);
-
     // Ensure passed loadingContext has trailing slash
+    const lastChar = str => str.charAt(str.length - 1);
     this.config.loadingContext = lastChar(loadingContext) === '/' ? loadingContext : `${loadingContext}/`;
 
-    this.config.isCreditCardType = NON_CREDIT_CARD_TYPE_SECURED_FIELDS.includes(this.props.type) === false;
+    // Is this for the regular creditCard or for another use-case for securedFields e.g. 'ach' or 'giftcard'
+    this.config.isCreditCardType = NON_CREDIT_CARD_TYPE_SECURED_FIELDS.includes(props.type) === false;
 
-    // Configuration object for individual txVariants
-    // Contains styling object, placeholders & aria-label content for securedFields inputs
-    this.config.iframeUIConfig = this.props.iframeUIConfig;
+    // Configuration object for individual txVariants - contains styling object values for securedFields inputs
+    this.config.iframeUIConfig = props.iframeUIConfig;
 
     // By default CSF is allowed to add the encrypted element to the DOM - user of CSF must explicitly 'opt-out' to prevent this happening
     // (If either condition is true - then set allowedDOMAccess to false)
-    this.config.allowedDOMAccess = !(this.props.allowedDOMAccess === false || this.props.allowedDOMAccess === 'false');
+    this.config.allowedDOMAccess = !(props.allowedDOMAccess === false || props.allowedDOMAccess === 'false');
 
     // By default CSF is allowed to automatically shift focus from the date to CVC fields - user of CSF must explicitly 'opt-out' to prevent this happening
-    this.config.autoFocus = !(this.props.autoFocus === false || this.props.autoFocus === 'false');
+    this.config.autoFocus = !(props.autoFocus === false || props.autoFocus === 'false');
 
     // By default CSF will NOT perform a console.warn when receiving postMessages with origin or numKey mismatches - user of CSF must explicitly 'opt-in' to get this
-    this.config.showWarnings = this.props.showWarnings === true || this.props.showWarnings === 'true';
+    this.config.showWarnings = props.showWarnings === true || props.showWarnings === 'true';
 
     // By default CSF will strip the trailing separator character from valid credit card numbers - user of CSF must explicitly 'opt-out' to prevent this happening
-    this.config.trimTrailingSeparator = !(this.props.trimTrailingSeparator === false || this.props.trimTrailingSeparator === 'false');
+    this.config.trimTrailingSeparator = !(props.trimTrailingSeparator === false || props.trimTrailingSeparator === 'false');
 
     // By default CSF is allowed to add a fix for iOS to force the keypad to retract - user of CSF must explicitly 'opt-out' to prevent this happening
-    this.config.keypadFix = !(this.props.keypadFix === false || this.props.keypadFix === 'false');
+    this.config.keypadFix = !(props.keypadFix === false || props.keypadFix === 'false');
 
     // To set the type on the iframe input fields to 'tel' c.f. the default 'text' (with inputmode='numeric')
-    this.config.legacyInputMode = this.props.legacyInputMode || null;
+    this.config.legacyInputMode = props.legacyInputMode || null;
 
     // To configure the minimum expiry date to a merchant defined value - this means the card has to be valid until at least this date
-    this.config.minimumExpiryDate = this.props.minimumExpiryDate || null;
+    this.config.minimumExpiryDate = props.minimumExpiryDate || null;
 
     // To distinguish between regular 'components' initiated securedField or 'custom' card component
-    this.config.implementationType = this.props.implementationType;
+    this.config.implementationType = props.implementationType;
 
     // Whether Component is collating errors into a single element for the screenreader & therefore whether indiv. SFs will have an aria-describedby attr
-    this.config.isCollatingErrors = this.props.isCollatingErrors;
+    this.config.isCollatingErrors = props.isCollatingErrors;
 
-    this.config.sfLogAtStart = this.props._b$dl === true;
+    this.config.sfLogAtStart = window._b$dl === true;
 
-    let sfBundleType: string = this.config.isCreditCardType ? 'card' : this.props.type;
+    let sfBundleType: string = this.config.isCreditCardType ? 'card' : props.type;
     if (sfBundleType.indexOf('sepa') > -1) sfBundleType = 'iban';
-
-    this.config.bundleType = sfBundleType;
 
     // Add a hash of the origin to ensure urls are different across domains
     const d = btoa(window.location.origin);
@@ -76,15 +74,17 @@ export function handleConfig(): void {
      * Unless we are forcing the use of the compat version via card config
      * - detect Edge vn \<= 18 & IE11 - who don't support TextEncoder; and use this as an indicator to load a different, compatible, version of SF
      */
-    const needsJWECompatVersion = this.props.forceCompat ? true : !(typeof window.TextEncoder === 'function');
+    const needsJWECompatVersion = props.forceCompat ? true : !(typeof window.TextEncoder === 'function');
 
     const bundleType = `${sfBundleType}${needsJWECompatVersion ? 'Compat' : ''}`; // e.g. 'card' or 'cardCompat'
 
-    this.config.iframeSrc = `${this.config.loadingContext}securedfields/${this.props.clientKey}/${SF_VERSION}/securedFields.html?type=${bundleType}&d=${d}`;
+    this.config.iframeSrc = `${this.config.loadingContext}securedfields/${props.clientKey}/${SF_VERSION}/securedFields.html?type=${bundleType}&d=${d}`;
 
     // TODO###### FOR QUICK LOCAL TESTING of sf
     if (process.env.NODE_ENV === 'development' && process.env.__SF_ENV__ !== 'build') {
         this.config.iframeSrc = `${process.env.__SF_ENV__}securedFields.${SF_VERSION}.html?type=${sfBundleType}`;
     }
     // TODO######
+
+    this.config.maskSecurityCode = props.maskSecurityCode;
 }

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
@@ -19,41 +19,54 @@ export interface CSFReturnObject {
 }
 
 /**
- * Base interface for SetupObject & ConfigObject
+ * Base interface for CSFSetupObject & CSFConfigObject
+ *
+ * These are the props that are passed from SFP when CSF is initialised but which also end up
+ * as props in CSF->this.config: CSFConfigObject
  */
 interface CSFCommonProps {
+    allowedDOMAccess?: boolean | string; // accept boolean or string representation of a boolean i.e. "false"
+    autoFocus?: boolean | string;
+    keypadFix?: boolean | string;
+    // Below are config props that also end up set on createSecuredFields->SecuredFieldInitObj
     loadingContext: string;
     cardGroupTypes?: string[];
-    allowedDOMAccess?: boolean;
-    autoFocus?: boolean;
-    trimTrailingSeparator?: boolean;
-    showWarnings?: boolean;
-    keypadFix?: boolean;
-    isKCP?: boolean;
+    trimTrailingSeparator?: boolean | string;
+    showWarnings?: boolean | string;
     iframeUIConfig?: object;
     legacyInputMode?: boolean;
     minimumExpiryDate?: string;
     implementationType?: 'components' | 'custom';
     isCollatingErrors?: boolean;
+    maskSecurityCode: boolean;
 }
 
 /**
- * Object sent when SecuredFieldsProvider initialises CSF
+ * The object sent when SecuredFieldsProvider initialises CSF
+ *
+ * The properties defined here are ones that will not end up on CSF->this.config
  */
 export interface CSFSetupObject extends CSFCommonProps {
     type: string;
     clientKey: string;
     rootNode: string | HTMLElement;
     callbacks?: object;
+    isKCP?: boolean;
     i18n?: Language;
     forceCompat: boolean;
 }
 
 /**
- * The type for the config object created by CSF: properties that just need to be set once, at startup, and then don't change
- * This object provides the source for many of the properties that are written into the SFSetupObject used to initialise a new SecuredField.ts
+ * The type for the this.config object created by CSF - properties that just need to be set once, at startup, and then don't change.
+ *
+ * The CSFConfigObject provides the source for many of the properties that are written into the
+ * SecuredFieldInitObj used by createSecuredFields.ts to initialise a new SecuredField.ts
+ *
+ * Properties defined directly in *this* interface c.f. CSFCommonProps are ones that are not part of the CSFSetupObject
+ * and which are generated/calculated in handleConfig.ts
  */
 export interface CSFConfigObject extends CSFCommonProps {
+    // These config props also end up set on createSecuredFields->SecuredFieldInitObj
     iframeSrc: string;
     isCreditCardType: boolean;
     sfLogAtStart: boolean;

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
@@ -13,40 +13,53 @@ import {
 } from '../configuration/constants';
 
 /**
- * Base interface, props common to both SFSetupObject & IframeConfigObject
+ * Base interface, props common to both SecuredFieldInitObj & IframeConfigObject
+ *
+ * These are the props that are passed from CSF.createSecuredFields when SecuredField.ts is initialised
+ * but which also end up as props in the IframeConfigObject
  */
 export interface SFInternalConfig {
-    fieldType: string; // extracted in createSecuredFields
-    extraFieldData: string; // extracted in createSecuredFields
+    // originally extracted in createSecuredFields
+    fieldType: string;
+    extraFieldData: string;
+    uid: string;
+    // originally calculated in createSecuredFields, for single branded cards, based on initial assessment of brand info; else defaults to true
+    cvcPolicy: CVCPolicyType;
+    // originally set in createSecuredFields
+    expiryDatePolicy: DatePolicyType;
+    // originally read from CSF->this.state
     txVariant: string;
+    // originally from CSF->this.config
     cardGroupTypes: string[];
     iframeUIConfig: IframeUIConfigObject;
     sfLogAtStart: boolean;
     trimTrailingSeparator: boolean;
     isCreditCardType: boolean;
     showWarnings: boolean;
-    cvcPolicy: CVCPolicyType;
-    expiryDatePolicy: DatePolicyType;
     legacyInputMode: boolean;
     minimumExpiryDate: string;
-    uid: string;
     implementationType: string;
-    bundleType: string;
     isCollatingErrors: boolean;
+    maskSecurityCode: boolean;
 }
 
 /**
- * The object passed from createSecuredFields to a new instance of SecuredField.ts
+ * The object sent when createSecuredFields initialises a new instance of SecuredField.ts
+ *
+ * Properties defined directly in *this* interface c.f. SFInternalConfig are ones
+ * that are needed by SecuredField.ts but are *not* required in the IframeConfigObject
  */
-export interface SFSetupObject extends SFInternalConfig {
-    expiryDatePolicy: DatePolicyType;
+export interface SecuredFieldInitObj extends SFInternalConfig {
     iframeSrc: string;
     loadingContext: string;
     holderEl: HTMLElement;
 }
 
 /**
- * Object sent via postMessage to a SecuredField iframe
+ * Object sent via postMessage to a SecuredField iframe in order to configure that iframe
+ *
+ * Properties defined directly in *this* interface are ones that are calculated by SecuredField.ts
+ * instead of just being read directly from the SecuredFieldInitObj
  */
 export interface IframeConfigObject extends SFInternalConfig {
     numKey: number;
@@ -84,7 +97,7 @@ export interface AriaConfigObject {
 }
 
 abstract class AbstractSecuredField {
-    public config: SFInternalConfig; // could be protected but needs to be public for tests to run
+    public sfConfig: SFInternalConfig; // could be protected but needs to be public for tests to run
     public fieldType: string;
     protected iframeSrc: string;
     protected loadingContext: string;
@@ -114,7 +127,7 @@ abstract class AbstractSecuredField {
     protected onAutoCompleteCallback: RtnType_callbackFn;
 
     protected constructor() {
-        this.config = ({} as any) as SFInternalConfig;
+        this.sfConfig = ({} as any) as SFInternalConfig;
     }
 }
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.test.ts
@@ -63,7 +63,8 @@ const setupObj = {
     minimumExpiryDate: null,
     uid: null,
     implementationType: null,
-    isCollatingErrors: false
+    isCollatingErrors: false,
+    maskSecurityCode: false
 };
 
 /**
@@ -73,30 +74,30 @@ describe('SecuredField handling ariaConfig object - should set defaults', () => 
     //
     test('Card number field should get translated title, label & error props plus a lang prop that equals the i18n.locale', () => {
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].iframeTitle).toEqual(TRANSLATED_NUMBER_IFRAME_TITLE);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].label).toEqual(TRANSLATED_NUMBER_IFRAME_LABEL);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
-        expect(card.config.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale); // = 'en-US'
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].iframeTitle).toEqual(TRANSLATED_NUMBER_IFRAME_TITLE);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].label).toEqual(TRANSLATED_NUMBER_IFRAME_LABEL);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale); // = 'en-US'
     });
 
     test('Date field should get translated title, label & error props plus a lang prop that equals the i18n.locale', () => {
         setupObj.fieldType = ENCRYPTED_EXPIRY_DATE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].iframeTitle).toEqual(TRANSLATED_DATE_IFRAME_TITLE);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].label).toEqual(TRANSLATED_DATE_IFRAME_LABEL);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
-        expect(card.config.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].iframeTitle).toEqual(TRANSLATED_DATE_IFRAME_TITLE);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].label).toEqual(TRANSLATED_DATE_IFRAME_LABEL);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale);
     });
 
     test('CVC field should get translated title, label & error props plus a lang prop that equals the i18n.locale', () => {
         setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].iframeTitle).toEqual(TRANSLATED_CVC_IFRAME_TITLE);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].label).toEqual(TRANSLATED_CVC_IFRAME_LABEL);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
-        expect(card.config.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].iframeTitle).toEqual(TRANSLATED_CVC_IFRAME_TITLE);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].label).toEqual(TRANSLATED_CVC_IFRAME_LABEL);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig.lang).toEqual(i18n.locale);
     });
 });
 
@@ -108,9 +109,9 @@ describe('SecuredField handling ariaConfig object - should trim the config objec
 
         const card = new SecuredField(setupObj, i18n);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER]).not.toBe(undefined);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER]).not.toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE]).toBe(undefined);
     });
 
     test('cvc field, with default ariaConfig, should only have a property related to the cvc and nothing for date or number', () => {
@@ -118,9 +119,9 @@ describe('SecuredField handling ariaConfig object - should trim the config objec
 
         const card = new SecuredField(setupObj, i18n);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE]).not.toBe(undefined);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_SECURITY_CODE]).not.toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
     });
 
     test('Card number field with default ariaConfig should have an error object containing certain keys relating to securedFields', () => {
@@ -129,11 +130,11 @@ describe('SecuredField handling ariaConfig object - should trim the config objec
 
         const card = new SecuredField(setupObj, i18n);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).not.toBe(undefined);
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[ERROR_CODES[ERROR_MSG_LUHN_CHECK_FAILED]]).not.toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).not.toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[ERROR_CODES[ERROR_MSG_LUHN_CHECK_FAILED]]).not.toBe(undefined);
 
         // non sf-related key should not be present
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[ERROR_CODES[ERROR_MSG_INVALID_FIELD]]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[ERROR_CODES[ERROR_MSG_INVALID_FIELD]]).toBe(undefined);
     });
 
     test('date field, with default ariaConfig, should have expected, translated, error strings', () => {
@@ -141,9 +142,9 @@ describe('SecuredField handling ariaConfig object - should trim the config objec
 
         const card = new SecuredField(setupObj, i18n);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[GENERAL_ERROR_CODE]).toEqual(TRANSLATED_INCOMPLETE_FIELD_ERROR);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[ERROR_CODES[ERROR_MSG_CARD_TOO_OLD]]).toEqual(
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_EXPIRY_DATE].error[ERROR_CODES[ERROR_MSG_CARD_TOO_OLD]]).toEqual(
             TRANSLATED_CARD_TOO_OLD_ERROR
         );
     });
@@ -154,10 +155,10 @@ describe('SecuredField handling ariaConfig object - should trim the config objec
 
         const card = new SecuredField(setupObj, i18n);
 
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).toEqual(i18n.get(GENERAL_ERROR_CODE));
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[GENERAL_ERROR_CODE]).toEqual(i18n.get(GENERAL_ERROR_CODE));
 
         const errorCode = ERROR_CODES[ERROR_MSG_LUHN_CHECK_FAILED];
-        expect(card.config.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[errorCode]).toEqual(i18n.get(errorCode));
+        expect(card.sfConfig.iframeUIConfig.ariaConfig[ENCRYPTED_CARD_NUMBER].error[errorCode]).toEqual(i18n.get(errorCode));
     });
 });
 
@@ -170,26 +171,26 @@ describe('SecuredField handling undefined placeholders config object - should se
         setupObj.fieldType = ENCRYPTED_CARD_NUMBER;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual(TRANSLATED_NUMBER_PLACEHOLDER);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual(TRANSLATED_NUMBER_PLACEHOLDER);
 
         // Placeholders object should only contain a value for cardNumber
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE]).toBe(undefined);
     });
 
     test('Date field with no defined placeholders config should get default value from translation field', () => {
         setupObj.fieldType = ENCRYPTED_EXPIRY_DATE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toEqual(TRANSLATED_DATE_PLACEHOLDER);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toEqual(TRANSLATED_DATE_PLACEHOLDER);
     });
 
     test('CVC field with no defined placeholders config should get default values from translation field', () => {
         setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_3_DIGITS);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_4_DIGITS);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_3_DIGITS);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_4_DIGITS);
     });
 });
 
@@ -201,7 +202,7 @@ describe('SecuredField handling placeholders config object that is set to null o
         setupObj.fieldType = ENCRYPTED_CARD_NUMBER;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual(TRANSLATED_NUMBER_PLACEHOLDER);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual(TRANSLATED_NUMBER_PLACEHOLDER);
     });
 
     test('Date field with a placeholders config set to an empty object should get default value from translation field', () => {
@@ -209,12 +210,12 @@ describe('SecuredField handling placeholders config object that is set to null o
         setupObj.fieldType = ENCRYPTED_EXPIRY_DATE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toEqual(TRANSLATED_DATE_PLACEHOLDER);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toEqual(TRANSLATED_DATE_PLACEHOLDER);
 
         // Placeholders object should only contain a value for expiryDate
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toBe(undefined);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toBe(undefined);
     });
 
     test('CVC field with a placeholders config set to null should get default values from translation field', () => {
@@ -222,12 +223,12 @@ describe('SecuredField handling placeholders config object that is set to null o
         setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_3_DIGITS);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_4_DIGITS);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_3_DIGITS);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual(TRANSLATED_CVC_PLACEHOLDER_4_DIGITS);
 
         // Placeholders object should only contain a value for cvc field
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
     });
 });
 
@@ -248,7 +249,7 @@ describe('SecuredField handling placeholders overridden with translations config
             setupObj.fieldType = ENCRYPTED_CARD_NUMBER;
 
             const card = new SecuredField(setupObj, i18n);
-            expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual('9999 9999 9999 9999');
+            expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual('9999 9999 9999 9999');
         });
     });
 
@@ -256,19 +257,19 @@ describe('SecuredField handling placeholders overridden with translations config
         setupObj.fieldType = ENCRYPTED_EXPIRY_DATE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toEqual('mo/ye');
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toEqual('mo/ye');
     });
 
     test('CVC field with overridden placeholders should use those values', () => {
         setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual('digits3');
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual('digits4');
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual('digits3');
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual('digits4');
 
         // Placeholders object should only contain a value for cvc
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toBe(undefined);
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_EXPIRY_DATE]).toBe(undefined);
     });
 
     // Setting empty placeholder
@@ -286,7 +287,7 @@ describe('SecuredField handling placeholders overridden with translations config
             setupObj.fieldType = ENCRYPTED_CARD_NUMBER;
 
             const card = new SecuredField(setupObj, i18n);
-            expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual('');
+            expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_CARD_NUMBER]).toEqual('');
         });
     });
 
@@ -294,7 +295,7 @@ describe('SecuredField handling placeholders overridden with translations config
         setupObj.fieldType = ENCRYPTED_SECURITY_CODE;
 
         const card = new SecuredField(setupObj, i18n);
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual('');
-        expect(card.config.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual('');
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_3_DIGITS]).toEqual('');
+        expect(card.sfConfig.iframeUIConfig.placeholders[ENCRYPTED_SECURITY_CODE_4_DIGITS]).toEqual('');
     });
 });

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
@@ -15,7 +15,13 @@ import {
 } from '../configuration/constants';
 import { generateRandomNumber } from '../utilities/commonUtils';
 import { SFFeedbackObj } from '../types';
-import AbstractSecuredField, { SFSetupObject, IframeConfigObject, AriaConfig, SFPlaceholdersObject, SFInternalConfig } from './AbstractSecuredField';
+import AbstractSecuredField, {
+    SecuredFieldInitObj,
+    IframeConfigObject,
+    AriaConfig,
+    SFPlaceholdersObject,
+    SFInternalConfig
+} from './AbstractSecuredField';
 import { CVCPolicyType, DatePolicyType, RtnType_noParamVoidFn, RtnType_postMessageListener, RtnType_callbackFn } from '../types';
 import { pick, reject } from '../../utils';
 import { processAriaConfig } from './utils/processAriaConfig';
@@ -28,17 +34,21 @@ const doLog = false;
 
 class SecuredField extends AbstractSecuredField {
     // --
-    constructor(pSetupObj: SFSetupObject, i18n: Language) {
+    constructor(pSetupObj: SecuredFieldInitObj, i18n: Language) {
         super();
 
         // List of props from setup object not required, or not directly required (e.g. cvcPolicy), in the iframe config object
         const deltaPropsArr: string[] = ['fieldType', 'iframeSrc', 'cvcPolicy', 'expiryDatePolicy', 'loadingContext', 'holderEl'];
 
-        // Copy passed setup object values to this.config...
+        // Copy passed setup object values to this.sfConfig...
         const configVarsFromSetUpObj = reject(deltaPropsArr).from(pSetupObj);
 
         // ...breaking references on iframeUIConfig object so we can overwrite its properties in each securedField instance
-        this.config = { ...this.config, ...configVarsFromSetUpObj, iframeUIConfig: { ...configVarsFromSetUpObj.iframeUIConfig } } as SFInternalConfig;
+        this.sfConfig = {
+            ...this.sfConfig,
+            ...configVarsFromSetUpObj,
+            iframeUIConfig: { ...configVarsFromSetUpObj.iframeUIConfig }
+        } as SFInternalConfig;
 
         // Copy passed setup object values to this
         const thisVarsFromSetupObj = pick(deltaPropsArr).from(pSetupObj);
@@ -70,16 +80,16 @@ class SecuredField extends AbstractSecuredField {
         /**
          * Ensure all fields have a related ariaConfig object containing, at minimum, an iframeTitle property and a (translated) errors object
          */
-        const processedAriaConfig: AriaConfig = processAriaConfig(this.config, this.fieldType, i18n);
+        const processedAriaConfig: AriaConfig = processAriaConfig(this.sfConfig, this.fieldType, i18n);
         // Set result back onto config object
-        this.config.iframeUIConfig.ariaConfig = processedAriaConfig;
+        this.sfConfig.iframeUIConfig.ariaConfig = processedAriaConfig;
 
         /**
          * Ensure that if a placeholder hasn't been set for a field then it gets a default, translated, one
          */
-        const processedPlaceholders: SFPlaceholdersObject = processPlaceholders(this.config, this.fieldType, i18n);
+        const processedPlaceholders: SFPlaceholdersObject = processPlaceholders(this.sfConfig, this.fieldType, i18n);
         // Set result back onto config object
-        this.config.iframeUIConfig.placeholders = processedPlaceholders;
+        this.sfConfig.iframeUIConfig.placeholders = processedPlaceholders;
 
         /**
          * Configure, create & reference iframe and add load listener
@@ -122,23 +132,23 @@ class SecuredField extends AbstractSecuredField {
         // Create and send config object to iframe
         const configObj: IframeConfigObject = {
             fieldType: this.fieldType,
+            extraFieldData: this.sfConfig.extraFieldData,
+            uid: this.sfConfig.uid,
             cvcPolicy: this.cvcPolicy,
             expiryDatePolicy: this.expiryDatePolicy,
             numKey: this.numKey,
-            txVariant: this.config.txVariant,
-            extraFieldData: this.config.extraFieldData,
-            cardGroupTypes: this.config.cardGroupTypes,
-            iframeUIConfig: this.config.iframeUIConfig,
-            sfLogAtStart: this.config.sfLogAtStart,
-            showWarnings: this.config.showWarnings,
-            trimTrailingSeparator: this.config.trimTrailingSeparator,
-            isCreditCardType: this.config.isCreditCardType,
-            legacyInputMode: this.config.legacyInputMode,
-            minimumExpiryDate: this.config.minimumExpiryDate,
-            uid: this.config.uid,
-            implementationType: this.config.implementationType,
-            bundleType: this.config.bundleType,
-            isCollatingErrors: this.config.isCollatingErrors
+            txVariant: this.sfConfig.txVariant,
+            cardGroupTypes: this.sfConfig.cardGroupTypes,
+            iframeUIConfig: this.sfConfig.iframeUIConfig,
+            sfLogAtStart: this.sfConfig.sfLogAtStart,
+            trimTrailingSeparator: this.sfConfig.trimTrailingSeparator,
+            isCreditCardType: this.sfConfig.isCreditCardType,
+            showWarnings: this.sfConfig.showWarnings,
+            legacyInputMode: this.sfConfig.legacyInputMode,
+            minimumExpiryDate: this.sfConfig.minimumExpiryDate,
+            implementationType: this.sfConfig.implementationType,
+            isCollatingErrors: this.sfConfig.isCollatingErrors,
+            maskSecurityCode: this.sfConfig.maskSecurityCode
         };
 
         if (window._b$dl) console.log('### SecuredField:::: onIframeLoaded:: created configObj=', configObj);
@@ -152,7 +162,7 @@ class SecuredField extends AbstractSecuredField {
 
     postMessageListenerFn(event: MessageEvent): void {
         // Check message is from expected domain
-        if (!originCheckPassed(event, this.loadingContext, this.config.showWarnings)) {
+        if (!originCheckPassed(event, this.loadingContext, this.sfConfig.showWarnings)) {
             return;
         }
 
@@ -164,7 +174,7 @@ class SecuredField extends AbstractSecuredField {
                 '\n###CSF SecuredField::postMessageListener:: DOMAIN & ORIGIN MATCH, NO WEBPACK WEIRDNESS fieldType=',
                 this.fieldType,
                 'txVariant=',
-                this.config.txVariant,
+                this.sfConfig.txVariant,
                 'this.numKey=',
                 this.numKey
             );
@@ -178,17 +188,17 @@ class SecuredField extends AbstractSecuredField {
         } catch (e) {
             // Was the message generated by webpack?
             if (isWebpackPostMsg(event)) {
-                if (this.config.showWarnings) logger.log('### SecuredField::postMessageListenerFn:: PARSE FAIL - WEBPACK');
+                if (this.sfConfig.showWarnings) logger.log('### SecuredField::postMessageListenerFn:: PARSE FAIL - WEBPACK');
                 return;
             }
 
             // Was the message generated by ChromeVox?
             if (isChromeVoxPostMsg(event)) {
-                if (this.config.showWarnings) logger.log('### SecuredField::postMessageListenerFn:: PARSE FAIL - CHROMEVOX');
+                if (this.sfConfig.showWarnings) logger.log('### SecuredField::postMessageListenerFn:: PARSE FAIL - CHROMEVOX');
                 return;
             }
 
-            if (this.config.showWarnings)
+            if (this.sfConfig.showWarnings)
                 logger.log('### SecuredField::postMessageListenerFn:: PARSE FAIL - UNKNOWN REASON: event.data=', event.data);
             return;
         }
@@ -197,7 +207,7 @@ class SecuredField extends AbstractSecuredField {
         const hasMainProps: boolean = hasOwnProperty(feedbackObj, 'action') && hasOwnProperty(feedbackObj, 'numKey');
 
         if (!hasMainProps) {
-            if (this.config.showWarnings) logger.warn('WARNING SecuredField :: postMessage listener for iframe :: data mismatch!');
+            if (this.sfConfig.showWarnings) logger.warn('WARNING SecuredField :: postMessage listener for iframe :: data mismatch!');
             return;
         }
 
@@ -206,7 +216,7 @@ class SecuredField extends AbstractSecuredField {
         }
 
         if (this.numKey !== feedbackObj.numKey) {
-            if (this.config.showWarnings) {
+            if (this.sfConfig.showWarnings) {
                 logger.warn(
                     'WARNING SecuredField :: postMessage listener for iframe :: data mismatch! ' +
                         '(Probably a message from an unrelated securedField)'
@@ -221,7 +231,7 @@ class SecuredField extends AbstractSecuredField {
                 '### SecuredField::postMessageListener:: numkeys match PROCEED WITH POST MESSAGE PROCESSING fieldType=',
                 this.fieldType,
                 'txVariant=',
-                this.config.txVariant
+                this.sfConfig.txVariant
             );
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
It is considered best practice in India to mask the digits in the CVC field and is an industry norm in that country.

This PR allows the use of a config property `maskSecurityCode` in the Card component which will be passed through to the CVC securedField and lead it to set `type="password"` on its input field.

This relies on securedFields version `4.3.2` which has been live since October and was included in adyen-web `v5.28.2`

Have also removed the `bundleType` property passed to securedFields which became unnecessary after sf v4.2.0
(Plus renamed some internal config objects and added comments to some Type definitions)

## Tested scenarios
Setting `maskSecurityCode: true` in the card component config causes the CVC field to be masked.
Setting it to `false`, or omitting the property, causes the CVC field to behave as normal
All unit & e2e tests pass

**Fixed issue**:  COWEB-1157
