### PR TITLE
Feature/small a11y fixes

### DIFF
--- a/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
@@ -75,7 +75,8 @@ function FieldContainer(props: FieldContainerProps) {
                         onBlur,
                         maxlength,
                         trimOnBlur,
-                        disabled
+                        disabled,
+                        required: isOptional ? false : true
                     })}
                 </Field>
             );

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -126,15 +126,13 @@ const Field: FunctionalComponent<FieldProps> = props => {
                         </span>
                     )}
                 </div>
-                {errorMessage && typeof errorMessage === 'string' && errorMessage.length && (
-                    <span
-                        className={'adyen-checkout__error-text'}
-                        {...(errorVisibleToSR && { id: `${uniqueId.current}${ARIA_ERROR_SUFFIX}` })}
-                        aria-hidden={errorVisibleToSR ? null : 'true'}
-                    >
-                        {errorMessage}
-                    </span>
-                )}
+                <span
+                    className={'adyen-checkout__error-text'}
+                    {...(errorVisibleToSR && { id: `${uniqueId.current}${ARIA_ERROR_SUFFIX}` })}
+                    aria-hidden={errorVisibleToSR ? null : 'true'}
+                >
+                    {errorMessage}
+                </span>
             </Fragment>
         );
     }, [children, errorMessage, isLoading, isValid, label, onFocusHandler, onBlurHandler]);

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -37,7 +37,8 @@ const Field: FunctionalComponent<FieldProps> = props => {
         errorVisibleToScreenReader
     } = props;
 
-    // Controls whether any error element has an aria-hidden attr & and id attr that can be pointed to by an aria-describedby attr on an input element
+    // Controls whether any error element has an aria-hidden="true" attr (which means it is the error for a securedField)
+    // or whether it has an id attr that can be pointed to by an aria-describedby attr on an input element
     const errorVisibleToSR = errorVisibleToScreenReader ?? true;
 
     const uniqueId = useRef(getUniqueId(`adyen-checkout-${name}`));
@@ -138,7 +139,7 @@ const Field: FunctionalComponent<FieldProps> = props => {
         );
     }, [children, errorMessage, isLoading, isValid, label, onFocusHandler, onBlurHandler]);
 
-    const LabelOrDiv = useCallback(({ onFocusField, focused, filled, disabled, name, uniqueId, useLabelElement, children }) => {
+    const LabelOrDiv = useCallback(({ onFocusField, focused, filled, disabled, name, uniqueId, useLabelElement, errorVisibleToSR, children }) => {
         const defaultWrapperProps = {
             onClick: onFocusField,
             className: classNames({
@@ -150,7 +151,8 @@ const Field: FunctionalComponent<FieldProps> = props => {
         };
 
         return useLabelElement ? (
-            <label {...defaultWrapperProps} htmlFor={name && uniqueId}>
+            // if errorVisibleToSR is true then we are NOT dealing with the label for a securedField... so give it a `for` attribute
+            <label {...defaultWrapperProps} {...(errorVisibleToSR && { htmlFor: name && uniqueId })}>
                 {children}
             </label>
         ) : (
@@ -183,6 +185,7 @@ const Field: FunctionalComponent<FieldProps> = props => {
                 focused={focused}
                 useLabelElement={useLabelElement}
                 uniqueId={uniqueId.current}
+                errorVisibleToSR={errorVisibleToSR}
             >
                 {renderContent()}
             </LabelOrDiv>

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -107,7 +107,7 @@ export default function PersonalDetails(props: PersonalDetailsProps) {
                 )}
 
                 {requiredFields.includes('gender') && (
-                    <Field errorMessage={!!errors.gender} classNameModifiers={['gender']} name={'gender'} useLabelElement={false}>
+                    <Field errorMessage={getErrorMessage(errors.gender)} classNameModifiers={['gender']} name={'gender'} useLabelElement={false}>
                         {renderFormField('radio', {
                             i18n,
                             name: generateFieldName('gender'),

--- a/packages/lib/src/components/internal/PersonalDetails/validate.ts
+++ b/packages/lib/src/components/internal/PersonalDetails/validate.ts
@@ -19,6 +19,11 @@ export const personalDetailsValidationRules: ValidatorRules = {
         errorMessage: 'error.va.gen.02', // = "field not valid"
         modes: ['blur']
     },
+    gender: {
+        validate: value => value && value.length > 0,
+        errorMessage: 'gender.notselected',
+        modes: ['blur']
+    },
     firstName: {
         validate: value => (isEmpty(value) ? null : true), // valid, if there are chars other than spaces,
         errorMessage: 'firstName.invalid',

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -68,6 +68,7 @@
     "dateOfBirth": "Date of birth",
     "shopperEmail": "Email address",
     "gender": "Gender",
+    "gender.notselected": "Select a gender",
     "male": "Male",
     "female": "Female",
     "billingAddress": "Billing address",

--- a/packages/playground/src/pages/Helpers/Helpers.js
+++ b/packages/playground/src/pages/Helpers/Helpers.js
@@ -67,6 +67,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                     },
                     modes: ['blur']
                 },
+                // Example of overwriting the default validation rule (which doesn't consider an empty field to be in error, unless the whole form is being validated)
+                // with a new rule that will throw an error on a field if you click into it and then click out again leaving it empty
                 default: {
                     validate: value => value && value.length > 0,
                     modes: ['blur']


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Some small fixes/improvements for a11y:
- the `gender` field (in the `PersonalDetails` component) now shows  a _visual_ error message
- `Address` _input_ fields have a `required/aria-required` attribute, where appropriate
- labels for securedField elements no longer have a `for` attribute pointing to the securedField input (since it exists in another DOM)
- `aria-describedby` elements (the visual error fields) are always present in the DOM

## Tested scenarios
Manually confirmed above scenarios
All unit tests pass


