### PR TITLE
Oxxo component ignores showPayButton configuration property

### DIFF
--- a/packages/lib/src/components/Oxxo/Oxxo.spec.ts
+++ b/packages/lib/src/components/Oxxo/Oxxo.spec.ts
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/preact';
+import { mock } from 'jest-mock-extended';
+import userEvent from '@testing-library/user-event';
+import Oxxo from './Oxxo';
+import Language from '../../language';
+
+test('should return expected data to perform the payment', () => {
+    const oxxoElement = new Oxxo({});
+    expect(oxxoElement.formatData()).toEqual({ paymentMethod: { type: 'oxxo' } });
+});
+
+test('should not show the pay button by default', () => {
+    const oxxoElement = new Oxxo({});
+    render(oxxoElement.render());
+    expect(screen.queryByRole('button', { name: 'Continue to Oxxo' })).toBeNull();
+    expect(oxxoElement.props.showPayButton).toBeFalsy();
+});
+
+test('should show pay button if property is set to true', async () => {
+    const i18n = mock<Language>();
+    i18n.get.mockImplementation(() => 'Continue to');
+    i18n.loaded = Promise.resolve();
+
+    const oxxoElement = new Oxxo({ showPayButton: true, i18n });
+
+    render(oxxoElement.render());
+    expect(await screen.findByRole('button', { name: 'Continue to Oxxo' })).toBeTruthy();
+});
+
+test('should trigger submit when Pay button is pressed', async () => {
+    const user = userEvent.setup();
+    const i18n = mock<Language>();
+    i18n.get.mockImplementation(() => 'Continue to');
+    i18n.loaded = Promise.resolve();
+
+    const oxxoElement = new Oxxo({ showPayButton: true, i18n });
+    oxxoElement.submit = jest.fn();
+
+    render(oxxoElement.render());
+
+    await user.click(await screen.findByRole('button', { name: 'Continue to Oxxo' }));
+    expect(oxxoElement.submit).toHaveBeenCalledTimes(1);
+});

--- a/packages/lib/src/components/Oxxo/Oxxo.tsx
+++ b/packages/lib/src/components/Oxxo/Oxxo.tsx
@@ -2,25 +2,22 @@ import { h } from 'preact';
 import UIElement from '../UIElement';
 import OxxoVoucherResult from './components/OxxoVoucherResult';
 import CoreProvider from '../../core/Context/CoreProvider';
+import { OxxoElementData } from './types';
+import { UIElementProps } from '../types';
 
 export class OxxoElement extends UIElement {
     public static type = 'oxxo';
 
-    get isValid() {
+    protected static defaultProps: UIElementProps = {
+        showPayButton: false,
+        name: 'Oxxo'
+    };
+
+    get isValid(): boolean {
         return true;
     }
 
-    formatProps(props) {
-        return {
-            ...props,
-            name: 'Oxxo'
-        };
-    }
-
-    /**
-     * Formats the component data output
-     */
-    formatData() {
+    formatData(): OxxoElementData {
         return {
             paymentMethod: {
                 type: this.props.type || OxxoElement.type
@@ -38,6 +35,7 @@ export class OxxoElement extends UIElement {
                 {this.props.reference ? (
                     <OxxoVoucherResult ref={this.handleRef} {...this.props} />
                 ) : (
+                    this.props.showPayButton &&
                     this.payButton({
                         ...this.props,
                         classNameModifiers: ['standalone'],

--- a/packages/lib/src/components/Oxxo/types.ts
+++ b/packages/lib/src/components/Oxxo/types.ts
@@ -10,3 +10,9 @@ export interface OxxoVoucherResultProps {
     downloadUrl?: string;
     ref?: any;
 }
+
+export type OxxoElementData = {
+    paymentMethod: {
+        type: 'oxxo' | string;
+    };
+};

--- a/packages/playground/src/pages/Components/Components.html
+++ b/packages/playground/src/pages/Components/Components.html
@@ -104,6 +104,15 @@
 
                 <div class="merchant-checkout__payment-method">
                     <div class="merchant-checkout__payment-method__header">
+                        <h2>Oxxo</h2>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div class="oxxo-field"></div>
+                    </div>
+                </div>
+
+                <div class="merchant-checkout__payment-method">
+                    <div class="merchant-checkout__payment-method__header">
                         <h2>Redirect</h2>
                     </div>
                     <div class="merchant-checkout__payment-method__details">

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -93,6 +93,9 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     // UPI
     window.upi = checkout.create('upi').mount('.upi-field');
 
+    // Oxxo
+    window.oxxo = checkout.create('oxxo').mount('.oxxo-field');
+
     // Redirect
     // window.redirect = checkout.create('paypal').mount('.redirect-field');
 });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`showPayButton` was being ignored by Oxxo component, therefore merchants would not be able to use custom pay button. 

This PR adjusts Oxxo to properly handle the property. Its value defaults to `false` as stated in our documentation. On Drop-in , it defaults to `true`

## Tested scenarios
- Added unit tests

**Fixed issue**: COWEB-1163
