### PR TITLE
make `totalPriceLabel` optional in `ApplePayElementProps` type

### DIFF
--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -48,7 +48,7 @@ export interface ApplePayElementProps extends UIElementProps {
      * Part of the 'ApplePayLineItem' object, which sets the label of the payment request
      * @see {@link https://developer.apple.com/documentation/apple_pay_on_the_web/applepaylineitem ApplePayLineItem docs}
      */
-    totalPriceLabel: string;
+    totalPriceLabel?: string;
 
     /**
      * @default 'final'


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Raised a change to make the `totalPriceLabel` property optional within the `ApplePayElementProps` type.

According to the example in the docs [here](https://docs.adyen.com/payment-methods/apple-pay/web-component?tab=_code_payments_code__2#use-adyens-apple-pay-certificate), when you set up an `applepay` web component you only need to pass the `amount` and `currencyCode` properties. However, within the `ApplePayElementProps` type the `totalPriceLabel` property is required, which causes a typing issue when initialising the component via the `checkout.create()` method as it doesn't correctly identify the `applePayConfiguration` object as an `ApplePayElementProps` type.

The result of this is a typescript error when trying to use the `.isAvailable()` method on the component as defined in Step 3 on the docs [here](https://docs.adyen.com/payment-methods/apple-pay/web-component?tab=_code_payments_code__2#step-3-mount-the-component), as `applePayComponent` is of the `RedirectElement` type and not the `ApplePayElement` type that `isAvailable` exists on.

## Tested scenarios
<!-- Description of tested scenarios -->
I can see [here](https://github.com/Adyen/adyen-web/blob/cc7aa40e89d46ce9b121c63576190a4b62faae4b/packages/lib/src/components/ApplePay/ApplePay.tsx#L39) that `totalPriceLabel` gets set to `props.configuration?.merchantName` as a fallback in the event of it not being set, along with test coverage on that scenario [here](https://github.com/Adyen/adyen-web/blob/cc7aa40e89d46ce9b121c63576190a4b62faae4b/packages/lib/src/components/ApplePay/ApplePay.test.ts#L22-L25) - which suggests that this value probably doesn't need to explicitly be set when creating the component?

**Fixed issue**:  <!-- #-prefixed issue number -->
#2100 

