### PR TITLE
Removed auto redirect from QR code loader

### DIFF
--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -54,24 +54,8 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
     };
 
     componentDidMount() {
-        const { shouldRedirectOnMobile, url } = this.props;
-        const isMobile = window.matchMedia('(max-width: 768px)').matches && /Android|iPhone|iPod/.test(navigator.userAgent);
-
-        const startPolling = () => {
-            this.interval = setInterval(this.statusInterval, this.state.delay);
-        };
-
-        if (shouldRedirectOnMobile && url && isMobile) {
-            this.redirectToApp(url, startPolling);
-        } else {
-            startPolling();
-        }
+        this.interval = setInterval(this.statusInterval, this.state.delay);
     }
-
-    public redirectToApp = (url, fallback = () => {}) => {
-        setTimeout(fallback, 1000);
-        window.location.assign(url);
-    };
 
     componentDidUpdate(prevProps, prevState) {
         if (prevState.delay !== this.state.delay) {
@@ -219,7 +203,6 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
                         />
                     </div>
                 )}
-
                 {url && (
                     <div className="adyen-checkout__qr-loader__app-link">
                         <ContentSeparator />

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -57,7 +57,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
         this.interval = setInterval(this.statusInterval, this.state.delay);
     }
 
-    public redirectToApp = (url, fallback = () => {}) => {
+    public redirectToApp = url => {
         window.location.assign(url);
     };
 

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -57,6 +57,10 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
         this.interval = setInterval(this.statusInterval, this.state.delay);
     }
 
+    public redirectToApp = (url, fallback = () => {}) => {
+        window.location.assign(url);
+    };
+
     componentDidUpdate(prevProps, prevState) {
         if (prevState.delay !== this.state.delay) {
             clearInterval(this.interval);


### PR DESCRIPTION
## Summary
Removed the auto redirect from QR code loader on mobile. Instead the user will now have to use the "open app" button below the QR code.

## Tested scenarios
- [x] Tested in the playground.