### PR TITLE
Remove ach placeholder and formatting.

### DIFF
--- a/packages/lib/src/components/Ach/components/AchInput/components/AchSecuredFields.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/components/AchSecuredFields.tsx
@@ -15,7 +15,7 @@ const AchSecuredFields = ({ focusedElement, onFocusField, errors, valid }) => {
                 onFocusField={onFocusField}
                 filled={!!errors.encryptedBankAccountNumber || !!valid.encryptedBankAccountNumber}
                 errorMessage={!!errors.encryptedBankAccountNumber && i18n.get(errors.encryptedBankAccountNumber)}
-                dataInfo='{"length":"4-17", "maskInterval": 4}'
+                dataInfo='{"length":"4-17"}'
                 className={'adyen-checkout__field--50'}
                 dir={'ltr'}
             />

--- a/packages/lib/src/components/internal/SecuredFields/utils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/utils.ts
@@ -8,10 +8,9 @@ import {
     ENCRYPTED_SECURITY_CODE,
     ENCRYPTED_PWD_FIELD,
     ENCRYPTED_SECURITY_CODE_3_DIGITS,
-    ENCRYPTED_SECURITY_CODE_4_DIGITS
-    // TODO Comment out until translations are available
-    // ENCRYPTED_BANK_ACCNT_NUMBER_FIELD,
-    // ENCRYPTED_BANK_LOCATION_FIELD
+    ENCRYPTED_SECURITY_CODE_4_DIGITS,
+    ENCRYPTED_BANK_ACCNT_NUMBER_FIELD,
+    ENCRYPTED_BANK_LOCATION_FIELD
 } from './lib/configuration/constants';
 import { SFPlaceholdersObject } from './lib/securedField/AbstractSecuredField';
 
@@ -19,19 +18,31 @@ import { SFPlaceholdersObject } from './lib/securedField/AbstractSecuredField';
  * Lookup translated values for the placeholders for the SecuredFields
  * and return an object with these mapped to the data-cse value of the SecuredField
  */
-export const resolvePlaceholders = (i18n?: Language): SFPlaceholdersObject => ({
-    [ENCRYPTED_CARD_NUMBER]: i18n.get && i18n.get('creditCard.numberField.placeholder'),
-    [ENCRYPTED_EXPIRY_DATE]: i18n.get && i18n.get('creditCard.expiryDateField.placeholder'),
-    [ENCRYPTED_EXPIRY_MONTH]: i18n.get && i18n.get('creditCard.expiryDateField.month.placeholder'),
-    [ENCRYPTED_EXPIRY_YEAR]: i18n.get && i18n.get('creditCard.expiryDateField.year.placeholder'),
-    [ENCRYPTED_SECURITY_CODE]: i18n.get && i18n.get('creditCard.cvcField.placeholder'), // Used for gift cards
-    [ENCRYPTED_SECURITY_CODE_3_DIGITS]: i18n.get && i18n.get('creditCard.cvcField.placeholder.3digits'),
-    [ENCRYPTED_SECURITY_CODE_4_DIGITS]: i18n.get && i18n.get('creditCard.cvcField.placeholder.4digits'),
-    [ENCRYPTED_PWD_FIELD]: i18n.get && i18n.get('creditCard.encryptedPassword.placeholder')
-    // TODO Comment out until translations are available
-    // [ENCRYPTED_BANK_ACCNT_NUMBER_FIELD]: i18n.get && i18n.get('accountNumberField.placeholder'),
-    // [ENCRYPTED_BANK_LOCATION_FIELD]: i18n.get && i18n.get('accountLocationId.placeholder')
-});
+export const resolvePlaceholders = (i18n?: Language): SFPlaceholdersObject => {
+    const phObj = {
+        [ENCRYPTED_CARD_NUMBER]: i18n.get && i18n.get('creditCard.numberField.placeholder'),
+        [ENCRYPTED_EXPIRY_DATE]: i18n.get && i18n.get('creditCard.expiryDateField.placeholder'),
+        [ENCRYPTED_EXPIRY_MONTH]: i18n.get && i18n.get('creditCard.expiryDateField.month.placeholder'),
+        [ENCRYPTED_EXPIRY_YEAR]: i18n.get && i18n.get('creditCard.expiryDateField.year.placeholder'),
+        [ENCRYPTED_SECURITY_CODE]: i18n.get && i18n.get('creditCard.cvcField.placeholder'), // Used for gift cards
+        [ENCRYPTED_SECURITY_CODE_3_DIGITS]: i18n.get && i18n.get('creditCard.cvcField.placeholder.3digits'),
+        [ENCRYPTED_SECURITY_CODE_4_DIGITS]: i18n.get && i18n.get('creditCard.cvcField.placeholder.4digits'),
+        [ENCRYPTED_PWD_FIELD]: i18n.get && i18n.get('creditCard.encryptedPassword.placeholder'),
+        [ENCRYPTED_BANK_ACCNT_NUMBER_FIELD]: i18n.get && i18n.get('ach.accountNumberField.placeholder'),
+        [ENCRYPTED_BANK_LOCATION_FIELD]: i18n.get && i18n.get('ach.accountLocationId.placeholder')
+    };
+
+    // For ach - if the merchant has specified a placeholder (which can only be done through a translations object, it doesn't exist in the translations files)
+    // then use it... else default to nothing
+    if (phObj[ENCRYPTED_BANK_ACCNT_NUMBER_FIELD] === 'ach.accountNumberField.placeholder') {
+        phObj[ENCRYPTED_BANK_ACCNT_NUMBER_FIELD] = '';
+    }
+    if (phObj[ENCRYPTED_BANK_LOCATION_FIELD] === 'ach.accountLocationId.placeholder') {
+        phObj[ENCRYPTED_BANK_LOCATION_FIELD] = '';
+    }
+
+    return phObj;
+};
 
 /**
  * Used by SecuredFieldsProviderHandlers


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Since the ACH bank account number can be 4-17 digits, with no standard format - the placeholder can't be specific enough to imply how many digits can be added there. So we have decided to remove it.
Likewise we have removed the formatting that added a space every 4 digits.

If the merchant _really_ wants a placeholder they can add one through a translations config object - but by default the placeholder has been removed

## Tested scenarios
All tests pass

**Fixed issue**:  COWEB-1166