### PR TITLE
Added onActionHandled callback

### DIFF
--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -62,6 +62,7 @@ class BlikElement extends UIElement {
                         countdownTime={config.COUNTDOWN_MINUTES}
                         throttleTime={config.THROTTLE_TIME}
                         throttleInterval={config.THROTTLE_INTERVAL}
+                        onActionHandled={this.props.onActionHandled}
                     />
                 </CoreProvider>
             );

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -64,6 +64,7 @@ export class MBWayElement extends UIElement {
                         countdownTime={config.COUNTDOWN_MINUTES}
                         throttleTime={config.THROTTLE_TIME}
                         throttleInterval={config.THROTTLE_INTERVAL}
+                        onActionHandled={this.props.onActionHandled}
                     />
                 </CoreProvider>
             );

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -1,11 +1,12 @@
 import { h } from 'preact';
 import UIElement from '../UIElement';
-import Challenge from './components/Challenge';
+import PrepareChallenge from './components/Challenge';
 import { ErrorCodeObject } from './components/utils';
 import { DEFAULT_CHALLENGE_WINDOW_SIZE } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import Language from '../../language';
+import { ActionHandledReturnObject } from '../types';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;
@@ -19,6 +20,7 @@ export interface ThreeDS2ChallengeProps {
     loadingContext?: string;
     useOriginalFlow?: boolean;
     i18n?: Language;
+    onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
 }
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
@@ -49,7 +51,7 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
             return null;
         }
 
-        return <Challenge {...this.props} onComplete={this.onComplete} />;
+        return <PrepareChallenge {...this.props} onComplete={this.onComplete} />;
     }
 }
 

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -1,9 +1,10 @@
 import { h } from 'preact';
 import UIElement from '../UIElement';
-import DeviceFingerprint from './components/DeviceFingerprint';
+import PrepareFingerprint from './components/DeviceFingerprint';
 import { ErrorCodeObject } from './components/utils';
 import callSubmit3DS2Fingerprint from './callSubmit3DS2Fingerprint';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
