### PR TITLE
Detect custom http environment and show console.warning

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/initCSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/initCSF.ts
@@ -47,6 +47,22 @@ const initCSF = (pSetupObj: CSFSetupObject): CSFReturnObject => {
 
     setupObj.rootNode = rootNode; // Overwrite with actual node (in case we were sent a string)
 
+    // //////// 3. Add warning if in development mode and a custom http domain is detected
+    const origin = window.origin;
+    if (
+        process.env.NODE_ENV === 'development' &&
+        origin.indexOf('http') > -1 &&
+        origin.indexOf('localhost') === -1 &&
+        origin.indexOf('127.0.0.1') === -1
+    ) {
+        console.warn(
+            'WARNING: you are are running from an insecure context:',
+            origin,
+            '\nCrypto.subtle cannot function in this environment.\nThe only secure contexts under http contain "localhost" or "127.0.0.1" in their url.' +
+                '\nSee https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts'
+        );
+    }
+
     const myCSF: CSF = new CSF(setupObj);
     return myCSF.createReturnObject();
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Add warning if trying to initialise securedFields in development mode and a custom http domain is detected.
Under these circumstances window.crypto.subtle cannot work and errors of the type mentioned in #1710 are to be expected.

**Relates to issue**:  #1710
