### PR TITLE
ApplePay -  Fixing Typescript types and Wallets playground

### DIFF
--- a/packages/lib/src/components/ApplePay/payment-request.ts
+++ b/packages/lib/src/components/ApplePay/payment-request.ts
@@ -1,8 +1,11 @@
 import { getDecimalAmount } from '../../utils/amount-util';
+import { PaymentAmount } from '../../types';
 
-const formatAmount = amount => String(getDecimalAmount(amount.value, amount.currency));
+const formatAmount = (amount: PaymentAmount) => String(getDecimalAmount(amount.value, amount.currency));
 
-export const preparePaymentRequest = ({ countryCode, companyName, amount, ...props }): ApplePayJS.ApplePayPaymentRequest => {
+export const preparePaymentRequest = (paymentRequest): ApplePayJS.ApplePayPaymentRequest => {
+    const { countryCode, companyName, amount, ...props } = paymentRequest;
+
     const formattedAmount = formatAmount(amount);
 
     return {

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -1,4 +1,3 @@
-import { PaymentAmount } from '../../types';
 import { UIElementProps } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -40,8 +39,6 @@ export interface ApplePayElementProps extends UIElementProps {
      */
     version?: number;
 
-    amount: PaymentAmount;
-
     /**
      * The merchant’s two-letter ISO 3166 country code.
      */
@@ -58,7 +55,10 @@ export interface ApplePayElementProps extends UIElementProps {
      */
     totalPriceStatus?: ApplePayJS.ApplePayLineItemType;
 
-    configuration: {
+    /**
+     * ApplePay configuration sent by the /paymentMethods response
+     */
+    configuration?: {
         merchantName?: string;
         merchantId?: string;
     };

--- a/packages/playground/src/pages/Wallets/Wallets.js
+++ b/packages/playground/src/pages/Wallets/Wallets.js
@@ -167,20 +167,13 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
 
     // APPLE PAY
     const applepay = checkout.create('applepay', {
-        // Callbacks
+        onClick: (resolve, reject) => {
+            console.log('Apple Pay - Button clicked');
+            resolve();
+        },
         onAuthorized: (resolve, reject, event) => {
             console.log('Apple Pay onAuthorized', event);
             resolve();
-        },
-        // onError: console.error,
-
-        // Payment info
-        countryCode: 'DE', // Required. The merchant’s two-letter ISO 3166 country code.
-
-        // Merchant config (required)
-        configuration: {
-            merchantName: 'Adyen Test merchant', // Name to be displayed
-            merchantIdentifier: '000000000200001' // Required. https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951611-merchantidentifier
         },
         buttonType: 'buy'
     });
@@ -188,11 +181,12 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     applepay
         .isAvailable()
         .then(isAvailable => {
-            // Demo only
-            if (isAvailable) document.querySelector('#applepay').classList.remove('merchant-checkout__payment-method--hidden');
-
-            // If Available mount it in the dom
-            if (isAvailable) applepay.mount('.applepay-field');
+            if (isAvailable) {
+                // For this Demo only
+                document.querySelector('#applepay').classList.remove('merchant-checkout__payment-method--hidden');
+                // Required: mount ApplePay component
+                applepay.mount('.applepay-field');
+            }
         })
         .catch(e => {
             console.warn(e);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- `UIElement` already has `amount` passed by the Core, therefore there is no need to pass it as props
- `configuration` is passed from the paymentMethods call, so it shouldn't be required
- Adjusted `Wallets` to not use the legacy config values

**Fixed issue**:  #2074 
