### PR TITLE
Fixed credit card brand animation

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
@@ -15,6 +15,7 @@
 .adyen-checkout__card__brands--hidden {
   opacity: 0;
   height: 0;
+  margin: -8px 0 8px;
 }
 
 .adyen-checkout__card__brands img {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed the spacing in the credit card brand animations

## Tested scenarios
Tested in playground, changes in the following screen recording:
https://user-images.githubusercontent.com/11157209/214022759-f2043916-3859-44cb-9101-f0349536d29f.mov

