### PR TITLE
Fixing failing e2e tests

### DIFF
--- a/packages/e2e/tests/bacsDD/bacs.clientScripts.js
+++ b/packages/e2e/tests/bacsDD/bacs.clientScripts.js
@@ -3,5 +3,10 @@ window.dropinConfig = {
 };
 
 window.mainConfiguration = {
-    removePaymentMethods: ['paywithgoogle', 'applepay']
+    removePaymentMethods: ['paywithgoogle', 'applepay'],
+    paymentMethodsConfiguration: {
+        card: {
+            _disableClickToPay: true
+        }
+    }
 };

--- a/packages/e2e/tests/cards/Bancontact/bancontact.clientScripts.js
+++ b/packages/e2e/tests/cards/Bancontact/bancontact.clientScripts.js
@@ -4,5 +4,10 @@ window.dropinConfig = {
 
 window.mainConfiguration = {
     removePaymentMethods: ['paywithgoogle', 'applepay'],
-    allowPaymentMethods: ['bcmc']
+    allowPaymentMethods: ['bcmc'],
+    paymentMethodsConfiguration: {
+        bcmc: {
+            _disableClickToPay: true
+        }
+    }
 };

--- a/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.clientScripts.js
+++ b/packages/e2e/tests/cards/binLookup/responseAndCallbacks/binLookup.clientScripts.js
@@ -21,6 +21,6 @@ window.cardConfig = {
 window.dropinConfig = {
     showStoredPaymentMethods: false, // hide stored PMs so credit card is first on list
     paymentMethodsConfiguration: {
-        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire'] }
+        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire'], _disableClickToPay: true }
     }
 };

--- a/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.clientScripts.js
+++ b/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.clientScripts.js
@@ -21,6 +21,6 @@ window.cardConfig = {
 window.dropinConfig = {
     showStoredPaymentMethods: false, // hide stored PMs so credit card is first on list
     paymentMethodsConfiguration: {
-        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire'] }
+        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire'], _disableClickToPay: true }
     }
 };

--- a/packages/e2e/tests/cards/dualBranding/binLookup.branding.reset.clientScripts.js
+++ b/packages/e2e/tests/cards/dualBranding/binLookup.branding.reset.clientScripts.js
@@ -13,6 +13,6 @@ window.dropinConfig = {
 window.mainConfiguration = {
     removePaymentMethods: ['paywithgoogle', 'applepay'],
     paymentMethodsConfiguration: {
-        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire', 'bcmc', 'maestro'] }
+        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire', 'bcmc', 'maestro'], _disableClickToPay: true }
     }
 };

--- a/packages/e2e/tests/cards/dualBranding/dualBranding.clientScripts.js
+++ b/packages/e2e/tests/cards/dualBranding/dualBranding.clientScripts.js
@@ -13,6 +13,6 @@ window.dropinConfig = {
 window.mainConfiguration = {
     removePaymentMethods: ['paywithgoogle', 'applepay'],
     paymentMethodsConfiguration: {
-        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire', 'star'] }
+        card: { brands: ['mc', 'amex', 'visa', 'cartebancaire', 'star'], _disableClickToPay: true }
     }
 };

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.clientScripts.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.clientScripts.js
@@ -14,6 +14,9 @@ window.mainConfiguration = {
     paymentMethodsConfiguration: {
         threeDS2: {
             challengeWindowSize: '04'
+        },
+        card: {
+            _disableClickToPay: true
         }
     }
 };

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.default.size.clientScripts.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.default.size.clientScripts.js
@@ -3,5 +3,10 @@ window.dropinConfig = {
 };
 
 window.mainConfiguration = {
-    removePaymentMethods: ['paywithgoogle', 'applepay']
+    removePaymentMethods: ['paywithgoogle', 'applepay'],
+    paymentMethodsConfiguration: {
+        card: {
+            _disableClickToPay: true
+        }
+    }
 };

--- a/packages/e2e/tests/cards/threeDS2/threeDS2.handleAction.clientScripts.js
+++ b/packages/e2e/tests/cards/threeDS2/threeDS2.handleAction.clientScripts.js
@@ -14,6 +14,9 @@ window.mainConfiguration = {
     paymentMethodsConfiguration: {
         threeDS2: {
             challengeWindowSize: '04'
+        },
+        card: {
+            _disableClickToPay: true
         }
     }
 };

--- a/packages/e2e/tests/cards/utils/threeDS2Utils.js
+++ b/packages/e2e/tests/cards/utils/threeDS2Utils.js
@@ -1,15 +1,36 @@
-import { fillIFrame, getIframeSelector } from '../../utils/commonUtils';
+import { getIframeSelector } from '../../utils/commonUtils';
 
 const iframeSelector = getIframeSelector('.adyen-checkout__threeds2__challenge iframe');
 
+// Added now acs simulator places another iframe inside the iframe that we provide in Components
+const iframeSelector2 = getIframeSelector('[name="acsFrame"]');
+
 export const fillChallengeField = async (t, value = 'password', action) => {
-    return fillIFrame(t, iframeSelector, 0, '.input-field', value, action);
+    let replace = false;
+    let paste = false;
+    switch (action) {
+        case 'replace':
+            replace = true;
+            break;
+        case 'paste':
+            replace = paste = true;
+            break;
+        default: // 'add'
+    }
+
+    return t
+        .switchToMainWindow()
+        .switchToIframe(iframeSelector.nth(0))
+        .switchToIframe(iframeSelector2.nth(0))
+        .typeText('.input-field', value, { replace, paste })
+        .switchToMainWindow();
 };
 
 export const submitChallenge = async t => {
     return t
         .switchToMainWindow()
         .switchToIframe(iframeSelector.nth(0))
+        .switchToIframe(iframeSelector2.nth(0))
         .click('[type="submit"]')
         .switchToMainWindow();
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixing existing e2e tests most of which were failing because of the presence of ClickToPay (which was slowing things down &/or adding unexpected elements to the page)
Also the 3DS2 tests were failing because the ACS simulator has added another iframe to the markup.

## Tested scenarios
e2e tests are now passing
