### PR TITLE
Fix/personal details validation

### DIFF
--- a/packages/e2e/tests/cards/errorPanel/errorPanel.kcpCard.visible.test.js
+++ b/packages/e2e/tests/cards/errorPanel/errorPanel.kcpCard.visible.test.js
@@ -12,7 +12,7 @@ const INVALID_TAX_NUMBER = LANG['creditCard.taxNumber.invalid'];
 
 const cardPage = new CardComponentPage();
 
-fixture.only`Testing kcpCard, with holderName, error panel`
+fixture`Testing kcpCard, with holderName, error panel`
     .beforeEach(async t => {
         await t.navigateTo(cardPage.pageUrl);
     })

--- a/packages/e2e/tests/cards/errorPanel/errorPanel.kcpCard.visible.test.js
+++ b/packages/e2e/tests/cards/errorPanel/errorPanel.kcpCard.visible.test.js
@@ -12,7 +12,7 @@ const INVALID_TAX_NUMBER = LANG['creditCard.taxNumber.invalid'];
 
 const cardPage = new CardComponentPage();
 
-fixture`Testing kcpCard, with holderName, error panel`
+fixture.only`Testing kcpCard, with holderName, error panel`
     .beforeEach(async t => {
         await t.navigateTo(cardPage.pageUrl);
     })

--- a/packages/e2e/tests/cards/expiryDate/expiryDate.clientScripts.js
+++ b/packages/e2e/tests/cards/expiryDate/expiryDate.clientScripts.js
@@ -1,5 +1,5 @@
 window.cardConfig = {
     type: 'scheme',
     brands: ['mc', 'visa', 'amex'],
-    minimumExpiryDate: '09/22'
+    minimumExpiryDate: '09/24'
 };

