### PR TITLE
Fixes errors being thrown for Google Pay cancellation

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -60,7 +60,11 @@ class GooglePay extends UIElement<GooglePayProps> {
                 return onAuthorized(paymentData);
             })
             .catch((error: google.payments.api.PaymentsError) => {
-                this.handleError(new AdyenCheckoutError('ERROR', error.toString()));
+                if (error.statusCode === 'CANCELED') {
+                    this.handleError(new AdyenCheckoutError('CANCEL', error.toString(), { cause: error }));
+                } else {
+                    this.handleError(new AdyenCheckoutError('ERROR', error.toString()));
+                }
             });
     };
 

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -63,7 +63,7 @@ class GooglePay extends UIElement<GooglePayProps> {
                 if (error.statusCode === 'CANCELED') {
                     this.handleError(new AdyenCheckoutError('CANCEL', error.toString(), { cause: error }));
                 } else {
-                    this.handleError(new AdyenCheckoutError('ERROR', error.toString()));
+                    this.handleError(new AdyenCheckoutError('ERROR', error.toString(), { cause: error }));
                 }
             });
     };

--- a/packages/lib/src/core/Errors/AdyenCheckoutError.ts
+++ b/packages/lib/src/core/Errors/AdyenCheckoutError.ts
@@ -1,3 +1,7 @@
+interface CheckoutErrorOptions {
+    cause: any;
+}
+
 class AdyenCheckoutError extends Error {
     protected static errorTypes = {
         /** Network error. */
@@ -13,10 +17,12 @@ class AdyenCheckoutError extends Error {
         ERROR: 'ERROR'
     };
 
-    constructor(type: keyof typeof AdyenCheckoutError.errorTypes, message?: string) {
+    constructor(type: keyof typeof AdyenCheckoutError.errorTypes, message?: string, options?: CheckoutErrorOptions) {
         super(message);
 
         this.name = AdyenCheckoutError.errorTypes[type];
+
+        this.cause = options?.cause;
     }
 }
 

--- a/packages/lib/src/core/Errors/AdyenCheckoutError.ts
+++ b/packages/lib/src/core/Errors/AdyenCheckoutError.ts
@@ -17,6 +17,8 @@ class AdyenCheckoutError extends Error {
         ERROR: 'ERROR'
     };
 
+    public cause: unknown;
+
     constructor(type: keyof typeof AdyenCheckoutError.errorTypes, message?: string, options?: CheckoutErrorOptions) {
         super(message);
 

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -5,7 +5,7 @@
 
         "moduleResolution": "node",
         "module": "esnext",
-        "target": "es2021",
+        "target": "es2022",
         "jsx": "react",
         "jsxFactory": "h",
         "resolveJsonModule": true,

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -5,7 +5,7 @@
 
         "moduleResolution": "node",
         "module": "esnext",
-        "target": "es2022",
+        "target": "es2021",
         "jsx": "react",
         "jsxFactory": "h",
         "resolveJsonModule": true,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

The objective of this PR is to standardized the behaviour of popup cancellation between Google Pay and other window cancelations (ie: Paypal). 

## Tested scenarios
<!-- Description of tested scenarios -->

- Tested generating error on Chrome, Firefox, Safari 

**Fixed issue**:  <!-- #-prefixed issue number -->
#1877 