### PR TITLE
Click to Pay - Removing useClickToPay flag

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -9,7 +9,7 @@ import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLook
 import { CbObjOnBinLookup } from '../internal/SecuredFields/lib/types';
 import { reject } from '../internal/SecuredFields/utils';
 import { hasValidInstallmentsObject } from './components/CardInput/utils';
-import { createClickToPayService } from './components/ClickToPay/utils';
+import { createClickToPayService } from './components/ClickToPay/services/create-clicktopay-service';
 import { ClickToPayCheckoutPayload, IClickToPayService } from './components/ClickToPay/services/types';
 import ClickToPayWrapper from './ClickToPayWrapper';
 import { UIElementStatus } from '../types';
@@ -27,16 +27,13 @@ export class CardElement extends UIElement<CardElementProps> {
     constructor(props) {
         super(props);
 
-        if (this.props.useClickToPay) {
-            this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);
-            this.clickToPayService?.initialize();
-        }
+        this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);
+        this.clickToPayService?.initialize();
     }
 
     protected static defaultProps = {
         onBinLookup: () => {},
         showBrandsUnderCardNumber: true,
-        useClickToPay: false,
         SRConfig: {}
     };
 

--- a/packages/lib/src/components/Card/components/ClickToPay/services/create-clicktopay-service.test.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/create-clicktopay-service.test.ts
@@ -1,0 +1,77 @@
+import { createClickToPayService } from './create-clicktopay-service';
+import { CardConfiguration } from '../../../types';
+import { CtpState } from './ClickToPayService';
+import { IClickToPayService } from './types';
+
+const ENVIRONMENT = 'test';
+
+test('should not create the service if card `configuration` property is not provided', () => {
+    let service: IClickToPayService,
+        configuration = {};
+    service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(service).toBeNull();
+
+    configuration = null;
+    service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(service).toBeNull();
+});
+
+test('should not create the service if Visa config properties are missing', () => {
+    let service: IClickToPayService = null,
+        configuration: CardConfiguration = {
+            visaSrciDpaId: 'xxxx'
+        };
+    service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(createClickToPayService(configuration, null, ENVIRONMENT)).toBeNull();
+
+    configuration = {
+        visaSrcInitiatorId: 'yyyy'
+    };
+    service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(service).toBeNull();
+});
+
+test('should not create the service if MC config properties are missing', () => {
+    let service: IClickToPayService = null,
+        configuration: CardConfiguration = {
+            mcDpaId: 'xxxx'
+        };
+    service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(createClickToPayService(configuration, null, ENVIRONMENT)).toBeNull();
+
+    configuration = {
+        mcSrcClientId: 'yyyy'
+    };
+    service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(service).toBeNull();
+});
+
+test('should create service if Visa config is set properly', () => {
+    const configuration: CardConfiguration = {
+        visaSrciDpaId: 'xxx',
+        visaSrcInitiatorId: 'yyyy'
+    };
+    const service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(service).toBeDefined();
+});
+
+test('should create service if MC config is set properly', () => {
+    const configuration: CardConfiguration = {
+        mcSrcClientId: 'xxx',
+        mcDpaId: 'yyyy'
+    };
+    const service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(service).toBeDefined();
+});
+
+test('should create service if MC config is set properly', () => {
+    const configuration: CardConfiguration = {
+        mcSrcClientId: 'xxx',
+        mcDpaId: 'yyyy',
+        visaSrciDpaId: 'xxx',
+        visaSrcInitiatorId: 'yyyy'
+    };
+    const service = createClickToPayService(configuration, null, ENVIRONMENT);
+    expect(service).toBeDefined();
+    expect(service.state).toBe(CtpState.Idle);
+});

