### PR TITLE
Fix: work around solution for some currencies not getting the correct decimal points

### DIFF
--- a/packages/lib/src/utils/amount-util.ts
+++ b/packages/lib/src/utils/amount-util.ts
@@ -1,5 +1,6 @@
 import CURRENCY_CODES from './constants/currency-codes';
 import CURRENCY_DECIMALS from './constants/currency-decimals';
+import { currencyMinorUnitsConfig } from './constants/currency-minor-units';
 
 /**
  * @internal
@@ -37,11 +38,12 @@ export const getLocalisedAmount = (amount: number, locale: string, currencyCode:
     const decimalAmount = getDecimalAmount(stringAmount, currencyCode);
     const formattedLocale = locale.replace('_', '-');
 
+    const modifiedOptions = currencyMinorUnitsConfig[currencyCode] ? { ...options, ...currencyMinorUnitsConfig[currencyCode] } : options;
     const localeOptions = {
         style: 'currency',
         currency: currencyCode,
         currencyDisplay: 'symbol',
-        ...options
+        ...modifiedOptions
     };
 
     try {

--- a/packages/lib/src/utils/constants/currency-minor-units.ts
+++ b/packages/lib/src/utils/constants/currency-minor-units.ts
@@ -1,0 +1,16 @@
+/** Work around solution until chromium bug is fixed https://bugs.chromium.org/p/chromium/issues/detail?id=1381996
+ * We need to hardcode minimumFractionDigits for the following currencies
+ */
+export const currencyMinorUnitsConfig = {
+    RSD: { minimumFractionDigits: 2 },
+    AFN: { minimumFractionDigits: 2 },
+    ALL: { minimumFractionDigits: 2 },
+    IRR: { minimumFractionDigits: 2 },
+    LAK: { minimumFractionDigits: 2 },
+    LBP: { minimumFractionDigits: 2 },
+    MMK: { minimumFractionDigits: 2 },
+    SOS: { minimumFractionDigits: 2 },
+    SYP: { minimumFractionDigits: 2 },
+    YER: { minimumFractionDigits: 2 },
+    IQD: { minimumFractionDigits: 3 }
+};

--- a/packages/playground/src/config/commonConfig.js
+++ b/packages/playground/src/config/commonConfig.js
@@ -9,7 +9,7 @@ const merchantAccount = urlParams.merchantAccount;
 export const shopperLocale = urlParams.shopperLocale || DEFAULT_LOCALE;
 export const countryCode = urlParams.countryCode || DEFAULT_COUNTRY;
 export const currency = getCurrency(countryCode);
-export const amountValue = urlParams.amount ?? 25900;
+export const amountValue = urlParams.amount ?? 25940;
 export const shopperReference = 'newshoppert';
 export const amount = {
     currency,

--- a/packages/playground/src/config/getCurrency.js
+++ b/packages/playground/src/config/getCurrency.js
@@ -31,6 +31,8 @@ const currencies = {
     TW: 'TWD',
     US: 'USD',
     VN: 'VND',
+    LA: 'LAK',
+    RS: 'RSD',
     default: 'EUR'
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We are incorrectly rounding the amount for the currency RSD in the pay button. For example the value RSD 10.45 is rendered as RSD 10 in the pay button. This only happens in the chromium-based browsers.

The root cause is the [chromium issue 1381996](https://bugs.chromium.org/p/chromium/issues/detail?id=1381996), some currencies' minimum  number of decimal points are not set correctly according to the [spec](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml).

#### Fix:
This is a workaround solution to hard code minimum decimal points for those problematic currencies following the [same spec](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml).

[Adyen doc](https://docs.adyen.com/development-resources/currency-codes) should be leading, I double checked those problematic currencies, they are aligned.

## Tested scenarios
RSD currency rounded to the correct decimal points.

**Fixed issue:** COWEB-1216
