### PR TITLE
Fix card brand image alignment

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
@@ -20,6 +20,7 @@
 }
 
 .adyen-checkout__card__brands img {
+    display: block;
     border-radius: 3px;
     height: 16px;
     width: 24px;


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->
## Summary

I've fixed a case where the card brand images are not correctly aligned. Like so: 

![image](https://user-images.githubusercontent.com/7161066/219648366-ec0b7566-4f20-434d-9a77-07eeae1d039a.png)

Probably due to a combination of the margin here, plus the `margin-top: -8px` of the brand image wrapper. 

![image](https://user-images.githubusercontent.com/7161066/219682158-1700523e-b394-4635-8b9e-9e48bcbbef8c.png)

Setting the images as `display: block` instead of the default `inline` is one solution to the problem. Another viable solution would be to set `vertical-align: top` on the image element. 

![image](https://user-images.githubusercontent.com/7161066/219683167-c6b9a808-4cba-4b41-8ca0-4124851dd7a3.png)


<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
