### PR TITLE
PayPal - Allowing merchant to pass 'intent' property as Component configuration

### DIFF
--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -3,7 +3,7 @@ import UIElement from '../UIElement';
 import PaypalComponent from './components/PaypalComponent';
 import defaultProps from './defaultProps';
 import { PaymentAction } from '../../types';
-import { PayPalElementProps } from './types';
+import { Intent, PayPalElementProps } from './types';
 import './Paypal.scss';
 import CoreProvider from '../../core/Context/CoreProvider';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
@@ -28,11 +28,16 @@ class PaypalElement extends UIElement<PayPalElementProps> {
         this.submit = this.submit.bind(this);
     }
 
-    protected formatProps(props) {
+    formatProps(props: PayPalElementProps): PayPalElementProps {
+        // should we deprecate isZeroAuth?
         const isZeroAuth = props.amount?.value === 0;
+
+        const intent: Intent = props.intent || props.configuration.intent;
+
         return {
             ...props,
-            vault: isZeroAuth || props.vault,
+            vault: isZeroAuth || props.vault, // what has priority?
+            intent: isZeroAuth ? 'tokenize' : intent, // should prop take priority over isZeroAuth?
             configuration: {
                 ...props.configuration,
                 intent: isZeroAuth ? 'tokenize' : props.configuration.intent

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -29,18 +29,18 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     }
 
     formatProps(props: PayPalElementProps): PayPalElementProps {
-        // should we deprecate isZeroAuth?
+        const { merchantId, intent: intentFromConfig } = props.configuration;
         const isZeroAuth = props.amount?.value === 0;
 
-        const intent: Intent = props.intent || props.configuration.intent;
+        const intent: Intent = isZeroAuth ? 'tokenize' : props.intent || intentFromConfig;
+        const vault = isZeroAuth || props.vault;
 
         return {
             ...props,
-            vault: isZeroAuth || props.vault, // what has priority?
-            intent: isZeroAuth ? 'tokenize' : intent, // should prop take priority over isZeroAuth?
+            vault,
             configuration: {
-                ...props.configuration,
-                intent: isZeroAuth ? 'tokenize' : props.configuration.intent
+                intent,
+                ...(merchantId && { merchantId })
             }
         };
     }

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -40,7 +40,7 @@ class PaypalElement extends UIElement<PayPalElementProps> {
             vault,
             configuration: {
                 intent,
-                ...(merchantId && { merchantId })
+                merchantId
             }
         };
     }

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -33,7 +33,7 @@ class PaypalElement extends UIElement<PayPalElementProps> {
         const isZeroAuth = props.amount?.value === 0;
 
         const intent: Intent = isZeroAuth ? 'tokenize' : props.intent || intentFromConfig;
-        const vault = isZeroAuth || props.vault;
+        const vault = intent === 'tokenize' || props.vault;
 
         return {
             ...props,

--- a/packages/lib/src/components/PayPal/types.ts
+++ b/packages/lib/src/components/PayPal/types.ts
@@ -14,11 +14,11 @@ declare global {
  * The intent for the transaction. This determines whether the funds are captured immediately, or later.
  * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#intent}
  */
-type Intent = 'sale' | 'capture' | 'authorize' | 'order' | 'tokenize';
+export type Intent = 'sale' | 'capture' | 'authorize' | 'order' | 'tokenize';
 
 export type FundingSource = 'paypal' | 'credit';
 
-interface PayPalStyles {
+export interface PayPalStyles {
     /**
      * @see {@link https://developer.paypal.com/docs/checkout/integration-features/customize-button/#color}
      */
@@ -185,4 +185,4 @@ export interface PaypalSettings {
     components: string;
 }
 
-export type SupportedLocale = typeof SUPPORTED_LOCALES[number];
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];

--- a/packages/lib/src/components/PayPal/types.ts
+++ b/packages/lib/src/components/PayPal/types.ts
@@ -86,7 +86,10 @@ interface PayPalCommonProps {
     cspNonce?: string;
 
     /**
+     * Determines whether the funds are captured immediately on checkout or if the buyer authorizes the funds to be captured later.
      * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#intent}
+     *
+     * If set, it will override the intent passed inside the 'configuration' object
      */
     intent?: Intent;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Updated the PayPal formatProps logic, so now the Component can get the `intent` from the Component configuration, which has higher priority than the one passed in the `configuration` object which is retrieved from the Backend

**Fixed issue**:  COWEB-1154