--- a/packages/e2e/tests/cards/expiryDate/minimumExpiryDate.test.js
+++ b/packages/e2e/tests/cards/expiryDate/minimumExpiryDate.test.js
@@ -45,7 +45,7 @@ test('With minimumExpiryDate set - input an expiry date that is 1 month before i
     await start(t, 2000, TEST_SPEED);
 
     // Card out of date
-    await cardUtils.fillDate(t, '08/22');
+    await cardUtils.fillDate(t, '08/24');
 
     // Expect errors
     await t.expect(errorHolder.exists).ok();
@@ -64,7 +64,7 @@ test('With minimumExpiryDate set - input an expiry date that is matches it & exp
     await start(t, 2000, TEST_SPEED);
 
     // Card in date
-    await cardUtils.fillDate(t, '09/22');
+    await cardUtils.fillDate(t, '09/24');
 
     // Expect NO errors
     await t.expect(errorHolder.exists).notOk();
@@ -78,7 +78,7 @@ test('With minimumExpiryDate set - input an expiry date that exceeds it (a bit) 
     await start(t, 2000, TEST_SPEED);
 
     // Card in date
-    await cardUtils.fillDate(t, '04/23');
+    await cardUtils.fillDate(t, '04/25');
 
     // Expect NO errors
     await t.expect(errorHolder.exists).notOk();
@@ -114,7 +114,7 @@ test(
         await start(t, 2000, TEST_SPEED);
 
         // Card in date
-        await cardUtils.fillDate(t, '09/22');
+        await cardUtils.fillDate(t, '09/24');
 
         // Expect NO errors
         await t.expect(errorHolder.exists).notOk();
@@ -123,7 +123,7 @@ test(
         await t.expect(errorLabel.exists).notOk();
 
         // Card out of date
-        await cardUtils.fillDate(t, '08/22', 'paste');
+        await cardUtils.fillDate(t, '08/24', 'paste');
 
         // Expect errors
         await t.expect(errorHolder.exists).ok();

--- a/packages/e2e/tests/customcard/expiryDate/expiryDate.clientScripts.js
+++ b/packages/e2e/tests/customcard/expiryDate/expiryDate.clientScripts.js
@@ -1,3 +1,3 @@
 window.cardConfig = {
-    minimumExpiryDate: '09/22'
+    minimumExpiryDate: '09/24'
 };

--- a/packages/e2e/tests/customcard/expiryDate/minimumExpiryDate.regular.test.js
+++ b/packages/e2e/tests/customcard/expiryDate/minimumExpiryDate.regular.test.js
@@ -40,7 +40,7 @@ test('With minimumExpiryDate set - input an expiry date that is 1 month before i
     await start(t, 2000, TEST_SPEED);
 
     // Card out of date
-    await cardUtilsRegular.fillDate(t, '08/22');
+    await cardUtilsRegular.fillDate(t, '08/24');
 
     // Expect visible error: "Card expires before..."
     await t
@@ -55,7 +55,7 @@ test('With minimumExpiryDate set - input an expiry date that is matches it & exp
     await start(t, 2000, TEST_SPEED);
 
     // Card in date
-    await cardUtilsRegular.fillDate(t, '09/22');
+    await cardUtilsRegular.fillDate(t, '09/24');
 
     // Expect NO errors
     await t.expect(errorHolder.filterHidden().exists).ok();
@@ -66,7 +66,7 @@ test('With minimumExpiryDate set - input an expiry date that exceeds it (a bit) 
     await start(t, 2000, TEST_SPEED);
 
     // Card in date
-    await cardUtilsRegular.fillDate(t, '04/23');
+    await cardUtilsRegular.fillDate(t, '04/25');
 
     // Expect NO errors
     await t.expect(errorHolder.filterHidden().exists).ok();
@@ -95,13 +95,13 @@ test(
         await start(t, 2000, TEST_SPEED);
 
         // Card in date
-        await cardUtilsRegular.fillDate(t, '09/22');
+        await cardUtilsRegular.fillDate(t, '09/24');
 
         // Expect NO errors
         await t.expect(errorHolder.filterHidden().exists).ok();
 
         // Card out of date
-        await cardUtilsRegular.fillDate(t, '08/22', 'paste');
+        await cardUtilsRegular.fillDate(t, '08/24', 'paste');
 
         // Expect visible error: "Card expires before..."
         await t

--- a/packages/e2e/tests/customcard/expiryDate/minimumExpiryDate.separate.test.js
+++ b/packages/e2e/tests/customcard/expiryDate/minimumExpiryDate.separate.test.js
@@ -42,7 +42,7 @@ test('With minimumExpiryDate set - input an expiry date that is 1 month before i
 
     // Card out of date
     await customCardUtils.fillMonth(t, '08');
-    await customCardUtils.fillYear(t, '22');
+    await customCardUtils.fillYear(t, '24');
 
     // Expect visible error: "Card expires before..."
     await t
@@ -58,7 +58,7 @@ test('With minimumExpiryDate set - input an expiry date that is matches it & exp
 
     // Card in date
     await customCardUtils.fillMonth(t, '09');
-    await customCardUtils.fillYear(t, '22');
+    await customCardUtils.fillYear(t, '24');
 
     // Expect NO errors
     await t.expect(errorHolder.filterHidden().exists).ok();
@@ -70,7 +70,7 @@ test('With minimumExpiryDate set - input an expiry date that exceeds it (a bit) 
 
     // Card in date
     await customCardUtils.fillMonth(t, '04');
-    await customCardUtils.fillYear(t, '23');
+    await customCardUtils.fillYear(t, '25');
 
     // Expect NO errors
     await t.expect(errorHolder.filterHidden().exists).ok();
@@ -101,7 +101,7 @@ test(
 
         // Card in date
         await customCardUtils.fillMonth(t, '09');
-        await customCardUtils.fillYear(t, '22');
+        await customCardUtils.fillYear(t, '24');
 
         // Expect NO errors
         await t.expect(errorHolder.filterHidden().exists).ok();

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -66,6 +66,7 @@ export default function InputBase(props) {
         <input
             id={uniqueId}
             {...newProps}
+            aria-required={newProps.required}
             type={type}
             className={inputClassNames}
             readOnly={readonly}

--- a/packages/lib/src/components/internal/FormFields/InputText.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputText.tsx
@@ -2,5 +2,5 @@ import { h } from 'preact';
 import InputBase from './InputBase';
 
 export default function InputText(props) {
-    return <InputBase classNameModifiers={['large']} {...props} aria-required={props.required} type="text" />;
+    return <InputBase classNameModifiers={['large']} {...props} type="text" />;
 }

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -22,7 +22,8 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
     const isDateInputSupported = useMemo(checkDateInputSupport, []);
     const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm<PersonalDetailsSchema>({
         schema: requiredFields,
-        rules: props.validationRules,
+        // Ensure any passed validation rules are merged with the default ones
+        rules: { ...personalDetailsValidationRules, ...props.validationRules },
         defaultData: props.data
     });
 
@@ -52,7 +53,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                 <Field
                     label={i18n.get('firstName')}
                     classNameModifiers={['col-50', 'firstName']}
-                    errorMessage={!!errors.firstName}
+                    errorMessage={getErrorMessage(errors.firstName)}
                     name={'firstName'}
                 >
                     {renderFormField('text', {
@@ -62,13 +63,19 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         onInput: eventHandler('input'),
                         onBlur: eventHandler('blur'),
                         placeholder: placeholders.firstName,
-                        spellCheck: false
+                        spellCheck: false,
+                        required: true
                     })}
                 </Field>
             )}
 
             {requiredFields.includes('lastName') && (
-                <Field label={i18n.get('lastName')} classNameModifiers={['col-50', 'lastName']} errorMessage={!!errors.lastName} name={'lastName'}>
+                <Field
+                    label={i18n.get('lastName')}
+                    classNameModifiers={['col-50', 'lastName']}
+                    errorMessage={getErrorMessage(errors.lastName)}
+                    name={'lastName'}
+                >
                     {renderFormField('text', {
                         name: generateFieldName('lastName'),
                         value: data.lastName,
@@ -76,7 +83,8 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         onInput: eventHandler('input'),
                         onBlur: eventHandler('blur'),
                         placeholder: placeholders.lastName,
-                        spellCheck: false
+                        spellCheck: false,
+                        required: true
                     })}
                 </Field>
             )}
@@ -93,7 +101,8 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         ],
                         classNameModifiers: ['gender'],
                         onInput: eventHandler('input'),
-                        onChange: eventHandler('blur')
+                        onChange: eventHandler('blur'),
+                        required: true
                     })}
                 </Field>
             )}
@@ -112,7 +121,8 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         classNameModifiers: ['dateOfBirth'],
                         onInput: eventHandler('input'),
                         onBlur: eventHandler('blur'),
-                        placeholder: placeholders.dateOfBirth
+                        placeholder: placeholders.dateOfBirth,
+                        required: true
                     })}
                 </Field>
             )}
@@ -131,7 +141,8 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         classNameModifiers: ['shopperEmail'],
                         onInput: eventHandler('input'),
                         onBlur: eventHandler('blur'),
-                        placeholder: placeholders.shopperEmail
+                        placeholder: placeholders.shopperEmail,
+                        required: true
                     })}
                 </Field>
             )}
