### PR TITLE
Fix(installments): preselect value on brand change

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
@@ -56,8 +56,11 @@ function Installments(props: InstallmentsProps) {
     };
 
     useEffect(() => {
-        const newAmount = installmentOptions?.values?.includes(installmentAmount) ? installmentAmount : installmentOptions?.values[0];
-        setInstallmentAmount(newAmount);
+        if (installmentOptions?.values?.includes(installmentAmount)) {
+            return;
+        }
+
+        setInstallmentAmount(installmentOptions?.preselectedValue ?? installmentOptions?.values[0]);
     }, [brand]);
 
     useEffect(() => {

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -52,11 +52,13 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                 brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
                 installmentOptions: {
                     mc: {
-                        values: [1, 2, 3]
+                        values: [1, 2],
+                        preselectedValue: 2
                     },
                     visa: {
                         values: [1, 2, 3, 4],
-                        plans: ['regular', 'revolving']
+                        plans: ['regular', 'revolving'],
+                        preselectedValue: 4
                     }
                 },
                 showBrandsUnderCardNumber: true,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Fix the issue that the preselect value is not working for the Installments component
- Add tests to test brand change effect
#### Explanation for the root cause:
- Let's say we have the following configuration:
```javascript
                installmentOptions: {
                    mc: {
                        values: [1, 2, 3],
                        preselectedValue: 2
                    }         
                },
```
- During the initial rendering, the `brand` is `card`, as we are setting the initial `installmentAmount` value to `installmentOptions?.preselectedValue || installmentOptions?.values[0]` in the `useState` hook, it sets the initial `installmentAmount` value to `undefined`.
- Then the `useEffect` is called, `newAmount` is still `undefined`
- Change the card number to a master card. As `useState` is stateful, it would NOT get called, hence the `installmentAmount` stays `undefined` at this stage. 
- However the `useEffect` would be called because the `brand` changed. As the current `installmentAmount` is `undefined`, the `installmentOptions?.values?.includes(installmentAmount)` is `false`. `newAmount` would set to `installmentOptions?.values[0]`, which is `1`. 
- That's why the `preselectedValue` is not working as it was not used in the `useEffect` hook.
#### Fix:
- Based on the analysis, we need to change the `useEffect` to 
``` javascript
setInstallmentAmount(installmentOptions?.preselectedValue ?? installmentOptions?.values[0]);
```
so that the `preselectedValue` is picked up. 
- To keep the same intention as the previous code, when the new branch `installmentOptions?.values?.includes(installmentAmount)`, we skip setting up the new value for `installmentAmount` 

## Tested scenarios
- Go to the playground http://localhost:3020/cards
- Go to the `CARD` section
- Fill in a test master card number, the preselected value `2x $129.50` for the installments is selected in the `Installments payment` field. 
- Switching to a `visa` card, the preselected value would depend on if the visa installment configuration supports that value. If so, the `Installments payment` field would remain unchanged. Otherwise, it would switch to the visa `installmentOptions` (either to the `preselectedValue` or `values[0]` )
