### PR TITLE
Added config option "disableIOSArrowKeys"

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -140,6 +140,8 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
      * re. Disabling arrow keys in iOS:
      * Only by disabling all fields in the Card PM except for the active securedField input can we force the iOS soft keyboard arrow keys to disable
      *
+     * NOTE: only called if ua.__IS_IOS = true (as referenced in CSF)
+     *
      * @param obj - has fieldType prop saying whether this function is being called in response to an securedFields click ('encryptedCardNumber' etc)
      * - in which case we should disable all non-SF fields
      * or,
@@ -373,7 +375,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
                 onFocus={handleFocus}
                 type={props.brand}
                 isCollatingErrors={collateErrors}
-                onTouchstartIOS={handleTouchstartIOS}
+                {...(props.disableIOSArrowKeys && { onTouchstartIOS: handleTouchstartIOS })}
                 render={({ setRootNode, setFocusOn }, sfpState) => (
                     <div
                         ref={setRootNode}

--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -21,6 +21,7 @@ export default {
     configuration: { koreanAuthenticationRequired: false, socialSecurityNumberMode: 'auto' as SocialSecurityMode },
     autoFocus: true,
     isPayButtonPrimaryVariant: true,
+    disableIOSArrowKeys: true,
 
     // Events
     onLoad: (): any => {},

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -65,6 +65,7 @@ export interface CardInputProps {
     countryCode?: string;
     cvcPolicy?: CVCPolicyType;
     data?: CardInputDataState;
+    disableIOSArrowKeys?: boolean;
     enableStoreDetails?: boolean;
     expiryMonth?: string;
     expiryYear?: string;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For COWEB-1020, which was an issue about the fact that
> The keyboard arrow buttons on iOS devices do not work for the card component's securedFields 

... we decided that if we couldn't control whether the arrow keys on the "soft" iOS keyboard worked or not then we would instead just disable them.

There's a possibility however that the fix we put in place in #1581 is causing a11y issues by interfering with the navigation within the VoiceOver screenreader

In order to test this, this PR adds a config option `disableIOSArrowKeys:true|false` that allows us to control whether the feature from #1581 is applied or not

## Tested scenarios
Setting `disableIOSArrowKeys` to `true` (which is also the default value) enables the disabling of the iOS arrow keys.
Setting `disableIOSArrowKeys` to `false` turns off the disabling of the iOS arrow keys.

**Relates to issue**:  COWEB-1020, #1581
