### PR TITLE
Fixes contrast ratio for button outline and brand number indicator

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
@@ -157,7 +157,7 @@
     overflow: hidden;
 
     & .adyen-checkout__payment-method__brand-number {
-        color: #99a3ad;
+        color: $color-gray-darker;
         font-size: 13px;
     }
 }

--- a/packages/lib/src/style/colors.scss
+++ b/packages/lib/src/style/colors.scss
@@ -8,7 +8,7 @@ $color-gray-lighter: #f7f8f9;
 $color-white: #fff;
 $color-new-gray-darker: #707070;
 $color-blue: #0075ff;
-$color-blue-light: #99c2ff;
+$color-blue-light: #3070ED;
 $color-blue-lighter: #e5efff;
 $color-green: #089a43;
 $color-orange: #ffae42;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Adds a new colour and fixes the contrast ratio of the brand number indicator.

The new colour for the button and UI outline can be seen in this screnshot.

![Screenshot 2023-03-24 at 18 41 14](https://user-images.githubusercontent.com/6471825/227601731-ab610b4f-3a84-4bf2-959b-bde144f7aa81.png)


## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
