### PR TITLE
Enabling eslint for unit test files

### DIFF
--- a/packages/lib/.eslintignore
+++ b/packages/lib/.eslintignore
@@ -1,5 +1,4 @@
 dist/
 server/
 config/
-*.test.*
 src/polyfills.ts

--- a/packages/lib/src/components/AmazonPay/AmazonPay.test.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.test.tsx
@@ -1,6 +1,8 @@
 import AmazonPay from './AmazonPay';
 import defaultProps from './defaultProps';
 import { httpPost } from '../../core/Services/http';
+import { mock } from 'jest-mock-extended';
+import { AmazonPayElementProps } from './types';
 
 jest.mock('../../core/Services/http');
 
@@ -11,7 +13,13 @@ const declineFlowMock = {
 const spyFetch = (httpPost as jest.Mock).mockImplementation(jest.fn(() => Promise.resolve(declineFlowMock)));
 
 describe('AmazonPay', () => {
-    const getElement = (props?) => new AmazonPay({ ...defaultProps, ...props });
+    const amazonProps = mock<AmazonPayElementProps>();
+    const getElement = (props = {}) =>
+        new AmazonPay({
+            ...defaultProps,
+            ...props,
+            ...amazonProps
+        });
 
     test('always returns isValid as true', () => {
         const amazonPay = getElement();
@@ -28,7 +36,7 @@ describe('AmazonPay', () => {
             environment: 'test',
             locale: 'en-US',
             configuration: {
-                region: 'EU',
+                region: 'EU'
             }
         };
         const amazonPay = getElement(props);

--- a/packages/lib/src/components/ApplePay/ApplePay.test.ts
+++ b/packages/lib/src/components/ApplePay/ApplePay.test.ts
@@ -2,7 +2,7 @@ import ApplePay from '.';
 import defaultProps from './defaultProps';
 
 (global as any).ApplePaySession = {
-    supportsVersion: jest.fn(version => true)
+    supportsVersion: jest.fn(() => true)
 };
 
 describe('ApplePay', () => {

--- a/packages/lib/src/components/BacsDD/components/BacsInput.test.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.test.tsx
@@ -1,6 +1,8 @@
 import { h } from 'preact';
 import { mount } from 'enzyme';
 import BacsInput from './BacsInput';
+import { BacsInputProps } from './types';
+import { mock } from 'jest-mock-extended';
 
 const defaultProps = {
     onChange: () => {},
@@ -8,7 +10,8 @@ const defaultProps = {
 };
 
 describe('BacsInput', () => {
-    const getWrapper = (props?) => mount(<BacsInput {...defaultProps} {...props} />);
+    const bacsPropsMock = mock<BacsInputProps>();
+    const getWrapper = (props = {}) => mount(<BacsInput {...defaultProps} {...props} {...bacsPropsMock} />);
 
     test('Should display expected fields for opening (enter-data) state', () => {
         const wrapper = getWrapper({});

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -97,7 +97,6 @@ describe('CardInput - Brands beneath Card Number field', () => {
             { name: 'amex', icon: 'amex.png' }
         ];
         const wrapper = mount(<CardInput i18n={i18n} brand={detectedBrand} brandsIcons={brandsIcons} />);
-        const brandWrapper = wrapper.find('.checkout__card__brands');
         expect(wrapper.find('.adyen-checkout__card__brands--hidden')).toHaveLength(0);
     });
 });

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.test.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { h } from 'preact';
 import CardNumber from './CardNumber';
 
-let wrapper = mount(
+const wrapper = mount(
     <CardNumber
         label="Card number"
         error=""

--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
@@ -5,7 +5,7 @@ import { InstallmentOptions } from '../types';
 
 describe('Installments', () => {
     let installmentOptions;
-    const getWrapper = (props?) => mount(<Installments installmentOptions={installmentOptions} {...props} />);
+    const getWrapper = (props = {}) => mount(<Installments installmentOptions={installmentOptions} {...props} />);
 
     beforeEach(() => {
         installmentOptions = {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.test.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.test.ts
@@ -3,7 +3,7 @@ import { mock } from 'jest-mock-extended';
 import { ISrcSdkLoader } from './sdks/SrcSdkLoader';
 import VisaSdk from './sdks/VisaSdk';
 import MastercardSdk from './sdks/MastercardSdk';
-import { IdentityLookupParams, SchemesConfiguration, SrcProfileWithScheme } from './types';
+import { IdentityLookupParams, SchemesConfiguration } from './types';
 import { SrciIdentityLookupResponse, SrcProfile } from './sdks/types';
 import SrciError from './sdks/SrciError';
 
@@ -12,11 +12,11 @@ test('should pass the correct configuration to the respective scheme SDKs', asyn
     const mc = mock<MastercardSdk>();
     const sdkLoader = mock<ISrcSdkLoader>();
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     visa.schemeName = 'visa';
     visa.isRecognized.mockResolvedValue({ recognized: false });
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     mc.schemeName = 'mc';
     mc.isRecognized.mockResolvedValue({ recognized: false });
 
@@ -126,7 +126,7 @@ test('should load shopper cards when cookie is available AND shopper has CtP pro
 
     sdkLoader.load.mockResolvedValue([visa, mc]);
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     visa.schemeName = 'visa';
     visa.init.mockResolvedValue();
     visa.isRecognized.mockResolvedValue({ recognized: true, idTokens: mockedIdToken });
@@ -228,13 +228,13 @@ test('should load shopper cards when cookie is available AND shopper has CtP pro
 
     sdkLoader.load.mockResolvedValue([visa, mc]);
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     visa.schemeName = 'visa';
     visa.init.mockResolvedValue();
     visa.isRecognized.mockResolvedValue({ recognized: true, idTokens: mockedIdToken });
     visa.getSrcProfile.mockResolvedValue(profileFromVisaSrcSystem);
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     mc.schemeName = 'mc';
     mc.init.mockResolvedValue();
     mc.isRecognized.mockResolvedValue({ recognized: false });
@@ -298,7 +298,7 @@ test('should clean up shopper cards and set CtP state as Login after performing 
 
     sdkLoader.load.mockResolvedValue([visa, mc]);
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     visa.schemeName = 'visa';
     visa.init.mockResolvedValue();
     visa.unbindAppInstance.mockResolvedValue();
@@ -388,7 +388,7 @@ test('should authenticate the shopper with the fastest SDK that finds the shoppe
 
     sdkLoader.load.mockResolvedValue([visa, mc]);
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     visa.schemeName = 'visa';
     visa.init.mockResolvedValue();
     visa.isRecognized.mockResolvedValue({ recognized: false });
@@ -397,7 +397,7 @@ test('should authenticate the shopper with the fastest SDK that finds the shoppe
         () => new Promise<SrciIdentityLookupResponse>(resolve => setTimeout(() => resolve({ consumerPresent: true }), 700))
     );
 
-    // @ts-ignore
+    // @ts-ignore Mocking readonly property
     mc.schemeName = 'mc';
     mc.init.mockResolvedValue();
     mc.isRecognized.mockResolvedValue({ recognized: false });

--- a/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.test.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.test.tsx
@@ -1,7 +1,6 @@
 import { h } from 'preact';
 import { shallow } from 'enzyme';
 import DragonpayVoucherResult from './DragonpayVoucherResult';
-import Voucher from '../../../internal/Voucher';
 
 describe('DragonpayVoucherResult', () => {
     test('should not render issuer image for dragonpay_otc_philippines', () => {

--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import Dropin from './Dropin';
 import AdyenCheckout from '../../core';
 import ThreeDS2DeviceFingerprint from '../ThreeDS2/ThreeDS2DeviceFingerprint';
 import ThreeDS2Challenge from '../ThreeDS2/ThreeDS2Challenge';
@@ -122,7 +121,6 @@ describe('Dropin', () => {
     describe('Instant Payments feature', () => {
         test('formatProps formats instantPaymentTypes removing duplicates and invalid values', () => {
             const checkout = new AdyenCheckout({});
-            // @ts-ignore
             const dropin = checkout.create('dropin', { instantPaymentTypes: ['alipay', 'paywithgoogle', 'paywithgoogle', 'paypal'] });
 
             expect(dropin.props.instantPaymentTypes).toStrictEqual(['paywithgoogle']);

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
@@ -1,11 +1,10 @@
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { h } from 'preact';
 import PaymentMethodList from './PaymentMethodList';
 import PaymentMethodItem from './PaymentMethodItem';
 import InstantPaymentMethods from './InstantPaymentMethods';
 
 const i18n = { get: key => key };
-const index = 0;
 const paymentMethods = [
     {
         props: {

--- a/packages/lib/src/components/Dropin/elements/filters.test.ts
+++ b/packages/lib/src/components/Dropin/elements/filters.test.ts
@@ -1,4 +1,4 @@
-import { UNSUPPORTED_PAYMENT_METHODS, filterUnsupported, filterPresent, filterAvailable } from './filters';
+import { filterPresent, filterAvailable } from './filters';
 
 describe('elements filters', () => {
     // describe('filterUnsupported', () => {

--- a/packages/lib/src/components/Econtext/components/EcontextInput/EcontextInput.test.tsx
+++ b/packages/lib/src/components/Econtext/components/EcontextInput/EcontextInput.test.tsx
@@ -5,7 +5,7 @@ import EcontextInput from './EcontextInput';
 describe('Econtext: EcontextInput', () => {
     test('renders PersonalDetails form by default', () => {
         const wrapper = shallow(
-            <EcontextInput onChange={jest.fn()} onSubmit={jest.fn()} showPayButton payButton={() => <button class="pay-button" />} />
+            <EcontextInput onChange={jest.fn()} onSubmit={jest.fn()} showPayButton payButton={() => <button className="pay-button" />} />
         );
         expect(wrapper.find('PersonalDetails')).toHaveLength(1);
     });
@@ -17,7 +17,7 @@ describe('Econtext: EcontextInput', () => {
                 onChange={jest.fn()}
                 onSubmit={jest.fn()}
                 showPayButton
-                payButton={() => <button class="pay-button" />}
+                payButton={() => <button className="pay-button" />}
             />
         );
         expect(wrapper.find('PersonalDetails')).toHaveLength(0);
@@ -30,9 +30,9 @@ describe('Econtext: EcontextInput', () => {
                 onChange={jest.fn()}
                 onSubmit={jest.fn()}
                 showPayButton={false}
-                payButton={() => <button class="pay-button" />}
+                payButton={() => <button className="pay-button" />}
             />
         );
-        expect(wrapper.contains(<button class="pay-button" />)).toBeFalsy();
+        expect(wrapper.contains(<button className="pay-button" />)).toBeFalsy();
     });
 });

--- a/packages/lib/src/components/Giftcard/Giftcard.test.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.test.tsx
@@ -3,7 +3,6 @@ const flushPromises = () => new Promise(setImmediate);
 
 describe('Giftcard', () => {
     const baseProps = { amount: { value: 1000, currency: 'EUR' }, name: 'My Test Gift Card', type: 'giftcard', brand: 'genericgiftcard' };
-    const balanceMock = { balance: { value: 100, currency: 'EUR' } };
 
     describe('onBalanceCheck', () => {
         test('If onBalanceCheck is not provided, step is skipped and calls onSubmit', async () => {

--- a/packages/lib/src/components/GooglePay/requests.test.ts
+++ b/packages/lib/src/components/GooglePay/requests.test.ts
@@ -67,8 +67,9 @@ describe('Google Pay Requests', () => {
         });
 
         test('should not have merchantOrigin when not in use', () => {
-            const paymentRequest = initiatePaymentRequest({...defaultProps});
+            const paymentRequest = initiatePaymentRequest({ ...defaultProps });
 
+            // eslint-disable-next-line no-prototype-builtins
             expect(paymentRequest.merchantInfo.hasOwnProperty('merchantOrigin')).toBe(false);
         });
     });

--- a/packages/lib/src/components/Twint/Twint.test.tsx
+++ b/packages/lib/src/components/Twint/Twint.test.tsx
@@ -1,4 +1,3 @@
-import { h } from 'preact';
 import TwintElement from './Twint';
 
 //mock i18n
@@ -7,13 +6,14 @@ const i18n = {
     // this is useful to check if function is called with right params
     amount: (value, currency) => `${currency} ${value}`
 };
-const mockDefaultTwintProps = { i18n,
-    name: "TWINT",
+const mockDefaultTwintProps = {
+    i18n,
+    name: 'TWINT',
     amount: {
         currency: 'CHF',
         value: 20000
     }
-}
+};
 
 describe('Twint', () => {
     describe('isValid', () => {
@@ -25,26 +25,25 @@ describe('Twint', () => {
 
     describe('displayName', () => {
         test('Says saved in title if stored payment method', () => {
-            const twintElement = new TwintElement({ ...mockDefaultTwintProps, storedPaymentMethodId: '0123456789'});
-            expect(twintElement.displayName).toBe("TWINT twint.saved");
+            const twintElement = new TwintElement({ ...mockDefaultTwintProps, storedPaymentMethodId: '0123456789' });
+            expect(twintElement.displayName).toBe('TWINT twint.saved');
         });
 
         test('Just say TWINT in title if not stored payment method', () => {
-            const twintElement = new TwintElement({ ...mockDefaultTwintProps});
-            expect(twintElement.displayName).toBe("TWINT");
+            const twintElement = new TwintElement({ ...mockDefaultTwintProps });
+            expect(twintElement.displayName).toBe('TWINT');
         });
     });
 
     describe('payButtonLabel', () => {
         test('Says Pay + currency + amount', () => {
-            const twintElement = new TwintElement({ ...mockDefaultTwintProps, storedPaymentMethodId: '0123456789'});
-            expect(twintElement.payButtonLabel()).toBe("payButton CHF 20000");
+            const twintElement = new TwintElement({ ...mockDefaultTwintProps, storedPaymentMethodId: '0123456789' });
+            expect(twintElement.payButtonLabel()).toBe('payButton CHF 20000');
         });
 
         test('Says Continue to TWINT', () => {
-            const twintElement = new TwintElement({ ...mockDefaultTwintProps});
-            expect(twintElement.payButtonLabel()).toBe("continueTo TWINT");
+            const twintElement = new TwintElement({ ...mockDefaultTwintProps });
+            expect(twintElement.payButtonLabel()).toBe('continueTo TWINT');
         });
     });
-
 });

--- a/packages/lib/src/components/UIElement.test.ts
+++ b/packages/lib/src/components/UIElement.test.ts
@@ -92,7 +92,7 @@ describe('UIElement', () => {
         test("calls component's showValidation method", () => {
             const showValidation = jest.fn();
             class MyElement extends UIElement {
-                showValidation = () => showValidation();
+                public showValidation = () => showValidation();
             }
 
             const myElement = new MyElement({});
@@ -109,7 +109,7 @@ describe('UIElement', () => {
 
         test('returns the constructor type if no name prop is passed', () => {
             class MyElement extends UIElement {
-                static type = 'test123';
+                protected static type = 'test123';
             }
 
             const myElement = new MyElement({});

--- a/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.test.tsx
+++ b/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.test.tsx
@@ -1,7 +1,7 @@
 import OpenInvoiceContainer from './OpenInvoiceContainer';
 
 describe('OpenInvoiceContainer', () => {
-    const getWrapper = (props?) => new OpenInvoiceContainer({ ...props });
+    const getWrapper = (props = {}) => new OpenInvoiceContainer({ ...props });
 
     test('should use the passed countryCode in the address fieldsets', () => {
         const countryCode = 'US';

--- a/packages/lib/src/components/internal/Address/components/CountryField.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.test.tsx
@@ -2,6 +2,8 @@ import { mount } from 'enzyme';
 import { h } from 'preact';
 import CountryField from './CountryField';
 import getDataset from '../../../../core/Services/get-dataset';
+import { mock } from 'jest-mock-extended';
+import { CountryFieldProps } from '../types';
 
 jest.mock('../../../../core/Services/get-dataset');
 const countriesMock = [
@@ -22,7 +24,8 @@ const countriesMock = [
 (getDataset as jest.Mock).mockImplementation(jest.fn(() => Promise.resolve(countriesMock)));
 
 describe('CountryField', () => {
-    const getWrapper = (props?) => mount(<CountryField {...props} />);
+    const countryFieldPropsMock = mock<CountryFieldProps>();
+    const getWrapper = (props = {}) => mount(<CountryField {...props} {...countryFieldPropsMock} />);
 
     test('calls getDataset', () => {
         getWrapper();

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.test.tsx
@@ -2,6 +2,8 @@ import { shallow } from 'enzyme';
 import { h } from 'preact';
 import FieldContainer from './FieldContainer';
 import Specifications from '../Specifications';
+import { mock } from 'jest-mock-extended';
+import { FieldContainerProps } from '../types';
 
 const propsMock = {
     errors: {},
@@ -11,7 +13,8 @@ const propsMock = {
 };
 
 describe('FieldContainer', () => {
-    const getWrapper = (props?) => shallow(<FieldContainer fields {...propsMock} {...props} />);
+    const mockedProps = mock<FieldContainerProps>();
+    const getWrapper = (props = {}) => shallow(<FieldContainer {...propsMock} {...props} {...mockedProps} />);
 
     test('renders the StateField', () => {
         const wrapper = getWrapper({ fieldName: 'stateOrProvince' });

--- a/packages/lib/src/components/internal/Address/components/StateField.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.test.tsx
@@ -3,6 +3,8 @@ import { h } from 'preact';
 import StateField from './StateField';
 import getDataset from '../../../../core/Services/get-dataset';
 import Specifications from '../Specifications';
+import { mock } from 'jest-mock-extended';
+import { StateFieldProps } from '../types';
 
 jest.mock('../../../../core/Services/get-dataset');
 const statesMock = [
@@ -19,7 +21,8 @@ const statesMock = [
 (getDataset as jest.Mock).mockImplementation(jest.fn(() => Promise.resolve(statesMock)));
 
 describe('StateField', () => {
-    const getWrapper = (props?) => mount(<StateField specifications={new Specifications()} {...props} />);
+    const mockedProps = mock<StateFieldProps>();
+    const getWrapper = (props = {}) => mount(<StateField specifications={new Specifications()} {...props} {...mockedProps} />);
 
     test('does not call getDataset when no country is passed', () => {
         getWrapper();

--- a/packages/lib/src/components/internal/IFrame/Iframe.test.tsx
+++ b/packages/lib/src/components/internal/IFrame/Iframe.test.tsx
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 import { h } from 'preact';
-import iframe from './Iframe';
 
-const createWrapper = (props?) => mount(<iframe name={'test'} width={'200'} height={'300'} src={'https://www.google.com'} {...props} />);
+const createWrapper = (props = {}) => mount(<iframe name={'test'} width={'200'} height={'300'} src={'https://www.google.com'} {...props} />);
 
 describe('iframe', () => {
     test('Renders an iframe', () => {

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.test.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.test.tsx
@@ -4,7 +4,7 @@ import IbanInput from './IbanInput';
 
 const i18n = { get: key => key };
 
-const createWrapper = (props?) => mount(<IbanInput i18n={i18n} {...props} />);
+const createWrapper = (props = {}) => mount(<IbanInput i18n={i18n} {...props} />);
 
 describe('IbanInput', () => {
     test('Renders two fields', () => {
@@ -66,28 +66,28 @@ describe('IbanInput', () => {
 
     describe('Send values from outside', () => {
         test('Set ibanNumber', () => {
-            const wrapper = createWrapper({ data: { 'ibanNumber': 'NL13TEST0123456789' } });
+            const wrapper = createWrapper({ data: { ibanNumber: 'NL13TEST0123456789' } });
             setTimeout(() => {
                 expect(wrapper.find('input[name="ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
             });
         });
 
         test('Set ibanNumber formatted', () => {
-            const wrapper = createWrapper({ data: { 'ibanNumber': 'NL13 TEST 0123 4567 89' } });
+            const wrapper = createWrapper({ data: { ibanNumber: 'NL13 TEST 0123 4567 89' } });
             setTimeout(() => {
                 expect(wrapper.find('input[name="ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
             });
         });
 
         test('Set ownerName', () => {
-            const wrapper = createWrapper({ data: { 'ownerName': 'Hello World' } });
+            const wrapper = createWrapper({ data: { ownerName: 'Hello World' } });
             setTimeout(() => {
                 expect(wrapper.find('input[name="ownerName"]').text()).toBe('Hello World');
             });
         });
 
         test('Set ibanNumber and ownerName', () => {
-            const wrapper = createWrapper({ data: { 'ibanNumber': 'NL13TEST0123456789', 'ownerName': 'Hello World' } });
+            const wrapper = createWrapper({ data: { ibanNumber: 'NL13TEST0123456789', ownerName: 'Hello World' } });
             setTimeout(() => {
                 expect(wrapper.find('input[name="ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
                 expect(wrapper.find('input[name="ownerName"]').text()).toBe('Hello World');

--- a/packages/lib/src/components/internal/Img/Img.test.tsx
+++ b/packages/lib/src/components/internal/Img/Img.test.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 import Img from './Img';
 
 describe('Image', () => {
-    const getWrapper = (props?) => shallow(<Img {...props} />);
+    const getWrapper = (props = {}) => shallow(<Img {...props} />);
 
     test('renders a component', () => {
         const wrapper = getWrapper();

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
@@ -1,19 +1,23 @@
 import { h } from 'preact';
 import { shallow } from 'enzyme';
 import OpenInvoice from './OpenInvoice';
+import { mock } from 'jest-mock-extended';
+import { OpenInvoiceProps } from './types';
+import { FieldsetVisibility } from '../../../types';
 
 const defaultProps = {
     onChange: () => {},
     data: { personalDetails: {}, billingAddress: {}, deliveryAddress: {} },
     visibility: {
-        personalDetails: 'editable',
-        billingAddress: 'editable',
-        deliveryAddress: 'editable'
+        personalDetails: 'editable' as FieldsetVisibility,
+        billingAddress: 'editable' as FieldsetVisibility,
+        deliveryAddress: 'editable' as FieldsetVisibility
     }
 };
 
 describe('OpenInvoice', () => {
-    const getWrapper = (props?) => shallow(<OpenInvoice {...defaultProps} {...props} />);
+    const openInvoicePropsMock = mock<OpenInvoiceProps>();
+    const getWrapper = (props = {}) => shallow(<OpenInvoice {...openInvoicePropsMock} {...defaultProps} {...props} />);
 
     test('should not display fieldsets set to hidden', () => {
         const visibility = { personalDetails: 'hidden' };

--- a/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
@@ -1,10 +1,12 @@
 import { mount } from 'enzyme';
 import { h } from 'preact';
-import PayButton from './PayButton';
+import PayButton, { PayButtonProps } from './PayButton';
 import { PAY_BTN_DIVIDER } from './utils';
+import { mock } from 'jest-mock-extended';
 
 describe('PayButton', () => {
-    const getWrapper = (props?) => mount(<PayButton {...props} />);
+    const mockedProps = mock<PayButtonProps>();
+    const getWrapper = (props = {}) => mount(<PayButton {...props} {...mockedProps} />);
 
     test('Renders a pay button', () => {
         const wrapper = getWrapper();

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.test.tsx
@@ -2,8 +2,7 @@ import { shallow } from 'enzyme';
 import { h } from 'preact';
 import SecuredFieldsProvider from './SecuredFieldsProvider';
 import Language from '../../../../language/Language';
-import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD, ERROR_MSG_UNSUPPORTED_CARD_ENTERED, ERROR_MSG_CLEARED } from '../../../../core/Errors/constants';
-import { getError } from '../../../../core/Errors/utils';
+import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD, ERROR_MSG_UNSUPPORTED_CARD_ENTERED } from '../../../../core/Errors/constants';
 
 jest.mock('../lib/CSF', () => {
     return () => true;
@@ -14,12 +13,8 @@ const i18n = new Language('en-US', {});
 let wrapper;
 let sfp;
 
-let errorObj;
-
-const onError = jest.fn(errObj => {
-    errorObj = errObj;
-});
-const renderFn = jest.fn((props, state) => {});
+const onError = jest.fn(() => {});
+const renderFn = jest.fn(() => {});
 
 const handleSecuredFieldsRef = ref => {
     sfp = ref;

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/extensions.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/extensions.test.ts
@@ -4,7 +4,7 @@ import { BRAND_ICON_UI_EXCLUSION_LIST, CVC_POLICY_REQUIRED } from '../lib/config
 let CIExtensions;
 
 // Mock sfp useRef
-let sfp = {
+const sfp = {
     current: {
         processBinLookupResponse: () => {}
     }

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType-tests/cardType-otherFns.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/cardType-tests/cardType-otherFns.test.ts
@@ -35,7 +35,7 @@ describe('Tests for cardType.getShortestPermittedCardLength & getCardByBrand fun
 
     test('Should throw error since a type argument has not been passed', () => {
         expect(() => {
-            /* @ts-ignore */
+            // @ts-ignore Expected to complain as the argument is missing
             CardType.isGenericCardType();
         }).toThrow('Error: isGenericCardType: type param has not been specified');
     });

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/processErrors.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/utils/processErrors.test.ts
@@ -17,7 +17,7 @@ let callbackFnCalled = false;
 
 const rootNode = null;
 
-const onError = dataObj => {
+const onError = () => {
     callbackFnCalled = true;
 };
 

--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/filters.test.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/filters.test.ts
@@ -1,9 +1,4 @@
-import {
-    filterAllowedPaymentMethods,
-    filterRemovedPaymentMethods,
-    filterEcomStoredPaymentMethods,
-    filterSupportedStoredPaymentMethods
-} from './filters';
+import { filterEcomStoredPaymentMethods, filterSupportedStoredPaymentMethods } from './filters';
 
 describe('PaymentMethodsResponse filters', () => {
     test('filterEcomStoredPaymentMethods', () => {

--- a/packages/lib/src/core/core.component.props.test.ts
+++ b/packages/lib/src/core/core.component.props.test.ts
@@ -41,7 +41,6 @@ const amazonPayPMObj = {
     type: 'amazonpay',
     configuration: {
         merchantId: '1000',
-        // @ts-ignore
         publicKeyId: 'AG77',
         region: 'eu',
         storeId: 'amzn1.aaaaa'
@@ -251,8 +250,8 @@ describe('Core - tests ensuring props reach components', () => {
         let newPmResponsePaymentMethods;
 
         beforeEach(() => {
-            // @ts-ignore
-            checkoutConfig['paymentMethodsResponse'].paymentMethods[1] = amazonPayPMObj; // Need to swap out googlepay since it does some other async process at startup that the flushPromises won't resolve
+            // @ts-ignore Need to swap out googlepay since it does some other async process at startup that the flushPromises won't resolve
+            checkoutConfig['paymentMethodsResponse'].paymentMethods[1] = amazonPayPMObj;
 
             newPmResponsePaymentMethods = checkoutConfig['paymentMethodsResponse'].paymentMethods;
 

--- a/packages/lib/src/utils/useForm/useForm.test.tsx
+++ b/packages/lib/src/utils/useForm/useForm.test.tsx
@@ -13,6 +13,7 @@ describe('useForm', () => {
     describe('schema', () => {
         let useFormHook;
         beforeEach(() => {
+            // eslint-disable-next-line testing-library/no-render-in-setup
             const { result } = renderHook(() => useForm({ schema: defaultSchema }));
             useFormHook = result;
         });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In order to support the team to have consistent code style, avoid errors and improve code quality, this PR enables the eslint to lint test files as well.

- Removed `*.test.*` from the ignored files
- Fixed all lint issues detected by the linter