### PR TITLE
Removed hardcoded url on expiryDate hint icon

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -12,6 +12,7 @@ import {
     DATE_POLICY_REQUIRED,
     ENCRYPTED_EXPIRY_DATE
 } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import getImage from '../../../../../utils/get-image';
 
 export default function ExpirationDate(props: ExpirationDateProps) {
     const { label, focused, filled, onFocusField, className = '', error = '', isValid = false, expiryDatePolicy = DATE_POLICY_REQUIRED } = props;
@@ -64,7 +65,7 @@ export default function ExpirationDate(props: ExpirationDateProps) {
                 })}
             >
                 <img
-                    src={`${loadingContext}images/components/expiry_date_hint.svg`}
+                    src={getImage({ loadingContext, imageFolder: 'components/' })('expiry_date_hint')}
                     className="adyen-checkout__field__exp-date_hint"
                     alt={fieldLabel}
                 />

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -17,6 +17,7 @@ export default function ExpirationDate(props: ExpirationDateProps) {
     const { label, focused, filled, onFocusField, className = '', error = '', isValid = false, expiryDatePolicy = DATE_POLICY_REQUIRED } = props;
     const {
         i18n,
+        loadingContext,
         commonProps: { isCollatingErrors }
     } = useCoreContext();
 
@@ -57,15 +58,13 @@ export default function ExpirationDate(props: ExpirationDateProps) {
                     }
                 )}
             />
-            <div className={classNames(
-                'adyen-checkout__field__exp-date_hint_wrapper',
-                [styles['checkout__field__exp-date_hint_wrapper']],
-                {
-                    'adyen-checkout__field__exp-date_hint_wrapper--hidden': error || isValid,
-                }
-            )}>
+            <div
+                className={classNames('adyen-checkout__field__exp-date_hint_wrapper', [styles['checkout__field__exp-date_hint_wrapper']], {
+                    'adyen-checkout__field__exp-date_hint_wrapper--hidden': error || isValid
+                })}
+            >
                 <img
-                    src="https://checkoutshopper-test.adyen.com/checkoutshopper/images/components/expiry_date_hint.svg"
+                    src={`${loadingContext}images/components/expiry_date_hint.svg`}
                     className="adyen-checkout__field__exp-date_hint"
                     alt={fieldLabel}
                 />


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The url for the icon used as an expiryDate hint was hardcoded to the Test environment.
It now uses the dynamic `loadingContext` to set the root for this url

## Tested scenarios
expiryDate hint icon loads based on `loadingContext`


**Fixed issue**:  #1981 
