### PR TITLE
When local storage isn't available fall back to a non-persistent storage solution

### DIFF
--- a/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
+++ b/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
@@ -28,7 +28,7 @@ class Session {
         const session = sanitizeSession(rawSession) as CheckoutSession;
         if (!clientKey) throw new Error('No clientKey available');
 
-        this.storage = new Storage('session');
+        this.storage = new Storage('session', 'localStorage');
         this.clientKey = clientKey;
         this.loadingContext = loadingContext;
         this.session = session;

--- a/packages/lib/src/core/Services/analytics/collect-id.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.ts
@@ -32,7 +32,7 @@ const collectId = ({ loadingContext, clientKey, experiments }: CollectIdProps) =
         if (promise) return promise;
         if (!clientKey) return Promise.reject();
 
-        const storage = new Storage<CheckoutAttemptIdSession>('checkout-attempt-id', window.sessionStorage);
+        const storage = new Storage<CheckoutAttemptIdSession>('checkout-attempt-id', 'sessionStorage');
         const checkoutAttemptIdSession = storage.get();
 
         if (confirmSessionDurationIsMaxFifteenMinutes(checkoutAttemptIdSession)) {

--- a/packages/lib/src/utils/Storage.ts
+++ b/packages/lib/src/utils/Storage.ts
@@ -1,10 +1,42 @@
+class NonPersistentStorage {
+    private storage;
+
+    constructor() {
+        this.storage = {};
+    }
+
+    get length() {
+        return Object.keys(this.storage).length;
+    }
+
+    key(keyName) {
+        return Object.keys(this.storage).indexOf(keyName);
+    }
+    getItem(keyName) {
+        return this.storage[keyName] || null;
+    }
+    setItem(keyName, keyValue) {
+        return (this.storage[keyName] = keyValue);
+    }
+    removeItem(keyName) {
+        delete this.storage[keyName];
+    }
+    clear() {
+        this.storage = {};
+    }
+}
+
 class Storage<T> {
     private readonly prefix = 'adyen-checkout__';
     private readonly key: string;
-    private storage: globalThis.Storage;
+    private storage: globalThis.Storage | NonPersistentStorage;
 
-    constructor(key: string, storage = window.localStorage) {
-        this.storage = storage;
+    constructor(key: string, storageType: 'sessionStorage' | 'localStorage') {
+        try {
+            this.storage = storageType ? window[storageType] : window.localStorage;
+        } catch (e) {
+            this.storage = new NonPersistentStorage();
+        }
         this.key = this.prefix + key;
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Following the reported issue (#2020) that `window.localStorage` (and `window.sessionStorage`) throw errors when they are accessed within a Dropin/Components instance that is presented in an _iframe, in a Chrome Incognito window_ - this PR provides a fallback to a non persistent form of storage to avoid these errors.

~~**TODO** The ClickToPay, checking for registered cards functionality, also seems to fail in this scenario - which requires further investigation~~

## Tested scenarios
Dropin, in an iframe, in a Chrome Incognito window - doesn't throw errors related to `localStorage` or `sessionStorage`


**Fixed issue**:  #2020 
