### PR TITLE
Add parameter to request GPay `assuranceDetails`

### DIFF
--- a/packages/lib/src/components/GooglePay/defaultProps.ts
+++ b/packages/lib/src/components/GooglePay/defaultProps.ts
@@ -42,6 +42,7 @@ export default {
     allowPrepaidCards: true, // Set to false if you don't support prepaid cards.
     billingAddressRequired: false, // A billing address should only be requested if it's required to process the transaction.
     billingAddressParameters: undefined, // The expected fields returned if billingAddressRequired is set to true.
+    assuranceDetailsRequired: false, // https://developers.google.com/pay/api/web/reference/response-objects#assurance-details-specifications
 
     emailRequired: false,
     shippingAddressRequired: false,

--- a/packages/lib/src/components/GooglePay/requests.ts
+++ b/packages/lib/src/components/GooglePay/requests.ts
@@ -1,6 +1,6 @@
 import { getDecimalAmount } from '../../utils/amount-util';
 import config from './config';
-import {GooglePaymentDataRequest, GooglePayProps} from './types';
+import { GooglePaymentDataRequest, GooglePayProps } from './types';
 
 /**
  * Configure your site's support for payment methods supported by the Google Pay API.
@@ -80,6 +80,7 @@ export function initiatePaymentRequest({ configuration, ...props }: GooglePayPro
                 parameters: {
                     allowedAuthMethods: props.allowedAuthMethods,
                     allowedCardNetworks: props.allowedCardNetworks,
+                    assuranceDetailsRequired: props.assuranceDetailsRequired,
                     allowPrepaidCards: props.allowPrepaidCards,
                     allowCreditCards: props.allowCreditCards,
                     billingAddressRequired: props.billingAddressRequired,

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -59,6 +59,14 @@ export interface GooglePayProps extends UIElementProps {
     allowedCardNetworks?: google.payments.api.CardNetwork[];
 
     /**
+     * Set to true to request assuranceDetails. This object provides information
+     * about the validation performed on the returned payment data.
+     *
+     * @defaultValue false
+     */
+    assuranceDetailsRequired?: boolean;
+
+    /**
      * Set to false if you don't support credit cards.
      * @defaultValue true
      */


### PR DESCRIPTION
## Summary

Add parameter to request GPay `assuranceDetails`.
