### PR TITLE
Fix/open invoice sr panel receives on blur errors

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -28,7 +28,7 @@ import { getPartialAddressValidationRules } from '../../../internal/Address/vali
 import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../../core/Errors/constants';
 import useSRPanelContext from '../../../../core/Errors/useSRPanelContext';
 import { SetSRMessagesReturnFn } from '../../../../core/Errors/SRPanelProvider';
-import { getErrorArrayDifferences } from '../../../../core/Errors/utils';
+import { getArrayDifferences } from '../../../../utils/arrayUtils';
 
 const CardInput: FunctionalComponent<CardInputProps> = props => {
     const sfp = useRef(null);
@@ -379,7 +379,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
                 break;
             /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
             case ERROR_ACTION_BLUR_SCENARIO: {
-                const difference = getErrorArrayDifferences(currentErrorsSortedByLayout, previousSortedErrors);
+                const difference = getArrayDifferences<SortedErrorObject, string>(currentErrorsSortedByLayout, previousSortedErrors, 'field');
 
                 const latestErrorMsg = difference?.[0];
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -12,15 +12,8 @@ import { cardInputFormatters, cardInputValidationRules, getRuleByNameAndMode } f
 import CIExtensions from '../../../internal/SecuredFields/binLookup/extensions';
 import useForm from '../../../../utils/useForm';
 import { SetSRMessagesReturnObject, SortedErrorObject } from '../../../../core/Errors/types';
-import {
-    handlePartialAddressMode,
-    extractPropsForCardFields,
-    extractPropsForSFP,
-    getLayout,
-    usePrevious,
-    lookupBlurBasedErrors,
-    mapFieldKey
-} from './utils';
+import { handlePartialAddressMode, extractPropsForCardFields, extractPropsForSFP, getLayout, lookupBlurBasedErrors, mapFieldKey } from './utils';
+import { usePrevious } from '../../../../utils/hookUtils';
 import { AddressData } from '../../../../types';
 import Specifications from '../../../internal/Address/Specifications';
 import { StoredCardFieldsWrapper } from './components/StoredCardFieldsWrapper';
@@ -35,6 +28,7 @@ import { getPartialAddressValidationRules } from '../../../internal/Address/vali
 import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../../core/Errors/constants';
 import useSRPanelContext from '../../../../core/Errors/useSRPanelContext';
 import { SetSRMessagesReturnFn } from '../../../../core/Errors/SRPanelProvider';
+import { getErrorArrayDifferences } from '../../../../core/Errors/utils';
 
 const CardInput: FunctionalComponent<CardInputProps> = props => {
     const sfp = useRef(null);
@@ -385,21 +379,12 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
                 break;
             /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
             case ERROR_ACTION_BLUR_SCENARIO: {
-                let difference;
-
-                // If nothing to compare - take the new item...
-                if (currentErrorsSortedByLayout.length === 1 && !previousSortedErrors) {
-                    difference = currentErrorsSortedByLayout;
-                }
-                // .. else, find the difference: what's in the new array that wasn't in the old array?
-                if (currentErrorsSortedByLayout.length > previousSortedErrors?.length) {
-                    difference = currentErrorsSortedByLayout.filter(({ field: id1 }) => !previousSortedErrors.some(({ field: id2 }) => id2 === id1));
-                }
+                const difference = getErrorArrayDifferences(currentErrorsSortedByLayout, previousSortedErrors);
 
                 const latestErrorMsg = difference?.[0];
 
                 if (latestErrorMsg) {
-                    // Use the error code to look up whether error is actually a blur base one (most are but some SF ones aren't)
+                    // Use the error code to look up whether error is actually a blur based one (most are but some SF ones aren't)
                     const isBlurBasedError = lookupBlurBasedErrors(latestErrorMsg.errorCode);
 
                     // Only add blur based errors to the error panel - doing this step prevents the non-blur based errors from being read out twice

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -16,7 +16,6 @@ import { AddressSpecifications, StringObject } from '../../../internal/Address/t
 import { PARTIAL_ADDRESS_SCHEMA } from '../../../internal/Address/constants';
 import { InstallmentsObj } from './components/Installments/Installments';
 import { SFPProps } from '../../../internal/SecuredFields/SFP/types';
-import { useEffect, useRef } from 'preact/hooks';
 
 export const getCardImageUrl = (brand: string, loadingContext: string): string => {
     const imageOptions = {
@@ -172,17 +171,4 @@ export const handlePartialAddressMode = (addressMode: AddressModeOptions): Addre
 // Almost all errors are blur based, but some SF ones are not i.e. when an unsupported card is entered or the expiry date is out of range
 export function lookupBlurBasedErrors(errorCode) {
     return !['error.va.sf-cc-num.03', 'error.va.sf-cc-dat.01', 'error.va.sf-cc-dat.02', 'error.va.sf-cc-dat.03'].includes(errorCode);
-}
-
-// Hook
-export function usePrevious<T>(value: T): T {
-    const ref: any = useRef<T>();
-
-    // Store current value in ref
-    useEffect(() => {
-        ref.current = value;
-    }, [value]); // Only re-run if value changes
-
-    // Return previous value
-    return ref.current;
 }

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -18,7 +18,7 @@ import {
 import './OpenInvoice.scss';
 import IbanInput from '../IbanInput';
 import { ComponentMethodsRef } from '../../types';
-import { enhanceErrorObjectKeys, getErrorArrayDifferences } from '../../../core/Errors/utils';
+import { enhanceErrorObjectKeys } from '../../../core/Errors/utils';
 import { GenericError, SetSRMessagesReturnObject, SortedErrorObject } from '../../../core/Errors/types';
 import useSRPanelContext from '../../../core/Errors/useSRPanelContext';
 import { SetSRMessagesReturnFn } from '../../../core/Errors/SRPanelProvider';
@@ -28,6 +28,7 @@ import { COMPANY_DETAILS_SCHEMA } from '../CompanyDetails/CompanyDetails';
 import { setFocusOnField } from '../../../utils/setFocus';
 import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../core/Errors/constants';
 import { usePrevious } from '../../../utils/hookUtils';
+import { getArrayDifferences } from '../../../utils/arrayUtils';
 
 const consentCBErrorObj: GenericError = {
     isValid: false,
@@ -187,7 +188,7 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
 
             /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
             case ERROR_ACTION_BLUR_SCENARIO: {
-                const difference = getErrorArrayDifferences(currentErrorsSortedByLayout, previousSortedErrors);
+                const difference = getArrayDifferences(currentErrorsSortedByLayout, previousSortedErrors, 'field');
 
                 const latestErrorMsg = difference?.[0];
 

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -180,3 +180,23 @@ export const enhanceErrorObjectKeys = (errorObj, keyPrefix) => {
 
     return enhancedObj;
 };
+
+// Find the difference: what's in the new array that wasn't in the old array?
+function getErrorArrayDifference(currentArray, previousArray) {
+    return currentArray.filter(({ field: id1 }) => !previousArray.some(({ field: id2 }) => id2 === id1));
+}
+
+// Pass 2 arrays of similar objects - and compare for differences
+export function getErrorArrayDifferences(currentArray: SortedErrorObject[], previousArray: SortedErrorObject[]): SortedErrorObject[] {
+    let difference;
+
+    // If nothing to compare - take the new item...
+    if (currentArray.length === 1 && !previousArray) {
+        difference = currentArray;
+    }
+    // .. else, find the difference: what's in the new array that wasn't in the old array?
+    if (currentArray.length > previousArray?.length) {
+        difference = getErrorArrayDifference(currentArray, previousArray);
+    }
+    return difference;
+}

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -180,23 +180,3 @@ export const enhanceErrorObjectKeys = (errorObj, keyPrefix) => {
 
     return enhancedObj;
 };
-
-// Find the difference: what's in the new array that wasn't in the old array?
-function getErrorArrayDifference(currentArray, previousArray) {
-    return currentArray.filter(({ field: id1 }) => !previousArray.some(({ field: id2 }) => id2 === id1));
-}
-
-// Pass 2 arrays of similar objects - and compare for differences
-export function getErrorArrayDifferences(currentArray: SortedErrorObject[], previousArray: SortedErrorObject[]): SortedErrorObject[] {
-    let difference;
-
-    // If nothing to compare - take the new item...
-    if (currentArray.length === 1 && !previousArray) {
-        difference = currentArray;
-    }
-    // .. else, find the difference: what's in the new array that wasn't in the old array?
-    if (currentArray.length > previousArray?.length) {
-        difference = getErrorArrayDifference(currentArray, previousArray);
-    }
-    return difference;
-}

--- a/packages/lib/src/utils/arrayUtils.ts
+++ b/packages/lib/src/utils/arrayUtils.ts
@@ -10,7 +10,6 @@ export function getArrayDifferences<A, S extends string>(currentArray: A[], prev
     }
     // .. else, find the difference: what's in the new array that wasn't in the old array?
     if (currentArray.length > previousArray?.length) {
-        // difference = getArrayDifference<A, B, S>(currentArray, previousArray, comparisonKey);
         difference = currentArray.filter(({ [compKey]: id1 }) => !previousArray.some(({ [compKey]: id2 }) => id2 === id1));
     }
     return difference;

--- a/packages/lib/src/utils/arrayUtils.ts
+++ b/packages/lib/src/utils/arrayUtils.ts
@@ -1,0 +1,17 @@
+// Pass 2 arrays of similar objects - and compare for differences
+export function getArrayDifferences<A, S extends string>(currentArray: A[], previousArray: A[], comparisonKey?: S): A[] {
+    let difference;
+
+    const compKey = comparisonKey || 'id';
+
+    // If nothing to compare - take the new item...
+    if (currentArray.length === 1 && !previousArray) {
+        difference = currentArray;
+    }
+    // .. else, find the difference: what's in the new array that wasn't in the old array?
+    if (currentArray.length > previousArray?.length) {
+        // difference = getArrayDifference<A, B, S>(currentArray, previousArray, comparisonKey);
+        difference = currentArray.filter(({ [compKey]: id1 }) => !previousArray.some(({ [compKey]: id2 }) => id2 === id1));
+    }
+    return difference;
+}

--- a/packages/lib/src/utils/hookUtils.ts
+++ b/packages/lib/src/utils/hookUtils.ts
@@ -1,0 +1,13 @@
+import { useRef, useEffect } from 'preact/hooks';
+
+export function usePrevious<T>(value: T): T {
+    const ref: any = useRef<T>();
+
+    // Store current value in ref
+    useEffect(() => {
+        ref.current = value;
+    }, [value]); // Only re-run if value changes
+
+    // Return previous value
+    return ref.current;
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The email field in `OpenInvoice` components validates when the field loses focus and shows an error if the email fails the regEx.
This error needs handling in the same way as similar errors in the `CardInput`-  so that it is propagated to the SRPanel, to be read by the screenreader.
This is now done - and some of the utils for doing this have been moved out the `CardInput` directory to become more generic/reusable.

## Tested scenarios
All unit tests pass.
All e2e test pass except the custom card ones related to the getImage issue (#2135)


