### PR TITLE
Add a paymentMethodVariants array to the object sent to the onBinLookup callback

### DIFF
--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -211,6 +211,7 @@ export interface BrandObject {
     supported: boolean;
     brandImageUrl?: string;
     panLength?: number;
+    paymentMethodVariant?: string;
 }
 
 export interface BinLookupResponseRaw {

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
@@ -86,6 +86,8 @@ export default parent => {
                             (acc, item) => {
                                 // All brand strings end up in the detectedBrands array
                                 acc.detectedBrands.push(item.brand);
+                                // Also add the paymentMethodVariants (more granular description of the txvariant)
+                                acc.paymentMethodVariants.push(item.paymentMethodVariant);
 
                                 // Add supported brand objects to the supportedBrands array
                                 if (item.supported === true) {
@@ -95,7 +97,7 @@ export default parent => {
 
                                 return acc;
                             },
-                            { supportedBrands: [], detectedBrands: [] }
+                            { supportedBrands: [], detectedBrands: [], paymentMethodVariants: [] }
                         );
 
                         /**
@@ -113,9 +115,9 @@ export default parent => {
                             parent.onBinLookup({
                                 type: callbackObj.type,
                                 detectedBrands: mappedResponse.detectedBrands,
-                                supportedBrands: mappedResponse.supportedBrands.map(item => item.brand), // supportedBrands contains the subset of
-                                // this.props.brands that matches the card
-                                // number that the shopper has typed
+                                // supportedBrands contains the subset of this.props.brands that matches the card number that the shopper has typed
+                                supportedBrands: mappedResponse.supportedBrands.map(item => item.brand),
+                                paymentMethodVariants: mappedResponse.paymentMethodVariants,
                                 supportedBrandsRaw: mappedResponse.supportedBrands, // full supportedBrands data (for customCard comp)
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES,
                                 issuingCountryCode: data.issuingCountryCode
@@ -142,6 +144,7 @@ export default parent => {
                                 type: callbackObj.type,
                                 detectedBrands: mappedResponse.detectedBrands,
                                 supportedBrands: null,
+                                paymentMethodVariants: mappedResponse.paymentMethodVariants,
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES
                             } as CbObjOnBinLookup);
 
@@ -155,6 +158,7 @@ export default parent => {
                             type: callbackObj.type,
                             detectedBrands: null,
                             supportedBrands: null,
+                            paymentMethodVariants: null,
                             brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES
                         } as CbObjOnBinLookup);
 


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR adds a `paymentMethodVariants` array to the object sent to the merchant defined, `onBinLookup`, callback.
This is the callback we use to tell the merchant what the results of the call to the `/binLookup` endpoint were.

That means the object sent to this callback now looks something like this:
```
{
    "type": "card",
    "detectedBrands": ["mc"],
    "supportedBrands": ["mc"],
    "paymentMethodVariants": ["mcdebit"],
    "brands": ["visa", "mc", "amex"],
    "issuingCountryCode": "US"
}
```

The `paymentMethodVariant` represents a more granular description of the payment method, e.g. '"mcdebit"` rather than just `"mc"`. See, https://docs.adyen.com/development-resources/paymentmethodvariant.

So now, as well as telling the merchant what brands we detect the entered card number to be, and whether it is one of the brands they support, we also say what the `paymentMethodVariant` is of the entered card number.

## Tested scenarios
A `paymentMethodVariants` array is present in the object sent to the `onBinLookup` callback in both the "supported brands detected" and "supported brands not detected" scenarios.


**Fixed issue**:  COAPI-79
