### PR TITLE
Adjusting Renovate to check the relevant projects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   ],
   "labels": ["dependencies"],
   "stabilityDays": 21,
-  "prConcurrentLimit": 5
+  "prConcurrentLimit": 5,
+  "includePaths": [
+    "packages/lib/",
+    "packages/server/",
+    ".github/",
+    "./package.json"
+  ]
+
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Configuring Renovate to create dependency updates only for the `lib`, `server` and root `package.json` files, so it will stop spamming with useless dependency updates (The other packages are going to be deprecated/removed as we move to playwright and to storybook)
