### PR TITLE
Prevent double readout of PM names, by a screenreader, in Dropin

### DIFF
--- a/.changeset/honest-cherries-wash.md
+++ b/.changeset/honest-cherries-wash.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Prevent double readout of PM names, by a screenreader, in Dropin.

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -112,7 +112,12 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
                             aria-hidden="true"
                         />
 
-                        <PaymentMethodIcon altDescription={paymentMethod.props.name} type={paymentMethod.type} src={paymentMethod.icon} />
+                        <PaymentMethodIcon
+                            // Only add alt attribute to storedPaymentMethods (to avoid SR reading the PM name twice)
+                            {...(paymentMethod.props.oneClick && { altDescription: paymentMethod.props.name })}
+                            type={paymentMethod.type}
+                            src={paymentMethod.icon}
+                        />
 
                         <PaymentMethodName
                             displayName={paymentMethod.displayName}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Because we add filled `alt` tags to the icons for the `paymentMethodItems` in the Dropin - the screenreader was reading both the paymentMethod `name` as well as the `alt` tag, effectively reading the PM name twice.

Now we only fill this `alt` tag if the PM is a `storedPaymentMethod` since this does not get a text description by default

## Tested scenarios
PM names are only read out once


**Fixed issue**:  #1692
