### PR TITLE
Fix getImage crashing custom card integration

### DIFF
--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -92,6 +92,7 @@ export class AchElement extends UIElement<AchElementProps> {
                         onChange={this.setState}
                         onSubmit={this.submit}
                         payButton={this.payButton}
+                        resources={this.resources}
                     />
                 )}
             </CoreProvider>

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
@@ -217,6 +217,7 @@ const extractPropsForSFP = (props: ACHInputProps) => {
         showWarnings: props.showWarnings,
         styles: props.styles,
         type: props.type,
-        forceCompat: props.forceCompat
+        forceCompat: props.forceCompat,
+        resources: props.resources
     };
 };

--- a/packages/lib/src/components/Ach/components/AchInput/types.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/types.ts
@@ -1,6 +1,7 @@
 import Language from '../../../../language/Language';
 import { StylesObject } from '../../../internal/SecuredFields/lib/types';
 import UIElement from '../../../UIElement';
+import { Resources } from '../../../../core/Context/Resources';
 
 export interface ACHInputStateValid {
     holderName?: boolean;
@@ -53,6 +54,7 @@ export interface ACHInputProps {
     payButton?: (obj) => {};
     placeholders?: Placeholders;
     ref?: any;
+    resources: Resources;
     showPayButton?: boolean;
     showWarnings?: boolean;
     styles?: StylesObject;

--- a/packages/lib/src/components/SecuredFields/SecuredFieldsInput/SecuredFieldsInput.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFieldsInput/SecuredFieldsInput.tsx
@@ -6,6 +6,7 @@ import { SFPState } from '../../internal/SecuredFields/SFP/types';
 import { BinLookupResponse, CardBrandsConfiguration } from '../../Card/types';
 import SFExtensions from '../../internal/SecuredFields/binLookup/extensions';
 import { StylesObject } from '../../internal/SecuredFields/lib/types';
+import { Resources } from '../../../core/Context/Resources';
 
 interface SecuredFieldsProps {
     allowedDOMAccess?: boolean;
@@ -33,6 +34,7 @@ interface SecuredFieldsProps {
     onFocus?: (e) => {};
     onLoad?: () => {};
     rootNode: HTMLElement;
+    resources: Resources;
     showWarnings?: boolean;
     styles?: StylesObject;
     trimTrailingSeparator?: boolean;
@@ -158,6 +160,7 @@ const extractPropsForSFP = (props: SecuredFieldsProps) => {
         showWarnings: props.showWarnings,
         styles: props.styles,
         trimTrailingSeparator: props.trimTrailingSeparator,
-        type: props.type
+        type: props.type,
+        resources: props.resources
     };
 };

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -13,7 +13,6 @@ export interface AddressProps {
     countryCode?: string;
     data?: object;
     label?: string;
-    onAddressLookup?: (string) => Array<AddressLookupItem>;
     onChange: (newState) => void;
     requiredFields?: string[];
     ref?: any;
@@ -25,11 +24,6 @@ export interface AddressProps {
     payButton?: (obj) => {};
     showPayButton?: boolean;
     setComponentRef?: (ref) => void;
-}
-
-export interface AddressLookupItem extends AddressData {
-    id: string;
-    value: string;
 }
 
 export interface AddressStateError {

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -13,6 +13,7 @@ export interface AddressProps {
     countryCode?: string;
     data?: object;
     label?: string;
+    onAddressLookup?: (string) => Array<AddressLookupItem>;
     onChange: (newState) => void;
     requiredFields?: string[];
     ref?: any;
@@ -24,6 +25,11 @@ export interface AddressProps {
     payButton?: (obj) => {};
     showPayButton?: boolean;
     setComponentRef?: (ref) => void;
+}
+
+export interface AddressLookupItem extends AddressData {
+    id: string;
+    value: string;
 }
 
 export interface AddressStateError {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The was a bug passing the resource prop to the SecureFields component use in custom card integrations. The prop was not being passed because it uses "extractProps" function to get the correct props.
This also didn't trigger a linting issue because the function where resources was being used is not part of the Class component but instead it's "bound" to it.


## Tested scenarios
<!-- Description of tested scenarios -->
Tested the scenario that cause the crash.
Go into custom card integration (`securefields` component) and start typing credit card information. It should crash.

**Fixed issue**:  <!-- #-prefixed issue number -->
#2135 