### PR TITLE
Add support for sessionResult

### DIFF
--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -46,6 +46,7 @@ export interface PaymentResponse {
     resultCode: string;
     sessionData?: string;
     order?: Order;
+    sessionResult?: string;
 }
 
 export interface RawPaymentResponse extends PaymentResponse {

--- a/packages/lib/src/components/utils.test.ts
+++ b/packages/lib/src/components/utils.test.ts
@@ -9,11 +9,13 @@ describe('components utils', () => {
         test('filters unallowed properties', () => {
             const rawResponse = {
                 resultCode: 'Authorised',
-                someBackendProperty: true
+                someBackendProperty: true,
+                sessionResult: 'XYZ123'
             };
 
             const sanitizedResponse = getSanitizedResponse(rawResponse);
             expect(sanitizedResponse.resultCode).toBeTruthy();
+            expect(sanitizedResponse.sessionResult).toBeTruthy();
             expect((sanitizedResponse as any).someBackendProperty).toBeUndefined();
         });
     });

--- a/packages/lib/src/components/utils.ts
+++ b/packages/lib/src/components/utils.ts
@@ -1,6 +1,6 @@
 import {PaymentResponse, RawPaymentResponse, UIElementStatus} from './types';
 
-const ALLOWED_PROPERTIES = ['action', 'resultCode', 'sessionData', 'order'];
+const ALLOWED_PROPERTIES = ['action', 'resultCode', 'sessionData', 'order', 'sessionResult'];
 
 export function getSanitizedResponse(response: RawPaymentResponse): PaymentResponse {
     const removedProperties = [];


### PR DESCRIPTION

## Summary
Added support for sessionResult to be forwarded to the client when using the sessions flow and completing a payment. 

## Tested scenarios
Extend test-case to ensure sessionResult is no longer removed during sanitising.  

**Fixed issue**:  COWEB-1162
