### PR TITLE
Adds missing alternative text on some images 

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import Img from '../../../../../internal/Img';
 import './AvailableBrands.scss';
 import { BrandConfiguration } from '../../../../types';
+import { BRAND_READABLE_NAME_MAP } from '../../../../../internal/SecuredFields/lib/configuration/constants';
 
 type AvailableBrands = Array<BrandConfiguration>;
 
@@ -24,11 +25,8 @@ const AvailableBrands = ({ brands, activeBrand }: PaymentMethodBrandsProps) => {
             })}
         >
             {brands.map(({ name, icon }) => (
-                <span
-                    key={name}
-                    className="adyen-checkout__card__brands__brand-wrapper"
-                >
-                    <Img src={icon} alt="" />
+                <span key={name} className="adyen-checkout__card__brands__brand-wrapper">
+                    <Img src={icon} alt={BRAND_READABLE_NAME_MAP[name]} />
                 </span>
             ))}
         </span>

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -63,7 +63,7 @@ export default function CVC(props: CVCProps) {
         >
             <DataSfSpan encryptedFieldType={ENCRYPTED_SECURITY_CODE} className={cvcClassnames} />
 
-            <CVCHint frontCVC={frontCVC} />
+            <CVCHint frontCVC={frontCVC} fieldLabel={fieldLabel} />
         </Field>
     );
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import classNames from 'classnames';
 import { CVCHintProps } from './types';
 
-export default function CVCHint({ frontCVC = false }: CVCHintProps) {
+export default function CVCHint({ frontCVC = false, fieldLabel }: CVCHintProps) {
     const hintClassnames = classNames({
         'adyen-checkout__card__cvc__hint__wrapper': true,
         'adyen-checkout__field__cvc--front-hint': !!frontCVC,
@@ -11,7 +11,7 @@ export default function CVCHint({ frontCVC = false }: CVCHintProps) {
 
     /* eslint-disable max-len */
     return (
-        <div className={hintClassnames} aria-hidden={true}>
+        <div className={hintClassnames}>
             <svg
                 className={'adyen-checkout__card__cvc__hint adyen-checkout__card__cvc__hint--front'}
                 width="27"
@@ -19,7 +19,11 @@ export default function CVCHint({ frontCVC = false }: CVCHintProps) {
                 viewBox="0 0 27 18"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                aria-hidden={!frontCVC}
+                aria-describedby={'adyen-checkout__cvc__front-hint-img'}
+                role={'img'}
             >
+                <title id={'adyen-checkout__cvc__front-hint-img'}>{fieldLabel}</title>
                 <path
                     d="M0 3C0 1.34315 1.34315 0 3 0H24C25.6569 0 27 1.34315 27 3V15C27 16.6569 25.6569 18 24 18H3C1.34315 18 0 16.6569 0 15V3Z"
                     fill="#E6E9EB"
@@ -36,7 +40,11 @@ export default function CVCHint({ frontCVC = false }: CVCHintProps) {
                 viewBox="0 0 27 18"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                aria-hidden={!!frontCVC}
+                aria-describedby={'adyen-checkout__cvc__back-hint-img'}
+                role={'img'}
             >
+                <title id={'adyen-checkout__cvc__back-hint-img'}>{fieldLabel}</title>
                 <path
                     d="M27 4.00001V3.37501C27 2.4799 26.6444 1.62146 26.0115 0.988518C25.3786 0.355581 24.5201 0 23.625 0H3.375C2.47989 0 1.62145 0.355581 0.988514 0.988518C0.355579 1.62146 0 2.4799 0 3.37501V4.00001H27Z"
                     fill="#E6E9EB"

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -66,6 +66,7 @@ export interface CVCProps {
 }
 
 export interface CVCHintProps {
+    fieldLabel: string;
     frontCVC: boolean;
 }
 

--- a/packages/lib/src/components/helpers/QRLoaderContainer.tsx
+++ b/packages/lib/src/components/helpers/QRLoaderContainer.tsx
@@ -66,6 +66,7 @@ class QRLoaderContainer<T extends QRLoaderContainerProps = QRLoaderContainerProp
                     countdownTime={this.props.countdownTime}
                     instructions={this.props.instructions}
                     onActionHandled={this.props.onActionHandled}
+                    brandName={this.displayName}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -12,6 +12,7 @@ import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import ContentSeparator from '../ContentSeparator';
 import { StatusObject } from '../Await/types';
+
 const QRCODE_URL = 'barcode.shtml?barcodeType=qrCode&fileType=png&data=';
 
 class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
@@ -136,7 +137,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
             });
     };
 
-    render({ amount, url, brandLogo, countdownTime, type, onActionHandled }: QRLoaderProps, { expired, completed, loading }) {
+    render({ amount, url, brandLogo, brandName, countdownTime, type, onActionHandled }: QRLoaderProps, { expired, completed, loading }) {
         const { i18n, loadingContext } = useCoreContext();
         const qrCodeImage = this.props.qrCodeData ? `${loadingContext}${QRCODE_URL}${this.props.qrCodeData}` : this.props.qrCodeImage;
 
@@ -162,7 +163,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
         if (loading) {
             return (
                 <div className="adyen-checkout__qr-loader">
-                    {brandLogo && <img alt={type} src={brandLogo} className="adyen-checkout__qr-loader__brand-logo" />}
+                    {brandLogo && <img alt={brandName} src={brandLogo} className="adyen-checkout__qr-loader__brand-logo" />}
                     <Spinner />
                 </div>
             );
@@ -178,7 +179,7 @@ class QRLoader extends Component<QRLoaderProps, QRLoaderState> {
                     ${this.props.classNameModifiers.map(m => `adyen-checkout__qr-loader--${m}`)}
                 `}
             >
-                {brandLogo && <img src={brandLogo} alt={type} className="adyen-checkout__qr-loader__brand-logo" />}
+                {brandLogo && <img src={brandLogo} alt={brandName} className="adyen-checkout__qr-loader__brand-logo" />}
 
                 <div className="adyen-checkout__qr-loader__subtitle">{i18n.get(this.props.introduction)}</div>
 

--- a/packages/lib/src/components/internal/QRLoader/types.ts
+++ b/packages/lib/src/components/internal/QRLoader/types.ts
@@ -20,6 +20,7 @@ export interface QRLoaderProps {
     i18n?: Language;
     classNameModifiers?: string[];
     brandLogo?: string;
+    brandName?: string;
     introduction?: string;
     instructions?: string;
     copyBtn?: boolean;

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -60,3 +60,15 @@ export const DATA_INFO = 'data-info';
 export const DATA_UID = 'data-uid';
 
 export const BRAND_ICON_UI_EXCLUSION_LIST = ['accel', 'pulse', 'star', 'nyce'];
+
+export const BRAND_READABLE_NAME_MAP = {
+    visa: 'VISA',
+    mc: 'MasterCard',
+    amex: 'American Express',
+    discover: 'Discover',
+    cup: 'China Union Pay',
+    jcb: 'JCB',
+    diners: 'Diners Club',
+    maestro: 'Maestro',
+    bcmc: 'Bancontact card'
+};


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This PR adds the missing alternative text in some images. Mainly the available brands in the card component, the QR code component, and the CVC hint.

Note theres a few limitations with this PR. 
Not all available brands will have alt image, and they are not localised, this is something we should solve by getting this information from the backend.
If the QR code component is loaded from an action, outside of Dropin the alt is not going to be available since the `payment/` call will not retrieve the `displayName`.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