+import { ActionHandledReturnObject } from '../types';
 
 export interface ThreeDS2DeviceFingerprintProps {
     dataKey: string;
@@ -17,6 +18,7 @@ export interface ThreeDS2DeviceFingerprintProps {
     loadingContext?: string;
     clientKey?: string;
     elementRef?: UIElement;
+    onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
 }
 
 class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps> {
@@ -52,7 +54,7 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
          * It means the call to create this component came from the old 'threeDS2Fingerprint' action and upon completion should call the /details endpoint
          * instead of the new /submitThreeDS2Fingerprint endpoint
          */
-        return <DeviceFingerprint {...this.props} onComplete={this.props.useOriginalFlow ? this.onComplete : this.callSubmit3DS2Fingerprint} />;
+        return <PrepareFingerprint {...this.props} onComplete={this.props.useOriginalFlow ? this.onComplete : this.callSubmit3DS2Fingerprint} />;
     }
 }
 

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -29,7 +29,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
 
     private iframeCallback = () => {
         this.setState({ status: 'iframeLoaded' });
-        this.props.onActionHandled({ componentType: '3DS2Challenge', actionType: 'challenge-iframe-loaded' });
+        this.props.onActionHandled({ componentType: '3DS2Challenge', actionDescription: 'challenge-iframe-loaded' });
     };
 
     private get3DS2ChallengePromise(): Promise<any> {

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -29,6 +29,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
 
     private iframeCallback = () => {
         this.setState({ status: 'iframeLoaded' });
+        this.props.onActionHandled({ componentType: '3DS2Challenge', actionType: 'challenge-iframe-loaded' });
     };
 
     private get3DS2ChallengePromise(): Promise<any> {

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -12,7 +12,8 @@ import { hasOwnProperty } from '../../../../utils/hasOwnProperty';
 class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareChallenge3DS2State> {
     public static defaultProps = {
         onComplete: () => {},
-        onError: () => {}
+        onError: () => {},
+        onActionHandled: () => {}
     };
 
     constructor(props) {
@@ -71,7 +72,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
         this.props.onError(errorInfoObj); // For some reason this doesn't fire if it's in a callback passed to the setState function
     }
 
-    render(props, { challengeData }) {
+    render({ onActionHandled }, { challengeData }) {
         if (this.state.status === 'retrievingChallengeToken') {
             return (
                 <DoChallenge3DS2
@@ -98,6 +99,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                         }
                     }}
                     {...challengeData}
+                    onActionHandled={onActionHandled}
                 />
             );
         }

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
@@ -1,10 +1,12 @@
 import { ChallengeData, ThreeDS2FlowObject } from '../../types';
 import { ChallengeResolveData } from '../utils';
 import { ThreeDS2ChallengeProps } from '../../ThreeDS2Challenge';
+import { ActionHandledReturnObject } from '../../../types';
 
 export interface DoChallenge3DS2Props extends ChallengeData {
     onCompleteChallenge: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorChallenge: (rejectObject: ThreeDS2FlowObject) => void;
+    onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
 }
 
 export interface DoChallenge3DS2State {

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -73,12 +73,17 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
         window.removeEventListener('message', this.processMessageHandler);
     }
 
-    render({ threeDSMethodURL }, { base64URLencodedData }) {
+    render({ threeDSMethodURL, onActionHandled }, { base64URLencodedData }) {
         return (
             <div className="adyen-checkout__3ds2-device-fingerprint">
                 {this.props.showSpinner && <Spinner />}
                 <div style={{ display: 'none' }}>
-                    <Iframe name={iframeName} />
+                    <Iframe
+                        name={iframeName}
+                        callback={() => {
+                            onActionHandled({ componentType: '3DS2Fingerprint', actionType: 'fingerprint-iframe-loaded' });
+                        }}
+                    />
                     <ThreeDS2Form
                         name={'threeDSMethodForm'}
                         action={threeDSMethodURL}

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -81,7 +81,7 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
                     <Iframe
                         name={iframeName}
                         callback={() => {
-                            onActionHandled({ componentType: '3DS2Fingerprint', actionType: 'fingerprint-iframe-loaded' });
+                            onActionHandled({ componentType: '3DS2Fingerprint', actionDescription: 'fingerprint-iframe-loaded' });
                         }}
                     />
                     <ThreeDS2Form

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -34,7 +34,8 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
         onComplete: () => {},
         onError: () => {},
         paymentData: '',
-        showSpinner: true
+        showSpinner: true,
+        onActionHandled: () => {}
     };
 
     componentDidMount() {
@@ -67,7 +68,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
         });
     }
 
-    render(props, { fingerPrintData }) {
+    render({ showSpinner, onActionHandled }, { fingerPrintData }) {
         if (this.state.status === 'retrievingFingerPrint') {
             return (
                 <DoFingerprint3DS2
@@ -82,8 +83,9 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
                         console.debug('### PrepareFingerprint3DS2::fingerprint timed-out:: errorCodeObject=', errorCodeObject);
                         this.setStatusComplete(fingerprint.result);
                     }}
-                    showSpinner={this.props.showSpinner}
+                    showSpinner={showSpinner}
                     {...fingerPrintData}
+                    onActionHandled={onActionHandled}
                 />
             );
         }

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
@@ -1,11 +1,13 @@
 import { ThreeDS2FlowObject, FingerPrintData } from '../../types';
 import { ThreeDS2DeviceFingerprintProps } from '../../ThreeDS2DeviceFingerprint';
 import { FingerprintResolveData } from '../utils';
+import { ActionHandledReturnObject } from '../../../types';
 
 export interface DoFingerprint3DS2Props extends FingerPrintData {
     onCompleteFingerprint: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorFingerprint: (rejectObject: ThreeDS2FlowObject) => void;
     showSpinner: boolean;
+    onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
 }
 
 export interface DoFingerprint3DS2State {

--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -65,6 +65,7 @@ class UPI extends UIElement<UPIElementProps> {
                         onComplete={this.onComplete}
                         introduction={this.props.i18n.get('upi.qrCodeWaitingMessage')}
                         countdownTime={5}
+                        onActionHandled={this.props.onActionHandled}
                     />
                 );
             case 'await':
@@ -83,6 +84,7 @@ class UPI extends UIElement<UPIElementProps> {
                         awaitText={this.props.i18n.get('await.waitForConfirmation')}
                         showCountdownTimer
                         countdownTime={5}
+                        onActionHandled={this.props.onActionHandled}
                     />
                 );
             default:

--- a/packages/lib/src/components/helpers/QRLoaderContainer.tsx
+++ b/packages/lib/src/components/helpers/QRLoaderContainer.tsx
@@ -34,7 +34,8 @@ class QRLoaderContainer<T extends QRLoaderContainerProps = QRLoaderContainerProp
         amount: null,
         paymentData: null,
         onError: () => {},
-        onComplete: () => {}
+        onComplete: () => {},
+        onActionHandled: () => {}
     };
 
     formatData() {
@@ -66,6 +67,7 @@ class QRLoaderContainer<T extends QRLoaderContainerProps = QRLoaderContainerProp
                     onComplete={this.onComplete}
                     countdownTime={this.props.countdownTime}
                     instructions={this.props.instructions}
+                    onActionHandled={this.props.onActionHandled}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -18,6 +18,7 @@ function Await(props: AwaitComponentProps) {
     const [completed, setCompleted] = useState(false);
     const [expired, setExpired] = useState(false);
     const [loading, setLoading] = useState(true);
+    const [hasCalledActionHandled, setHasCalledActionHandled] = useState(false);
     const [delay, setDelay] = useState(props.delay);
     const [percentage, setPercentage] = useState(100);
     const [timePassed, setTimePassed] = useState(0);
@@ -74,6 +75,11 @@ function Await(props: AwaitComponentProps) {
 
     const checkStatus = (): void => {
         const { paymentData, clientKey } = props;
+
+        if (!hasCalledActionHandled) {
+            props.onActionHandled({ componentType: props.type, actionType: 'polling-started' });
+            setHasCalledActionHandled(true);
+        }
 
         checkPaymentStatus(paymentData, clientKey, loadingContext)
             .then(processResponse)
@@ -223,6 +229,7 @@ Await.defaultProps = {
     countdownTime: 15,
     onError: () => {},
     onComplete: () => {},
+    onActionHandled: () => {},
     delay: 2000,
     throttleTime: 60000,
     throttleInterval: 10000,

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -77,7 +77,7 @@ function Await(props: AwaitComponentProps) {
         const { paymentData, clientKey } = props;
 
         if (!hasCalledActionHandled) {
-            props.onActionHandled({ componentType: props.type, actionType: 'polling-started' });
+            props.onActionHandled({ componentType: props.type, actionDescription: 'polling-started' });
             setHasCalledActionHandled(true);
         }
 

--- a/packages/lib/src/components/internal/Await/types.ts
+++ b/packages/lib/src/components/internal/Await/types.ts
@@ -1,3 +1,5 @@
+import { ActionHandledReturnObject } from '../../types';
+
 interface StatusObjectProps {
     payload: string;
     resultCode: string;
@@ -27,4 +29,5 @@ export interface AwaitComponentProps {
     messageText: string;
     awaitText: string;
     ref: any;
+    onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
 }

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -191,7 +191,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
                     src={qrCodeImage}
                     alt={i18n.get('wechatpay.scanqrcode')}
                     onLoad={() => {
-                        onActionHandled({ componentType: this.props.type, actionType: 'qr-code-loaded' });
+                        onActionHandled({ componentType: this.props.type, actionDescription: 'qr-code-loaded' });
                     }}
                 />
 

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -141,7 +141,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
             });
     };
 
-    render({ amount, url, brandLogo, countdownTime, type }: QRLoaderProps, { expired, completed, loading }) {
+    render({ amount, url, brandLogo, countdownTime, type, onActionHandled }: QRLoaderProps, { expired, completed, loading }) {
         const { i18n, loadingContext } = useCoreContext();
         const qrCodeImage = this.props.qrCodeData ? `${loadingContext}${QRCODE_URL}${this.props.qrCodeData}` : this.props.qrCodeImage;
 
@@ -187,7 +187,13 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
 
                 <div className="adyen-checkout__qr-loader__subtitle">{i18n.get(this.props.introduction)}</div>
 
-                <img src={qrCodeImage} alt={i18n.get('wechatpay.scanqrcode')} />
+                <img
+                    src={qrCodeImage}
+                    alt={i18n.get('wechatpay.scanqrcode')}
+                    onLoad={() => {
+                        onActionHandled({ componentType: this.props.type, actionType: 'qr-code-loaded' });
+                    }}
+                />
 
                 {amount && amount.value && amount.currency && (
                     <div className="adyen-checkout__qr-loader__payment_amount">{i18n.amount(amount.value, amount.currency)}</div>

--- a/packages/lib/src/components/internal/QRLoader/types.ts
+++ b/packages/lib/src/components/internal/QRLoader/types.ts
@@ -1,5 +1,6 @@
 import { PaymentAmount } from '../../../types';
 import Language from '../../../language/Language';
+import { ActionHandledReturnObject } from '../../types';
 
 export interface QRLoaderProps {
     delay?: number;
@@ -23,6 +24,7 @@ export interface QRLoaderProps {
     introduction?: string;
     instructions?: string;
     copyBtn?: boolean;
+    onActionHandled?: (rtnObj: ActionHandledReturnObject) => void;
 }
 
 export interface QRLoaderState {

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -81,6 +81,11 @@ export type UIElementStatus = 'ready' | 'loading' | 'error' | 'success';
 
 export type PayButtonFunctionProps = Omit<PayButtonProps, 'amount'>;
 
+export interface ActionHandledReturnObject {
+    componentType: string;
+    actionType: string;
+}
+
 export interface UIElementProps extends BaseElementProps {
     session?: Session;
     onChange?: (state: any, element: UIElement) => void;
@@ -88,6 +93,7 @@ export interface UIElementProps extends BaseElementProps {
     beforeSubmit?: (state: any, element: UIElement, actions: any) => Promise<void>;
     onSubmit?: (state: any, element: UIElement) => void;
     onComplete?: (state, element: UIElement) => void;
+    onActionHandled?: (rtnObj: ActionHandledReturnObject) => void;
     onAdditionalDetails?: (state: any, element: UIElement) => void;
     onError?: (error, element?: UIElement) => void;
     onPaymentCompleted?: (result: any, element: UIElement) => void;

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -78,12 +78,13 @@ export interface IUIElement {
 }
 
 export type UIElementStatus = 'ready' | 'loading' | 'error' | 'success';
+export type ActionDescriptionType = 'qr-code-loaded' | 'polling-started' | 'fingerprint-iframe-loaded' | 'challenge-iframe-loaded';
 
 export type PayButtonFunctionProps = Omit<PayButtonProps, 'amount'>;
 
 export interface ActionHandledReturnObject {
     componentType: string;
-    actionType: string;
+    actionDescription: ActionDescriptionType;
 }
 
 export interface UIElementProps extends BaseElementProps {

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -58,6 +58,7 @@ const actionTypes = {
             // Props common to both flows
             token: action.token,
             paymentData,
+            onActionHandled: props.onActionHandled,
             onComplete: props.onAdditionalDetails,
             onError: props.onError,
             isDropin: !!props.isDropin,

--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -22,6 +22,7 @@ export const GENERIC_OPTIONS = [
     'beforeRedirect',
     'beforeSubmit',
     'onSubmit',
+    'onActionHandled',
     'onAdditionalDetails',
     'onCancel',
     'onChange',

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -19,6 +19,9 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         onError: (error, component) => {
             console.info(error, component);
         },
+        onActionHandled: rtnObj => {
+            console.log('onActionHandled', rtnObj);
+        },
         showPayButton: true
     });
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -64,6 +64,9 @@ export async function initManual() {
         onError: (error, component) => {
             console.info(error.name, error.message, error.stack, component);
         },
+        onActionHandled: rtnObj => {
+            console.log('onActionHandled', rtnObj);
+        },
         paymentMethodsConfiguration: {
             card: {
                 enableStoreDetails: false,

--- a/packages/playground/src/pages/QRCodes/QRCodes.js
+++ b/packages/playground/src/pages/QRCodes/QRCodes.js
@@ -81,7 +81,7 @@ import './QRCodes.scss';
         amount: {
             currency: 'THB',
             value: 101
-        },
+        }
     })
         .then(result => {
             if (result.action) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR adds a callback `onActionHandled` which can be listened to to know that an action has proceeded as planned.

For example: 
- for an action that leads to the presentation of a QR code we call this callback when the QR code image has loaded
- similarly for a 3DS2 action we call it when the generated iframe has loaded its content
- and for something that leads to an `Await` action (UPI, Blik, MBWay) we call it once the `/status` polling starts

What is received within this handler is an object describing the component and the action that has been handled,
examples:
- `{componentType: 'wechatpayQR', actionDescription: 'qr-code-loaded'}`
- `{componentType: '3DS2Fingerprint', actionDescription: 'fingerprint-iframe-loaded' }`
- `{componentType: 'mbway', actionDescription: 'polling-started'}`

## Tested scenarios
Tested both the described scenarios from within Dropin, and also from within the respective standalone components


**Relates to issue**:  #941 

This also relates to the many queries we have received about whether it is possible to know that a 3DS action has actually taken place as expected
