### PR TITLE
Stop creating double modules in /sessions flow

### DIFF
--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -198,11 +198,12 @@ class Core {
         this.options.loadingContext = resolveEnvironment(this.options.environment);
         this.options.locale = this.options.locale || this.options.shopperLocale;
 
+        // In a sessions flow setOptions gets called twice, but we only need one set of modules (except for i18n needs to be re-initialised as the options settle)
         this.modules = {
-            risk: new RiskModule(this.options),
-            analytics: new Analytics(this.options),
+            risk: !this.modules?.risk ? new RiskModule(this.options) : this.modules.risk,
+            analytics: !this.modules?.analytics ? new Analytics(this.options) : this.modules.analytics,
             i18n: new Language(this.options.locale, this.options.translations),
-            srPanel: new SRPanel(this.options.srConfig)
+            srPanel: !this.modules?.srPanel ? new SRPanel(this.options.srConfig) : this.modules.srPanel
         };
 
         this.paymentMethodsResponse = new PaymentMethodsResponse(this.options.paymentMethodsResponse ?? this.options.paymentMethods, this.options);

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -200,10 +200,10 @@ class Core {
 
         // In a sessions flow setOptions gets called twice, but we only need one set of modules (except for i18n needs to be re-initialised as the options settle)
         this.modules = {
-            risk: !this.modules?.risk ? new RiskModule(this.options) : this.modules.risk,
-            analytics: !this.modules?.analytics ? new Analytics(this.options) : this.modules.analytics,
+            risk: this.modules?.risk ?? new RiskModule(this.options),
+            analytics: this.modules?.analytics ?? new Analytics(this.options),
             i18n: new Language(this.options.locale, this.options.translations),
-            srPanel: !this.modules?.srPanel ? new SRPanel(this.options.srConfig) : this.modules.srPanel
+            srPanel: this.modules?.srPanel ?? new SRPanel(this.options.srConfig)
         };
 
         this.paymentMethodsResponse = new PaymentMethodsResponse(this.options.paymentMethodsResponse ?? this.options.paymentMethods, this.options);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`core.ts` calls `setOptions` twice during the setup for the `/sessions` flow - which has the side effect of instantiating the modules twice.
This PR prevents this and is a stopgap whilst we re-examine the startup process to investigate how we can call `setOptions` just once

## Tested scenarios
Risk, Analytics & SRPanel modules are only created once
