### PR TITLE
Removed isCollatingErrors prop since it is never used

### DIFF
--- a/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/handlingErrors/unsupportedCardErrors.test.js
@@ -38,7 +38,7 @@ test('#1 Enter number of unsupported card, ' + 'then check UI shows an error ' +
     await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, 'paste');
 
     // Test UI shows "Unsupported card" error has gone
-    await t.expect(cardPage.numErrorText.exists).notOk();
+    await t.expect(cardPage.numErrorText.withExactText('').exists).ok();
 });
 
 test(
@@ -77,7 +77,7 @@ test(
         await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, 'paste');
 
         // Test UI shows "Unsupported card" error has gone
-        await t.expect(cardPage.numErrorText.exists).notOk();
+        await t.expect(cardPage.numErrorText.withExactText('').exists).ok();
 
         // PAN error cleared but other errors persist
         await t
@@ -109,7 +109,7 @@ test('#3 Enter number of unsupported card, ' + 'then check UI shows an error ' +
     await cardPage.cardUtils.fillCardNumber(t, UNKNOWN_VISA_CARD, 'paste');
 
     // Test UI shows "Unsupported card" error has gone
-    await t.expect(cardPage.numErrorText.exists).notOk();
+    await t.expect(cardPage.numErrorText.withExactText('').exists).ok();
 });
 
 test('#4 Enter number of unsupported card, ' + 'then check UI shows an error ' + 'then delete PAN & check UI error is cleared', async t => {
@@ -131,5 +131,5 @@ test('#4 Enter number of unsupported card, ' + 'then check UI shows an error ' +
     await cardPage.cardUtils.deleteCardNumber(t);
 
     // Test UI shows "Unsupported card" error has gone
-    await t.expect(cardPage.numErrorText.exists).notOk();
+    await t.expect(cardPage.numErrorText.withExactText('').exists).ok();
 });

--- a/packages/e2e/tests/cards/expiryDate/minimumExpiryDate.test.js
+++ b/packages/e2e/tests/cards/expiryDate/minimumExpiryDate.test.js
@@ -21,7 +21,7 @@ fixture`Testing setting minimumExpiryDate - that it is recognised but doesn't ov
     .page(CARDS_URL)
     .clientScripts('expiryDate.clientScripts.js');
 
-test('With minimumExpiryDate set - input an expiry date that is too old & expect the correct error ', async t => {
+test('#1 With minimumExpiryDate set - input an expiry date that is too old & expect the correct error ', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
@@ -40,7 +40,7 @@ test('With minimumExpiryDate set - input an expiry date that is too old & expect
         .ok();
 });
 
-test('With minimumExpiryDate set - input an expiry date that is 1 month before it & expect the correct error', async t => {
+test('#2 With minimumExpiryDate set - input an expiry date that is 1 month before it & expect the correct error', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
@@ -59,7 +59,7 @@ test('With minimumExpiryDate set - input an expiry date that is 1 month before i
         .ok();
 });
 
-test('With minimumExpiryDate set - input an expiry date that is matches it & expect no error ', async t => {
+test('#3 With minimumExpiryDate set - input an expiry date that is matches it & expect no error ', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
@@ -70,10 +70,10 @@ test('With minimumExpiryDate set - input an expiry date that is matches it & exp
     await t.expect(errorHolder.exists).notOk();
 
     // Test UI shows no error
-    await t.expect(errorLabel.exists).notOk();
+    await t.expect(errorLabel.withExactText('').exists).ok();
 });
 
-test('With minimumExpiryDate set - input an expiry date that exceeds it (a bit) & expect no error', async t => {
+test('#4 With minimumExpiryDate set - input an expiry date that exceeds it (a bit) & expect no error', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
@@ -84,10 +84,10 @@ test('With minimumExpiryDate set - input an expiry date that exceeds it (a bit) 
     await t.expect(errorHolder.exists).notOk();
 
     // Test UI shows no error
-    await t.expect(errorLabel.exists).notOk();
+    await t.expect(errorLabel.withExactText('').exists).ok();
 });
 
-test('With minimumExpiryDate set - input an expiry date that is too far in the future, & expect the correct error ', async t => {
+test('#5 With minimumExpiryDate set - input an expiry date that is too far in the future, & expect the correct error ', async t => {
     // Start, allow time for iframes to load
     await start(t, 2000, TEST_SPEED);
 
@@ -107,7 +107,7 @@ test('With minimumExpiryDate set - input an expiry date that is too far in the f
 });
 
 test(
-    'General "date edit" bug: with minimumExpiryDate set - input an expiry date that is matches it & expect no error ' +
+    '#6 General "date edit" bug: with minimumExpiryDate set - input an expiry date that is matches it & expect no error ' +
         'then edit the date to be before the minimumExpiryDate and expect that to register as an error',
     async t => {
         // Start, allow time for iframes to load
@@ -120,7 +120,7 @@ test(
         await t.expect(errorHolder.exists).notOk();
 
         // Test UI shows no error
-        await t.expect(errorLabel.exists).notOk();
+        await t.expect(errorLabel.withExactText('').exists).ok();
 
         // Card out of date
         await cardUtils.fillDate(t, '08/24', 'paste');
@@ -152,7 +152,7 @@ test(
         await t.expect(errorHolder.exists).notOk();
 
         // Test UI shows no error
-        await t.expect(errorLabel.exists).notOk();
+        await t.expect(errorLabel.withExactText('').exists).ok();
 
         // Card out of date
         await cardUtils.fillDate(t, '04/10', 'paste');

--- a/packages/e2e/tests/cards/general/general.test.js
+++ b/packages/e2e/tests/cards/general/general.test.js
@@ -39,28 +39,14 @@ test('#1 Can fill out the fields in the regular card and make a successful payme
     await t.expect(history[0].text).eql('Authorised');
 });
 
-test("#2 Value of label's 'for' attr should match value of corresponding securedField input's 'id' attr", async t => {
-    // Wait for field to appear in DOM
-    await cardPage.numHolder();
+// KEEP AS REF - process needed if we actually want to be able to store or log the value of an attr on an iframe
+//    await t.switchToMainWindow().switchToIframe(cardPage.iframeSelector.nth(0));
+//    const idVal = await getInputSelector('encryptedCardNumber', true).getAttribute('id');
+//    console.log('### general.test:::: idVal', idVal);
+//    await t.switchToMainWindow();
+//    await t.expect(numAttrVal).eql(idVal);
 
-    const numAttrVal = await cardPage.numLabel.getAttribute('for');
-    await cardPage.cardUtils.checkIframeForAttrVal(t, 0, 'encryptedCardNumber', 'id', numAttrVal);
-
-    const dateAttrVal = await cardPage.dateLabel.getAttribute('for');
-    await cardPage.cardUtils.checkIframeForAttrVal(t, 1, 'encryptedExpiryDate', 'id', dateAttrVal);
-
-    const cvcAttrVal = await cardPage.cvcLabel.getAttribute('for');
-    await cardPage.cardUtils.checkIframeForAttrVal(t, 2, 'encryptedSecurityCode', 'id', cvcAttrVal);
-
-    // KEEP AS REF - process needed if we actually want to be able to store or log the value of an attr on an iframe
-    //    await t.switchToMainWindow().switchToIframe(cardPage.iframeSelector.nth(0));
-    //    const idVal = await getInputSelector('encryptedCardNumber', true).getAttribute('id');
-    //    console.log('### general.test:::: idVal', idVal);
-    //    await t.switchToMainWindow();
-    //    await t.expect(numAttrVal).eql(idVal);
-});
-
-test('#3 PAN that consists of the same digit (but passes luhn) causes an error', async t => {
+test('#2 PAN that consists of the same digit (but passes luhn) causes an error', async t => {
     // Wait for field to appear in DOM
     await cardPage.numHolder();
 
@@ -76,7 +62,7 @@ test('#3 PAN that consists of the same digit (but passes luhn) causes an error',
         .ok();
 });
 
-test('#4 Clicking pay button with an empty PAN causes an "empty" error on the PAN field', async t => {
+test('#3 Clicking pay button with an empty PAN causes an "empty" error on the PAN field', async t => {
     // Wait for field to appear in DOM
     await cardPage.numHolder();
 
@@ -91,7 +77,7 @@ test('#4 Clicking pay button with an empty PAN causes an "empty" error on the PA
         .ok();
 });
 
-test('#5 PAN that consists of the 1 digit causes a "wrong length" error ', async t => {
+test('#4 PAN that consists of the 1 digit causes a "wrong length" error ', async t => {
     // Wait for field to appear in DOM
     await cardPage.numHolder();
 

--- a/packages/e2e/tests/storedCard/general.test.js
+++ b/packages/e2e/tests/storedCard/general.test.js
@@ -20,11 +20,7 @@ test('#1 Can fill out the cvc fields in the stored card and make a successful pa
     await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
 
     // click pay
-    await t
-        .click(cardPage.payButton)
-        .expect(cardPage.cvcLabelTextError.exists)
-        .notOk()
-        .wait(1000);
+    await t.click(cardPage.payButton).expect(cardPage.cvcLabelTextError.exists).notOk().wait(1000);
 
     // Check the value of the alert text
     const history = await t.getNativeDialogHistory();
@@ -43,12 +39,4 @@ test('#2 Pressing pay without filling the cvc should generate a translated error
         // with text
         .expect(cardPage.cvcErrorText.withExactText(EMPTY_FIELD).exists)
         .ok();
-});
-
-test("#3 Value of label's 'for' attr should match value of corresponding securedField input's 'id' attr", async t => {
-    // Wait for field to appear in DOM
-    await cardPage.cvcHolder();
-
-    const cvcAttrVal = await cardPage.cvcLabel.getAttribute('for');
-    await cardPage.cardUtils.checkIframeForAttrVal(t, 0, 'encryptedSecurityCode', 'id', cvcAttrVal);
 });

--- a/packages/lib/src/components/internal/Address/components/CountryField.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.tsx
@@ -8,11 +8,7 @@ import { CountryFieldProps, CountryFieldItem } from '../types';
 
 export default function CountryField(props: CountryFieldProps) {
     const { allowedCountries = [], classNameModifiers = [], errorMessage, onDropdownChange, value } = props;
-    const {
-        i18n,
-        loadingContext,
-        commonProps: { isCollatingErrors }
-    } = useCoreContext();
+    const { i18n, loadingContext } = useCoreContext();
     const [countries, setCountries] = useState<CountryFieldItem[]>([]);
     const [loaded, setLoaded] = useState<boolean>(false);
     const [readOnly, setReadOnly] = useState(props.readOnly);
@@ -43,7 +39,6 @@ export default function CountryField(props: CountryFieldProps) {
             classNameModifiers={classNameModifiers}
             isValid={!!value}
             showValidIcon={false}
-            isCollatingErrors={isCollatingErrors}
             i18n={i18n}
         >
             {renderFormField('select', {
@@ -52,8 +47,7 @@ export default function CountryField(props: CountryFieldProps) {
                 placeholder: i18n.get('select.country'),
                 selected: value,
                 items: countries,
-                readonly: readOnly && !!value,
-                isCollatingErrors
+                readonly: readOnly && !!value
             })}
         </Field>
     );

--- a/packages/lib/src/components/internal/Address/components/StateField.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.tsx
@@ -8,11 +8,7 @@ import { StateFieldItem, StateFieldProps } from '../types';
 
 export default function StateField(props: StateFieldProps) {
     const { classNameModifiers, label, onDropdownChange, readOnly, selectedCountry, specifications, value } = props;
-    const {
-        i18n,
-        loadingContext,
-        commonProps: { isCollatingErrors }
-    } = useCoreContext();
+    const { i18n, loadingContext } = useCoreContext();
     const [states, setStates] = useState<StateFieldItem[]>([]);
     const [loaded, setLoaded] = useState<boolean>(false);
     const placeholderKey: string = specifications.getPlaceholderKeyForField('stateOrProvince', selectedCountry);
@@ -46,7 +42,6 @@ export default function StateField(props: StateFieldProps) {
             isValid={!!value}
             showValidIcon={false}
             name={'stateOrProvince'}
-            isCollatingErrors={isCollatingErrors}
             i18n={i18n}
         >
             {renderFormField('select', {
@@ -55,8 +50,7 @@ export default function StateField(props: StateFieldProps) {
                 selected: value,
                 placeholder: i18n.get(placeholderKey),
                 items: states,
-                readonly: readOnly && !!value,
-                isCollatingErrors
+                readonly: readOnly && !!value
             })}
         </Field>
     );

--- a/packages/lib/src/components/internal/FormFields/Field/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Field/types.ts
@@ -22,7 +22,6 @@ export interface FieldProps {
     dir?;
     name?: string;
     showValidIcon?: boolean;
-    isCollatingErrors?: boolean;
     useLabelElement?: boolean;
     i18n?: Language;
     errorVisibleToScreenReader?: boolean;

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -24,7 +24,6 @@ function Select({
     isValid,
     placeholder,
     uniqueId,
-    isCollatingErrors,
     disabled
 }: SelectProps) {
     const filterInputRef = useRef(null);
@@ -274,7 +273,7 @@ function Select({
                 toggleButtonRef={toggleButtonRef}
                 toggleList={toggleList}
                 disabled={disabled}
-                ariaDescribedBy={!isCollatingErrors && uniqueId ? `${uniqueId}${ARIA_ERROR_SUFFIX}` : null}
+                ariaDescribedBy={uniqueId ? `${uniqueId}${ARIA_ERROR_SUFFIX}` : null}
             />
             <SelectList
                 active={activeOption}

--- a/packages/lib/src/components/internal/FormFields/Select/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Select/types.ts
@@ -20,7 +20,6 @@ export interface SelectProps {
     readonly: boolean;
     selected: string;
     uniqueId?: string;
-    isCollatingErrors: boolean;
     disabled: boolean;
 }
 

--- a/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInputNew/PhoneInput.tsx
@@ -12,10 +12,7 @@ import { ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
 import { getUniqueId } from '../../../utils/idGenerator';
 
 function PhoneInput(props: PhoneInputProps) {
-    const {
-        i18n,
-        commonProps: { isCollatingErrors }
-    } = useCoreContext();
+    const { i18n } = useCoreContext();
 
     const schema = props.requiredFields || [...(props?.items?.length ? ['phonePrefix'] : []), 'phoneNumber'];
     const showPrefix = schema.includes('phonePrefix') && !!props?.items?.length;
@@ -132,7 +129,6 @@ function PhoneInput(props: PhoneInputProps) {
                             // readonly: props.phonePrefixIsReadonly,
                             placeholder: i18n.get('infix'),
                             selected: data.phonePrefix,
-                            isCollatingErrors,
                             uniqueId: uniqueIDPhonePrefix
                         })}
 
@@ -157,7 +153,7 @@ function PhoneInput(props: PhoneInputProps) {
                     )}
                 </div>
             </Field>
-            {!isCollatingErrors && (
+            {
                 <div className="adyen-checkout-phone-input__error-holder">
                     {showPrefix && getPhoneFieldError('phonePrefix') && (
                         <span className={'adyen-checkout__error-text'} aria-live="polite" id={`${uniqueIDPhonePrefix}${ARIA_ERROR_SUFFIX}`}>
@@ -170,7 +166,7 @@ function PhoneInput(props: PhoneInputProps) {
                         </span>
                     )}
                 </div>
-            )}
+            }
         </div>
     );
 }

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.test.ts
@@ -63,7 +63,6 @@ const setupObj = {
     minimumExpiryDate: null,
     uid: null,
     implementationType: null,
-    isCollatingErrors: false,
     maskSecurityCode: false
 };
 

--- a/packages/lib/src/components/internal/SocialSecurityNumberBrazil/SocialSecurityNumberBrazil.tsx
+++ b/packages/lib/src/components/internal/SocialSecurityNumberBrazil/SocialSecurityNumberBrazil.tsx
@@ -3,11 +3,8 @@ import renderFormField from '../../internal/FormFields';
 import Field from '../../internal/FormFields/Field';
 import useCoreContext from '../../../core/Context/useCoreContext';
 
-export default function({ onBlur, onInput, valid = false, error = null, data = '', required = false, disabled = false }) {
-    const {
-        i18n,
-        commonProps: { isCollatingErrors }
-    } = useCoreContext();
+export default function ({ onBlur, onInput, valid = false, error = null, data = '', required = false, disabled = false }) {
+    const { i18n } = useCoreContext();
 
     return (
         <Field
@@ -16,7 +13,6 @@ export default function({ onBlur, onInput, valid = false, error = null, data = '
             errorMessage={error && error.errorMessage ? i18n.get(error.errorMessage) : !!error}
             isValid={Boolean(valid)}
             name={'socialSecurityNumber'}
-            isCollatingErrors={isCollatingErrors}
         >
             {renderFormField('text', {
                 name: 'socialSecurityNumber',
@@ -27,7 +23,6 @@ export default function({ onBlur, onInput, valid = false, error = null, data = '
                 onInput,
                 onBlur,
                 required,
-                isCollatingErrors,
                 disabled
             })}
         </Field>

--- a/packages/lib/src/core/Context/CoreProvider.tsx
+++ b/packages/lib/src/core/Context/CoreProvider.tsx
@@ -9,7 +9,7 @@ interface CoreProviderProps {
 }
 
 export interface CommonPropsTypes {
-    isCollatingErrors?: boolean;
+    [key: string]: any;
 }
 /**
  * CoreProvider Component


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The `isCollatingErrors` prop was part of the `ErrorPanel` functionality.
Now we have moved to using the `SRPanel` it is a redundant property.
(The only reason it wasn't removed in the SRPanel PR was in an attempt to keep down the number of changed files for that PR)

Have also fixed some e2e tests to reflect the new markup that has come with the a11y changes i.e. `aria-describedby` elements are _always_ in the DOM, and `label` elements for securedFields don't have a `for` attribute

## Tested scenarios
All unit tests pass
All e2e tests pass

