### PR TITLE
Fixes mismatched label for Selectbox

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -8,7 +8,7 @@ import Img from '../../../Img';
 function SelectButtonElement({ filterable, toggleButtonRef, ...props }) {
     if (filterable) return <div {...props} ref={toggleButtonRef} />;
 
-    return <button {...props} ref={toggleButtonRef} />;
+    return <button id={props.id} aria-describedby={props.ariaDescribedBy} type={'button'} {...props} ref={toggleButtonRef} />;
 }
 
 function SelectButton(props: SelectButtonProps) {
@@ -54,11 +54,7 @@ function SelectButton(props: SelectButtonProps) {
             filterable={props.filterable}
             onClick={onClickHandler}
             onKeyDown={!readonly ? props.onButtonKeyDown : null}
-            title={selected.name || props.placeholder}
             toggleButtonRef={props.toggleButtonRef}
-            type={!props.filterable ? 'button' : null}
-            aria-describedby={props.ariaDescribedBy}
-            id={props.id}
         >
             {!props.filterable ? (
                 <Fragment>
@@ -85,6 +81,8 @@ function SelectButton(props: SelectButtonProps) {
                         aria-activedescendant={`listItem-${active.id}`}
                         type="text"
                         readOnly={props.readonly}
+                        id={props.id}
+                        aria-describedby={props.ariaDescribedBy}
                     />
                     {!showList && selected.secondaryText && (
                         <span className="adyen-checkout__dropdown__button__secondary-text">{selected.secondaryText}</span>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This is a fix for a problem that came back from the second round of a11y testing. The `label` was pointing for a different element then the `combobox`. This occurs because this element that had the `id` can be either a button or div depending  if it's a filterable select or not.

Also remove `title`, not sure if this was doing anything, but doesn't seem necessary for a11y purposes. And was causing duplication of placeholder when using the Chrome a11y inspector.



## Tested scenarios
<!-- Description of tested scenarios -->
- Tested with Voice Over to make sure "Country" was announced
- Tested with Chrome a11y inspector 

**Fixed issue**:  <!-- #-prefixed issue number -->
