### PR TITLE
Fixing storedPaymentMethods check typo

### DIFF
--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/PaymentMethodsResponse.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/PaymentMethodsResponse.ts
@@ -1,11 +1,11 @@
-import { PaymentMethod } from '../../../types';
+import { PaymentMethod, StoredPaymentMethod } from '../../../types';
 import { checkPaymentMethodsResponse, processPaymentMethods, processStoredPaymentMethods } from './utils';
 
 class PaymentMethodsResponse {
     public paymentMethods: PaymentMethod[] = [];
-    public storedPaymentMethods: PaymentMethod[] = [];
+    public storedPaymentMethods: StoredPaymentMethod[] = [];
 
-    constructor(response, options = {}) {
+    constructor(response: PaymentMethodsResponse, options = {}) {
         checkPaymentMethodsResponse(response);
 
         this.paymentMethods = response ? processPaymentMethods(response.paymentMethods, options) : [];

--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/types.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/types.ts
@@ -1,16 +1,12 @@
 import { PaymentMethod, StoredPaymentMethod } from '../../../types';
 
-export interface PaymentMethodsResponseObject {
+export interface PaymentMethodsResponse {
     /**
      * Detailed list of payment methods required to generate payment forms.
      */
-    paymentMethods: PaymentMethod[];
-
+    paymentMethods?: PaymentMethod[];
     /**
      * List of all stored payment methods.
      */
     storedPaymentMethods?: StoredPaymentMethod[];
-
-    groups?: any;
-    oneClickPaymentMethods?: any;
 }

--- a/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/utils.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentMethodsResponse/utils.ts
@@ -5,8 +5,9 @@ import {
     filterRemovedPaymentMethods,
     filterSupportedStoredPaymentMethods
 } from './filters';
+import { PaymentMethodsResponse } from './types';
 
-const processStoredPaymentMethod = (pm): PaymentMethod => ({
+const processStoredPaymentMethod = (pm): StoredPaymentMethod => ({
     ...pm,
     storedPaymentMethodId: pm.id
 });
@@ -20,7 +21,7 @@ export const processPaymentMethods = (paymentMethods: PaymentMethod[], { allowPa
 export const processStoredPaymentMethods = (
     storedPaymentMethods: StoredPaymentMethod[],
     { allowPaymentMethods = [], removePaymentMethods = [] }
-): PaymentMethod[] => {
+): StoredPaymentMethod[] => {
     if (!storedPaymentMethods) return [];
 
     return storedPaymentMethods
@@ -31,22 +32,22 @@ export const processStoredPaymentMethods = (
         .map(processStoredPaymentMethod);
 };
 
-export const checkPaymentMethodsResponse = response => {
-    if (typeof response === 'string') {
+export const checkPaymentMethodsResponse = (paymentMethodsResponse: PaymentMethodsResponse) => {
+    if (typeof paymentMethodsResponse === 'string') {
         throw new Error(
             'paymentMethodsResponse was provided but of an incorrect type (should be an object but a string was provided).' +
                 'Try JSON.parse("{...}") your paymentMethodsResponse.'
         );
     }
 
-    if (response instanceof Array) {
+    if (paymentMethodsResponse instanceof Array) {
         throw new Error(
             'paymentMethodsResponse was provided but of an incorrect type (should be an object but an array was provided).' +
                 'Please check you are passing the whole response.'
         );
     }
 
-    if (response && !response?.paymentMethods?.length && !response?.storePaymentMethods?.length) {
+    if (paymentMethodsResponse && !paymentMethodsResponse?.paymentMethods?.length && !paymentMethodsResponse?.storedPaymentMethods?.length) {
         console.warn('paymentMethodsResponse was provided but no payment methods were found.');
     }
 };

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -1,7 +1,7 @@
 import { CustomTranslations, Locales } from '../language/types';
 import { PaymentMethods, PaymentMethodOptions, PaymentActionsType, PaymentAmountExtended, Order } from '../types';
 import { AnalyticsOptions } from './Analytics/types';
-import { PaymentMethodsResponseObject } from './ProcessResponse/PaymentMethodsResponse/types';
+import { PaymentMethodsResponse } from './ProcessResponse/PaymentMethodsResponse/types';
 import { RiskModuleOptions } from './RiskModule/RiskModule';
 
 export interface CoreOptions {
@@ -33,7 +33,7 @@ export interface CoreOptions {
     /**
      * The full `/paymentMethods` response
      */
-    paymentMethodsResponse?: PaymentMethodsResponseObject;
+    paymentMethodsResponse?: PaymentMethodsResponse;
 
     /**
      * Amount of the payment

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -148,6 +148,7 @@ export interface StoredPaymentMethod extends PaymentMethod {
 
     /**
      * A unique identifier of this stored payment method.
+     * Mapped from 'storedPaymentMethod.id'
      */
     storedPaymentMethodId?: string;
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The property name wasn't correct when checking for 'storedPaymentMethods'. It was written as 'storePaymentMethods'.

This PR:
- Fix the typo
- Adds typescript to that part of the code, so we don't have such mistakes again
