### PR TITLE
Enable messages component for configuring pay later in Paypal

### DIFF
--- a/packages/lib/src/components/PayPal/defaultProps.ts
+++ b/packages/lib/src/components/PayPal/defaultProps.ts
@@ -44,6 +44,8 @@ const defaultProps: PayPalElementProps = {
     blockPayPalCreditButton: false,
 
     blockPayPalPayLaterButton: false,
+    
+    enableMessages: false,
 
     configuration: {
         /**

--- a/packages/lib/src/components/PayPal/types.ts
+++ b/packages/lib/src/components/PayPal/types.ts
@@ -81,6 +81,12 @@ interface PayPalCommonProps {
     blockPayPalPayLaterButton?: boolean;
 
     /**
+     * Set to true to force the UI to load Paypal Messages Component
+     * @defaultValue false
+     */
+    enableMessages?: boolean;
+
+    /**
      * @see {@link https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-configuration/#csp-nonce}
      */
     cspNonce?: string;

--- a/packages/lib/src/components/PayPal/utils.test.ts
+++ b/packages/lib/src/components/PayPal/utils.test.ts
@@ -1,5 +1,4 @@
-import { getStyle, getSupportedLocale } from './utils';
-
+import { getStyle, getSupportedLocale, getPaypalUrl } from './utils';
 describe('getStyle', () => {
     test('return the same styles for the regular PayPal button', () => {
         const style = { color: 'gold', height: 48 };
@@ -19,5 +18,40 @@ describe('getSupportedLocale', () => {
 
     test('return null if the passed locale is not supported', () => {
         expect(getSupportedLocale('es_AR')).toBe(null);
+    });
+});
+
+describe('getPaypalUrl', () => {
+    test('return the url to be with messages component when enableMessages is undefined/false', () => {
+        const props: any = {
+            amount: { currency: 'USD', value: 100 },
+            countryCode: 'US',
+            environment: 'test',
+            locale: 'en-US',
+            configuration: {
+                merchantId: 'fakeMerchant',
+                intent: 'fakeIntents'
+            }
+        };
+        const url = getPaypalUrl(props);
+        const messagesComponent = url.split('&components=')[1];
+        expect(messagesComponent).toBe('buttons,funding-eligibility');
+    });
+
+    test('return the url to be with messages component when all enableMessages is set to true', () => {
+        const props: any = {
+            amount: { currency: 'USD', value: 100 },
+            countryCode: 'US',
+            environment: 'test',
+            locale: 'en-US',
+            enableMessages: true,
+            configuration: {
+                merchantId: 'fakeMerchant',
+                intent: 'fakeIntents'
+            }
+        };
+        const url = getPaypalUrl(props);
+        const messagesComponent = url.split('&components=')[1];
+        expect(messagesComponent).toBe('buttons,funding-eligibility,messages');
     });
 });

--- a/packages/lib/src/components/PayPal/utils.ts
+++ b/packages/lib/src/components/PayPal/utils.ts
@@ -37,7 +37,7 @@ const getPaypalSettings = ({
     configuration,
     commit,
     vault,
-    enableMessages = false
+    enableMessages
 }: PayPalElementProps): PaypalSettings => {
     const shopperLocale: SupportedLocale = getSupportedLocale(locale);
     const currency: string = amount ? amount.currency : null;

--- a/packages/lib/src/components/PayPal/utils.ts
+++ b/packages/lib/src/components/PayPal/utils.ts
@@ -44,10 +44,8 @@ const getPaypalSettings = ({
     const isTestEnvironment: boolean = environment.toLowerCase() === 'test';
     const clientId: string = isTestEnvironment ? ADYEN_CLIENTID_TEST : ADYEN_CLIENTID_LIVE;
     const { merchantId, intent } = configuration;
-    let components = 'buttons,funding-eligibility';
-    if (enableMessages) {
-        components = components + ',messages';
-    }
+    const components = `buttons,funding-eligibility${enableMessages ? ',messages' : ''}`;
+
     return {
         ...(merchantId && { 'merchant-id': merchantId }),
         ...(shopperLocale && { locale: shopperLocale }),

--- a/packages/lib/src/components/PayPal/utils.ts
+++ b/packages/lib/src/components/PayPal/utils.ts
@@ -57,7 +57,7 @@ const getPaypalSettings = ({
         'client-id': clientId,
         'integration-date': INTEGRATION_DATE,
         'enable-funding': 'paylater',
-        components: 'buttons,funding-eligibility'
+        components: 'buttons,funding-eligibility,messages'
     };
 };
 

--- a/packages/lib/src/components/PayPal/utils.ts
+++ b/packages/lib/src/components/PayPal/utils.ts
@@ -36,15 +36,18 @@ const getPaypalSettings = ({
     locale,
     configuration,
     commit,
-    vault
+    vault,
+    enableMessages = false
 }: PayPalElementProps): PaypalSettings => {
     const shopperLocale: SupportedLocale = getSupportedLocale(locale);
     const currency: string = amount ? amount.currency : null;
     const isTestEnvironment: boolean = environment.toLowerCase() === 'test';
     const clientId: string = isTestEnvironment ? ADYEN_CLIENTID_TEST : ADYEN_CLIENTID_LIVE;
-
     const { merchantId, intent } = configuration;
-
+    let components = 'buttons,funding-eligibility';
+    if (enableMessages) {
+        components = components + ',messages';
+    }
     return {
         ...(merchantId && { 'merchant-id': merchantId }),
         ...(shopperLocale && { locale: shopperLocale }),
@@ -57,7 +60,7 @@ const getPaypalSettings = ({
         'client-id': clientId,
         'integration-date': INTEGRATION_DATE,
         'enable-funding': 'paylater',
-        components: 'buttons,funding-eligibility,messages'
+        components
     };
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- This change will enable the messages component for paypal's pay later 
- Refer https://developer.paypal.com/docs/checkout/pay-later/us/
- 
- What existing problem does this pull request solve?
--> Currently Adyen web lacks the functionality to configure/customise pay-later messages if somebody is trying to integrate paypal's [pay in 4](https://developer.paypal.com/docs/checkout/pay-later/us/)
With the proposed changes the library will expose the Messages component from the paypal's sdk (refer url above)

Highlights:
- Added new configuration property for Paypal, named `enableMessages`  (default value: false) , which based on its value the SDK enables the [PayPal Pay Later Messages](https://developer.paypal.com/docs/checkout/pay-later/us/integrate/)

## Tested scenarios
<!-- Description of tested scenarios -->
-NA-

**Fixed issue**:  <!-- #-prefixed issue number -->
