### PR TITLE
Add try block round setSelectionRange call in touch handler

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleIOSTouchEvents.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleIOSTouchEvents.ts
@@ -39,18 +39,27 @@ function touchendListener(e: Event): void {
 
         targetEl.value = val;
 
-        if (targetEl.setSelectionRange) {
-            targetEl.focus();
-            targetEl.setSelectionRange(caretPos, caretPos);
+        /**
+         * If the input element is of an unexpected type (perhaps the merchant is using a custom button that is an input element, type="button", or,
+         * it is something presented in the 3DS2 flow - both, TBC) then this next line will not work.
+         * However, the input element still has a setSelectionRange property of type "function", but trying to call it will throw an error...
+         * so, try, to see if setSelectionRange can be called
+         */
+        try {
+            if (targetEl.setSelectionRange) {
+                targetEl.focus();
+                targetEl.setSelectionRange(caretPos, caretPos);
 
-            // Quirky! (see comment above)
-            if (adjFlag) {
-                caretPos += 1;
-                setTimeout(() => {
-                    targetEl.setSelectionRange(caretPos, caretPos);
-                }, 0);
+                // Quirky! (see comment above)
+                if (adjFlag) {
+                    caretPos += 1;
+                    setTimeout(() => {
+                        targetEl.setSelectionRange(caretPos, caretPos);
+                    }, 0);
+                }
             }
-        }
+            /* eslint-disable-next-line */
+        } catch (e) {}
     } else {
         /**
          * Workaround for iOS/Safari bug where keypad doesn't retract when SF paymentMethod is no longer active

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleIOSTouchEvents.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleIOSTouchEvents.ts
@@ -50,7 +50,7 @@ function touchendListener(e: Event): void {
                 targetEl.focus();
                 targetEl.setSelectionRange(caretPos, caretPos);
 
-                // Quirky! (see comment above)
+                // Quirky! (see comment about iOS Safari, above)
                 if (adjFlag) {
                     caretPos += 1;
                     setTimeout(() => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In one of our handlers, added to deal with touch events in iOS, there was a scenario where the `input` element on which the event was fired could be of the wrong _type_. 
The cause of this seems to be when the merchant has added a custom Pay button (an `input` with `type="button"`).
The code that was then run triggered an error.
This PR wraps a `try/catch` block around the code we try to call.

## Tested scenarios
Manually added `input` element, `type="button" - which re-created the error.
Adding the `try` block stops the error from happening.

**Fixed issue**:  #2046
