### PR TITLE
Fieldset component uses actual fieldset (and legend) elements

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.scss
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.scss
@@ -4,6 +4,14 @@
     display: block;
     padding-bottom: 8px;
     width: 100%;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+    margin: 0;
+    border: none;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
 }
 
 .adyen-checkout__fieldset:last-of-type {

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
@@ -14,16 +14,16 @@ export default function Fieldset({ children, classNameModifiers = [], label, rea
     const { i18n } = useCoreContext();
 
     return (
-        <div
+        <fieldset
             className={cx([
                 'adyen-checkout__fieldset',
                 ...classNameModifiers.map(m => `adyen-checkout__fieldset--${m}`),
                 { 'adyen-checkout__fieldset--readonly': readonly }
             ])}
         >
-            {label && <div className="adyen-checkout__fieldset__title">{i18n.get(label)}</div>}
+            {label && <legend className="adyen-checkout__fieldset__title">{i18n.get(label)}</legend>}
 
             <div className="adyen-checkout__fieldset__fields">{children}</div>
-        </div>
+        </fieldset>
     );
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Following another comment from our a11y partners - the `Fieldset` component we use (in `Address`, `PersonalDetails`, `CompanyDetails`, `IbanInput` & `Installments`) now makes use of the HTML `fieldset` and `legend` elements.
This serves to programmatically group sets of form controls in such a way that Screen reader users will be able to understand the relationship between these form controls

## Tested scenarios
Manually checked that all the components (`Address`, `PersonalDetails` etc) now have a `fieldset` and `legend` in their markup.
Once in the release, further testing will be performed by our a11y partners


**Fixed issue**:  Raised by our a11y partners
