### PR TITLE
Fix: open bank pay button can be toggled for no issuer list

### DIFF
--- a/packages/lib/src/components/PayByBank/PayByBank.spec.ts
+++ b/packages/lib/src/components/PayByBank/PayByBank.spec.ts
@@ -9,21 +9,21 @@ test('should return expected data to perform the payment', () => {
     expect(payByBankEle.formatData()).toEqual({ paymentMethod: { type: 'paybybank' } });
 });
 
-test('should not show the pay button by default', () => {
-    const payByBankEle = new PayByBank({});
-    render(payByBankEle.render());
-    expect(screen.queryByRole('button', { name: 'Continue to Pay By Bank' })).toBeNull();
-    expect(payByBankEle.props.showPayButton).toBeFalsy();
-});
-
-test('should show pay button if property is set to true', async () => {
+test('should show the pay button by default', async () => {
     const i18n = mock<Language>();
     i18n.get.mockImplementation(() => 'Continue to');
     i18n.loaded = Promise.resolve();
 
-    const payByBankEle = new PayByBank({ showPayButton: true, name: 'Pay By Bank', i18n });
+    const payByBankEle = new PayByBank({ name: 'Pay By Bank', i18n });
     render(payByBankEle.render());
     expect(await screen.findByRole('button', { name: 'Continue to Pay By Bank' })).toBeTruthy();
+    expect(payByBankEle.props.showPayButton).toBeTruthy();
+});
+
+test('should hide pay button if property is set to false', () => {
+    const payByBankEle = new PayByBank({ showPayButton: false });
+    render(payByBankEle.render());
+    expect(screen.queryByRole('button', { name: 'Continue to Pay By Bank' })).toBeFalsy();
 });
 
 test('should trigger submit when Pay button is pressed', async () => {

--- a/packages/lib/src/components/PayByBank/PayByBank.spec.ts
+++ b/packages/lib/src/components/PayByBank/PayByBank.spec.ts
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/preact';
+import { mock } from 'jest-mock-extended';
+import userEvent from '@testing-library/user-event';
+import Language from '../../language';
+import PayByBank from './PayByBank';
+
+test('should return expected data to perform the payment', () => {
+    const payByBankEle = new PayByBank({});
+    expect(payByBankEle.formatData()).toEqual({ paymentMethod: { type: 'paybybank' } });
+});
+
+test('should not show the pay button by default', () => {
+    const payByBankEle = new PayByBank({});
+    render(payByBankEle.render());
+    expect(screen.queryByRole('button', { name: 'Continue to Pay By Bank' })).toBeNull();
+    expect(payByBankEle.props.showPayButton).toBeFalsy();
+});
+
+test('should show pay button if property is set to true', async () => {
+    const i18n = mock<Language>();
+    i18n.get.mockImplementation(() => 'Continue to');
+    i18n.loaded = Promise.resolve();
+
+    const payByBankEle = new PayByBank({ showPayButton: true, name: 'Pay By Bank', i18n });
+    render(payByBankEle.render());
+    expect(await screen.findByRole('button', { name: 'Continue to Pay By Bank' })).toBeTruthy();
+});
+
+test('should trigger submit when Pay button is pressed', async () => {
+    const user = userEvent.setup();
+    const i18n = mock<Language>();
+    i18n.get.mockImplementation(() => 'Continue to');
+    i18n.loaded = Promise.resolve();
+
+    const payByBankEle = new PayByBank({ showPayButton: true, name: 'Pay By Bank', i18n });
+    payByBankEle.submit = jest.fn();
+    render(payByBankEle.render());
+    await user.click(await screen.findByRole('button', { name: 'Continue to Pay By Bank' }));
+    expect(payByBankEle.submit).toHaveBeenCalledTimes(1);
+});

--- a/packages/lib/src/components/PayByBank/PayByBank.tsx
+++ b/packages/lib/src/components/PayByBank/PayByBank.tsx
@@ -2,7 +2,6 @@ import IssuerListContainer from '../helpers/IssuerListContainer';
 
 class PayByBank extends IssuerListContainer {
     public static type = 'paybybank';
-
     constructor(props) {
         super({ ...props, showPaymentMethodItemImages: true });
     }

--- a/packages/lib/src/components/PayByBank/PayByBank.tsx
+++ b/packages/lib/src/components/PayByBank/PayByBank.tsx
@@ -2,6 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer';
 
 class PayByBank extends IssuerListContainer {
     public static type = 'paybybank';
+
     constructor(props) {
         super({ ...props, showPaymentMethodItemImages: true });
     }

--- a/packages/lib/src/components/PayByBank/PayByBank.tsx
+++ b/packages/lib/src/components/PayByBank/PayByBank.tsx
@@ -2,8 +2,6 @@ import IssuerListContainer from '../helpers/IssuerListContainer';
 
 class PayByBank extends IssuerListContainer {
     public static type = 'paybybank';
-
-
     constructor(props) {
         super({ ...props, showPaymentMethodItemImages: true });
     }

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -47,7 +47,11 @@ class IssuerListContainer extends UIElement<IssuerListContainerProps> {
         issuers: [],
         highlightedIssuers: [],
         loadingContext: FALLBACK_CONTEXT,
-        showPaymentMethodItemImages: false
+        showPaymentMethodItemImages: false,
+        // Previously we didn't check the showPayButton before rendering the RedirectButton.
+        // Now that we are checking it, all the merchants who don't specify showPayButton in the config will not see the RedirectButton anymore.
+        // To prevent the backward compatible issue, we add it as the default prop, but it should be fixed properly on v6.
+        showPayButton: true
     };
 
     formatProps(props) {

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -112,15 +112,17 @@ class IssuerListContainer extends UIElement<IssuerListContainerProps> {
                         />
                     </SRPanelProvider>
                 ) : (
-                    <RedirectButton
-                        name={this.props.name}
-                        {...this.props}
-                        onSubmit={this.submit}
-                        payButton={this.payButton}
-                        ref={ref => {
-                            this.componentRef = ref;
-                        }}
-                    />
+                    this.props.showPayButton && (
+                        <RedirectButton
+                            name={this.props.name}
+                            {...this.props}
+                            onSubmit={this.submit}
+                            payButton={this.payButton}
+                            ref={ref => {
+                                this.componentRef = ref;
+                            }}
+                        />
+                    )
                 )}
             </CoreProvider>
         );

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.html
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.html
@@ -94,6 +94,15 @@
                         <div class="molpay-field"></div>
                     </div>
                 </div>
+
+                <div class="merchant-checkout__payment-method">
+                    <div class="merchant-checkout__payment-method__header">
+                        <h2>Pay By Bank - NL 🇳🇱</h2>
+                    </div>
+                    <div class="merchant-checkout__payment-method__details">
+                        <div class="paybybank_NL-field"></div>
+                    </div>
+                </div>
             </form>
         </main>
 

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.js
@@ -56,4 +56,7 @@ import '../../style.scss';
 
     // Molpay MY
     window.molpay = checkout.create('molpay_ebanking_fpx_MY').mount('.molpay-field');
+
+    // Pay By Bank
+    window.paybybank_NL = checkout.create('paybybank').mount('.paybybank_NL-field');
 })();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Previously we cannot show/hide the pay button for the payByBank payment when there is no issuer, now it's been fixed.

## Tested scenarios
<!-- Description of tested scenarios -->
- On the playground issuerlists page, set `showPayButton: false` to the `AdyenCheckout` config, the pay button hides
- On the playground issuerlists page, set `showPayButton: true` to the `AdyenCheckout` config, the pay button shows
