### PR TITLE
Adding buttonRootNode property to GooglePay

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -18,7 +18,7 @@ class GooglePay extends UIElement<GooglePayProps> {
      * Formats the component data input
      * For legacy support - maps configuration.merchantIdentifier to configuration.merchantId
      */
-    formatProps(props) {
+    formatProps(props): GooglePayProps {
         const allowedCardNetworks = props.brands?.length ? mapBrands(props.brands) : props.allowedCardNetworks;
         const buttonSizeMode = props.buttonSizeMode ?? (props.isDropin ? 'fill' : 'static');
         const buttonLocale = getGooglePayLocale(props.buttonLocale ?? props.i18n?.locale);
@@ -122,6 +122,7 @@ class GooglePay extends UIElement<GooglePayProps> {
                     buttonType={this.props.buttonType}
                     buttonSizeMode={this.props.buttonSizeMode}
                     buttonLocale={this.props.buttonLocale}
+                    buttonRootNode={this.props.buttonRootNode}
                     paymentsClient={this.googlePay.paymentsClient}
                     onClick={this.submit}
                 />

--- a/packages/lib/src/components/GooglePay/components/GooglePayButton.tsx
+++ b/packages/lib/src/components/GooglePay/components/GooglePayButton.tsx
@@ -6,6 +6,7 @@ interface GooglePayButtonProps {
     buttonType: google.payments.api.ButtonType;
     buttonSizeMode: google.payments.api.ButtonSizeMode;
     buttonLocale: string;
+    buttonRootNode?: HTMLDocument | ShadowRoot;
     paymentsClient: Promise<google.payments.api.PaymentsClient>;
     onClick: (e: Event) => void;
 }
@@ -35,10 +36,19 @@ class GooglePayButton extends Component<GooglePayButtonProps> {
     };
 
     componentDidMount() {
-        const { buttonColor, buttonType, buttonLocale, buttonSizeMode, paymentsClient } = this.props;
+        const { buttonColor, buttonType, buttonLocale, buttonSizeMode, buttonRootNode, paymentsClient } = this.props;
 
         paymentsClient
-            .then(client => client.createButton({ onClick: this.handleClick, buttonType, buttonColor, buttonLocale, buttonSizeMode }))
+            .then(client =>
+                client.createButton({
+                    onClick: this.handleClick,
+                    buttonType,
+                    buttonColor,
+                    buttonLocale,
+                    buttonSizeMode,
+                    buttonRootNode
+                })
+            )
             .then(googlePayButton => {
                 this.paywithgoogleWrapper.appendChild(googlePayButton);
             });

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -29,7 +29,7 @@ export interface GooglePayPropsConfiguration {
      * Google JWT solution for platforms
      * To request Google Pay credentials, you can enable platforms to send requests that are authenticated with the platform credentials. You don't need to register individual domain names to call Google Pay APIs.
      */
-     authJwt?: string;
+    authJwt?: string;
 }
 
 export interface GooglePayProps extends UIElementProps {
@@ -129,6 +129,7 @@ export interface GooglePayProps extends UIElementProps {
     buttonColor?: google.payments.api.ButtonColor;
     buttonType?: google.payments.api.ButtonType;
     buttonSizeMode?: google.payments.api.ButtonSizeMode;
+    buttonRootNode?: HTMLDocument | ShadowRoot;
     buttonLocale?: string;
 
     // Events
@@ -138,9 +139,9 @@ export interface GooglePayProps extends UIElementProps {
 
 // Used to add undocumented google payment options
 export interface GooglePaymentDataRequest extends google.payments.api.PaymentDataRequest {
-    merchantInfo: ExtendedMerchantInfo
+    merchantInfo: ExtendedMerchantInfo;
 }
 
 export interface ExtendedMerchantInfo extends google.payments.api.MerchantInfo {
-    merchantOrigin?: string
+    merchantOrigin?: string;
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Adding support for [buttonRootNode](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions) property for GooglePay.


**Fixed issue**:  COWEB-1167
