### PR TITLE
Set static type on SRPanel comp

### DIFF
--- a/packages/lib/src/core/Errors/SRPanel.tsx
+++ b/packages/lib/src/core/Errors/SRPanel.tsx
@@ -10,6 +10,8 @@ import { SRMessages, SRMessagesRef } from './SRMessages';
  * For testing purposes can be made visible
  */
 export class SRPanel extends BaseElement<SRPanelProps> {
+    public static type = 'srPanel';
+
     public static defaultProps = {
         enabled: true,
         node: 'body',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Set `static type` on `SRPanel`, so it doesn't have `"undefined"` in its `_id` prop

## Tested scenarios
`_id` prop is properly filled


