### PR TITLE
Stop calling onError during 3DS2 fingerprinting

### DIFF
--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -36,6 +36,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
         // If no fingerPrintData or no threeDSMethodURL - don't render component. Instead exit with threeDSCompInd: 'U'
         if (!this.state.fingerPrintData || !this.state.fingerPrintData.threeDSMethodURL) {
             this.setStatusComplete({ threeDSCompInd: 'U' });
+            console.debug('### PrepareFingerprint3DS2::exiting:: no fingerPrintData or no threeDSMethodURL');
             return;
         }
 
@@ -53,6 +54,10 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
             const resolveDataFunction = this.props.useOriginalFlow ? createOldFingerprintResolveData : createFingerprintResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj, this.props.paymentData);
 
+            /**
+             * For 'threeDS2' action = call to callSubmit3DS2Fingerprint
+             * For 'threeDS2Fingerprint' action = equals call to onAdditionalDetails (except for in 3DS2InMDFlow)
+             */
             this.props.onComplete(data);
         });
     }
@@ -65,8 +70,11 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
                         this.setStatusComplete(fingerprint.result);
                     }}
                     onErrorFingerprint={fingerprint => {
+                        /**
+                         * Called when fingerprint times-out (which is still a valid scenario)...
+                         */
                         const errorCodeObject = handleErrorCode(fingerprint.errorCode);
-                        this.props.onError(errorCodeObject);
+                        console.debug('### PrepareFingerprint3DS2::fingerprint timed-out:: errorCodeObject=', errorCodeObject);
                         this.setStatusComplete(fingerprint.result);
                     }}
                     showSpinner={this.props.showSpinner}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When performing a 3DS2 fingerprint it is possible for the process to timeout - in which case we generate an error and call the merchant defined `onError` callback.
This error is not _fatal_ and the 3DS2 process can continue.
However it seems some merchants are treating it as fatal and from their `onError` callback abort the whole Checkout process.
To combat this, this PR no longer calls the  `onError` callback for the "timeout" scenario

## Tested scenarios
`onError` no longer called when fingerprinting times-out
All e2e tests pass

**Relates to issue**:  FOC-68756
