### PR TITLE
Renovate: Reverting ignorePaths change

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,5 @@
   ],
   "labels": ["dependencies"],
   "stabilityDays": 21,
-  "prConcurrentLimit": 5,
-  "ignorePaths": [
-    "**/node_modules/**",
-    "packages/e2e/**",
-    "packages/playground/**"
-  ]
+  "prConcurrentLimit": 5
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Renovate is having issues to update dependencies now (conflicts with package-lock files). Seems like it is depending on the ignored paths somehow. 
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
