### PR TITLE
Optional Chaining for Blik Code

### DIFF
--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -22,7 +22,7 @@ class BlikElement extends UIElement {
         return {
             paymentMethod: {
                 type: BlikElement.type,
-                ...(!recurringPayment && { blikCode: this.state.data.blikCode }),
+                ...(!recurringPayment && { blikCode: this.state?.data?.blikCode }),
                 ...(recurringPayment && { storedPaymentMethodId: this.props.storedPaymentMethodId })
             }
         };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
When access Blik `component.data` before component rendered it throw an error because `state` is undefined during `formatData` call.
It works only if BlikInput is rendered and onChange runs inside useEffect at least once.

## Tested scenarios
<!-- Description of tested scenarios -->
```js
const component = checkout.create('blik', {});
component.mount('.blik-field');
console.log(component.data); // throw error
```


**Fixed issue**:  <!-- #-prefixed issue number -->
