### PR TITLE
Fix onAdditionalDetails call for Checkout Sessions on the Klarna Widget component

### DIFF
--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -50,7 +50,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
                         this.componentRef = ref;
                     }}
                     displayName={this.displayName}
-                    onComplete={state => this.props.onAdditionalDetails(state, this.elementRef)}
+                    onComplete={state => this.handleAdditionalDetails(state)}
                     onError={this.props.onError}
                     payButton={this.payButton}
                 />


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes the Klarna widget component's `onAdditionalDetails` call with the Checkout Sessions integration.

## Tested scenarios
- Klarna Widget calls the right details endpoint when no `onAdditionalDetails` event is provided and a Checkout Session is available.


**Fixed issue**:  COWEB-908
