### PR TITLE
Adding field specific errors for fields in the PersonalDetails component

### DIFF
--- a/packages/lib/src/components/internal/PersonalDetails/validate.ts
+++ b/packages/lib/src/components/internal/PersonalDetails/validate.ts
@@ -15,7 +15,21 @@ export const personalDetailsValidationRules: ValidatorRules = {
         validate: value => {
             return value && value.length > 0;
         },
-        errorMessage: 'error.va.gen.02', // = "field not valid" TODO make more specific errors for firstName & lastName (requires translations)
+        errorMessage: 'error.va.gen.02', // = "field not valid"
+        modes: ['blur']
+    },
+    firstName: {
+        validate: value => {
+            return value && value.length > 0;
+        },
+        errorMessage: 'firstName.invalid',
+        modes: ['blur']
+    },
+    lastName: {
+        validate: value => {
+            return value && value.length > 0;
+        },
+        errorMessage: 'lastName.invalid',
         modes: ['blur']
     },
     dateOfBirth: {


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adding field specific errors for first & last name fields in the PersonalDetails component now that the translations are available. This brings the errors on these fields into line with a11y guidelines.

## Tested scenarios
Translated field specific errors are used for these fields

**Relates to issue**:  FOC-66770
