### PR TITLE
Validating postal code when billingAddressMode is partial

### DIFF
--- a/packages/e2e/tests/_models/CardComponent.page.js
+++ b/packages/e2e/tests/_models/CardComponent.page.js
@@ -104,6 +104,9 @@ export default class CardPage extends BasePage {
         this.addressLabel = Selector(`${BASE_EL} .adyen-checkout__field--street .adyen-checkout__label`);
         this.addressInput = Selector(`${BASE_EL} .adyen-checkout__field--street .adyen-checkout__input--street`);
 
+        this.postalCodeInput = Selector(`${BASE_EL} .adyen-checkout__field--postalCode .adyen-checkout__input--postalCode`);
+        this.postalCodeErrorText = Selector(`${BASE_EL} .adyen-checkout__field--postalCode .adyen-checkout__error-text`);
+
         this.houseNumberLabelWithFocus = Selector(`${BASE_EL} .adyen-checkout__field--houseNumberOrName .adyen-checkout__label--focused`);
 
         // Country dropdown

--- a/packages/e2e/tests/cards/avs/avs.partial.clientScripts.js
+++ b/packages/e2e/tests/cards/avs/avs.partial.clientScripts.js
@@ -1,0 +1,20 @@
+const CLIENTSCRIPT_PARTIAL_AVS_WITH_COUNTRY = `
+    window.cardConfig = {
+        billingAddressRequired: true,
+        billingAddressMode: 'partial',
+        data: {
+            billingAddress: {
+                country: 'BR'
+            }
+        }    
+    };
+`;
+
+const CLIENTSCRIPT_PARTIAL_AVS_WITHOUT_COUNTRY = `
+    window.cardConfig = {
+        billingAddressRequired: true,
+        billingAddressMode: 'partial'
+    };
+`;
+
+export { CLIENTSCRIPT_PARTIAL_AVS_WITH_COUNTRY, CLIENTSCRIPT_PARTIAL_AVS_WITHOUT_COUNTRY };

--- a/packages/e2e/tests/cards/avs/avs.partial.test.js
+++ b/packages/e2e/tests/cards/avs/avs.partial.test.js
@@ -1,0 +1,45 @@
+import { CARDS_URL } from '../../pages';
+import { start } from '../../utils/commonUtils';
+import { REGULAR_TEST_CARD } from '../utils/constants';
+import CardComponentPage from '../../_models/CardComponent.page';
+import { CLIENTSCRIPT_PARTIAL_AVS_WITH_COUNTRY, CLIENTSCRIPT_PARTIAL_AVS_WITHOUT_COUNTRY } from './avs.partial.clientScripts';
+
+const TEST_SPEED = 1;
+const INVALID_POSTALCODE = 'aaaaaaaaaa';
+
+let cardPage = null;
+
+fixture`Card with Partial AVS`.page(CARDS_URL).beforeEach(() => {
+    cardPage = new CardComponentPage();
+});
+
+test('should validate Postal Code if property data.billingAddress.country is provided', async t => {
+    // Start, allow time for iframes to load
+    await start(t, 2000, TEST_SPEED);
+
+    await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+    await cardPage.cardUtils.fillDateAndCVC(t);
+
+    // Fill in wrong Postal code format
+    await t.typeText(cardPage.postalCodeInput, INVALID_POSTALCODE);
+    await t.click(cardPage.payButton);
+
+    await t.expect(cardPage.postalCodeErrorText.innerText).contains('Invalid format. Expected format: 99999999');
+}).clientScripts({ content: CLIENTSCRIPT_PARTIAL_AVS_WITH_COUNTRY });
+
+test('should not validate Postal Code if property data.billingAddress.country is not provided', async t => {
+    // Start, allow time for iframes to load
+    await t.setNativeDialogHandler(() => true);
+    await start(t, 2000, TEST_SPEED);
+
+    await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
+    await cardPage.cardUtils.fillDateAndCVC(t);
+
+    // Fill in wrong Postal code format
+    await t.typeText(cardPage.postalCodeInput, INVALID_POSTALCODE);
+    await t.click(cardPage.payButton);
+
+    // Check the value of the alert text
+    const history = await t.getNativeDialogHistory();
+    await t.expect(history[0].text).eql('Authorised');
+}).clientScripts({ content: CLIENTSCRIPT_PARTIAL_AVS_WITHOUT_COUNTRY });

--- a/packages/e2e/tests/cards/avs/avs.partial.test.js
+++ b/packages/e2e/tests/cards/avs/avs.partial.test.js
@@ -14,13 +14,11 @@ fixture`Card with Partial AVS`.page(CARDS_URL).beforeEach(() => {
 });
 
 test('should validate Postal Code if property data.billingAddress.country is provided', async t => {
-    // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
     await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
     await cardPage.cardUtils.fillDateAndCVC(t);
 
-    // Fill in wrong Postal code format
     await t.typeText(cardPage.postalCodeInput, INVALID_POSTALCODE);
     await t.click(cardPage.payButton);
 
@@ -28,14 +26,12 @@ test('should validate Postal Code if property data.billingAddress.country is pro
 }).clientScripts({ content: CLIENTSCRIPT_PARTIAL_AVS_WITH_COUNTRY });
 
 test('should not validate Postal Code if property data.billingAddress.country is not provided', async t => {
-    // Start, allow time for iframes to load
     await t.setNativeDialogHandler(() => true);
     await start(t, 2000, TEST_SPEED);
 
     await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD);
     await cardPage.cardUtils.fillDateAndCVC(t);
 
-    // Fill in wrong Postal code format
     await t.typeText(cardPage.postalCodeInput, INVALID_POSTALCODE);
     await t.click(cardPage.payButton);
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -77,9 +77,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
 
     const partialAddressSchema = handlePartialAddressMode(props.billingAddressMode);
     // Keeps the value of the country set initially by the merchant, before the Address Component mutates it
-    const partialAddressCountry = useRef<string>(partialAddressSchema && props.data.billingAddress?.country);
-
-    console.log(partialAddressCountry);
+    const partialAddressCountry = useRef<string>(partialAddressSchema && props.data?.billingAddress?.country);
 
     const [storePaymentMethod, setStorePaymentMethod] = useState(false);
     const [billingAddress, setBillingAddress] = useState<AddressData>(showBillingAddress ? props.data.billingAddress : null);

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -77,7 +77,9 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
 
     const partialAddressSchema = handlePartialAddressMode(props.billingAddressMode);
     // Keeps the value of the country set initially by the merchant, before the Address Component mutates it
-    const partialAddressCountry = useRef<string>(props.data.billingAddress?.country);
+    const partialAddressCountry = useRef<string>(partialAddressSchema && props.data.billingAddress?.country);
+
+    console.log(partialAddressCountry);
 
     const [storePaymentMethod, setStorePaymentMethod] = useState(false);
     const [billingAddress, setBillingAddress] = useState<AddressData>(showBillingAddress ? props.data.billingAddress : null);
@@ -428,11 +430,11 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
                             // For Store details
                             handleOnStoreDetails={setStorePaymentMethod}
                             // For Address
+                            billingAddressRef={billingAddressRef}
                             billingAddress={billingAddress}
                             billingAddressValidationRules={partialAddressSchema && getPartialAddressValidationRules(partialAddressCountry.current)}
-                            handleAddress={handleAddress}
-                            billingAddressRef={billingAddressRef}
                             partialAddressSchema={partialAddressSchema}
+                            handleAddress={handleAddress}
                             //
                             iOSFocusedField={iOSFocusedField}
                         />

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -23,6 +23,7 @@ import { getAddressHandler, getAutoJumpHandler, getErrorPanelHandler, getFocusHa
 import { InstallmentsObj } from './components/Installments/Installments';
 import { TouchStartEventObj } from './components/types';
 import classNames from 'classnames';
+import { getPartialAddressValidationRules } from '../../../internal/Address/validate';
 
 const CardInput: FunctionalComponent<CardInputProps> = props => {
     const sfp = useRef(null);
@@ -75,6 +76,8 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
     const showBillingAddress = props.billingAddressMode !== AddressModeOptions.none && props.billingAddressRequired;
 
     const partialAddressSchema = handlePartialAddressMode(props.billingAddressMode);
+    // Keeps the value of the country set initially by the merchant, before the Address Component mutates it
+    const partialAddressCountry = useRef<string>(props.data.billingAddress?.country);
 
     const [storePaymentMethod, setStorePaymentMethod] = useState(false);
     const [billingAddress, setBillingAddress] = useState<AddressData>(showBillingAddress ? props.data.billingAddress : null);
@@ -426,6 +429,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
                             handleOnStoreDetails={setStorePaymentMethod}
                             // For Address
                             billingAddress={billingAddress}
+                            billingAddressValidationRules={partialAddressSchema && getPartialAddressValidationRules(partialAddressCountry.current)}
                             handleAddress={handleAddress}
                             billingAddressRef={billingAddressRef}
                             partialAddressSchema={partialAddressSchema}

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
@@ -56,6 +56,7 @@ export const CardFieldsWrapper = ({
     billingAddressRequired,
     billingAddressRequiredFields,
     billingAddressAllowedCountries,
+    billingAddressValidationRules = null,
     brandsConfiguration,
     enableStoreDetails,
     hasCVC,
@@ -171,6 +172,7 @@ export const CardFieldsWrapper = ({
                     allowedCountries={billingAddressAllowedCountries}
                     requiredFields={billingAddressRequiredFields}
                     ref={billingAddressRef}
+                    validationRules={billingAddressValidationRules}
                     specifications={partialAddressSchema}
                     iOSFocusedField={iOSFocusedField}
                 />

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -1,6 +1,6 @@
 import Language from '../../../../language/Language';
 import { BinLookupResponse, BrandConfiguration, CardBrandsConfiguration, CardConfiguration, DualBrandSelectElement } from '../../types';
-import { PaymentAmount } from '../../../../types';
+import { AddressData, PaymentAmount } from '../../../../types';
 import { InstallmentOptions } from './components/types';
 import { ValidationResult } from '../../../internal/PersonalDetails/types';
 import { CVCPolicyType, DatePolicyType } from '../../../internal/SecuredFields/lib/types';
@@ -34,7 +34,7 @@ export interface CardInputErrorState {
 
 export interface CardInputDataState {
     holderName?: string;
-    billingAddress?: object;
+    billingAddress?: AddressData;
     socialSecurityNumber?: string;
     taxNumber?: string;
 }

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -14,7 +14,7 @@ import {
     SSN_CARD_NAME_BOTTOM,
     SSN_CARD_NAME_TOP
 } from './layouts';
-import { StringObject } from '../../../internal/Address/types';
+import { AddressSpecifications, StringObject } from '../../../internal/Address/types';
 import { PARTIAL_ADDRESS_SCHEMA } from '../../../internal/Address/constants';
 import { InstallmentsObj } from './components/Installments/Installments';
 import { SFPProps } from '../../../internal/SecuredFields/SFP/types';
@@ -205,6 +205,6 @@ export const extractPropsForSFP = (props: CardInputProps) => {
     } as SFPProps; // Can't set as return type on fn or it will complain about missing, mandatory, props
 };
 
-export const handlePartialAddressMode = (addressMode: AddressModeOptions) => {
-    return addressMode == AddressModeOptions.partial ? PARTIAL_ADDRESS_SCHEMA : [];
+export const handlePartialAddressMode = (addressMode: AddressModeOptions): AddressSpecifications | null => {
+    return addressMode == AddressModeOptions.partial ? PARTIAL_ADDRESS_SCHEMA : null;
 };

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -126,6 +126,7 @@ export default function Address(props: AddressProps) {
 
 Address.defaultProps = {
     countryCode: null,
+    validationRules: null,
     data: {},
     onChange: () => {},
     visibility: 'editable',

--- a/packages/lib/src/components/internal/Address/constants.ts
+++ b/packages/lib/src/components/internal/Address/constants.ts
@@ -67,7 +67,7 @@ export const ADDRESS_SPECIFICATIONS: AddressSpecifications = {
     }
 };
 
-export const PARTIAL_ADDRESS_SCHEMA = {
+export const PARTIAL_ADDRESS_SCHEMA: AddressSpecifications = {
     default: {
         labels: {
             [POSTAL_CODE]: 'zipCode'

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -77,7 +77,7 @@ const postalCodePatterns = {
  * Validates only postalCode property. As the partial address form does not have the country selector, the country value
  * must be informed beforehand and can't be picked up from the form context
  *
- * @param country
+ * @param country - Country that will be used to validate postal code
  */
 export const getPartialAddressValidationRules = (country: string): ValidatorRules => {
     const validationRules: ValidatorRules = {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When setting `billingAddressMode` to `partial` , the postal code wasn't being validated as there was no country set.

In this PR, we add support for validating the postal code field for such case. In order to trigger the validation, the country needs to be set in the Component configuration. Example:

```js
const card = checkout.create('card', {
    billingAddressRequired: true,
    billingAddressMode: 'partial',
    data: {
        billingAddress: {
            country: 'US'
        }
    }
});
```
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
- Added e2e tests
<!-- Description of tested scenarios -->


**Fixed issue**:  COWEB-1138
