### PR TITLE
Adjust PayNow countdown time to 3 minutes

### DIFF
--- a/packages/lib/src/components/PayNow/config.ts
+++ b/packages/lib/src/components/PayNow/config.ts
@@ -1,4 +1,4 @@
-export const countdownTime = 15; // min
+export const countdownTime = 3; // min
 export const delay = 2000; // ms
 
 export default {


### PR DESCRIPTION
## Summary
* Adjust PayNow timer from 15 minutes to 3 minutes.
