### PR TITLE
Fix Dropin onSelect callback being triggered multiple times

### DIFF
--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -137,7 +137,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                         {elements && !!elements.length && (
                             <PaymentMethodList
                                 isLoading={isLoading || isRedirecting}
-                                isDisabling={this.state.isDisabling}
+                                isDisablingPaymentMethod={this.state.isDisabling}
                                 paymentMethods={elements}
                                 instantPaymentMethods={instantPaymentElements}
                                 activePaymentMethod={activePaymentMethod}

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.test.tsx
@@ -38,9 +38,4 @@ describe('PaymentMethodItem', () => {
         wrapper.simulate('focus');
         expect(onSelect.mock.calls.length).toBe(0);
     });
-
-    test('Defaults events', () => {
-        const wrapper = getWrapper({ paymentMethod });
-        wrapper.simulate('click');
-    });
 });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -15,7 +15,7 @@ interface PaymentMethodItemProps {
     isSelected: boolean;
     isLoaded: boolean;
     isLoading: boolean;
-    isDisabling: boolean;
+    isDisablingPaymentMethod: boolean;
     showRemovePaymentMethodButton: boolean;
     onDisableStoredPaymentMethod: (paymentMethod) => void;
     onSelect: (paymentMethod: UIElement) => void;
@@ -63,7 +63,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         onSelect(paymentMethod);
     };
 