@@ -150,7 +161,8 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                         classNameModifiers: ['telephoneNumber'],
                         onInput: eventHandler('input'),
                         onBlur: eventHandler('blur'),
-                        placeholder: placeholders.telephoneNumber
+                        placeholder: placeholders.telephoneNumber,
+                        required: true
                     })}
                 </Field>
             )}

--- a/packages/lib/src/components/internal/PersonalDetails/validate.ts
+++ b/packages/lib/src/components/internal/PersonalDetails/validate.ts
@@ -12,7 +12,10 @@ const isDateOfBirthValid = value => {
 
 export const personalDetailsValidationRules: ValidatorRules = {
     default: {
-        validate: value => value && value.length > 0,
+        validate: value => {
+            return value && value.length > 0;
+        },
+        errorMessage: 'error.va.gen.02', // = "field not valid" TODO make more specific errors for firstName & lastName (requires translations)
         modes: ['blur']
     },
     dateOfBirth: {
@@ -22,10 +25,12 @@ export const personalDetailsValidationRules: ValidatorRules = {
     },
     telephoneNumber: {
         validate: value => telephoneNumber.test(value),
+        errorMessage: 'telephoneNumber.invalid',
         modes: ['blur']
     },
     shopperEmail: {
         validate: value => email.test(value),
+        errorMessage: 'shopperEmail.invalid',
         modes: ['blur']
     }
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes to how the `PersonalDetails` component validates:
- if validation rules were passed as a prop - they weren't being merged with the default rules to ensure all fields were still validated
- errors were being registered but not converted into translatable (and displayed) error messages
- `required` & `aria-required` attributes were not being set on the (required) input fields

## Tested scenarios
All tests pass
Also fixed some e2e tests that were failing because the constant used for the date had "expired"

**Fixed issue**:  Relates to some of the points raised in our a11y review
