### PR TITLE
Refactor(DisclaimerMessage): to use only InternalDisclaimerMsgObject

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
@@ -160,7 +160,12 @@ export const CardFieldsWrapper = ({
                 />
             )}
 
-            {disclaimerMessage && <DisclaimerMessage disclaimer={disclaimerMessage} />}
+            {disclaimerMessage && (
+                <DisclaimerMessage
+                    message={disclaimerMessage.message.replace('%{linkText}', `%#${disclaimerMessage.linkText}%#`)}
+                    urls={[disclaimerMessage.link]}
+                />
+            )}
         </LoadingWrapper>
     );
 };

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFieldsWrapper.tsx
@@ -51,7 +51,12 @@ export const StoredCardFieldsWrapper = ({
                 />
             )}
 
-            {disclaimerMessage && <DisclaimerMessage disclaimer={disclaimerMessage} />}
+            {disclaimerMessage && (
+                <DisclaimerMessage
+                    message={disclaimerMessage.message.replace('%{linkText}', `%#${disclaimerMessage.linkText}%#`)}
+                    urls={[disclaimerMessage.link]}
+                />
+            )}
         </LoadingWrapper>
     );
 };

--- a/packages/lib/src/components/Donation/components/DonationComponent.tsx
+++ b/packages/lib/src/components/Donation/components/DonationComponent.tsx
@@ -90,7 +90,12 @@ export default function DonationComponent(props: DonationComponentProps) {
                         onChange={handleAmountSelected}
                     />
                 </div>
-                {disclaimerMessage && <DisclaimerMessage disclaimer={disclaimerMessage} />}
+                {disclaimerMessage && (
+                    <DisclaimerMessage
+                        message={disclaimerMessage.message.replace('%{linkText}', `%#${disclaimerMessage.linkText}%#`)}
+                        urls={[disclaimerMessage.link]}
+                    />
+                )}
                 <Button
                     classNameModifiers={['donate']}
                     onClick={handleDonate}

--- a/packages/lib/src/components/internal/DisclaimerMessage/DisclaimerMessage.test.tsx
+++ b/packages/lib/src/components/internal/DisclaimerMessage/DisclaimerMessage.test.tsx
@@ -4,13 +4,12 @@ import { render, screen } from '@testing-library/preact';
 
 describe('DisclaimerMessage', () => {
     const disclaimerMessage = {
-        message: 'By continuing you accept the %{linkText} of MyStore',
-        linkText: 'terms and conditions',
-        link: 'https://www.adyen.com'
+        message: 'By continuing you accept the %#terms and conditions%# of MyStore',
+        urls: ['https://www.adyen.com']
     };
 
     test('Renders the DisclaimerMessage with text before and after the link', () => {
-        render(<DisclaimerMessage disclaimer={disclaimerMessage} />);
+        render(<DisclaimerMessage {...disclaimerMessage} />);
         expect(screen.getByText('By continuing', { exact: false }).textContent).toEqual(
             'By continuing you accept the terms and conditions of MyStore'
         );
@@ -19,9 +18,9 @@ describe('DisclaimerMessage', () => {
 
     test('Renders the DisclaimerMessage just with text before the link', () => {
         const nuMsg = { ...disclaimerMessage };
-        nuMsg.message = 'By continuing you accept the %{linkText}';
+        nuMsg.message = 'By continuing you accept the %#terms and conditions%#';
 
-        render(<DisclaimerMessage disclaimer={nuMsg} />);
+        render(<DisclaimerMessage {...nuMsg} />);
 
         /* eslint-disable-next-line */
         expect(screen.queryByText('By continuing', { exact: false })).toBeTruthy(); // presence
@@ -34,9 +33,9 @@ describe('DisclaimerMessage', () => {
 
     test("Doesn't render the DisclaimerMessage because the link is not https", () => {
         const nuMsg = { ...disclaimerMessage };
-        nuMsg.link = 'http://www.adyen.com';
+        nuMsg.urls = ['http://www.adyen.com'];
 
-        render(<DisclaimerMessage disclaimer={nuMsg} />);
+        render(<DisclaimerMessage {...nuMsg} />);
         expect(screen.queryByText('By continuing', { exact: false })).toBeNull(); // non-presence
     });
 
@@ -44,9 +43,9 @@ describe('DisclaimerMessage', () => {
         const nuMsg = { ...disclaimerMessage };
 
         /* eslint-disable-next-line */
-        nuMsg.linkText = <script>alert("busted")</script>;
+        nuMsg.message = <script>alert("busted")</script>;
 
-        render(<DisclaimerMessage disclaimer={nuMsg} />);
+        render(<DisclaimerMessage {...nuMsg} />);
         expect(screen.queryByText('By continuing', { exact: false })).toBeNull(); // non-presence
     });
 
@@ -55,7 +54,7 @@ describe('DisclaimerMessage', () => {
         // @ts-ignore allow assignment
         nuMsg.message = {};
 
-        render(<DisclaimerMessage disclaimer={nuMsg} />);
+        render(<DisclaimerMessage {...nuMsg} />);
         expect(screen.queryByRole('link')).toBeNull(); // non-presence
     });
 });

--- a/packages/lib/src/components/internal/DisclaimerMessage/DisclaimerMessage.tsx
+++ b/packages/lib/src/components/internal/DisclaimerMessage/DisclaimerMessage.tsx
@@ -8,10 +8,6 @@ export interface DisclaimerMsgObject {
     link: string;
 }
 
-interface DisclaimerMessageProps {
-    disclaimer: DisclaimerMsgObject;
-}
-
 interface InternalDisclaimerMsgObject {
     message: string;
     urls: Array<string>;
@@ -33,14 +29,6 @@ function render(message: string, urls: Array<string>) {
 }
 /* eslint-disable */
 /**
- * 1. Expects a config object with this shape:
- *  disclaimerMessage: {
- *      message: 'By continuing you accept the %{linkText} of MyStore',
- *      linkText: 'terms and conditions',
- *      link: 'https://www.adyen.com'
- *  }
- *
- *  2. Internal structure which contains a message and a list of urls.
  *  props: {
  *    message: 'By continuing you agree with the %#terms and conditions%#',
  *    urls: ['https://www.adyen.com']
@@ -48,18 +36,10 @@ function render(message: string, urls: Array<string>) {
  *  String inside the '%#' token pair will be rendered as an anchor element.
  */
 /* eslint-enable */
-export default function DisclaimerMessage(props: DisclaimerMessageProps | InternalDisclaimerMsgObject) {
-    if ('disclaimer' in props) {
-        const { disclaimer } = props;
-        const messageIsStr = typeof disclaimer.message === 'string';
-        const linkTextIsStr = typeof disclaimer.linkText === 'string';
-        const isValidUrl = isValidHttpUrl(disclaimer.link);
-        if (!messageIsStr || !linkTextIsStr || !isValidUrl) return null;
+export default function DisclaimerMessage({ message, urls }: InternalDisclaimerMsgObject) {
+    const messageIsStr = typeof message === 'string';
+    const validUrls = urls.every(url => typeof url === 'string' && isValidHttpUrl(url));
+    if (!messageIsStr || !validUrls) return null;
 
-        const message = disclaimer.message.replace('%{linkText}', `%#${disclaimer.linkText}%#`);
-        return render(message, [disclaimer.link]);
-    }
-
-    const { message, urls } = props as InternalDisclaimerMsgObject;
     return render(message, urls);
 }

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -17,6 +17,11 @@ const showComps = {
     avsPartialCard: true,
     kcpCard: true
 };
+const disclaimerMessage = {
+    message: 'By continuing you accept the %{linkText} of MyStore',
+    linkText: 'terms and conditions',
+    link: 'https://www.adyen.com'
+};
 
 getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse => {
     window.checkout = await AdyenCheckout({
@@ -41,7 +46,12 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     if (showComps.storedCard) {
         if (checkout.paymentMethodsResponse.storedPaymentMethods && checkout.paymentMethodsResponse.storedPaymentMethods.length > 0) {
             const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[0];
-            window.storedCard = checkout.create('card', storedCardData).mount('.storedcard-field');
+            window.storedCard = checkout
+                .create('card', {
+                    ...storedCardData,
+                    disclaimerMessage
+                })
+                .mount('.storedcard-field');
         }
     }
 
@@ -59,6 +69,7 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                         plans: ['regular', 'revolving']
                     }
                 },
+                disclaimerMessage,
                 showBrandsUnderCardNumber: true,
                 showInstallmentAmounts: true,
                 onError: obj => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Refactor the DisclaimerMessage component to only use the InternalDisclaimerMsgObject.

## Tested scenarios
`Card`, `StoredCard`, `Donation` and `OnlineBanking` display the disclaimer message correctly.