### PR TITLE
Fixes resources not being passed to provider

### DIFF
--- a/packages/e2e-playwright/app/config/webpack.config.js
+++ b/packages/e2e-playwright/app/config/webpack.config.js
@@ -1,16 +1,18 @@
 const webpack = require('webpack');
 const path = require('path');
+const fs = require('fs');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
 const checkoutDevServer = require('@adyen/adyen-web-server');
 const host = process.env.HOST || '0.0.0.0';
 const port = '3024';
 const resolve = dir => path.resolve(__dirname, dir);
 
+const basePageDir = path.join(__dirname, `../src/pages/`);
 // NOTE: The first page in the array will be considered the index page.
-const htmlPages = [
-    { name: 'Cards', id: 'Cards' },
-    { name: 'Issuer Lists', id: 'IssuerLists' }
-];
+// Automatically get
+const htmlPages = fs.readdirSync(basePageDir).map(fileName => ({
+    id: fileName
+}));
 
 const htmlPageGenerator = ({ id }, index) =>
     new HTMLWebpackPlugin({
@@ -94,7 +96,7 @@ module.exports = {
 
     devServer: {
         port,
-        host,
+        host: '0.0.0.0',
         https: false,
         hot: true,
         compress: true,

--- a/packages/e2e-playwright/app/src/pages/CustomCards/CustomCards.html
+++ b/packages/e2e-playwright/app/src/pages/CustomCards/CustomCards.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html class="no-js" lang="">
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <title>Adyen Web | Custom Cards</title>
+    <meta name="description" content=""/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+</head>
+
+<body>
+<header></header>
+<main>
+    <!-- Custom Card w. unified date field -->
+    <div class="merchant-checkout__form">
+        <div class="merchant-checkout__payment-method">
+            <div class="merchant-checkout__payment-method__header">
+                <h3 class="card-text sf-text">CustomCard #1</h3>
+            </div>
+            <div class="merchant-checkout__payment-method__details secured-fields" >
+                <span class="pm-image">
+                    <img
+                        class="pm-image-1"
+                        width="40"
+                        src="https://checkoutshopper-test.adyen.com/checkoutshopper/images/logos/nocard.svg"
+                        alt="card"
+                    />
+                </span>
+                <span class="pm-image-dual">
+                    <img
+                        class="pm-image-dual-1"
+                        width="40"
+                        alt=""
+                    />
+                    <img
+                        class="pm-image-dual-2"
+                        width="40"
+                        alt=""
+                    />
+                </span>
+                <label class="pm-form-label pm-form-label-pan">
+                    <span class="pm-form-label__text">Card number:</span>
+                    <span class="pm-input-field" data-cse="encryptedCardNumber"></span>
+                    <span class="pm-form-label__error-text">Please enter a valid credit card number</span>
+                </label>
+                <label class="pm-form-label pm-form-label--exp-date">
+                    <span class="pm-form-label__text">Expiry date:</span>
+                    <span class="pm-input-field" data-cse="encryptedExpiryDate"></span>
+                    <span class="pm-form-label__error-text">Date error text</span>
+                </label>
+                </label>
+                <label class="pm-form-label pm-form-label--cvc">
+                    <span class="pm-form-label__text">CVV/CVC:</span>
+                    <span class="pm-input-field" data-cse="encryptedSecurityCode"></span>
+                    <span class="pm-form-label__error-text">CVC Error text</span>
+                </label>
+            </div>
+
+            <div id='result-message' class="merchant-checkout__result hide"></div>
+        </div>
+    </div>
+
+</main>
+
+<script type="text/javascript">
+    window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' %>;
+</script>
+</body>
+</html>

--- a/packages/e2e-playwright/app/src/pages/CustomCards/CustomCards.js
+++ b/packages/e2e-playwright/app/src/pages/CustomCards/CustomCards.js
@@ -1,0 +1,66 @@
+import AdyenCheckout from '@adyen/adyen-web';
+import '@adyen/adyen-web/dist/es/adyen.css';
+import { handleSubmit, handleAdditionalDetails } from '../../handlers';
+import { amount, shopperLocale, countryCode } from '../../services/commonConfig';
+import '../../style.scss';
+import './customcards.style.scss';
+import { setFocus, onBrand, onConfigSuccess, onBinLookup, onChange } from './customCards.config';
+
+const initCheckout = async () => {
+    // window.TextEncoder = null; // Comment in to force use of "compat" version
+    window.checkout = await AdyenCheckout({
+        amount,
+        clientKey: process.env.__CLIENT_KEY__,
+        locale: shopperLocale,
+        countryCode,
+        environment: 'test',
+        showPayButton: true,
+        onSubmit: handleSubmit,
+        onAdditionalDetails: handleAdditionalDetails,
+        ...window.mainConfiguration
+    });
+
+    window.securedFields = checkout
+        .create('securedfields', {
+            type: 'card',
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro', 'cartebancaire'],
+            onConfigSuccess,
+            onBrand,
+            onFocus: setFocus,
+            onBinLookup,
+            onChange,
+            ...window.cardConfig
+        })
+        .mount('.secured-fields');
+
+    createPayButton('.secured-fields', window.securedFields, 'securedfields');
+
+    function createPayButton(parent, component, attribute) {
+        const payBtn = document.createElement('button');
+
+        payBtn.textContent = 'Pay';
+        payBtn.name = 'pay';
+        payBtn.classList.add('adyen-checkout__button', 'js-components-button--one-click', `js-${attribute}`);
+
+        payBtn.addEventListener('click', e => {
+            e.preventDefault();
+
+            if (!component.isValid) return component.showValidation();
+
+            // formatData
+            const paymentMethod = {
+                type: 'scheme',
+                ...component.state.data
+            };
+            component.state.data = { paymentMethod };
+
+            handleSubmit(component.state, component);
+        });
+
+        document.querySelector(parent).appendChild(payBtn);
+
+        return payBtn;
+    }
+};
+
+initCheckout();

--- a/packages/e2e-playwright/app/src/pages/CustomCards/customCards.config.js
+++ b/packages/e2e-playwright/app/src/pages/CustomCards/customCards.config.js
@@ -1,0 +1,279 @@
+let hideCVC = false;
+let optionalCVC = false;
+let hideDate = false;
+let optionalDate = false;
+let isDualBranding = false;
+
+function setAttributes(el, attrs) {
+    for (const key in attrs) {
+        el.setAttribute(key, attrs[key]);
+    }
+}
+
+function setLogosActive(rootNode, mode) {
+    const imageHolder = rootNode.querySelector('.pm-image');
+    const dualBrandingImageHolder = rootNode.querySelector('.pm-image-dual');
+
+    switch (mode) {
+        case 'dualBranding_notValid':
+            Object.assign(imageHolder.style, { display: 'none' });
+            Object.assign(dualBrandingImageHolder.style, { display: 'block', 'pointer-events': 'none', opacity: 0.5 });
+            break;
+
+        case 'dualBranding_valid':
+            Object.assign(imageHolder.style, { display: 'none' });
+            Object.assign(dualBrandingImageHolder.style, { display: 'block', 'pointer-events': 'auto', opacity: 1 });
+            break;
+
+        default:
+            // reset
+            Object.assign(imageHolder.style, { display: 'block' });
+            Object.assign(dualBrandingImageHolder.style, { display: 'none' });
+    }
+}
+
+export function onConfigSuccess(pCallbackObj) {
+    /**
+     * Set the UI to it's starting state
+     */
+    pCallbackObj.rootNode.style.display = 'block';
+
+    pCallbackObj.rootNode.querySelector('.pm-image-dual').style.display = 'none';
+
+    setLogosActive(pCallbackObj.rootNode);
+}
+
+export function setCCErrors(pCallbackObj) {
+    if (!pCallbackObj.rootNode) return;
+
+    const sfNode = pCallbackObj.rootNode.querySelector(`[data-cse="${pCallbackObj.fieldType}"]`);
+    const errorNode = sfNode.parentNode.querySelector('.pm-form-label__error-text');
+
+    if (errorNode.innerText === '' && pCallbackObj.error === '') return;
+
+    if (pCallbackObj.error !== '') {
+        errorNode.style.display = 'block';
+        errorNode.innerText = pCallbackObj.errorI18n;
+
+        // Add error classes
+        setErrorClasses(sfNode, true);
+        return;
+    }
+
+    // Else: error === ''
+    errorNode.style.display = 'none';
+    errorNode.innerText = '';
+
+    // Remove error classes
+    setErrorClasses(sfNode, false);
+}
+
+export function setFocus(pCallbackObj) {
+    const sfNode = pCallbackObj.rootNode.querySelector(`[data-cse="${pCallbackObj.fieldType}"]`);
+    setFocusClasses(sfNode, pCallbackObj.focus);
+}
+
+export function onBrand(pCallbackObj) {
+    /**
+     * If not in dual branding mode - add card brand to first image element
+     */
+    if (!isDualBranding) {
+        const brandLogo1 = pCallbackObj.rootNode.querySelector('img');
+        setAttributes(brandLogo1, {
+            src: pCallbackObj.brandImageUrl,
+            alt: pCallbackObj.brand
+        });
+    }
+
+    /**
+     * Deal with showing/hiding CVC field
+     */
+    const cvcNode = pCallbackObj.rootNode.querySelector('.pm-form-label--cvc');
+
+    if (pCallbackObj.cvcPolicy === 'hidden' && !hideCVC) {
+        hideCVC = true;
+        cvcNode.style.display = 'none';
+    }
+
+    if (hideCVC && pCallbackObj.cvcPolicy !== 'hidden') {
+        hideCVC = false;
+        cvcNode.style.display = 'block';
+    }
+
+    // Optional cvc fields
+    if (pCallbackObj.cvcPolicy === 'optional' && !optionalCVC) {
+        optionalCVC = true;
+        if (cvcNode) cvcNode.querySelector('.pm-form-label__text').innerText = 'CVV/CVC (optional):';
+    }
+
+    if (optionalCVC && pCallbackObj.cvcPolicy !== 'optional') {
+        optionalCVC = false;
+        if (cvcNode) cvcNode.querySelector('.pm-form-label__text').innerText = 'CVV/CVC:';
+    }
+
+    /**
+     * Deal with showing/hiding date field(s)
+     */
+    const dateNode = pCallbackObj.rootNode.querySelector('.pm-form-label--exp-date');
+    const monthNode = pCallbackObj.rootNode.querySelector('.pm-form-label--exp-month');
+    const yearNode = pCallbackObj.rootNode.querySelector('.pm-form-label--exp-year');
+
+    if (pCallbackObj.expiryDatePolicy === 'hidden' && !hideDate) {
+        hideDate = true;
+        if (dateNode) dateNode.style.display = 'none';
+        if (monthNode) monthNode.style.display = 'none';
+        if (yearNode) yearNode.style.display = 'none';
+    }
+
+    if (hideDate && pCallbackObj.expiryDatePolicy !== 'hidden') {
+        hideDate = false;
+        if (dateNode) dateNode.style.display = 'block';
+        if (monthNode) monthNode.style.display = 'block';
+        if (yearNode) yearNode.style.display = 'block';
+    }
+
+    // Optional date fields
+    if (pCallbackObj.expiryDatePolicy === 'optional' && !optionalDate) {
+        optionalDate = true;
+        if (dateNode) dateNode.querySelector('.pm-form-label__text').innerText = 'Expiry date (optional):';
+        if (monthNode) monthNode.querySelector('.pm-form-label__text').innerText = 'Expiry month (optional):';
+        if (yearNode) yearNode.querySelector('.pm-form-label__text').innerText = 'Expiry year (optional):';
+    }
+
+    if (optionalDate && pCallbackObj.expiryDatePolicy !== 'optional') {
+        optionalDate = false;
+        if (dateNode) dateNode.querySelector('.pm-form-label__text').innerText = 'Expiry date:';
+        if (monthNode) monthNode.querySelector('.pm-form-label__text').innerText = 'Expiry month:';
+        if (yearNode) yearNode.querySelector('.pm-form-label__text').innerText = 'Expiry year:';
+    }
+}
+
+function dualBrandListener(e) {
+    securedFields.dualBrandingChangeHandler(e);
+}
+
+function resetDualBranding(rootNode) {
+    isDualBranding = false;
+
+    setLogosActive(rootNode);
+
+    const brandLogo1 = rootNode.querySelector('.pm-image-dual-1');
+    brandLogo1.removeEventListener('click', dualBrandListener);
+
+    const brandLogo2 = rootNode.querySelector('.pm-image-dual-2');
+    brandLogo2.removeEventListener('click', dualBrandListener);
+}
+
+/**
+ * Implementing dual branding
+ */
+function onDualBrand(pCallbackObj) {
+    const brandLogo1 = pCallbackObj.rootNode.querySelector('.pm-image-dual-1');
+    const brandLogo2 = pCallbackObj.rootNode.querySelector('.pm-image-dual-2');
+
+    isDualBranding = true;
+
+    const supportedBrands = pCallbackObj.supportedBrandsRaw;
+
+    /**
+     * Set first brand icon (and, importantly also add alt &/or data-value attrs); and add event listener
+     */
+    setAttributes(brandLogo1, {
+        src: supportedBrands[0].brandImageUrl,
+        alt: supportedBrands[0].brand,
+        'data-value': supportedBrands[0].brand
+    });
+
+    brandLogo1.addEventListener('click', dualBrandListener);
+
+    /**
+     * Set second brand icon (and, importantly also add alt &/or data-value attrs); and add event listener
+     */
+    setAttributes(brandLogo2, {
+        src: supportedBrands[1].brandImageUrl,
+        alt: supportedBrands[1].brand,
+        'data-value': supportedBrands[1].brand
+    });
+    brandLogo2.addEventListener('click', dualBrandListener);
+}
+
+export function onBinLookup(pCallbackObj) {
+    /**
+     * Dual branded result...
+     */
+    if (pCallbackObj.supportedBrandsRaw?.length > 1) {
+        onDualBrand(pCallbackObj);
+        return;
+    }
+
+    /**
+     * ...else - binLookup 'reset' result or binLookup result with only one brand
+     */
+    resetDualBranding(pCallbackObj.rootNode);
+}
+
+export function onChange(state, component) {
+    // From v5 the onError handler is no longer only for card comp related errors - so watch state.errors and call the card specific setCCErrors based on this
+    if (!!Object.keys(state.errors).length) {
+        const errors = Object.entries(state.errors).map(([fieldType, error]) => {
+            return {
+                fieldType,
+                ...(error ? error : { error: '', rootNode: component._node })
+            };
+        });
+        errors.forEach(setCCErrors);
+    }
+
+    /**
+     * If we're in a dual branding scenario & the number field becomes valid or is valid and become invalid
+     * - set the brand logos to the required 'state'
+     */
+    if (isDualBranding) {
+        const mode = state.valid.encryptedCardNumber ? 'dualBranding_valid' : 'dualBranding_notValid';
+        setLogosActive(component._node, mode);
+    }
+
+    /**
+     * For running the e2e tests in testcafe - we need a mapped version of state.errors
+     * since, for v5, we enhance the securedFields state.errors object with a rootNode prop
+     * & Testcafe doesn't like a ClientFunction retrieving an object with a DOM node in it!?
+     */
+    if (!!Object.keys(state.errors).length) {
+        // Replace any rootNode values in the objects in state.errors with an empty string
+        const nuErrors = Object.entries(state.errors).reduce((acc, [fieldType, error]) => {
+            acc[fieldType] = error ? { ...error, rootNode: '' } : error;
+            return acc;
+        }, {});
+        window.mappedStateErrors = nuErrors;
+    }
+}
+
+const setErrorClasses = function(pNode, pSetErrors) {
+    if (pSetErrors) {
+        if (pNode.className.indexOf('pm-input-field--error') === -1) {
+            pNode.className += ' pm-input-field--error';
+        }
+        return;
+    }
+
+    // Remove errors
+    if (pNode.className.indexOf('pm-input-field--error') > -1) {
+        const newClassName = pNode.className.replace('pm-input-field--error', '');
+        pNode.className = newClassName.trim();
+    }
+};
+
+const setFocusClasses = function(pNode, pSetFocus) {
+    if (pSetFocus) {
+        if (pNode.className.indexOf('pm-input-field--focus') === -1) {
+            pNode.className += ' pm-input-field--focus';
+        }
+        return;
+    }
+
+    // Remove focus
+    if (pNode.className.indexOf('pm-input-field--focus') > -1) {
+        const newClassName = pNode.className.replace('pm-input-field--focus', '');
+        pNode.className = newClassName.trim();
+    }
+};

--- a/packages/e2e-playwright/app/src/pages/CustomCards/customcards.style.scss
+++ b/packages/e2e-playwright/app/src/pages/CustomCards/customcards.style.scss
@@ -1,0 +1,99 @@
+.merchant-checkout__payment-method{
+    padding-top: 20px;
+}
+
+.secured-fields,
+.secured-fields-2 {
+    position: relative;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 14px;
+    padding: 0 24px;
+}
+.pm-image, .pm-image-dual{
+    background-color: #ffffff;
+    border-radius: 4px;
+    -moz-boder-radius: 4px;
+    -webkit-border-radius: 4px;
+    float: right;
+    line-height: 0;
+    position: relative;
+    overflow: hidden;
+}
+.pm-form-label {
+    float: left;
+    padding-bottom: 1em;
+    position: relative;
+    width: 100%;
+}
+.pm-form-label--exp-date {
+    width: 40%;
+}
+.pm-form-label--cvc {
+    float: right;
+    width: 40%;
+}
+.pm-form-label__text {
+    color: #00112c;
+    float: left;
+    font-size: 0.93333em;
+    padding-bottom: 6px;
+    position: relative;
+}
+.pm-input-field {
+    background: white;
+    border: 1px solid #d8d8d8;
+    -moz-border-radius: 4px;
+    -webkit-border-radius: 4px;
+    border-radius: 4px;
+    box-sizing: border-box;
+    clear: left;
+    font-size: 0.93333333333em;
+    float: left;
+    padding: 8px;
+    position: relative;
+    width: 100%;
+    height: 35px;
+}
+
+.pm-form-label__error-text {
+    color: #ff7d00;
+    display: none;
+    float: left;
+    font-size: 13px;
+    padding-top: 0.4em;
+    position: relative;
+    width: 100%;
+}
+
+/* Set dynamically */
+.pm-input-field--error,
+.secured-fields-si.pm-input-field--error {
+    border: 1px solid #ff7d00;
+}
+
+.pm-input-field--focus {
+    border: 1px solid #969696;
+    outline: none;
+}
+.pm-input-field--error.pm-input-field--focus {
+    border: 1px solid #ff7d00;
+}
+
+.card-input__spinner__holder {
+    position: relative;
+    top: 40px;
+}
+
+.card-input__spinner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    display: none;
+}
+
+.card-input__spinner--active {
+    display: block;
+}

--- a/packages/e2e-playwright/models/card.ts
+++ b/packages/e2e-playwright/models/card.ts
@@ -9,7 +9,7 @@ class Card {
     readonly expiryDateInput: Locator;
     readonly cvcInput: Locator;
 
-    constructor(page: Page, rootElementSelector: string = '.adyen-checkout__card-input') {
+    constructor(page: Page, rootElementSelector = '.adyen-checkout__card-input') {
         this.rootElement = page.locator(rootElementSelector);
         this.rootElementSelector = rootElementSelector;
 

--- a/packages/e2e-playwright/pages/customCard/customCard.fixture.ts
+++ b/packages/e2e-playwright/pages/customCard/customCard.fixture.ts
@@ -1,0 +1,16 @@
+import { test as base, expect } from '@playwright/test';
+import { CustomCardPage } from './customCard.page';
+
+type Fixture = {
+    customCardPage: CustomCardPage;
+};
+
+const test = base.extend<Fixture>({
+    customCardPage: async ({ page }, use) => {
+        const cardPage = new CustomCardPage(page);
+        await cardPage.goto();
+        await use(cardPage);
+    }
+});
+
+export { test, expect };

--- a/packages/e2e-playwright/pages/customCard/customCard.page.ts
+++ b/packages/e2e-playwright/pages/customCard/customCard.page.ts
@@ -1,0 +1,25 @@
+import { Locator, Page } from '@playwright/test';
+import { Card } from '../../models/card';
+
+class CustomCardPage {
+    readonly page: Page;
+
+    readonly card: Card;
+    readonly payButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.card = new Card(page, '.secured-fields');
+        this.payButton = page.getByRole('button', { name: /Pay/i });
+    }
+
+    async goto(url?: string) {
+        await this.page.goto('http://localhost:3024/customcards');
+    }
+
+    async pay() {
+        await this.payButton.click();
+    }
+}
+
+export { CustomCardPage };

--- a/packages/e2e-playwright/tests/customCard/customCard.spec.ts
+++ b/packages/e2e-playwright/tests/customCard/customCard.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '../../pages/customCard/customCard.fixture';
+import { REGULAR_TEST_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../utils/constants';
+
+test('should fill in card fields and complete the payment', async ({ customCardPage }) => {
+    const { card, page } = customCardPage;
+
+    await card.typeCardNumber(REGULAR_TEST_CARD);
+
+    await card.typeExpiryDate(TEST_DATE_VALUE);
+
+    await card.typeCvc(TEST_CVC_VALUE);
+
+    await customCardPage.pay();
+
+    await expect(page.locator('#result-message')).toHaveText('Authorised');
+});

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -52,7 +52,7 @@ class RedirectElement extends UIElement {
 
         if (this.props.showButton) {
             return (
-                <CoreProvider {...this.props} loadingContext={this.props.loadingContext}>
+                <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                     <RedirectButton
                         {...this.props}
                         onSubmit={this.submit}

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -106,6 +106,7 @@ export class SecuredFieldsElement extends UIElement {
                     onChange={this.setState}
                     onBinValue={this.onBinValue}
                     implementationType={'custom'}
+                    resources={this.resources}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/Sepa/Sepa.tsx
+++ b/packages/lib/src/components/Sepa/Sepa.tsx
@@ -42,7 +42,7 @@ class SepaElement extends UIElement {
 
     render() {
         return (
-            <CoreProvider {...this.props} loadingContext={this.props.loadingContext}>
+            <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                 <IbanInput
                     ref={ref => {
                         this.componentRef = ref;

--- a/packages/lib/src/components/internal/Icon/Icon.tsx
+++ b/packages/lib/src/components/internal/Icon/Icon.tsx
@@ -12,7 +12,7 @@ interface IconProps {
 
 const Icon = ({ type, className = '', alt = '', height, width }: IconProps) => {
     const getImage = useImage();
-    const iconUrl = getImage({ imageFolder: 'components/' })(type);
+    const iconUrl = getImage({ imageFolder: 'components/' })?.(type);
 
     return <img className={cx('adyen-checkout__icon', className)} alt={alt} src={iconUrl} height={height} width={width} />;
 };

--- a/packages/lib/src/core/Context/CoreProvider.tsx
+++ b/packages/lib/src/core/Context/CoreProvider.tsx
@@ -31,6 +31,9 @@ class CoreProvider extends Component<CoreProviderProps> {
         } else {
             this.setState({ loaded: true });
         }
+        if (!this.props.i18n || !this.props.loadingContext || !this.props.resources) {
+            console.error('CoreProvider - WARNING core provider is missing one of the following: i18n, loadingContext or resources');
+        }
     }
 
     render({ children }: CoreProviderProps) {

--- a/packages/lib/src/core/Context/useImage.ts
+++ b/packages/lib/src/core/Context/useImage.ts
@@ -4,7 +4,7 @@ import { ImageOptions } from '../../utils/get-image';
 
 function useImage() {
     const { resources } = useCoreContext();
-    return useCallback((props: ImageOptions) => resources.getImage(props), []);
+    return useCallback((props: ImageOptions) => resources?.getImage(props), []);
 }
 
 export default useImage;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This PR provides fixes instances of `getImage` crashing the application. This is because not all the providers were getting passed resources correctly.

Also the PR adds/moves some of the tests for secure fields to playwright.

## Tested scenarios
<!-- Description of tested scenarios -->

- Tested making payments with SEPA, Redirect, and securefields components
- Tested reverting the changes to SEPA and Redirect CoreProvider to see if error was triggered
- Added e2e tests for secure fields component
- Check all the uses of useCoreContext to ensure only, i18n and loadingContext objects were being loaded

**Fixed issue**:  <!-- #-prefixed issue number -->
