### PR TITLE
Ensure Boleto validates properly

### DIFF
--- a/packages/lib/src/components/Boleto/components/BoletoInput/validate.ts
+++ b/packages/lib/src/components/Boleto/components/BoletoInput/validate.ts
@@ -5,13 +5,13 @@ import { personalDetailsValidationRules } from '../../../internal/PersonalDetail
 export const boletoValidationRules: ValidatorRules = {
     socialSecurityNumber: {
         validate: validateSSN,
-        errorMessage: '',
+        errorMessage: 'error.va.gen.02',
         modes: ['blur']
     },
     shopperEmail: personalDetailsValidationRules.shopperEmail,
     default: {
         validate: value => !!value && value.length > 0,
-        errorMessage: '',
+        errorMessage: 'error.va.gen.02',
         modes: ['blur']
     }
 };

--- a/packages/lib/src/components/Boleto/components/BoletoInput/validate.ts
+++ b/packages/lib/src/components/Boleto/components/BoletoInput/validate.ts
@@ -13,5 +13,15 @@ export const boletoValidationRules: ValidatorRules = {
         validate: value => !!value && value.length > 0,
         errorMessage: 'error.va.gen.02',
         modes: ['blur']
+    },
+    firstName: {
+        validate: value => !!value && value.length > 0,
+        errorMessage: 'firstName.invalid',
+        modes: ['blur']
+    },
+    lastName: {
+        validate: value => !!value && value.length > 0,
+        errorMessage: 'lastName.invalid',
+        modes: ['blur']
     }
 };

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -131,7 +131,7 @@ const Field: FunctionalComponent<FieldProps> = props => {
                     {...(errorVisibleToSR && { id: `${uniqueId.current}${ARIA_ERROR_SUFFIX}` })}
                     aria-hidden={errorVisibleToSR ? null : 'true'}
                 >
-                    {errorMessage}
+                    {errorMessage && typeof errorMessage === 'string' && errorMessage.length ? errorMessage : null}
                 </span>
             </Fragment>
         );

--- a/packages/lib/src/components/internal/SendCopyToEmail/SendCopyToEmail.tsx
+++ b/packages/lib/src/components/internal/SendCopyToEmail/SendCopyToEmail.tsx
@@ -27,7 +27,12 @@ export default function SendCopyToEmail(props) {
             </Field>
 
             {sendCopyToEmail && (
-                <Field label={i18n.get('shopperEmail')} classNameModifiers={['shopperEmail']} errorMessage={errors}>
+                <Field
+                    label={i18n.get('shopperEmail')}
+                    classNameModifiers={['shopperEmail']}
+                    errorMessage={errors && errors.errorMessage ? i18n.get(errors.errorMessage) : !!errors}
+                    name={'shopperEmail'}
+                >
                     {renderFormField('emailAddress', {
                         name: 'shopperEmail',
                         autoCorrect: 'off',

--- a/packages/lib/src/components/internal/SocialSecurityNumberBrazil/BrazilPersonalDetail.tsx
+++ b/packages/lib/src/components/internal/SocialSecurityNumberBrazil/BrazilPersonalDetail.tsx
@@ -5,12 +5,13 @@ import { h } from 'preact';
 
 export function BrazilPersonalDetail(props) {
     const { i18n, data, handleChangeFor, errors, valid } = props;
+    const getErrorMessage = error => (error && error.errorMessage ? i18n.get(error.errorMessage) : !!error);
     return (
         <div className={'adyen-checkout__fieldset adyen-checkout__fieldset--address adyen-checkout__fieldset--personalDetails'}>
             <div className="adyen-checkout__fieldset__title">{i18n.get('personalDetails')}</div>
 
             <div className="adyen-checkout__fieldset__fields">
-                <Field label={i18n.get('firstName')} classNameModifiers={['firstName', 'col-50']} errorMessage={!!errors.firstName}>
+                <Field label={i18n.get('firstName')} classNameModifiers={['firstName', 'col-50']} errorMessage={getErrorMessage(errors.firstName)}>
                     {renderFormField('text', {
                         name: 'firstName',
                         autocorrect: 'off',
@@ -21,7 +22,7 @@ export function BrazilPersonalDetail(props) {
                     })}
                 </Field>
 
-                <Field label={i18n.get('lastName')} classNameModifiers={['lastName', 'col-50']} errorMessage={!!errors.lastName}>
+                <Field label={i18n.get('lastName')} classNameModifiers={['lastName', 'col-50']} errorMessage={getErrorMessage(errors.lastName)}>
                     {renderFormField('text', {
                         name: 'lastName',
                         autocorrect: 'off',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The `SendCopyToEmail` component inside the  `Boleto` component wasn't validating properly - it was sending the whole error object instead of a boolean or a string.
Recent changes in `Field.tsx` meant that, if it was told to present the error in the DOM, it _always_ expected a string.
So, there was a scenario where if the "Send a copy to my email" checkbox was checked, and the form was then validated, an error was thrown.

In addition, the `Boleto` component generally, wasn't validating properly (by generating visual error messages).

Now, `SendCopyToEmail` passes a string, `Boleto` validates correctly, and `Field.tsx` is more robust (for other scenarios where a component doesn't validate in the expected way)

## Tested scenarios
`Boleto` validates correctly.
Even when it doesn't `Field.tsx` will no longer throw an error
All unit tests pass

