### PR TITLE
After handleAction retrieve Promise to know when action has been performed

### DIFF
--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -16,6 +16,8 @@ import Core from '../core';
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
     protected componentRef: any;
     public elementRef: UIElement;
+    public status: UIElementStatus;
+    public resolveInternalStatus: any;
 
     constructor(props: P) {
         super(props);
@@ -30,6 +32,26 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         this.setElementStatus = this.setElementStatus.bind(this);
 
         this.elementRef = (props && props.elementRef) || this;
+
+        this.status = 'loading';
+        this.setInternalStatus = this.setInternalStatus.bind(this);
+        this.resolveInternalStatus = () => {};
+    }
+
+    public getStatus() {
+        return new Promise(resolve => {
+            this.resolveInternalStatus = resolve;
+        });
+    }
+
+    protected setInternalStatus(val: UIElementStatus): void {
+        if (this.props.isDropin) {
+            this.elementRef.status = val;
+            this.elementRef.resolveInternalStatus(val);
+        } else {
+            this.status = val;
+            this.resolveInternalStatus(val);
+        }
     }
 
     public setState(newState: object): void {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -45,13 +45,9 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
     }
 
     protected setInternalStatus(val: UIElementStatus): void {
-        if (this.props.isDropin) {
-            this.elementRef.status = val;
-            this.elementRef.resolveInternalStatus(val);
-        } else {
-            this.status = val;
-            this.resolveInternalStatus(val);
-        }
+        const _this = this.props.isDropin ? this.elementRef : this;
+        _this.status = val;
+        _this.resolveInternalStatus(val);
     }
 
     public setState(newState: object): void {

--- a/packages/lib/src/components/helpers/QRLoaderContainer.tsx
+++ b/packages/lib/src/components/helpers/QRLoaderContainer.tsx
@@ -66,6 +66,7 @@ class QRLoaderContainer<T extends QRLoaderContainerProps = QRLoaderContainerProp
                     onComplete={this.onComplete}
                     countdownTime={this.props.countdownTime}
                     instructions={this.props.instructions}
+                    setInternalStatus={this.setInternalStatus}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -141,7 +141,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
             });
     };
 
-    render({ amount, url, brandLogo, countdownTime, type }: QRLoaderProps, { expired, completed, loading }) {
+    render({ amount, url, brandLogo, countdownTime, type, setInternalStatus }: QRLoaderProps, { expired, completed, loading }) {
         const { i18n, loadingContext } = useCoreContext();
         const qrCodeImage = this.props.qrCodeData ? `${loadingContext}${QRCODE_URL}${this.props.qrCodeData}` : this.props.qrCodeImage;
 
@@ -187,7 +187,13 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
 
                 <div className="adyen-checkout__qr-loader__subtitle">{i18n.get(this.props.introduction)}</div>
 
-                <img src={qrCodeImage} alt={i18n.get('wechatpay.scanqrcode')} />
+                <img
+                    src={qrCodeImage}
+                    alt={i18n.get('wechatpay.scanqrcode')}
+                    onLoad={() => {
+                        setInternalStatus('ready');
+                    }}
+                />
 
                 {amount && amount.value && amount.currency && (
                     <div className="adyen-checkout__qr-loader__payment_amount">{i18n.amount(amount.value, amount.currency)}</div>

--- a/packages/lib/src/components/internal/QRLoader/types.ts
+++ b/packages/lib/src/components/internal/QRLoader/types.ts
@@ -1,5 +1,6 @@
 import { PaymentAmount } from '../../../types';
 import Language from '../../../language/Language';
+import { UIElementStatus } from '../../types';
 
 export interface QRLoaderProps {
     delay?: number;
@@ -23,6 +24,7 @@ export interface QRLoaderProps {
     introduction?: string;
     instructions?: string;
     copyBtn?: boolean;
+    setInternalStatus?: (val: UIElementStatus) => void;
 }
 
 export interface QRLoaderState {

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -25,7 +25,10 @@ export async function initManual() {
             if (result.action) {
                 // demo only - store paymentData & order
                 if (result.action.paymentData) localStorage.setItem('storedPaymentData', result.action.paymentData);
-                component.handleAction(result.action);
+                const comp = component.handleAction(result.action);
+                comp.getStatus().then(status => {
+                    console.log('### manual:::: handleAction THEN status=', status);
+                });
             } else if (result.order && result.order?.remainingAmount?.value > 0) {
                 // handle orders
                 const order = {

--- a/packages/playground/src/pages/QRCodes/QRCodes.js
+++ b/packages/playground/src/pages/QRCodes/QRCodes.js
@@ -28,6 +28,9 @@ import './QRCodes.scss';
         .then(result => {
             if (result.action) {
                 window.wechatpayqr = checkout.createFromAction(result.action).mount('#wechatpayqr-container');
+                window.wechatpayqr.getStatus().then(status => {
+                    console.log('### QRCodes:::: THEN status=', status);
+                });
             }
         })
         .catch(error => {
@@ -81,7 +84,7 @@ import './QRCodes.scss';
         amount: {
             currency: 'THB',
             value: 101
-        },
+        }
     })
         .then(result => {
             if (result.action) {


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When `handleAction` or `createFromAction` is called a reference to the component is returned.

Now it is possible to call `getStatus` on this component instance which will return a Promise that will resolve when the action, or some event that is part of this action, has been performed.

In this example PR we resolve this Promise when the QR code image has loaded.

In theory any component can use this functionality to inform the merchant when an action has been implemented.
For example, I've also tested it with the card component - using it to know when the 3DS2 component has been rendered.

## Tested scenarios
Tested with both `handleAction` and `createFromAction` against both Dropin and a standalone component

To test 
- either run the Dropin and select the first WeChatPay pm and then press "continue..."
- or, go to the QRCodes playground page
- then look at the console to see how the promise is resolved when the QR code _loads_


**Relates to issue**:  #941 
