### PR TITLE
Prepping paymentsConfig for use with 3DS2 and API v69. 

### DIFF
--- a/packages/playground/src/config/paymentsConfig.js
+++ b/packages/playground/src/config/paymentsConfig.js
@@ -1,8 +1,8 @@
 import commonConfiguration from './commonConfig';
 
 const identifier = new Date().getMilliseconds();
-const { origin = 'http://localhost:3020', search } = window.location;
-const returnUrl = origin + search;
+const { origin = 'http://localhost:3020', pathname, search } = window.location;
+const returnUrl = origin + pathname + search;
 
 const paymentsConfig = {
     ...commonConfiguration,
@@ -13,7 +13,19 @@ const paymentsConfig = {
         // Force response code. See https://docs.adyen.com/development-resources/test-cards/result-code-testing/adyen-response-codes
         // RequestedTestAcquirerResponseCode: 2,
         allow3DS2: true
+        // To force threeds2InMDFlow:
+        // comment out "allow3DS2" & comment in the following 2 lines:
+        // threeDS2InMDFlow: true,
+        // executeThreeD: true
     },
+    // Ready for v69 - lose any additionalData 3DS2 related lines e.g. allow3DS2: true
+    // authenticationData: {
+    //     attemptAuthentication: 'always',
+    //     // To force MDFlow: comment out below, and just keep line above
+    //     threeDSRequestData: {
+    //         nativeThreeDS: 'preferred'
+    //     }
+    // },
     shopperEmail: 'test-shopper@storytel.com',
     shopperIP: '172.30.0.1',
     // threeDS2RequestData: {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Prepping paymentsConfig so it can work with 3DS2 against API v69. (ref: https://docs.adyen.com/online-payments/migrate-to-checkout-api-v69#3d-secure-authentication-fields)
- Also fixed returnUrl to point to the right playground page

