### PR TITLE
Click to Pay - disabling OTP auto focus and renamed shopper identity parameters

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -27,14 +27,17 @@ export class CardElement extends UIElement<CardElementProps> {
     constructor(props) {
         super(props);
 
-        this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);
-        this.clickToPayService?.initialize();
+        if (!props._disableClickToPay) {
+            this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);
+            this.clickToPayService?.initialize();
+        }
     }
 
     protected static defaultProps = {
         onBinLookup: () => {},
         showBrandsUnderCardNumber: true,
-        SRConfig: {}
+        SRConfig: {},
+        _disableClickToPay: false
     };
 
     public setStatus(status: UIElementStatus, props?): this {
@@ -88,7 +91,8 @@ export class CardElement extends UIElement<CardElementProps> {
              */
             clickToPayConfiguration: {
                 ...props.clickToPayConfiguration,
-                shopperIdentityValue: props.clickToPayConfiguration?.shopperIdentityValue || props?._parentInstance?.options?.session?.shopperEmail,
+                shopperEmail: props.clickToPayConfiguration?.shopperEmail || props?._parentInstance?.options?.session?.shopperEmail,
+                telephoneNumber: props.clickToPayConfiguration?.telephoneNumber || props?._parentInstance?.options?.session?.telephoneNumber,
                 locale: props.clickToPayConfiguration?.locale || props.i18n?.locale?.replace('-', '_')
             }
         };

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -91,6 +91,7 @@ export class CardElement extends UIElement<CardElementProps> {
              */
             clickToPayConfiguration: {
                 ...props.clickToPayConfiguration,
+                disableOtpAutoFocus: props.clickToPayConfiguration?.disableOtpAutoFocus || false,
                 shopperEmail: props.clickToPayConfiguration?.shopperEmail || props?._parentInstance?.options?.session?.shopperEmail,
                 telephoneNumber: props.clickToPayConfiguration?.telephoneNumber || props?._parentInstance?.options?.session?.telephoneNumber,
                 locale: props.clickToPayConfiguration?.locale || props.i18n?.locale?.replace('-', '_')
@@ -240,6 +241,7 @@ export class CardElement extends UIElement<CardElementProps> {
             >
                 <ClickToPayWrapper
                     amount={this.props.amount}
+                    configuration={this.props.clickToPayConfiguration}
                     clickToPayService={this.clickToPayService}
                     setClickToPayRef={this.setClickToPayRef}
                     onSetStatus={this.setElementStatus}

--- a/packages/lib/src/components/Card/ClickToPayWrapper.tsx
+++ b/packages/lib/src/components/Card/ClickToPayWrapper.tsx
@@ -2,9 +2,19 @@ import ClickToPayProvider, { ClickToPayProviderProps } from './components/ClickT
 import ClickToPayHolder from './ClickToPayHolder';
 import { h } from 'preact';
 
-const ClickToPayWrapper = ({ amount, clickToPayService, setClickToPayRef, onSetStatus, onSubmit, onError, ...props }: ClickToPayProviderProps) => {
+const ClickToPayWrapper = ({
+    amount,
+    configuration,
+    clickToPayService,
+    setClickToPayRef,
+    onSetStatus,
+    onSubmit,
+    onError,
+    ...props
+}: ClickToPayProviderProps) => {
     return (
         <ClickToPayProvider
+            configuration={configuration}
             amount={amount}
             clickToPayService={clickToPayService}
             setClickToPayRef={setClickToPayRef}

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLogin.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPLogin/CtPLogin.tsx
@@ -43,7 +43,7 @@ const CtPLogin = (): h.JSX.Element => {
         setIsLoggingIn(true);
 
         try {
-            const { isEnrolled } = await verifyIfShopperIsEnrolled(shopperLogin);
+            const { isEnrolled } = await verifyIfShopperIsEnrolled({ shopperEmail: shopperLogin });
             if (isEnrolled) {
                 await startIdentityValidation();
             } else {

--- a/packages/lib/src/components/Card/components/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
@@ -7,6 +7,7 @@ import Field from '../../../../../../internal/FormFields/Field';
 import renderFormField from '../../../../../../internal/FormFields';
 import './CtPOneTimePasswordInput.scss';
 import CtPResendOtpLink from './CtPResendOtpLink';
+import useClickToPayContext from '../../../context/useClickToPayContext';
 
 type OnChangeProps = { data: CtPOneTimePasswordInputDataState; valid; errors; isValid: boolean };
 
@@ -31,6 +32,10 @@ export type CtPOneTimePasswordInputHandlers = {
 
 const CtPOneTimePasswordInput = (props: CtPOneTimePasswordInputProps): h.JSX.Element => {
     const { i18n } = useCoreContext();
+    const {
+        configuration: { disableOtpAutoFocus }
+    } = useClickToPayContext();
+
     const formSchema = ['otp'];
     const [resendOtpError, setResendOtpError] = useState<string>(null);
     const { handleChangeFor, data, triggerValidation, valid, errors, isValid, setData } = useForm<CtPOneTimePasswordInputDataState>({
@@ -54,10 +59,10 @@ const CtPOneTimePasswordInput = (props: CtPOneTimePasswordInputProps): h.JSX.Ele
     }, [data.otp]);
 
     useEffect(() => {
-        if (inputRef) {
+        if (!disableOtpAutoFocus && inputRef) {
             inputRef.focus();
         }
-    }, [inputRef]);
+    }, [inputRef, disableOtpAutoFocus]);
 
     useEffect(() => {
         otpInputHandlersRef.current.validateInput = validateInput;
@@ -67,9 +72,11 @@ const CtPOneTimePasswordInput = (props: CtPOneTimePasswordInputProps): h.JSX.Ele
     const handleOnResendOtp = useCallback(() => {
         setData('otp', '');
         setResendOtpError(null);
-        inputRef.focus();
+        if (!disableOtpAutoFocus) {
+            inputRef.focus();
+        }
         props.onResendCode();
-    }, [props.onResendCode, inputRef]);
+    }, [props.onResendCode, inputRef, disableOtpAutoFocus]);
 
     const handleOnResendOtpError = useCallback(
         (errorCode: string) => {

--- a/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayContext.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayContext.ts
@@ -5,6 +5,7 @@ import { PaymentAmount } from '../../../../../types';
 import ShopperCard from '../models/ShopperCard';
 import { UIElementStatus } from '../../../../types';
 import AdyenCheckoutError from '../../../../../core/Errors/AdyenCheckoutError';
+import { ClickToPayConfiguration } from '../../../types';
 
 export interface IClickToPayContext
     extends Pick<IClickToPayService, 'checkout' | 'startIdentityValidation' | 'finishIdentityValidation' | 'verifyIfShopperIsEnrolled'> {
@@ -17,6 +18,7 @@ export interface IClickToPayContext
     otpMaskedContact: string;
     otpNetwork: string;
     amount: PaymentAmount;
+    configuration: ClickToPayConfiguration;
     status: UIElementStatus;
     onSubmit(payload: ClickToPayCheckoutPayload): void;
     onSetStatus(status: UIElementStatus): void;
@@ -29,6 +31,7 @@ const ClickToPayContext = createContext<IClickToPayContext>({
     onSetStatus: null,
     onError: null,
     amount: null,
+    configuration: null,
     isCtpPrimaryPaymentMethod: null,
     setIsCtpPrimaryPaymentMethod: null,
     logoutShopper: null,

--- a/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayProvider.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayProvider.tsx
@@ -7,6 +7,7 @@ import { PaymentAmount } from '../../../../../types';
 import ShopperCard from '../models/ShopperCard';
 import { UIElementStatus } from '../../../../types';
 import AdyenCheckoutError from '../../../../../core/Errors/AdyenCheckoutError';
+import { ClickToPayConfiguration } from '../../../types';
 
 type ClickToPayProviderRef = {
     setStatus?(status: UIElementStatus): void;
@@ -14,6 +15,7 @@ type ClickToPayProviderRef = {
 
 export type ClickToPayProviderProps = {
     clickToPayService: IClickToPayService | null;
+    configuration: ClickToPayConfiguration;
     amount: PaymentAmount;
     children: any;
     setClickToPayRef(ref): void;
@@ -22,7 +24,16 @@ export type ClickToPayProviderProps = {
     onError(error: AdyenCheckoutError): void;
 };
 
-const ClickToPayProvider = ({ clickToPayService, amount, children, setClickToPayRef, onSubmit, onSetStatus, onError }: ClickToPayProviderProps) => {
+const ClickToPayProvider = ({
+    clickToPayService,
+    amount,
+    configuration,
+    children,
+    setClickToPayRef,
+    onSubmit,
+    onSetStatus,
+    onError
+}: ClickToPayProviderProps) => {
     const [ctpService] = useState<IClickToPayService | null>(clickToPayService);
     const [ctpState, setCtpState] = useState<CtpState>(clickToPayService?.state || CtpState.NotAvailable);
     const [isCtpPrimaryPaymentMethod, setIsCtpPrimaryPaymentMethod] = useState<boolean>(null);
@@ -76,6 +87,7 @@ const ClickToPayProvider = ({ clickToPayService, amount, children, setClickToPay
                 onError,
                 onSetStatus,
                 amount,
+                configuration,
                 isCtpPrimaryPaymentMethod,
                 setIsCtpPrimaryPaymentMethod,
                 ctpState,

--- a/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayProvider.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPay/context/ClickToPayProvider.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { CtpState } from '../services/ClickToPayService';
 import { ClickToPayContext } from './ClickToPayContext';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
-import { ClickToPayCheckoutPayload, IClickToPayService } from '../services/types';
+import { ClickToPayCheckoutPayload, IClickToPayService, IdentityLookupParams } from '../services/types';
 import { PaymentAmount } from '../../../../../types';
 import ShopperCard from '../models/ShopperCard';
 import { UIElementStatus } from '../../../../types';
@@ -58,8 +58,8 @@ const ClickToPayProvider = ({ clickToPayService, amount, children, setClickToPay
     );
 
     const verifyIfShopperIsEnrolled = useCallback(
-        async (value: string, type?: string) => {
-            return await ctpService?.verifyIfShopperIsEnrolled(value, type);
+        async (shopperIdentity: IdentityLookupParams) => {
+            return await ctpService?.verifyIfShopperIsEnrolled(shopperIdentity);
         },
         [ctpService]
     );

--- a/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.test.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.test.ts
@@ -61,8 +61,7 @@ test('should set state to not available if there is no cookie AND provided shopp
     const sdkLoader = mock<ISrcSdkLoader>();
     const schemesConfig = mock<SchemesConfiguration>();
     const identity: IdentityLookupParams = {
-        value: 'shopper@email.com',
-        type: 'email'
+        shopperEmail: 'shopper@email.com'
     };
 
     sdkLoader.load.mockResolvedValue([visa]);
@@ -74,7 +73,7 @@ test('should set state to not available if there is no cookie AND provided shopp
     const service = new ClickToPayService(schemesConfig, sdkLoader, 'test', identity);
     await service.initialize();
 
-    expect(visa.identityLookup).toHaveBeenCalledWith(identity);
+    expect(visa.identityLookup).toHaveBeenCalledWith({ identityValue: identity.shopperEmail, type: 'email' });
     expect(service.state).toBe(CtpState.NotAvailable);
 });
 
@@ -334,8 +333,7 @@ test('should authenticate the shopper with the fastest SDK that finds the shoppe
     const mockedIdToken = 'xxxx-yyyy';
     const otp = '654321';
     const identity: IdentityLookupParams = {
-        value: 'shopper@email.com',
-        type: 'email'
+        shopperEmail: 'shopper@email.com'
     };
 
     const profileFromVisaSrcSystem: SrcProfile = {
@@ -411,8 +409,8 @@ test('should authenticate the shopper with the fastest SDK that finds the shoppe
     const service = new ClickToPayService(schemesConfig, sdkLoader, 'test', identity);
     await service.initialize();
 
-    expect(mc.identityLookup).toHaveBeenCalledWith(identity);
-    expect(visa.identityLookup).toHaveBeenCalledWith(identity);
+    expect(mc.identityLookup).toHaveBeenCalledWith({ identityValue: identity.shopperEmail, type: 'email' });
+    expect(visa.identityLookup).toHaveBeenCalledWith({ identityValue: identity.shopperEmail, type: 'email' });
     expect(service.state).toBe(CtpState.ShopperIdentified);
 
     await service.startIdentityValidation();

--- a/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/ClickToPayService.ts
@@ -77,7 +77,7 @@ class ClickToPayService implements IClickToPayService {
                 return;
             }
 
-            const { isEnrolled } = await this.verifyIfShopperIsEnrolled(this.shopperIdentity.value, this.shopperIdentity.type);
+            const { isEnrolled } = await this.verifyIfShopperIsEnrolled(this.shopperIdentity);
             if (isEnrolled) {
                 this.setState(CtpState.ShopperIdentified);
                 return;
@@ -184,10 +184,12 @@ class ClickToPayService implements IClickToPayService {
      * Based on the responses from the Click to Pay Systems, we should do the validation process using the SDK that
      * that responds faster with 'consumerPresent=true'
      */
-    public async verifyIfShopperIsEnrolled(value: string, type: 'email' | 'mobilePhone' = 'email'): Promise<{ isEnrolled: boolean }> {
+    public async verifyIfShopperIsEnrolled(shopperIdentity: IdentityLookupParams): Promise<{ isEnrolled: boolean }> {
+        const { shopperEmail } = shopperIdentity;
+
         return new Promise((resolve, reject) => {
             const lookupPromises = this.sdks.map(sdk => {
-                const identityLookupPromise = sdk.identityLookup({ value, type });
+                const identityLookupPromise = sdk.identityLookup({ identityValue: shopperEmail, type: 'email' });
 
                 identityLookupPromise
                     .then(response => {

--- a/packages/lib/src/components/Card/components/ClickToPay/services/create-clicktopay-service.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/create-clicktopay-service.ts
@@ -18,7 +18,7 @@ function createClickToPayService(
         return null;
     }
 
-    const shopperIdentity = createShopperIdentityObject(clickToPayConfiguration?.shopperIdentityValue, clickToPayConfiguration?.shopperIdentityType);
+    const shopperIdentity = createShopperIdentityObject(clickToPayConfiguration?.shopperEmail, clickToPayConfiguration?.telephoneNumber);
 
     const schemeNames = Object.keys(schemesConfig);
     const srcSdkLoader = new SrcSdkLoader(schemeNames, {
@@ -28,14 +28,14 @@ function createClickToPayService(
     return new ClickToPayService(schemesConfig, srcSdkLoader, environment, shopperIdentity);
 }
 
-const createShopperIdentityObject = (value: string, type?: 'email' | 'mobilePhone'): IdentityLookupParams => {
-    if (!value) {
-        return null;
-    }
-    return {
-        value,
-        type: type || 'email'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const createShopperIdentityObject = (shopperEmail: string, telephoneNumber: string): IdentityLookupParams | null => {
+    const identityLookup = {
+        ...(shopperEmail && { shopperEmail })
+        // ...(telephoneNumber && { telephoneNumber }) telephoneNumber not supported yet
     };
+
+    return Object.keys(identityLookup).length > 0 ? identityLookup : null;
 };
 
 /**

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/AbstractSrcInitiator.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/AbstractSrcInitiator.ts
@@ -1,10 +1,10 @@
-import { IdentityLookupParams } from '../types';
 import Script from '../../../../../../utils/Script';
 import {
     CustomSdkConfiguration,
     SrcCheckoutParams,
     SrciCheckoutResponse,
     SrciCompleteIdentityValidationResponse,
+    SrcIdentityLookupParams,
     SrciIdentityLookupResponse,
     SrciInitiateIdentityValidationResponse,
     SrciIsRecognizedResponse,
@@ -22,7 +22,7 @@ export interface ISrcInitiator {
     // SRCi specification methods
     init(params: SrcInitParams, srciTransactionId: string): Promise<void>;
     isRecognized(): Promise<SrciIsRecognizedResponse>;
-    identityLookup(params: IdentityLookupParams): Promise<SrciIdentityLookupResponse>;
+    identityLookup(params: SrcIdentityLookupParams): Promise<SrciIdentityLookupResponse>;
     initiateIdentityValidation(): Promise<SrciInitiateIdentityValidationResponse>;
     completeIdentityValidation(validationData: string): Promise<SrciCompleteIdentityValidationResponse>;
     getSrcProfile(idTokens: string[]): Promise<SrcProfile>;
@@ -143,7 +143,7 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
      * Obtains the user account associated with the consumer’s identity (an email address or phone
      * number).
      */
-    public abstract identityLookup(params: IdentityLookupParams): Promise<SrciIdentityLookupResponse>;
+    public abstract identityLookup(params: SrcIdentityLookupParams): Promise<SrciIdentityLookupResponse>;
 
     /**
      * This method completes the identity validation by receiving the one-time password (OTP) sent to the

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/MastercardSdk.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/MastercardSdk.ts
@@ -1,12 +1,17 @@
 import { getMastercardSettings, MC_SDK_PROD, MC_SDK_TEST } from './config';
-import { IdentityLookupParams } from '../types';
 import AbstractSrcInitiator from './AbstractSrcInitiator';
 import SrciError from './SrciError';
-import { CustomSdkConfiguration, SrciCompleteIdentityValidationResponse, SrciIdentityLookupResponse, SrcInitParams } from './types';
+import {
+    CustomSdkConfiguration,
+    SrciCompleteIdentityValidationResponse,
+    SrcIdentityLookupParams,
+    SrciIdentityLookupResponse,
+    SrcInitParams
+} from './types';
 
 const IdentityTypeMap = {
     email: 'EMAIL_ADDRESS',
-    mobilePhone: 'MOBILE_PHONE_NUMBER'
+    telephoneNumber: 'MOBILE_PHONE_NUMBER'
 };
 
 class MastercardSdk extends AbstractSrcInitiator {
@@ -36,11 +41,11 @@ class MastercardSdk extends AbstractSrcInitiator {
         await this.schemeSdk.init(sdkProps);
     }
 
-    public async identityLookup(params: IdentityLookupParams): Promise<SrciIdentityLookupResponse> {
+    public async identityLookup({ identityValue, type }: SrcIdentityLookupParams): Promise<SrciIdentityLookupResponse> {
         try {
             const consumerIdentity = {
-                identityValue: params.value,
-                identityType: IdentityTypeMap[params.type]
+                identityValue,
+                identityType: IdentityTypeMap[type]
             };
 
             const response = await this.schemeSdk.identityLookup({ consumerIdentity });

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/VisaSdk.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/VisaSdk.ts
@@ -1,12 +1,17 @@
 import { getVisaSetttings, VISA_SDK_PROD, VISA_SDK_TEST } from './config';
-import { IdentityLookupParams } from '../types';
 import AbstractSrcInitiator from './AbstractSrcInitiator';
 import SrciError from './SrciError';
-import { CustomSdkConfiguration, SrciCompleteIdentityValidationResponse, SrciIdentityLookupResponse, SrcInitParams } from './types';
+import {
+    CustomSdkConfiguration,
+    SrciCompleteIdentityValidationResponse,
+    SrcIdentityLookupParams,
+    SrciIdentityLookupResponse,
+    SrcInitParams
+} from './types';
 
 const IdentityTypeMap = {
     email: 'EMAIL',
-    mobilePhone: 'MOBILE_NUMBER'
+    telephoneNumber: 'MOBILE_NUMBER'
 };
 
 class VisaSdk extends AbstractSrcInitiator {
@@ -37,11 +42,11 @@ class VisaSdk extends AbstractSrcInitiator {
         await this.schemeSdk.init(sdkProps);
     }
 
-    public async identityLookup(params: IdentityLookupParams): Promise<SrciIdentityLookupResponse> {
+    public async identityLookup({ identityValue, type }: SrcIdentityLookupParams): Promise<SrciIdentityLookupResponse> {
         try {
             const consumerIdentity = {
-                identityValue: params.value,
-                type: IdentityTypeMap[params.type]
+                identityValue,
+                type: IdentityTypeMap[type]
             };
 
             const response = await this.schemeSdk.identityLookup(consumerIdentity);

--- a/packages/lib/src/components/Card/components/ClickToPay/services/sdks/types.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/sdks/types.ts
@@ -66,3 +66,8 @@ export interface SrcInitParams {
     srcInitiatorId: string;
     srciDpaId: string;
 }
+
+export interface SrcIdentityLookupParams {
+    identityValue: string;
+    type: 'email' | 'telephoneNumber';
+}

--- a/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
+++ b/packages/lib/src/components/Card/components/ClickToPay/services/types.ts
@@ -11,7 +11,7 @@ export interface IClickToPayService {
     initialize(): Promise<void>;
     checkout(card: ShopperCard): Promise<ClickToPayCheckoutPayload>;
     logout(): Promise<void>;
-    verifyIfShopperIsEnrolled(value: string, type?: string): Promise<{ isEnrolled: boolean }>;
+    verifyIfShopperIsEnrolled(shopperIdentity: IdentityLookupParams): Promise<{ isEnrolled: boolean }>;
     subscribeOnStateChange(callback: CallbackStateSubscriber): void;
     startIdentityValidation(): Promise<void>;
     finishIdentityValidation(otpCode: string): Promise<void>;
@@ -25,8 +25,8 @@ export type IdentityValidationData = {
 export type CallbackStateSubscriber = (state: CtpState) => void;
 
 export interface IdentityLookupParams {
-    value: string;
-    type?: 'email' | 'mobilePhone';
+    shopperEmail?: string;
+    telephoneNumber?: string;
 }
 
 export type MastercardCheckout = {

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -30,6 +30,12 @@ export interface CardElementProps extends UIElementProps {
     clickToPayConfiguration?: ClickToPayConfiguration;
 
     /**
+     * Disable Click to Pay for testing purposes
+     * @internal
+     */
+    _disableClickToPay?: boolean;
+
+    /**
      * type will always be "card" (generic card, stored card)
      * except for a single branded card when it will be the same as the brand prop
      */
@@ -119,8 +125,14 @@ export interface CardElementProps extends UIElementProps {
 export type ClickToPayScheme = 'mc' | 'visa';
 
 export type ClickToPayConfiguration = {
-    shopperIdentityValue: string;
-    shopperIdentityType?: 'email' | 'mobilePhone';
+    /**
+     * Shopper email used to be recognized with the Network schemes
+     */
+    shopperEmail?: string;
+    /**
+     * Shopper telephone number used to be recognized with the Network schemes
+     */
+    telephoneNumber?: string;
     /**
      * Used to display the merchant name in case the DCF appears (ex: first time doing transaction in the device),
      */
@@ -130,7 +142,7 @@ export type ClickToPayConfiguration = {
      * defined during the creation of the Checkout.
      * Format: ISO language_country pair (e.g., en_US )
      *
-     * @default en_US
+     * @defaultValue en_US
      */
     locale?: string;
 };

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -31,6 +31,7 @@ export interface CardElementProps extends UIElementProps {
 
     /**
      * Disable Click to Pay for testing purposes
+     * @defaultValue false
      * @internal
      */
     _disableClickToPay?: boolean;

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -145,6 +145,11 @@ export type ClickToPayConfiguration = {
      * @defaultValue en_US
      */
     locale?: string;
+    /**
+     * Disable autofocus on the One Time Password input field when it is either displayed or when the OTP is resent
+     * @defaultValue false
+     */
+    disableOtpAutoFocus?: boolean;
 };
 
 export type SocialSecurityMode = 'show' | 'hide' | 'auto';

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -165,6 +165,7 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                     mcSrcClientId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1'
                 },
                 clickToPayConfiguration: {
+                    disableOtpAutoFocus: true,
                     shopperEmail: 'gui.ctp@adyen.com',
                     merchantDisplayName: 'Adyen Merchant Name '
                 }

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -160,8 +160,12 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
             .create('card', {
                 type: 'scheme',
                 brands: ['mc', 'visa'],
+                configuration: {
+                    mcDpaId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1_dpa2',
+                    mcSrcClientId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1'
+                },
                 clickToPayConfiguration: {
-                    shopperIdentityValue: 'gui.ctp@adyen.com',
+                    shopperEmail: 'gui.ctp@adyen.com',
                     merchantDisplayName: 'Adyen Merchant Name '
                 }
             })

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -10,6 +10,7 @@ export async function initSession() {
         returnUrl,
         shopperLocale,
         shopperReference,
+        telephoneNumber: '+611223344',
         shopperEmail: 'shopper.ctp1@adyen.com',
         countryCode
     });
@@ -37,6 +38,8 @@ export async function initSession() {
                 buttonType: 'plain'
             },
             card: {
+                _disableClickToPay: true,
+
                 hasHolderName: true,
                 holderNameRequired: true,
                 holderName: 'J. Smith',

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -38,8 +38,6 @@ export async function initSession() {
                 buttonType: 'plain'
             },
             card: {
-                _disableClickToPay: true,
-
                 hasHolderName: true,
                 holderNameRequired: true,
                 holderName: 'J. Smith',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- The shopper should be able to try to authenticate with telephone number AND email. The previous logic took into account that would be allowed only one type of login, which was incorrect. This PR renames the property `shopperIdentityValue` to `shopperEmail`, and also introduced `telephoneNumber` which will be used anytime soon as soon as this feature is enabled for all network schemes.
- Added new property `disableOtpAutoFocus` which disables the autofocus on the OTP field once the Component is displayed, or when the Shopper triggers the 'Resend OTP' flow. By default, the property value is `false` and the autofocus will be enabled
- Added internal property of the Card component named `_disableClickToPay` , which can be used by us to disable the Click to Pay in the Card component, so we can avoid the loading screen, OTP flow, etc.. 


## Tested scenarios
- Fixed unit tests
- Tested disabling click to pay on Card component
- Manual test on the autofocus property
