### PR TITLE
Remove aria-hidden attribute on brand icon

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
@@ -18,7 +18,6 @@ export default function BrandIcon({ brand, brandsConfiguration = {} }: BrandIcon
             onError={handleError}
             alt={brand}
             src={imageUrl}
-            aria-hidden={'true'}
         />
     );
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
@@ -23,7 +23,6 @@ const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected, brandsConfig
             src={imageUrl}
             onClick={onClick}
             data-value={dataValue}
-            aria-hidden={'true'}
         />
     );
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The brand image in the credit card, visible once a brand has been identified, should have an `alt` tag detailing the card brand, and thus making it readable by screenreaders. 

This was the case _except_  we were also adding an `aria-hidden` attribute, which hid this element from screenreaders.

This has now been fixed. 

## Tested scenarios
`aria-hidden` attribute no longer set on brand or dual-brand icons

**Fixed issue**:  #1691 
