### PR TITLE
alt tag on error icon reads "Error"

### DIFF
--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -80,6 +80,7 @@ function BacsInput(props: BacsInputProps) {
                 errorMessage={errors.holderName ? i18n.get('bacs.accountHolderName.invalid') : false}
                 isValid={valid.holderName}
                 name={'accountHolderName'}
+                i18n={i18n}
             >
                 {renderFormField('text', {
                     name: 'bacs.accountHolderName',
@@ -108,6 +109,7 @@ function BacsInput(props: BacsInputProps) {
                     classNameModifiers={['col-70']}
                     isValid={valid.bankAccountNumber}
                     name={'bankAccountNumber'}
+                    i18n={i18n}
                 >
                     {renderFormField('text', {
                         value: data.bankAccountNumber,
@@ -134,6 +136,7 @@ function BacsInput(props: BacsInputProps) {
                     classNameModifiers={['col-30']}
                     isValid={valid.bankLocationId}
                     name={'bankLocationId'}
+                    i18n={i18n}
                 >
                     {renderFormField('text', {
                         value: data.bankLocationId,
@@ -160,6 +163,7 @@ function BacsInput(props: BacsInputProps) {
                 })}
                 isValid={valid.shopperEmail}
                 name={'emailAddress'}
+                i18n={i18n}
             >
                 {renderFormField('emailAddress', {
                     value: data.shopperEmail,
@@ -186,6 +190,7 @@ function BacsInput(props: BacsInputProps) {
                     label={i18n.get('bacs.consent.amount')}
                     onChange={handleChangeFor('amountConsentCheckbox')}
                     checked={!!data.amountConsentCheckbox}
+                    i18n={i18n}
                 />
             )}
 
@@ -196,6 +201,7 @@ function BacsInput(props: BacsInputProps) {
                     label={i18n.get('bacs.consent.account')}
                     onChange={handleChangeFor('accountConsentCheckbox')}
                     checked={!!data.accountConsentCheckbox}
+                    i18n={i18n}
                 />
             )}
 

--- a/packages/lib/src/components/internal/Address/components/CountryField.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.tsx
@@ -44,6 +44,7 @@ export default function CountryField(props: CountryFieldProps) {
             isValid={!!value}
             showValidIcon={false}
             isCollatingErrors={isCollatingErrors}
+            i18n={i18n}
         >
             {renderFormField('select', {
                 onChange: onDropdownChange,

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
@@ -69,6 +69,7 @@ function FieldContainer(props: FieldContainerProps) {
                     isValid={valid[fieldName]}
                     name={fieldName}
                     isCollatingErrors={isCollatingErrors}
+                    i18n={i18n}
                 >
                     {renderFormField('text', {
                         classNameModifiers,

--- a/packages/lib/src/components/internal/Address/components/StateField.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.tsx
@@ -47,6 +47,7 @@ export default function StateField(props: StateFieldProps) {
             showValidIcon={false}
             name={'stateOrProvince'}
             isCollatingErrors={isCollatingErrors}
+            i18n={i18n}
         >
             {renderFormField('select', {
                 name: 'stateOrProvince',

--- a/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
+++ b/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
@@ -43,7 +43,7 @@ export default function CompanyDetails(props: CompanyDetailsProps) {
     return (
         <Fieldset classNameModifiers={[label]} label={label}>
             {requiredFields.includes('name') && (
-                <Field label={i18n.get('companyDetails.name')} classNameModifiers={['name']} errorMessage={!!errors.name}>
+                <Field label={i18n.get('companyDetails.name')} classNameModifiers={['name']} errorMessage={!!errors.name} i18n={i18n}>
                     {renderFormField('text', {
                         name: generateFieldName('name'),
                         value: data.name,
@@ -60,6 +60,7 @@ export default function CompanyDetails(props: CompanyDetailsProps) {
                     label={i18n.get('companyDetails.registrationNumber')}
                     classNameModifiers={['registrationNumber']}
                     errorMessage={!!errors.registrationNumber}
+                    i18n={i18n}
                 >
                     {renderFormField('text', {
                         name: generateFieldName('registrationNumber'),

--- a/packages/lib/src/components/internal/FormFields/Checkbox/Checkbox.scss
+++ b/packages/lib/src/components/internal/FormFields/Checkbox/Checkbox.scss
@@ -115,7 +115,7 @@
     }
 
     .adyen-checkout-input__inline-validation {
-        right: -27px;
+        right: -5px;
         top: 10px;
     }
 }

--- a/packages/lib/src/components/internal/FormFields/ConsentCheckbox/ConsentCheckbox.tsx
+++ b/packages/lib/src/components/internal/FormFields/ConsentCheckbox/ConsentCheckbox.tsx
@@ -2,9 +2,9 @@ import { h } from 'preact';
 import Field from '../Field';
 import Checkbox from '../Checkbox';
 
-export default function ConsentCheckbox({ errorMessage, label, onChange, ...props }) {
+export default function ConsentCheckbox({ errorMessage, label, onChange, i18n, ...props }) {
     return (
-        <Field classNameModifiers={['consentCheckbox']} errorMessage={errorMessage}>
+        <Field classNameModifiers={['consentCheckbox']} errorMessage={errorMessage} i18n={i18n}>
             <Checkbox
                 name="consentCheckbox"
                 classNameModifiers={[...props.classNameModifiers??=[], 'consentCheckbox']}

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -119,7 +119,7 @@ const Field: FunctionalComponent<FieldProps> = props => {
 
                     {errorMessage && (
                         <span className="adyen-checkout-input__inline-validation adyen-checkout-input__inline-validation--invalid">
-                            <Icon type="field_error" alt={i18n?.get('field.invalid')} />
+                            <Icon type="field_error" alt={i18n?.get('error.title')} />
                         </span>
                     )}
                 </div>

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
@@ -165,6 +165,7 @@ class IbanInput extends Component<IbanInputProps, IbanInputState> {
                         filled={data['ownerName'] && data['ownerName'].length}
                         errorMessage={errors.holder ? i18n.get('creditCard.holderName.invalid') : false}
                         dir={'ltr'}
+                        i18n={i18n}
                     >
                         {renderFormField('text', {
                             name: 'ownerName',
@@ -186,6 +187,7 @@ class IbanInput extends Component<IbanInputProps, IbanInputState> {
                     isValid={valid.iban}
                     onBlur={this.handleIbanBlur}
                     dir={'ltr'}
+                    i18n={i18n}
                 >
                     {renderFormField('text', {
                         ref: ref => {

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -157,6 +157,7 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
                     errorMessage={!!errors.consentCheckbox}
                     label={props.consentCheckboxLabel}
                     onChange={handleConsentCheckbox}
+                    i18n={i18n}
                 />
             )}
 

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -55,6 +55,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     classNameModifiers={['col-50', 'firstName']}
                     errorMessage={getErrorMessage(errors.firstName)}
                     name={'firstName'}
+                    i18n={i18n}
                 >
                     {renderFormField('text', {
                         name: generateFieldName('firstName'),
@@ -75,6 +76,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     classNameModifiers={['col-50', 'lastName']}
                     errorMessage={getErrorMessage(errors.lastName)}
                     name={'lastName'}
+                    i18n={i18n}
                 >
                     {renderFormField('text', {
                         name: generateFieldName('lastName'),
@@ -114,6 +116,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     errorMessage={getErrorMessage(errors.dateOfBirth)}
                     helper={isDateInputSupported ? null : i18n.get('dateOfBirth.format')}
                     name={'dateOfBirth'}
+                    i18n={i18n}
                 >
                     {renderFormField('date', {
                         name: generateFieldName('dateOfBirth'),
@@ -134,6 +137,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     errorMessage={getErrorMessage(errors.shopperEmail)}
                     dir={'ltr'}
                     name={'emailAddress'}
+                    i18n={i18n}
                 >
                     {renderFormField('emailAddress', {
                         name: generateFieldName('shopperEmail'),
@@ -154,6 +158,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                     errorMessage={getErrorMessage(errors.telephoneNumber)}
                     dir={'ltr'}
                     name={'telephoneNumber'}
+                    i18n={i18n}
                 >
                     {renderFormField('tel', {
                         name: generateFieldName('telephoneNumber'),


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Following advice from our external a11y assessment the Error icon `alt` tag is always set & reads "Error" (or translated equivalent)

## Tested scenarios
Address component
PersonalDetails component
Credit card with address

Vouchers
  - Bacs
  - Boleto
  - Doku
  - EContext

Open Invoices
  - Atome
  - Affirm
  - Facilypay
  - Ratepay
  - Afterpay (b2b)