--- a/packages/lib/src/components/Card/components/ClickToPay/services/create-clicktopay-service.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/create-clicktopay-service.ts
@@ -1,8 +1,8 @@
-import SrcSdkLoader from './services/sdks/SrcSdkLoader';
-import ClickToPayService from './services/ClickToPayService';
-import { IClickToPayService, IdentityLookupParams } from './services/types';
-import { CardConfiguration, ClickToPayConfiguration, ClickToPayScheme } from '../../types';
-import { SrcInitParams } from './services/sdks/types';
+import SrcSdkLoader from './sdks/SrcSdkLoader';
+import ClickToPayService from './ClickToPayService';
+import { IClickToPayService, IdentityLookupParams } from './types';
+import { SrcInitParams } from './sdks/types';
+import { CardConfiguration, ClickToPayConfiguration, ClickToPayScheme } from '../../../types';
 
 /**
  * Creates the Click to Pay service in case the required configuration is provided

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/types.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/types.ts
@@ -24,8 +24,10 @@ export type SrciIsRecognizedResponse = {
 
 export type SrciCheckoutResponse = {
     dcfActionCode: string;
-    encryptedPayload?: string;
-    idToken?: string;
+    checkoutResponse: string;
+    checkoutResponseSignature: string;
+    idToken: string;
+    unbindAppInstance: boolean;
 };
 
 export type SrciIdentityLookupResponse = {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/utils.test.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/utils.test.ts
@@ -117,7 +117,7 @@ test('should place expired cards at the end of the list, placing the most recent
     ]);
 });
 
-test.only('should sort available cards placing most recent ones on top of the list', () => {
+test('should sort available cards placing most recent ones on top of the list', () => {
     const cardsFromSrcSystem: SrcProfileWithScheme[] = [
         {
             scheme: 'visa',

--- a/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/utils.ts
@@ -9,7 +9,7 @@ export const CTP_IFRAME_NAME = 'ctpIframe';
  */
 function createCheckoutPayloadBasedOnScheme(
     card: ShopperCard,
-    checkoutResponse: SrciCheckoutResponse,
+    srciCheckoutResponse: SrciCheckoutResponse,
     environment: string
 ): ClickToPayCheckoutPayload {
     const { scheme, tokenId, srcDigitalCardId, srcCorrelationId } = card;
@@ -25,7 +25,7 @@ function createCheckoutPayloadBasedOnScheme(
                       srcCorrelationId,
                       srcTokenReference: environment.toLowerCase().includes('live') ? tokenId : '987654321'
                   }
-                : { srcScheme: scheme, srcCheckoutPayload: checkoutResponse.encryptedPayload, srcCorrelationId };
+                : { srcScheme: scheme, srcCheckoutPayload: srciCheckoutResponse.checkoutResponse, srcCorrelationId };
         case 'mc':
         default:
             return { srcScheme: scheme, srcDigitalCardId, srcCorrelationId };

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -25,12 +25,6 @@ export interface CardElementProps extends UIElementProps {
     brandsConfiguration?: CardBrandsConfiguration;
 
     /**
-     * Flag indicating if merchant really intent to use Click to Pay
-     * Will be removed when we Click to Pay goes live
-     */
-    useClickToPay: boolean;
-
-    /**
      * Configuration for Click to Pay
      */
     clickToPayConfiguration?: ClickToPayConfiguration;

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -160,7 +160,6 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
             .create('card', {
                 type: 'scheme',
                 brands: ['mc', 'visa'],
-                useClickToPay: true,
                 clickToPayConfiguration: {
                     shopperIdentityValue: 'gui.ctp@adyen.com',
                     merchantDisplayName: 'Adyen Merchant Name '

--- a/yarn.lock
+++ b/yarn.lock
@@ -10224,7 +10224,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Removing the flag `useClickToPay` that explicitly enables ClickToPay for the merchant.  

We don't really need that flag anymore as we can figure out if Click to Pay should be displayed or not according to the configuration available in the card payment method object returned by the /paymentMethods response.

Removing the flag also makes the integration easier as merchants might not even need to change anything in their Card component configuration.


## Tested scenarios
- Added unit tests to make sure that ClickToPay service is not created if the configuration properties are incorrect
- Tested that it still works if merchants pass the `useClickToPay` flag  (the flag will be ignored)