### PR TITLE
Changes payment method buttons to have radio role

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -94,19 +94,13 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         const showBrands = !paymentMethod.props.oneClick && paymentMethod.brands && paymentMethod.brands.length > 0;
 
         return (
-            <li
-                key={paymentMethod._id}
-                className={paymentMethodClassnames}
-                onClick={onSelect}
-                aria-labelledby={buttonId}
-            >
+            <li key={paymentMethod._id} className={paymentMethodClassnames} onClick={onSelect}>
                 <div className="adyen-checkout__payment-method__header">
                     <button
                         className="adyen-checkout__payment-method__header__title"
                         id={buttonId}
-                        aria-label={paymentMethod.accessibleName}
-                        aria-expanded={isSelected}
-                        aria-controls={containerId}
+                        role="radio"
+                        aria-checked={isSelected}
                         onClick={onSelect}
                         type="button"
                     >

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -7,6 +7,7 @@ import UIElement from '../../../UIElement';
 import { Order, OrderStatus } from '../../../../types';
 import OrderPaymentMethods from './OrderPaymentMethods';
 import InstantPaymentMethods from './InstantPaymentMethods';
+import useCoreContext from '../../../../core/Context/useCoreContext';
 
 interface PaymentMethodListProps {
     paymentMethods: UIElement[];
@@ -56,6 +57,8 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
     public onSelect = paymentMethod => () => this.props.onSelect(paymentMethod);
 
     render({ paymentMethods, instantPaymentMethods, activePaymentMethod, cachedPaymentMethods, isLoading }) {
+        const { i18n } = useCoreContext();
+
         const paymentMethodListClassnames = classNames({
             [styles['adyen-checkout__payment-methods-list']]: true,
             'adyen-checkout__payment-methods-list': true,
@@ -70,7 +73,7 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
 
                 {!!instantPaymentMethods.length && <InstantPaymentMethods paymentMethods={instantPaymentMethods} />}
 
-                <ul className={paymentMethodListClassnames}>
+                <ul className={paymentMethodListClassnames} role="radiogroup" aria-label={i18n.get('a11y.paymentMethodsList')} required>
                     {paymentMethods.map((paymentMethod, index, paymentMethodsCollection) => {
                         const isSelected = activePaymentMethod && activePaymentMethod._id === paymentMethod._id;
                         const isLoaded = paymentMethod._id in cachedPaymentMethods;

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -266,5 +266,6 @@
     "ctp.errors.CODE_EXPIRED": "This code has expired",
     "ctp.errors.INVALID_PARAMETER": "Something went wrong",
     "ctp.errors.RETRIES_EXCEEDED": "The limit for the number of retries for OTP generation was exceeded",
-    "ctp.errors.OTP_SEND_FAILED": "The OTP could not be sent to the recipient"
+    "ctp.errors.OTP_SEND_FAILED": "The OTP could not be sent to the recipient",
+    "a11y.paymentMethodsList": "Choose a payment method"
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Change payment method items to have a radio role, this comes from the a11y audit.

## Tested scenarios
<!-- Description of tested scenarios -->

From the accessibility audit:
* [X] Radio buttons in the same logical group are children of an element with role="radiogroup".
* [X] Each radio button element has role="radio". 
* [X] When a radio button is checked, it must have aria-checked="true". Otherwise, it must have aria-checked="false". 
* [X] The radio button must have an accessible name provided by internal text, aria-label, or aria-labelledby.
* [X] The radiogroup element must have an accessible name set with aria-labelledby or aria-label.


**Fixed issue**:  <!-- #-prefixed issue number -->
#1695 