### PR TITLE
E2E - Fixing issuer list flaky tests

### DIFF
--- a/packages/e2e-playwright/models/issuer-list.ts
+++ b/packages/e2e-playwright/models/issuer-list.ts
@@ -1,4 +1,8 @@
 import { Locator, Page } from '@playwright/test';
+import { USER_TYPE_DELAY } from '../tests/utils/constants';
+
+const SELECTOR_DELAY = 300;
+const KEYBOARD_DELAY = 300;
 
 class IssuerList {
     readonly rootElement: Locator;
@@ -22,8 +26,12 @@ class IssuerList {
         this.highlightedIssuerButtonGroup = this.rootElement.getByRole('group');
     }
 
+    async clickOnSelector() {
+        await this.selectorCombobox.click({ delay: SELECTOR_DELAY });
+    }
+
     async selectIssuerOnSelectorDropdown(issuerName: string) {
-        await this.selectorCombobox.click();
+        await this.clickOnSelector();
         const option = this.selectorList.getByRole('option').getByText(issuerName, { exact: true });
         await option.click();
     }
@@ -32,21 +40,20 @@ class IssuerList {
         await this.highlightedIssuerButtonGroup.getByRole('button', { name: issuerName }).click();
     }
 
-    async typeToFilterTerm(filter: string) {
-        await this.selectorCombobox.focus();
-        await this.selectorCombobox.type(filter);
+    async typeOnSelectorField(filter: string) {
+        await this.selectorCombobox.type(filter, { delay: USER_TYPE_DELAY });
     }
 
     async pressKeyboardToNextItem() {
-        await this.page.keyboard.press('ArrowDown');
+        await this.page.keyboard.press('ArrowDown', { delay: KEYBOARD_DELAY });
     }
 
     async pressKeyboardToPreviousItem() {
-        await this.page.keyboard.press('ArrowDown');
+        await this.page.keyboard.press('ArrowDown', { delay: KEYBOARD_DELAY });
     }
 
     async pressKeyboardToSelectItem() {
-        await this.page.keyboard.press('Enter');
+        await this.page.keyboard.press('Enter', { delay: KEYBOARD_DELAY });
     }
 }
 

--- a/packages/e2e-playwright/tests/issuerList/issue-list.spec.ts
+++ b/packages/e2e-playwright/tests/issuerList/issue-list.spec.ts
@@ -1,17 +1,5 @@
 import { test, expect } from '../../pages/issuerList/issuer-list.fixture';
 
-test('should select issuers on dropdown and update pay button label', async ({ issuerListPage }) => {
-    const { issuerList } = issuerListPage;
-
-    await expect(issuerList.submitButton).toHaveText('Continue');
-
-    await issuerList.selectIssuerOnSelectorDropdown('Test Issuer 5');
-    await expect(issuerList.submitButton).toHaveText('Continue to Test Issuer 5');
-
-    await issuerList.selectIssuerOnSelectorDropdown('Test Issuer');
-    await expect(issuerList.submitButton).toHaveText('Continue to Test Issuer');
-});
-
 test('should select highlighted issuer and update pay button label', async ({ issuerListPage }) => {
     const { issuerList } = issuerListPage;
 
@@ -28,15 +16,18 @@ test('should select highlighted issuer and update pay button label', async ({ is
 test('it should be able to filter and select using the keyboard', async ({ issuerListPage }) => {
     const { issuerList } = issuerListPage;
 
-    await issuerList.typeToFilterTerm('');
+    await expect(issuerList.submitButton).toHaveText('Continue');
+
+    await issuerList.clickOnSelector();
     await expect(issuerList.selectorList).toContainText('SNS');
 
-    await issuerList.typeToFilterTerm('Test');
+    await issuerList.typeOnSelectorField('Test');
     await expect(issuerList.selectorList).not.toContainText('SNS');
 
     await issuerList.pressKeyboardToNextItem();
     await issuerList.pressKeyboardToNextItem();
     await issuerList.pressKeyboardToSelectItem();
+
     await expect(issuerList.submitButton).toHaveText('Continue to Test Issuer 5');
 
     // 1st press opens the dropdown
@@ -44,13 +35,16 @@ test('it should be able to filter and select using the keyboard', async ({ issue
     // 2nd selects next items
     await issuerList.pressKeyboardToNextItem();
     await issuerList.pressKeyboardToSelectItem();
+
     await expect(issuerList.submitButton).toHaveText('Continue to Test Issuer 4');
 });
 
 test('it should load a default when pressing enter', async ({ issuerListPage }) => {
     const { issuerList } = issuerListPage;
 
-    await issuerList.typeToFilterTerm('Test');
+    await issuerList.clickOnSelector();
+    await issuerList.typeOnSelectorField('Test');
     await issuerList.pressKeyboardToSelectItem();
+
     await expect(issuerList.submitButton).toHaveText('Continue to Test Issuer');
 });

--- a/packages/e2e-playwright/tests/utils/constants.ts
+++ b/packages/e2e-playwright/tests/utils/constants.ts
@@ -8,4 +8,3 @@ export const TEST_CVC_VALUE = '737';
 export const BIN_LOOKUP_URL = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 export const USER_TYPE_DELAY = 150;
-export const SELECTOR_DELAY = 500;

--- a/packages/e2e-playwright/tests/utils/constants.ts
+++ b/packages/e2e-playwright/tests/utils/constants.ts
@@ -8,3 +8,4 @@ export const TEST_CVC_VALUE = '737';
 export const BIN_LOOKUP_URL = `https://checkoutshopper-test.adyen.com/checkoutshopper/${BIN_LOOKUP_VERSION}/bin/binLookup?token=${process.env.CLIENT_KEY}`;
 
 export const USER_TYPE_DELAY = 150;
+export const SELECTOR_DELAY = 500;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Attempt to fix issuer list flaky tests

Current issue: 
When playwright clicks in the select box, it moves to the next task which is to type in the filterable select field, although the field isn't ready for handling the keyboard events (sometimes it is, but sometimes it isn't). Therefore, in some cases, the filter mechanism wasn't working as expected and was taking wrong values instead of the provided ones.

The fix:
- Added a small delay when the select field is clicked, so the options can be fully rendered
- Added a small delay after typing in the field, so the UI can be properly updated with the available options