-    render({ paymentMethod, isSelected, isDisabling, isLoaded, isLoading, standalone }, { activeBrand }) {
+    render({ paymentMethod, isSelected, isDisablingPaymentMethod, isLoaded, isLoading, standalone }, { activeBrand }) {
         const { i18n } = useCoreContext();
 
         if (!paymentMethod) {
@@ -78,7 +78,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
             'adyen-checkout__payment-method--selected': isSelected,
             [styles['adyen-checkout__payment-method--selected']]: isSelected,
             'adyen-checkout__payment-method--loading': isLoading,
-            'adyen-checkout__payment-method--disabling': isDisabling,
+            'adyen-checkout__payment-method--disabling': isDisablingPaymentMethod,
             'adyen-checkout__payment-method--confirming': this.state.showDisableStoredPaymentMethodConfirmation,
             'adyen-checkout__payment-method--standalone': standalone,
             [styles['adyen-checkout__payment-method--loading']]: isLoading,

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -18,7 +18,7 @@ interface PaymentMethodItemProps {
     isDisabling: boolean;
     showRemovePaymentMethodButton: boolean;
     onDisableStoredPaymentMethod: (paymentMethod) => void;
-    onSelect: () => void;
+    onSelect: (paymentMethod: UIElement) => void;
     standalone: boolean;
     className?: string;
 }
@@ -29,17 +29,12 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         isSelected: false,
         isLoaded: false,
         isLoading: false,
-        showDisableStoredPaymentMethodConfirmation: false,
-        onSelect: () => {}
+        showDisableStoredPaymentMethodConfirmation: false
     };
 
     public state = {
         showDisableStoredPaymentMethodConfirmation: false,
         activeBrand: null
-    };
-
-    public onClick = () => {
-        this.props.onSelect();
     };
 
     componentDidMount() {
@@ -63,7 +58,12 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         this.toggleDisableConfirmation();
     };
 
-    render({ paymentMethod, isSelected, isDisabling, isLoaded, isLoading, onSelect, standalone }, { activeBrand }) {
+    private handleOnListItemClick = (): void => {
+        const { onSelect, paymentMethod } = this.props;
+        onSelect(paymentMethod);
+    };
+
+    render({ paymentMethod, isSelected, isDisabling, isLoaded, isLoading, standalone }, { activeBrand }) {
         const { i18n } = useCoreContext();
 
         if (!paymentMethod) {
@@ -94,14 +94,13 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         const showBrands = !paymentMethod.props.oneClick && paymentMethod.brands && paymentMethod.brands.length > 0;
 
         return (
-            <li key={paymentMethod._id} className={paymentMethodClassnames} onClick={onSelect}>
+            <li key={paymentMethod._id} className={paymentMethodClassnames} onClick={this.handleOnListItemClick}>
                 <div className="adyen-checkout__payment-method__header">
                     <button
                         className="adyen-checkout__payment-method__header__title"
                         id={buttonId}
                         role="radio"
                         aria-checked={isSelected}
-                        onClick={onSelect}
                         type="button"
                     >
                         <span

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
@@ -1,92 +1,159 @@
-import { shallow } from 'enzyme';
 import { h } from 'preact';
 import PaymentMethodList from './PaymentMethodList';
-import PaymentMethodItem from './PaymentMethodItem';
-import InstantPaymentMethods from './InstantPaymentMethods';
-import { render, screen, waitFor } from '@testing-library/preact';
+import { render, screen } from '@testing-library/preact';
 import { mock } from 'jest-mock-extended';
-import Language from '../../../../language';
+import UIElement from '../../../UIElement';
+import EventEmitter from '../../../EventEmitter';
+import userEvent from '@testing-library/user-event';
 
-const i18n = { get: key => key };
-const paymentMethods = [
-    {
-        props: {
-            id: '1',
-            type: 'mytype',
-            oneClick: false
-        },
-        render: jest.fn()
-    },
-    {
-        props: {
-            id: '2',
-            type: 'mytype2',
-            oneClick: false
-        },
-        render: jest.fn()
-    }
-];
+function createInstantPaymentMethods() {
+    return [
+        mock<UIElement>({
+            props: {
+                id: '1',
+                type: 'googlepay'
+            },
+            _id: 'scheme-123456',
+            displayName: 'Google Pay',
+            eventEmitter: mock<EventEmitter>(),
+            render: () => <button data-testid="instant-googlepay">Pay with Google Pay</button>
+        }),
+        mock<UIElement>({
+            props: {
+                id: '1',
+                type: 'applepay'
+            },
+            _id: 'scheme-123456',
+            displayName: 'Apple Pay',
+            eventEmitter: mock<EventEmitter>(),
+            render: () => <button data-testid="instant-applepay">Pay with Apple Pay</button>
+        })
+    ];
+}
 
-const instantPaymentMethods = [
-    {
-        props: {
-            id: '3',
-            type: 'googlepay'
-        }
-    }
-];
+function createPaymentMethodsMock() {
+    return [
+        mock<UIElement>({
+            props: {
+                id: '1',
+                type: 'scheme'
+            },
+            _id: 'scheme-123456',
+            displayName: 'Card',
+            eventEmitter: mock<EventEmitter>()
+        }),
+        mock<UIElement>({
+            props: {
+                id: '2',
+                type: 'wechat'
+            },
+            _id: 'google-pay-123456',
+            displayName: 'WeChat',
+            eventEmitter: mock<EventEmitter>()
+        }),
+        mock<UIElement>({
+            props: {
+                id: '2',
+                type: 'pix'
+            },
+            _id: 'apple-pay-123456',
+            displayName: 'Pix',
+            eventEmitter: mock<EventEmitter>()
+        })
+    ];
+}
 
-test('onSelect should be triggered only once', () => {
-    render(
-        <PaymentMethodList
-            paymentMethods={[]}
-            instantPaymentMethods={[]}
-            activePaymentMethod={null}
-            cachedPaymentMethods={{}}
-            onSelect={() => {}}
-            onDisableStoredPaymentMethod={() => {}}
-            orderStatus={null}
-            isDisabling={false}
-            isLoading={false}
-        />
-    );
+test('onSelect should be triggered only once', async () => {
+    const user = userEvent.setup();
+    const paymentMethods = createPaymentMethodsMock();
+    const onSelectMock = jest.fn();
+
+    render(<PaymentMethodList paymentMethods={paymentMethods} cachedPaymentMethods={{}} isLoading={false} onSelect={onSelectMock} />);
+
+    await user.click(await screen.findByRole('radio', { name: /Card/ }));
+    await user.click(await screen.findByRole('radio', { name: /WeChat/ }));
+    await user.click(await screen.findByRole('radio', { name: /Pix/ }));
+
+    expect(onSelectMock).toHaveBeenCalledTimes(3);
 });
 
-describe('PaymentMethodList', () => {
-    const getWrapper = props => shallow(<PaymentMethodList i18n={i18n} {...props} />);
+test('should not call onSelect if there is no payment method', () => {
+    const onSelectMock = jest.fn();
 
-    test('Renders a PaymentMethodList', () => {
-        const wrapper = getWrapper({ paymentMethods });
+    render(
+        <PaymentMethodList paymentMethods={[]} cachedPaymentMethods={{}} isLoading={false} onSelect={onSelectMock} openFirstPaymentMethod={true} />
+    );
 
-        expect(wrapper.hasClass('adyen-checkout__payment-methods-list')).toBe(true);
-        expect(wrapper.find(PaymentMethodItem).length).toBe(2);
-    });
+    expect(onSelectMock).toHaveBeenCalledTimes(0);
+});
 
-    test('Does not respond to openFirstPaymentMethod if there is no paymentmethod', () => {
-        const onSelect = jest.fn();
+test('should call onSelect when mounting the Component if openFirstPaymentMethod is set', () => {
+    const onSelectMock = jest.fn();
+    const paymentMethods = createPaymentMethodsMock();
 
-        getWrapper({ paymentMethods: [], onSelect, openFirstPaymentMethod: true });
-        expect(onSelect.mock.calls.length).toBe(0);
-    });
+    render(
+        <PaymentMethodList
+            paymentMethods={paymentMethods}
+            cachedPaymentMethods={{}}
+            isLoading={false}
+            onSelect={onSelectMock}
+            openFirstPaymentMethod={true}
+        />
+    );
 
-    test('Responds to openFirstStoredPaymentMethod', () => {
-        const onSelect = jest.fn();
-        paymentMethods[0].props.oneClick = true;
+    expect(onSelectMock).toHaveBeenCalledTimes(1);
+    expect(onSelectMock).toHaveBeenCalledWith(paymentMethods[0]);
+});
 
-        getWrapper({ paymentMethods, onSelect, openFirstStoredPaymentMethod: true });
-        expect(onSelect.mock.calls[0][0]).toBe(paymentMethods[0]);
-    });
+test('should not call onSelect if openFirstStoredPaymentMethod is set but there is no oneClick payment', () => {
+    const onSelectMock = jest.fn();
+    const paymentMethods = createPaymentMethodsMock();
 
-    test('Does not respond to openFirstStoredPaymentMethod if no oneClick paymentMethod is found', () => {
-        const onSelect = jest.fn();
-        paymentMethods[0].props.oneClick = false;
+    render(
+        <PaymentMethodList
+            paymentMethods={paymentMethods}
+            cachedPaymentMethods={{}}
+            isLoading={false}
+            onSelect={onSelectMock}
+            openFirstStoredPaymentMethod={true}
+        />
+    );
 
-        getWrapper({ paymentMethods, onSelect, openFirstStoredPaymentMethod: true });
-        expect(onSelect.mock.calls.length).toBe(0);
-    });
+    expect(onSelectMock).toHaveBeenCalledTimes(0);
+});
 
-    test('Renders InstantPaymentMethods when prop is provided', () => {
-        const wrapper = getWrapper({ paymentMethods, instantPaymentMethods });
-        expect(wrapper.find(InstantPaymentMethods)).toHaveLength(1);
-    });
+test('should call onSelect if openFirstStoredPaymentMethod is set and there is no oneClick payment', () => {
+    const onSelectMock = jest.fn();
+    const paymentMethods = createPaymentMethodsMock();
+    paymentMethods[0].props.oneClick = true;
+
+    render(
+        <PaymentMethodList
+            paymentMethods={paymentMethods}
+            cachedPaymentMethods={{}}
+            isLoading={false}
+            onSelect={onSelectMock}
+            openFirstStoredPaymentMethod={true}
+        />
+    );
+
+    expect(onSelectMock).toHaveBeenCalledTimes(1);
+});
+
+test('should display instant payment methods', () => {
+    const instantPaymentMethods = createInstantPaymentMethods();
+    const paymentMethods = createPaymentMethodsMock();
+
+    render(
+        <PaymentMethodList
+            paymentMethods={paymentMethods}
+            instantPaymentMethods={instantPaymentMethods}
+            cachedPaymentMethods={{}}
+            isLoading={false}
+            openFirstStoredPaymentMethod={true}
+        />
+    );
+
+    expect(screen.getByTestId('instant-googlepay')).toBeVisible();
+    expect(screen.getByTestId('instant-applepay')).toBeVisible();
 });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
@@ -3,6 +3,9 @@ import { h } from 'preact';
 import PaymentMethodList from './PaymentMethodList';
 import PaymentMethodItem from './PaymentMethodItem';
 import InstantPaymentMethods from './InstantPaymentMethods';
+import { render, screen, waitFor } from '@testing-library/preact';
+import { mock } from 'jest-mock-extended';
+import Language from '../../../../language';
 
 const i18n = { get: key => key };
 const paymentMethods = [
@@ -32,6 +35,22 @@ const instantPaymentMethods = [
         }
     }
 ];
+
+test('onSelect should be triggered only once', () => {
+    render(
+        <PaymentMethodList
+            paymentMethods={[]}
+            instantPaymentMethods={[]}
+            activePaymentMethod={null}
+            cachedPaymentMethods={{}}
+            onSelect={() => {}}
+            onDisableStoredPaymentMethod={() => {}}
+            orderStatus={null}
+            isDisabling={false}
+            isLoading={false}
+        />
+    );
+});
 
 describe('PaymentMethodList', () => {
     const getWrapper = props => shallow(<PaymentMethodList i18n={i18n} {...props} />);

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -11,20 +11,23 @@ import useCoreContext from '../../../../core/Context/useCoreContext';
 
 interface PaymentMethodListProps {
     paymentMethods: UIElement[];
-    instantPaymentMethods: UIElement[];
-    activePaymentMethod: UIElement;
-    cachedPaymentMethods: object;
+    activePaymentMethod?: UIElement;
+    instantPaymentMethods?: UIElement[];
+    /**
+     * Map that keeps track of which Payment methods (UIElements) already got rendered in the UI
+     */
+    cachedPaymentMethods: Record<string, boolean>;
     order?: Order;
-    orderStatus: OrderStatus;
+    orderStatus?: OrderStatus;
     openFirstStoredPaymentMethod?: boolean;
     openFirstPaymentMethod?: boolean;
     showRemovePaymentMethodButton?: boolean;
 
-    onSelect: (paymentMethod: UIElement) => void;
-    onDisableStoredPaymentMethod: (storedPaymentMethod) => void;
+    onSelect?: (paymentMethod: UIElement) => void;
+    onDisableStoredPaymentMethod?: (storedPaymentMethod) => void;
     onOrderCancel?: (order) => void;
 
-    isDisabling: boolean;
+    isDisablingPaymentMethod?: boolean;
     isLoading: boolean;
 }
 
@@ -37,7 +40,7 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
         orderStatus: null,
         onSelect: () => {},
         onDisableStoredPaymentMethod: () => {},
-        isDisabling: false,
+        isDisablingPaymentMethod: false,
         isLoading: false
     };
 
@@ -54,7 +57,7 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
         }
     }
 
-    render({ paymentMethods, instantPaymentMethods, activePaymentMethod, cachedPaymentMethods, isLoading }) {
+    render({ paymentMethods, instantPaymentMethods, activePaymentMethod, cachedPaymentMethods, isLoading, isDisablingPaymentMethod }) {
         const { i18n } = useCoreContext();
 
         const paymentMethodListClassnames = classNames({
@@ -86,7 +89,7 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
                                 standalone={paymentMethods.length === 1}
                                 paymentMethod={paymentMethod}
                                 isSelected={isSelected}
-                                isDisabling={isSelected && this.props.isDisabling}
+                                isDisablingPaymentMethod={isSelected && isDisablingPaymentMethod}
                                 isLoaded={isLoaded}
                                 isLoading={isLoading}
                                 onSelect={this.props.onSelect}

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -20,7 +20,7 @@ interface PaymentMethodListProps {
     openFirstPaymentMethod?: boolean;
     showRemovePaymentMethodButton?: boolean;
 
-    onSelect: (paymentMethod) => void;
+    onSelect: (paymentMethod: UIElement) => void;
     onDisableStoredPaymentMethod: (storedPaymentMethod) => void;
     onOrderCancel?: (order) => void;
 
@@ -49,12 +49,10 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
             const shouldOpenFirstPaymentMethod = shouldOpenFirstStored || this.props.openFirstPaymentMethod;
 
             if (shouldOpenFirstPaymentMethod) {
-                this.onSelect(firstPaymentMethod)();
+                this.props.onSelect(firstPaymentMethod);
             }
         }
     }
-
-    public onSelect = paymentMethod => () => this.props.onSelect(paymentMethod);
 
     render({ paymentMethods, instantPaymentMethods, activePaymentMethod, cachedPaymentMethods, isLoading }) {
         const { i18n } = useCoreContext();
@@ -91,7 +89,7 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
                                 isDisabling={isSelected && this.props.isDisabling}
                                 isLoaded={isLoaded}
                                 isLoading={isLoading}
-                                onSelect={this.onSelect(paymentMethod)}
+                                onSelect={this.props.onSelect}
                                 key={paymentMethod._id}
                                 showRemovePaymentMethodButton={this.props.showRemovePaymentMethodButton}
                                 onDisableStoredPaymentMethod={this.props.onDisableStoredPaymentMethod}

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -3,7 +3,7 @@ import UIElement from '../UIElement';
 import { UIElementProps, UIElementStatus } from '../types';
 import { PaymentMethodsConfiguration } from '../../core/types';
 
-export type InstantPaymentTypes = 'paywithgoogle' | 'googlepay' | 'applepay' ;
+export type InstantPaymentTypes = 'paywithgoogle' | 'googlepay' | 'applepay';
 
 export interface DropinElementProps extends UIElementProps {
     /**
@@ -47,7 +47,7 @@ export interface DropinElementProps extends UIElementProps {
     openFirstPaymentMethod?: boolean;
     onSubmit?: (data, component) => void;
     onReady?: () => void;
-    onSelect?: (paymentMethod) => void;
+    onSelect?: (paymentMethod: UIElement) => void;
 
     /**
      * Show/Hide the remove payment method button on stored payment methods

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -30,7 +30,7 @@ export async function initSession() {
             console.info(JSON.stringify(error), component);
         },
         onChange: (state, component) => {
-            // console.log('onChange', state);
+            console.log('onChange', state);
         },
         paymentMethodsConfiguration: {
             paywithgoogle: {
@@ -51,14 +51,7 @@ export async function initSession() {
 
     const dropin = checkout
         .create('dropin', {
-            instantPaymentTypes: ['googlepay'],
-            // showRemovePaymentMethodButton: true,
-            // onDisableStoredPaymentMethod(...args) {
-            //     console.log(args);
-            // },
-            onSelect(...args) {
-                console.log(args);
-            }
+            instantPaymentTypes: ['googlepay']
         })
         .mount('#dropin-container');
     return [checkout, dropin];

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -30,7 +30,7 @@ export async function initSession() {
             console.info(JSON.stringify(error), component);
         },
         onChange: (state, component) => {
-            console.log('onChange', state);
+            // console.log('onChange', state);
         },
         paymentMethodsConfiguration: {
             paywithgoogle: {
@@ -49,6 +49,17 @@ export async function initSession() {
         }
     });
 
-    const dropin = checkout.create('dropin', { instantPaymentTypes: ['googlepay'] }).mount('#dropin-container');
+    const dropin = checkout
+        .create('dropin', {
+            instantPaymentTypes: ['googlepay'],
+            // showRemovePaymentMethodButton: true,
+            // onDisableStoredPaymentMethod(...args) {
+            //     console.log(args);
+            // },
+            onSelect(...args) {
+                console.log(args);
+            }
+        })
+        .mount('#dropin-container');
     return [checkout, dropin];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10563,7 +10563,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In the `PaymentMethodItem` component, the `<li>` and `<button>` elements had the `onClick` callback object. If the shopper would click in the `<button>` element, that would eventually also trigger the `onClick` of the `li` element, therefore calling `onSelect` multiple times.

Changes:
- Removed the `onClick` callback of the `button` element
- Renamed `isDisabled` to `isDisablingPaymentMethod` for more clarity of what is happening
- Fixed some typescript Types

## Tested scenarios
- Added unit tests
- Ran e2e tests
<!-- Description of tested scenarios -->


**Fixed issue**:  #1832 / COWEB-1169
