### PR TITLE
Fix/handling unexpected post message in 3DS2

### DIFF
--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -6,13 +6,13 @@ import { DEFAULT_CHALLENGE_WINDOW_SIZE } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import Language from '../../language';
-import { ThreeDS2ChallengeRejectObject } from './types';
+import { PostMsgParseErrorObject } from './types';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;
     dataKey?: string;
     notificationURL?: string;
-    onError?: (error: string | ErrorCodeObject | ThreeDS2ChallengeRejectObject) => void;
+    onError?: (error: string | ErrorCodeObject | PostMsgParseErrorObject) => void; // TODO PostMsgParseErrorObject only needed if this function gets passed down to get-process-message-handler
     paymentData?: string;
     size?: string;
     challengeWindowSize?: '01' | '02' | '03' | '04' | '05';

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -12,7 +12,7 @@ export interface ThreeDS2ChallengeProps {
     token?: string;
     dataKey?: string;
     notificationURL?: string;
-    onError?: (error: string | ErrorCodeObject | PostMsgParseErrorObject) => void; // TODO PostMsgParseErrorObject only needed if this function gets passed down to get-process-message-handler
+    onError?: (error: string | ErrorCodeObject) => void;
     paymentData?: string;
     size?: string;
     challengeWindowSize?: '01' | '02' | '03' | '04' | '05';

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -6,7 +6,6 @@ import { DEFAULT_CHALLENGE_WINDOW_SIZE } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import Language from '../../language';
-import { PostMsgParseErrorObject } from './types';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;

--- a/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
+++ b/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
@@ -22,6 +22,11 @@ export default function callSubmit3DS2Fingerprint({ data }): void {
             // elementRef exists when the fingerprint component is created from the Dropin
             const actionHandler = this.props.elementRef ?? this;
 
+            if (!actionHandler) {
+                console.error('Handled Error::callSubmit3DS2Fingerprint::FAILED:: actionHandler=', actionHandler);
+                return;
+            }
+
             if (!resData.action && !resData.details) {
                 console.error('Handled Error::callSubmit3DS2Fingerprint::FAILED:: resData=', resData);
                 return;

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -48,13 +48,11 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
         this.challengePromise = promiseTimeout(CHALLENGE_TIMEOUT, this.get3DS2ChallengePromise(), CHALLENGE_TIMEOUT_REJECT_OBJECT);
         this.challengePromise.promise
             .then((resolveObject: ThreeDS2FlowObject) => {
-                console.log('### DoChallenge3DS2::SUCCESS :: resolveObject', resolveObject);
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onCompleteChallenge(resolveObject);
             })
             // Catch, for when Challenge times-out
             .catch((rejectObject: ThreeDS2FlowObject) => {
-                console.log('### DoChallenge3DS2::ERROR :: rejectObject', rejectObject);
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onErrorChallenge(rejectObject);
             });

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -51,7 +51,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onCompleteChallenge(resolveObject);
             })
-            // Catch, for when Challenge times-out
+            /** Catch, for when Challenge times-out */
             .catch((rejectObject: ThreeDS2FlowObject) => {
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onErrorChallenge(rejectObject);

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -6,8 +6,9 @@ import ThreeDS2Form from '../Form';
 import getProcessMessageHandler from '../../../../utils/get-process-message-handler';
 import { encodeBase64URL } from '../utils';
 import promiseTimeout from '../../../../utils/promiseTimeout';
-import { CHALLENGE_TIMEOUT, CHALLENGE_TIMEOUT_REJECT_OBJECT, CHALLENGE_UNKNOWN_ERROR_REJECT_OBJECT } from '../../config';
+import { CHALLENGE_TIMEOUT, CHALLENGE_TIMEOUT_REJECT_OBJECT } from '../../config';
 import { DoChallenge3DS2Props, DoChallenge3DS2State } from './types';
+import { ThreeDS2FlowObject } from '../../types';
 
 const iframeName = 'threeDSIframe';
 
@@ -35,13 +36,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
             /**
              * Listen for postMessage responses from the notification url
              */
-            this.processMessageHandler = getProcessMessageHandler(
-                this.props.postMessageDomain,
-                resolve,
-                reject,
-                CHALLENGE_UNKNOWN_ERROR_REJECT_OBJECT,
-                'challengeResult'
-            );
+            this.processMessageHandler = getProcessMessageHandler(this.props.postMessageDomain, resolve, reject, 'challengeResult');
 
             /* eslint-disable-next-line */
             window.addEventListener('message', this.processMessageHandler);
@@ -52,12 +47,14 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
         // Render challenge
         this.challengePromise = promiseTimeout(CHALLENGE_TIMEOUT, this.get3DS2ChallengePromise(), CHALLENGE_TIMEOUT_REJECT_OBJECT);
         this.challengePromise.promise
-            .then(resolveObject => {
+            .then((resolveObject: ThreeDS2FlowObject) => {
+                console.log('### DoChallenge3DS2::SUCCESS :: resolveObject', resolveObject);
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onCompleteChallenge(resolveObject);
             })
-            // Catch, for when... Challenge times-out OR get3DS2ChallengePromise rejects (un-parseable JSON)
-            .catch(rejectObject => {
+            // Catch, for when Challenge times-out
+            .catch((rejectObject: ThreeDS2FlowObject) => {
+                console.log('### DoChallenge3DS2::ERROR :: rejectObject', rejectObject);
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onErrorChallenge(rejectObject);
             });

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -91,16 +91,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                          * Called when challenge times-out (which is still a valid scenario)...
                          */
                         if (hasOwnProperty(challenge, 'errorCode')) {
-                            console.log('\n### PrepareChallenge3DS2::onErrorChallenge::has errorCode:: challenge=', challenge);
                             const errorCodeObject = handleErrorCode(challenge.errorCode);
-                            console.log(
-                                '### PrepareChallenge3DS2::onErrorChallenge::has errorCode:: will call onError callback, passing',
-                                errorCodeObject
-                            );
-                            console.log(
-                                '### PrepareChallenge3DS2::onErrorChallenge::has errorCode:: will also call setStatusComplete, passing',
-                                challenge.result
-                            );
                             this.props.onError(errorCodeObject);
                             this.setStatusComplete(challenge.result);
                             return;

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -2,7 +2,7 @@ import { Component, h } from 'preact';
 import DoChallenge3DS2 from './DoChallenge3DS2';
 import { createChallengeResolveData, handleErrorCode, prepareChallengeData, createOldChallengeResolveData } from '../utils';
 import { PrepareChallenge3DS2Props, PrepareChallenge3DS2State } from './types';
-import { ChallengeData, ThreeDS2ChallengeRejectObject, ThreeDS2FlowObject } from '../../types';
+import { ChallengeData, ThreeDS2FlowObject } from '../../types';
 import '../../ThreeDS2.scss';
 import Img from '../../../internal/Img';
 import { getImageUrl } from '../../../../utils/get-image';
@@ -86,23 +86,25 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                         // Proceed with call to onAdditionalDetails
                         this.setStatusComplete(challenge.result);
                     }}
-                    onErrorChallenge={(challenge: ThreeDS2FlowObject | ThreeDS2ChallengeRejectObject) => {
+                    onErrorChallenge={(challenge: ThreeDS2FlowObject) => {
                         /**
                          * Called when challenge times-out (which is still a valid scenario)...
                          */
-                        // first part of if-clause checks errorCode isn't undefined or null, second part keeps typescript happy
-                        if (hasOwnProperty(challenge, 'errorCode') && 'errorCode' in challenge) {
+                        if (hasOwnProperty(challenge, 'errorCode')) {
+                            console.log('\n### PrepareChallenge3DS2::onErrorChallenge::has errorCode:: challenge=', challenge);
                             const errorCodeObject = handleErrorCode(challenge.errorCode);
+                            console.log(
+                                '### PrepareChallenge3DS2::onErrorChallenge::has errorCode:: will call onError callback, passing',
+                                errorCodeObject
+                            );
+                            console.log(
+                                '### PrepareChallenge3DS2::onErrorChallenge::has errorCode:: will also call setStatusComplete, passing',
+                                challenge.result
+                            );
                             this.props.onError(errorCodeObject);
                             this.setStatusComplete(challenge.result);
                             return;
                         }
-
-                        /**
-                         * ...OR, when the challenge response is un-parseable JSON - in which case something unknown has gone wrong
-                         * - So pass this on to the defined error handler *without* blocking the flow
-                         */
-                        this.props.onError(challenge as ThreeDS2ChallengeRejectObject);
                     }}
                     {...challengeData}
                 />

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -4,7 +4,7 @@ import Spinner from '../../../internal/Spinner';
 import ThreeDS2Form from '../Form';
 import promiseTimeout from '../../../../utils/promiseTimeout';
 import getProcessMessageHandler from '../../../../utils/get-process-message-handler';
-import { FAILED_METHOD_STATUS_RESOLVE_OBJECT, THREEDS_METHOD_TIMEOUT, FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT } from '../../config';
+import { THREEDS_METHOD_TIMEOUT, FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT } from '../../config';
 import { encodeBase64URL } from '../utils';
 import { DoFingerprint3DS2Props, DoFingerprint3DS2State } from './types';
 
@@ -47,13 +47,7 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
             /**
              * Listen for postMessage responses from the notification url
              */
-            this.processMessageHandler = getProcessMessageHandler(
-                this.props.postMessageDomain,
-                resolve,
-                reject,
-                FAILED_METHOD_STATUS_RESOLVE_OBJECT,
-                'fingerPrintResult'
-            );
+            this.processMessageHandler = getProcessMessageHandler(this.props.postMessageDomain, resolve, reject, 'fingerPrintResult');
 
             /* eslint-disable-next-line */
             window.addEventListener('message', this.processMessageHandler);

--- a/packages/lib/src/components/ThreeDS2/config.ts
+++ b/packages/lib/src/components/ThreeDS2/config.ts
@@ -1,15 +1,9 @@
-import { ThreeDS2FlowObject, ThreeDS2ChallengeRejectObject } from './types';
+import { ThreeDS2FlowObject } from './types';
 
 export const DEFAULT_CHALLENGE_WINDOW_SIZE = '02';
 
 export const THREEDS_METHOD_TIMEOUT = 10000;
 export const CHALLENGE_TIMEOUT = 600000;
-
-export const CHALLENGE_UNKNOWN_ERROR_REJECT_OBJECT: ThreeDS2ChallengeRejectObject = {
-    type: 'challengeError',
-    comment: 'something unexpected happened',
-    extraInfo: 'any info about what happened'
-};
 
 export const CHALLENGE_TIMEOUT_REJECT_OBJECT: ThreeDS2FlowObject = {
     result: {

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -35,8 +35,8 @@ export interface ThreeDS2FlowObject {
     threeDSServerTransID?: string;
 }
 
-export interface ThreeDS2ChallengeRejectObject {
-    type: 'challengeError';
+export interface PostMsgParseErrorObject {
+    type?: string;
     comment?: string;
     extraInfo?: string;
     eventDataRaw?: string;

--- a/packages/lib/src/core/RiskModule/components/DeviceFingerprint/GetDeviceFingerprint.tsx
+++ b/packages/lib/src/core/RiskModule/components/DeviceFingerprint/GetDeviceFingerprint.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from 'preact';
 import Iframe from '../../../../components/internal/IFrame';
 import promiseTimeout from '../../../../utils/promiseTimeout';
-import { DEVICE_FINGERPRINT, DF_TIMEOUT, FAILED_DFP_RESOLVE_OBJECT, FAILED_DFP_RESOLVE_OBJECT_TIMEOUT } from '../../constants';
+import { DEVICE_FINGERPRINT, DF_TIMEOUT, FAILED_DFP_RESOLVE_OBJECT_TIMEOUT } from '../../constants';
 import getProcessMessageHandler from '../../../../utils/get-process-message-handler';
 import { getOrigin } from '../../../../utils/getOrigin';
 import { GetDeviceFingerprintProps } from './types';
@@ -25,13 +25,7 @@ class GetDeviceFingerprint extends Component<GetDeviceFingerprintProps> {
             /**
              * Listen for postMessage responses from the notification url
              */
-            this.processMessageHandler = getProcessMessageHandler(
-                this.postMessageDomain,
-                resolve,
-                reject,
-                FAILED_DFP_RESOLVE_OBJECT,
-                DEVICE_FINGERPRINT
-            );
+            this.processMessageHandler = getProcessMessageHandler(this.postMessageDomain, resolve, reject, DEVICE_FINGERPRINT);
 
             /* eslint-disable-next-line */
             window.addEventListener('message', this.processMessageHandler);

--- a/packages/lib/src/core/RiskModule/constants.ts
+++ b/packages/lib/src/core/RiskModule/constants.ts
@@ -12,13 +12,6 @@ export const FAILED_DFP_RESOLVE_OBJECT_TIMEOUT = {
     errorCode: 'timeout'
 };
 
-export const FAILED_DFP_RESOLVE_OBJECT = {
-    result: {
-        type: DEVICE_FINGERPRINT,
-        value: 'df-failed'
-    }
-};
-
 export const ERRORS = {
     TIME_OUT: 'timeout',
     WRONG_ORIGIN: 'wrongOrigin',

--- a/packages/lib/src/utils/get-process-message-handler.test.ts
+++ b/packages/lib/src/utils/get-process-message-handler.test.ts
@@ -17,7 +17,7 @@ describe('getProcessMessageHandler', () => {
             data
         };
 
-        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, rejectObject, expectedType);
+        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, expectedType);
         processEvent(event);
 
         expect(resolveFunction.mock.calls.length).toBe(1);
@@ -33,7 +33,7 @@ describe('getProcessMessageHandler', () => {
             data
         };
 
-        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, rejectObject, expectedType);
+        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, expectedType);
         expect(processEvent(event)).toBe('Message was not sent from the expected domain');
         expect(resolveFunction.mock.calls.length).toBe(0);
     });
@@ -47,7 +47,7 @@ describe('getProcessMessageHandler', () => {
             data: rejectFunction
         };
 
-        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, rejectObject, expectedType);
+        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, expectedType);
         expect(processEvent(event)).toBe('Event data was not of type string');
         expect(resolveFunction.mock.calls.length).toBe(0);
     });
@@ -61,7 +61,7 @@ describe('getProcessMessageHandler', () => {
             data: ''
         };
 
-        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, rejectObject, expectedType);
+        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, expectedType);
         expect(processEvent(event)).toBe('Invalid event data string');
         expect(resolveFunction.mock.calls.length).toBe(0);
     });
@@ -76,7 +76,7 @@ describe('getProcessMessageHandler', () => {
             data
         };
 
-        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, rejectObject, notTheExpectedType);
+        const processEvent = getProcessMessageHandler('http://fake-domain.com', resolveFunction, rejectFunction, notTheExpectedType);
         expect(processEvent(event)).toBe('Event data was not of expected type');
         expect(resolveFunction.mock.calls.length).toBe(0);
     });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A new scenario with  post messages in the 3DS2 flow has become possible whereby a post message from a legitimate (i.e. Adyen) domain is sent but without any data that we need to process.

Previously we had considered all post messages from the Adyen domain, within the 3DS2 flow, to indicate an "end state" - a point at which we stop listening for such messages, settle Promises and proceed with finalising the 3DS2 process.

This new scenario means we need to detect it, ignore it & carry on listening.

As a side note the source of this unexpected post message is in a 3rd party dependency, corejs3, which (for some reason) sends out this message event when it detects an iOS device. More details can be found in the ticket mentioned below.

## Tested scenarios
Vast amount of manual testing both with regular components and components in the MDFlow
All e2e & unit tests pass

**Described by ticket**:  COWEB-1179
