### PR TITLE
ideal shows errors: both as visual, text, errors and in the SRPanel

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/handlers.ts
+++ b/packages/lib/src/components/Card/components/CardInput/handlers.ts
@@ -81,7 +81,7 @@ const setFocusOnNonSF = (field, sfp) => {
 
     if (nameVal === 'country' || nameVal === 'stateOrProvince') {
         // Set focus on dropdown
-        const field: HTMLElement = selectOne(sfp.current.rootNode, `.adyen-checkout__field--${nameVal} .adyen-checkout__dropdown__button`);
+        const field: HTMLElement = selectOne(sfp.current.rootNode, `.adyen-checkout__field--${nameVal} .adyen-checkout__filter-input`);
         field?.focus();
     } else {
         // Set focus on input

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -8,6 +8,7 @@ import CoreProvider from '../../core/Context/CoreProvider';
 import Language from '../../language/Language';
 import { IssuerItem } from '../internal/IssuerList/types';
 import RedirectButton from '../internal/RedirectButton';
+import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 
 interface IssuerListContainerProps extends UIElementProps {
     showImage?: boolean;
@@ -96,18 +97,20 @@ class IssuerListContainer extends UIElement<IssuerListContainerProps> {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext}>
                 {this.props.issuers.length > 0 ? (
-                    <IssuerList
-                        ref={ref => {
-                            this.componentRef = ref;
-                        }}
-                        items={this.props.issuers}
-                        highlightedIds={this.props.highlightedIssuers}
-                        {...this.props}
-                        {...this.state}
-                        onChange={this.setState}
-                        onSubmit={this.submit}
-                        payButton={this.payButton}
-                    />
+                    <SRPanelProvider srPanel={this.props.modules.srPanel}>
+                        <IssuerList
+                            ref={ref => {
+                                this.componentRef = ref;
+                            }}
+                            items={this.props.issuers}
+                            highlightedIds={this.props.highlightedIssuers}
+                            {...this.props}
+                            {...this.state}
+                            onChange={this.setState}
+                            onSubmit={this.submit}
+                            payButton={this.payButton}
+                        />
+                    </SRPanelProvider>
                 ) : (
                     <RedirectButton
                         name={this.props.name}

--- a/packages/lib/src/core/Errors/SRPanelContext.ts
+++ b/packages/lib/src/core/Errors/SRPanelContext.ts
@@ -4,7 +4,7 @@ import { SetSRMessagesReturnFn } from './SRPanelProvider';
 
 export interface ISRPanelContext {
     srPanel: SRPanel;
-    setSRMessagesFromObjects: ({ fieldTypeMappingFn }) => SetSRMessagesReturnFn;
+    setSRMessagesFromObjects: ({ fieldTypeMappingFn = null }) => SetSRMessagesReturnFn;
     setSRMessagesFromStrings: (strs) => void;
     clearSRPanel: () => void;
     shouldMoveFocusSR: boolean;

--- a/packages/lib/src/utils/setFocus.ts
+++ b/packages/lib/src/utils/setFocus.ts
@@ -8,13 +8,15 @@ import { selectOne } from '../components/internal/SecuredFields/lib/utilities/do
 export const setFocusOnField = (holder, fieldToFocus) => {
     const pdHolder = selectOne(document, holder);
 
-    if (fieldToFocus === 'country' || fieldToFocus === 'stateOrProvince') {
+    const actualFieldToFocus = fieldToFocus === 'issuer' ? 'issuer-list' : fieldToFocus;
+
+    if (actualFieldToFocus === 'country' || actualFieldToFocus === 'stateOrProvince' || actualFieldToFocus === 'issuer-list') {
         // Set focus on dropdown
-        const field: HTMLElement = selectOne(pdHolder, `.adyen-checkout__field--${fieldToFocus} .adyen-checkout__dropdown__button`);
+        const field: HTMLElement = selectOne(pdHolder, `.adyen-checkout__field--${actualFieldToFocus} .adyen-checkout__filter-input`);
         field?.focus();
     } else {
         // Set focus on input
-        const field: HTMLElement = selectOne(pdHolder, `[name="${fieldToFocus}"]`);
+        const field: HTMLElement = selectOne(pdHolder, `[name="${actualFieldToFocus}"]`);
         field?.focus();
     }
 };

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.html
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.html
@@ -88,15 +88,6 @@
 
                 <div class="merchant-checkout__payment-method">
                     <div class="merchant-checkout__payment-method__header">
-                        <h2>OpenBanking - GB 🇬🇧</h2>
-                    </div>
-                    <div class="merchant-checkout__payment-method__details">
-                        <div class="openbanking_UK-field"></div>
-                    </div>
-                </div>
-
-                <div class="merchant-checkout__payment-method">
-                    <div class="merchant-checkout__payment-method__header">
                         <h2>MolPay - MY 🇲🇾</h2>
                     </div>
                     <div class="merchant-checkout__payment-method__details">

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.js
@@ -56,7 +56,4 @@ import '../../style.scss';
 
     // Molpay MY
     window.molpay = checkout.create('molpay_ebanking_fpx_MY').mount('.molpay-field');
-
-    // Open Banking OK
-    window.openbanking_UK = checkout.create('openbanking_UK').mount('.openbanking_UK-field');
 })();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The `issuerList` component e.g. iDeal was neither showing a visual, text, error, nor was it announcing anything to the screenreader.
Now it uses the SRPanel as well as showing a translatable, text error.

## Tested scenarios
Manually tested - to see both types of error are now generated
All unit tests pass


