### PR TITLE
Fixes Pix not submiting when showPayButton was false

### DIFF
--- a/packages/lib/src/components/Pix/Pix.tsx
+++ b/packages/lib/src/components/Pix/Pix.tsx
@@ -45,23 +45,19 @@ class PixElement extends QRLoaderContainer<PixProps> {
             return this.renderQRCode();
         }
 
-        if (this.props.showPayButton) {
-            return (
-                <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
-                    <PixInput
-                        ref={ref => {
-                            this.componentRef = ref;
-                        }}
-                        {...this.props}
-                        onChange={this.setState}
-                        onSubmit={this.submit}
-                        payButton={this.payButton}
-                    />
-                </CoreProvider>
-            );
-        }
-
-        return null;
+        return (
+            <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
+                <PixInput
+                    ref={ref => {
+                        this.componentRef = ref;
+                    }}
+                    {...this.props}
+                    onChange={this.setState}
+                    onSubmit={this.submit}
+                    payButton={this.payButton}
+                />
+            </CoreProvider>
+        );
     }
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Fixes a bug FOC-67919 where Pix wouldn't work unless showPayButton was set to true. There was a bug where the Input component that manages the state was hidden when the property was set to false.

## Tested scenarios
<!-- Description of tested scenarios -->

- Successful payment methods with `showPayButton: true/false` and `personalDetailsRequired: true/false`.

**Fixed issue**:  <!-- #-prefixed issue number -->
FOC-67919