### PR TITLE
Fix Pix input element not hidden

### DIFF
--- a/packages/lib/src/components/Pix/PixInput/PixInput.tsx
+++ b/packages/lib/src/components/Pix/PixInput/PixInput.tsx
@@ -37,7 +37,7 @@ function PixInput({ name, data: dataProps, personalDetailsRequired, showPayButto
     const buttonModifiers = !personalDetailsRequired ? ['standalone'] : [];
 
     return (
-        <div className="adyen-checkout__pix-input__field">
+        <div className="adyen-checkout__pix-input__field" style={!showPayButton && !personalDetailsRequired ? { display: 'none' } : null}>
             {personalDetailsRequired && (
                 <BrazilPersonalDetail i18n={i18n} data={data} handleChangeFor={handleChangeFor} errors={errors} valid={valid} />
             )}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

The PixInput element controls the logic behind the validation of the Pix element, so we want to keep it instantiated. We should however hide it from the DOM in case there's nothing to render like the other elements (ie: Redirect).

## Tested scenarios
<!-- Description of tested scenarios -->

Tested by calling `.submit` on all the variations of `showPayButton` and `personalDetailsRequired`.

**Fixed issue**:  <!-- #-prefixed issue number -->
