### PR TITLE
Fixing uncaught analytics error

### DIFF
--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -41,10 +41,14 @@ class Analytics {
         if (enabled === true) {
             if (telemetry === true && !this.checkoutAttemptId) {
                 // fetch a new checkoutAttemptId if none is already available
-                this.collectId().then(checkoutAttemptId => {
-                    this.checkoutAttemptId = checkoutAttemptId;
-                    this.queue.run(this.checkoutAttemptId);
-                });
+                this.collectId()
+                    .then(checkoutAttemptId => {
+                        this.checkoutAttemptId = checkoutAttemptId;
+                        this.queue.run(this.checkoutAttemptId);
+                    })
+                    .catch(e => {
+                        console.warn(`Fetching checkoutAttemptId failed.${e ? ` Error=${e}` : ''}`);
+                    });
             }
 
             if (telemetry === true) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A promise, which performs a server call to retrieve a new `checkoutAttemptId` in `Analytics.ts`, is throwing an "uncaught error" when in PayByLInk.
Have added a `catch` statement in which we create a `console.warn`

## Tested scenarios
PayByLInk no longer throws this error
