### PR TITLE
Added conditional to getCardImageUrl

### DIFF
--- a/packages/lib/src/components/internal/SecuredFields/utils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/utils.ts
@@ -55,7 +55,7 @@ export const getCardImageUrl = (brand, resources: Resources) => {
         extension: 'svg'
     };
 
-    return resources.getImage(imageOptions)(type);
+    return resources && resources.getImage(imageOptions)(type);
 };
 
 // REGULAR "UTIL" UTILS

--- a/packages/lib/src/components/internal/SecuredFields/utils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/utils.ts
@@ -55,7 +55,7 @@ export const getCardImageUrl = (brand, resources: Resources) => {
         extension: 'svg'
     };
 
-    return resources && resources.getImage(imageOptions)(type);
+    return resources?.getImage(imageOptions)(type);
 };
 
 // REGULAR "UTIL" UTILS


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

- Component breaks when `onBrand` event is fired in Custom Card component due to `this.props.resources` being `undefined` when passed to `getCardImageUrl()` in [SecuredFieldsProviderHandlers.ts](https://github.com/Adyen/adyen-web/blob/master/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts#L176). This conditional checks that `resources` is truthy before trying to execute the `getImage()` method

## Tested scenarios
- confirmed this was an issue by running playground, any change to the card fields caused an error
- added change and retested, successfully entering full card details and creating an authorization in my test account
- tested all card brands on Custom Card Component, Drop-in, and Cards after change to ensure this did not affect working code


**Fixed issue**:  #2135
