### PR TITLE
New DisclaimerMessage comp to allow showing Terms & Conditions in Card

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
@@ -9,6 +9,7 @@ import Address from '../../../../internal/Address';
 import CardHolderName from './CardHolderName';
 import Installments from './Installments';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
+import DisclaimerMessage from './DisclaimerMessage';
 
 export const CardFieldsWrapper = ({
     // vars created in CardInput:
@@ -69,7 +70,8 @@ export const CardFieldsWrapper = ({
     showBrandIcon,
     showBrandsUnderCardNumber,
     //
-    iOSFocusedField
+    iOSFocusedField,
+    disclaimerMessage
 }) => {
     const { i18n } = useCoreContext();
 
@@ -177,6 +179,8 @@ export const CardFieldsWrapper = ({
                     iOSFocusedField={iOSFocusedField}
                 />
             )}
+
+            {disclaimerMessage && <DisclaimerMessage disclaimer={disclaimerMessage} />}
         </LoadingWrapper>
     );
 };

--- a/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.scss
@@ -1,0 +1,18 @@
+@import "../../../../../../style/index";
+
+.adyen-checkout-disclaimer__label {
+    position: relative;
+    margin-top: $spacing-medium;
+    padding-left: 0;
+    cursor: pointer;
+    display: inline-block;
+    line-height: 19px;
+    color: $color-black;
+    font-size: $font-size-small;
+    font-weight: normal;
+    user-select: none;
+
+    [dir="rtl"] & {
+        padding-right: 0;
+    }
+}

--- a/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.test.tsx
@@ -1,0 +1,65 @@
+import { shallow } from 'enzyme';
+import { h } from 'preact';
+import DisclaimerMessage from './DisclaimerMessage';
+
+describe('DisclaimerMessage', () => {
+    const disclaimerMessage = {
+        message: 'By continuing you accept the %{linkText} of MyStore',
+        linkText: 'terms and conditions',
+        link: 'https://www.adyen.com'
+    };
+
+    const getWrapper = prop => shallow(<DisclaimerMessage disclaimer={prop} />);
+
+    test('Renders the DisclaimerMessage with text before and after the link', () => {
+        const wrapper = getWrapper(disclaimerMessage);
+        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(1);
+        expect(wrapper.find('.adyen-checkout-disclaimer__label').text()).toContain('By continuing you accept the terms and conditions of MyStore');
+
+        expect(wrapper.find('.adyen-checkout__link')).toHaveLength(1);
+        expect(wrapper.find('.adyen-checkout__link').text()).toContain('terms and conditions');
+
+        expect(wrapper.find('[href="https://www.adyen.com"]')).toHaveLength(1);
+    });
+
+    test('Renders the DisclaimerMessage just with text before the link', () => {
+        const nuMsg = { ...disclaimerMessage };
+        nuMsg.message = 'By continuing you accept the %{linkText}';
+
+        const wrapper = getWrapper(nuMsg);
+        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(1);
+        expect(wrapper.find('.adyen-checkout-disclaimer__label').text()).toContain('By continuing you accept the terms and conditions');
+
+        expect(wrapper.find('.adyen-checkout__link')).toHaveLength(1);
+        expect(wrapper.find('.adyen-checkout__link').text()).toContain('terms and conditions');
+
+        expect(wrapper.find('[href="https://www.adyen.com"]')).toHaveLength(1);
+    });
+
+    test("Doesn't render the DisclaimerMessage because the link is not https", () => {
+        const nuMsg = { ...disclaimerMessage };
+        nuMsg.link = 'http://www.adyen.com';
+
+        const wrapper = getWrapper(nuMsg);
+        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(0);
+    });
+
+    test("Doesn't render the DisclaimerMessage because the linkText is not a string", () => {
+        const nuMsg = { ...disclaimerMessage };
+
+        /* eslint-disable-next-line */
+        nuMsg.linkText = <script>alert("busted")</script>;
+
+        const wrapper = getWrapper(nuMsg);
+        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(0);
+    });
+
+    test("Doesn't render the DisclaimerMessage because the message is not a string", () => {
+        const nuMsg = { ...disclaimerMessage };
+        // @ts-ignore allow assignment
+        nuMsg.message = {};
+
+        const wrapper = getWrapper(nuMsg);
+        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(0);
+    });
+});

--- a/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.test.tsx
@@ -1,6 +1,6 @@
-import { shallow } from 'enzyme';
 import { h } from 'preact';
 import DisclaimerMessage from './DisclaimerMessage';
+import { render, screen } from '@testing-library/preact';
 
 describe('DisclaimerMessage', () => {
     const disclaimerMessage = {
@@ -9,39 +9,35 @@ describe('DisclaimerMessage', () => {
         link: 'https://www.adyen.com'
     };
 
-    const getWrapper = prop => shallow(<DisclaimerMessage disclaimer={prop} />);
-
     test('Renders the DisclaimerMessage with text before and after the link', () => {
-        const wrapper = getWrapper(disclaimerMessage);
-        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(1);
-        expect(wrapper.find('.adyen-checkout-disclaimer__label').text()).toContain('By continuing you accept the terms and conditions of MyStore');
-
-        expect(wrapper.find('.adyen-checkout__link')).toHaveLength(1);
-        expect(wrapper.find('.adyen-checkout__link').text()).toContain('terms and conditions');
-
-        expect(wrapper.find('[href="https://www.adyen.com"]')).toHaveLength(1);
+        render(<DisclaimerMessage disclaimer={disclaimerMessage} />);
+        expect(screen.getByText('By continuing', { exact: false }).textContent).toEqual(
+            'By continuing you accept the terms and conditions of MyStore'
+        );
+        expect(screen.getByRole('link', { name: 'terms and conditions' })).toHaveAttribute('href', 'https://www.adyen.com');
     });
 
     test('Renders the DisclaimerMessage just with text before the link', () => {
         const nuMsg = { ...disclaimerMessage };
         nuMsg.message = 'By continuing you accept the %{linkText}';
 
-        const wrapper = getWrapper(nuMsg);
-        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(1);
-        expect(wrapper.find('.adyen-checkout-disclaimer__label').text()).toContain('By continuing you accept the terms and conditions');
+        render(<DisclaimerMessage disclaimer={nuMsg} />);
 
-        expect(wrapper.find('.adyen-checkout__link')).toHaveLength(1);
-        expect(wrapper.find('.adyen-checkout__link').text()).toContain('terms and conditions');
+        /* eslint-disable-next-line */
+        expect(screen.queryByText('By continuing', { exact: false })).toBeTruthy(); // presence
+        /* eslint-disable-next-line */
+        expect(screen.queryByRole('link')).toBeTruthy(); // presence
 
-        expect(wrapper.find('[href="https://www.adyen.com"]')).toHaveLength(1);
+        expect(screen.getByText('By continuing', { exact: false }).textContent).toEqual('By continuing you accept the terms and conditions');
+        expect(screen.getByRole('link', { name: 'terms and conditions' })).toHaveAttribute('href', 'https://www.adyen.com');
     });
 
     test("Doesn't render the DisclaimerMessage because the link is not https", () => {
         const nuMsg = { ...disclaimerMessage };
         nuMsg.link = 'http://www.adyen.com';
 
-        const wrapper = getWrapper(nuMsg);
-        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(0);
+        render(<DisclaimerMessage disclaimer={nuMsg} />);
+        expect(screen.queryByText('By continuing', { exact: false })).toBeNull(); // non-presence
     });
 
     test("Doesn't render the DisclaimerMessage because the linkText is not a string", () => {
@@ -50,8 +46,8 @@ describe('DisclaimerMessage', () => {
         /* eslint-disable-next-line */
         nuMsg.linkText = <script>alert("busted")</script>;
 
-        const wrapper = getWrapper(nuMsg);
-        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(0);
+        render(<DisclaimerMessage disclaimer={nuMsg} />);
+        expect(screen.queryByText('By continuing', { exact: false })).toBeNull(); // non-presence
     });
 
     test("Doesn't render the DisclaimerMessage because the message is not a string", () => {
@@ -59,7 +55,7 @@ describe('DisclaimerMessage', () => {
         // @ts-ignore allow assignment
         nuMsg.message = {};
 
-        const wrapper = getWrapper(nuMsg);
-        expect(wrapper.find('.adyen-checkout-disclaimer__label')).toHaveLength(0);
+        render(<DisclaimerMessage disclaimer={nuMsg} />);
+        expect(screen.queryByRole('link')).toBeNull(); // non-presence
     });
 });

--- a/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.tsx
@@ -1,0 +1,38 @@
+import { h } from 'preact';
+import { DisclaimerMsgObject } from '../../types';
+import { isValidHttpUrl } from '../../../../../../utils/isValidURL';
+import './DisclaimerMessage.scss';
+
+interface DisclaimerMessageProps {
+    disclaimer: DisclaimerMsgObject;
+}
+
+/**
+ * Expects a config object with this shape:
+ *  disclaimerMessage: {
+ *      message: 'By continuing you accept the %{linkText} of MyStore',
+ *      linkText: 'terms and conditions',
+ *      link: 'https://www.adyen.com'
+ *  }
+ */
+export default function DisclaimerMessage({ disclaimer }: DisclaimerMessageProps) {
+    const messageIsStr = typeof disclaimer.message === 'string';
+    const linkTextIsStr = typeof disclaimer.linkText === 'string';
+    if (!messageIsStr || !linkTextIsStr) return null;
+
+    const [textBeforeLink, textAfterLink] = disclaimer.message.split('%{linkText}');
+
+    if (isValidHttpUrl(disclaimer.link)) {
+        return (
+            <span className="adyen-checkout-disclaimer__label">
+                {textBeforeLink}
+                <a className="adyen-checkout__link" target="_blank" rel="noopener noreferrer" href={disclaimer.link}>
+                    {disclaimer.linkText}
+                </a>
+                {textAfterLink}
+            </span>
+        );
+    }
+
+    return null;
+}

--- a/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/DisclaimerMessage.tsx
@@ -7,6 +7,7 @@ interface DisclaimerMessageProps {
     disclaimer: DisclaimerMsgObject;
 }
 
+/* eslint-disable */
 /**
  * Expects a config object with this shape:
  *  disclaimerMessage: {
@@ -15,6 +16,7 @@ interface DisclaimerMessageProps {
  *      link: 'https://www.adyen.com'
  *  }
  */
+/* eslint-enable */
 export default function DisclaimerMessage({ disclaimer }: DisclaimerMessageProps) {
     const messageIsStr = typeof disclaimer.message === 'string';
     const linkTextIsStr = typeof disclaimer.linkText === 'string';

--- a/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/index.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/DisclaimerMessage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DisclaimerMessage';

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFieldsWrapper.tsx
@@ -4,6 +4,7 @@ import StoredCardFields from './StoredCardFields';
 import Installments from './Installments';
 import { ErrorPanel } from '../../../../../core/Errors/ErrorPanel';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
+import DisclaimerMessage from './DisclaimerMessage';
 
 export const StoredCardFieldsWrapper = ({
     // base (shared)
@@ -28,7 +29,8 @@ export const StoredCardFieldsWrapper = ({
     mergedSRErrors,
     handleErrorPanelFocus,
     moveFocus,
-    showPanel
+    showPanel,
+    disclaimerMessage
 }) => {
     const { i18n } = useCoreContext();
 
@@ -67,6 +69,8 @@ export const StoredCardFieldsWrapper = ({
                     type={showAmountsInInstallments ? 'amount' : 'months'}
                 />
             )}
+
+            {disclaimerMessage && <DisclaimerMessage disclaimer={disclaimerMessage} />}
         </LoadingWrapper>
     );
 };

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -44,6 +44,12 @@ type Placeholders = {
     holderName?: string;
 };
 
+export interface DisclaimerMsgObject {
+    message: string;
+    linkText: string;
+    link: string;
+}
+
 /**
  * Should be the subset of the props sent to CardInput that are *actually* used by CardInput
  * - either in the comp itself or are passed on to its children
@@ -113,6 +119,7 @@ export interface CardInputProps {
     trimTrailingSeparator?: boolean;
     type?: string;
     maskSecurityCode?: boolean;
+    disclaimerMessage?: DisclaimerMsgObject;
 }
 
 export interface CardInputState {

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -171,7 +171,8 @@ export const extractPropsForCardFields = (props: CardInputProps) => {
         // Extract props for StoredCardFields
         lastFour: props.lastFour,
         expiryMonth: props.expiryMonth,
-        expiryYear: props.expiryYear
+        expiryYear: props.expiryYear,
+        disclaimerMessage: props.disclaimerMessage
     };
 };
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '4.3.3';
+export const SF_VERSION = '4.4.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -32,6 +32,9 @@ class Core {
         this.createFromAction = this.createFromAction.bind(this);
 
         this.setOptions(options);
+
+        // Expose version number for npm builds
+        window['adyenWebVersion'] = Core.version.version;
     }
 
     initialize(): Promise<this> {

--- a/packages/lib/src/utils/isValidURL.test.ts
+++ b/packages/lib/src/utils/isValidURL.test.ts
@@ -1,0 +1,19 @@
+import { isValidHttpUrl } from './isValidURL';
+
+describe('isValidHttpUrl', () => {
+    test('https url is valid', () => {
+        expect(isValidHttpUrl('https://www.adyen.com')).toEqual(true);
+    });
+    test('http url is not valid', () => {
+        expect(isValidHttpUrl('http://www.adyen.com')).toEqual(false);
+    });
+    test('http url is valid when config arg is passed', () => {
+        expect(isValidHttpUrl('http://www.adyen.com', true)).toEqual(true);
+    });
+    test('url without https is not valid', () => {
+        expect(isValidHttpUrl('www.adyen.com')).toEqual(false);
+    });
+    test('random string is not valid', () => {
+        expect(isValidHttpUrl('blahblahblah')).toEqual(false);
+    });
+});

--- a/packages/lib/src/utils/isValidURL.ts
+++ b/packages/lib/src/utils/isValidURL.ts
@@ -1,0 +1,9 @@
+export const isValidHttpUrl = (string, allowHttp = false) => {
+    let url;
+    try {
+        url = new URL(string);
+    } catch (_) {
+        return false;
+    }
+    return allowHttp ? url.protocol === 'http:' || url.protocol === 'https:' : url.protocol === 'https:';
+};


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Due to the introduction of a new Danish regulation, we need to find a way to support the addition of a disclaimer message to the card components.

A new config property can now be added to a `card` or `storedCard`:
```
disclaimerMessage: {
     message: 'By continuing you accept the %{linkText} of MyStore',
     linkText: 'terms and conditions',
     link: 'https://www.adyen.com'
 }
```
This allows us to create disclaimer messages both in the form:
>"By continuing you accept the <a href="https://www.adyen.com">terms and conditions</a> of MyStore" 

and, 
>"By continuing you accept the <a href="https://www.adyen.com">terms and conditions</a>"

where "terms and conditions" is a merchant defined link (in this case to a https://www.adyen.com)

**Result:** This will add the disclaimer message as the final element in the component, placing it above the "Pay" button if one is present.

_Caveat:_ The url set in the `link` property must use the  `https://` protocol

## Tested scenarios
Added new unit tests
All existing unit tests pass

**Fixed issue**:  COWEB-1191
