### PR TITLE
fix: change meal voucher label Pin to Security code

### DIFF
--- a/.changeset/curly-cats-fold.md
+++ b/.changeset/curly-cats-fold.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Change meal voucher label _Pin_ to _Security code_

--- a/packages/lib/src/components/Giftcard/components/GiftcardPinField.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardPinField.tsx
@@ -4,10 +4,17 @@ import Field from '../../internal/FormFields/Field';
 import { h } from 'preact';
 import { GiftcardFieldProps } from './types';
 
-export const GiftcardPinField = ({ i18n, classNameModifiers, sfpState, focusedElement, setFocusOn }: GiftcardFieldProps) => {
+export const GiftcardPinField = ({
+    i18n,
+    classNameModifiers,
+    sfpState,
+    focusedElement,
+    setFocusOn,
+    label = i18n.get('creditCard.pin.title')
+}: GiftcardFieldProps) => {
     return (
         <Field
-            label={i18n.get('creditCard.pin.title')}
+            label={label}
             classNameModifiers={['pin', ...classNameModifiers]}
             errorMessage={sfpState.errors.encryptedSecurityCode && i18n.get(sfpState.errors.encryptedSecurityCode)}
             focused={focusedElement === 'encryptedSecurityCode'}

--- a/packages/lib/src/components/Giftcard/components/types.ts
+++ b/packages/lib/src/components/Giftcard/components/types.ts
@@ -9,6 +9,7 @@ export type GiftcardFieldsProps = {
     getCardErrorMessage;
     focusedElement;
     setFocusOn;
+    label?: string;
 };
 
 export type GiftcardFieldProps = {
@@ -18,4 +19,5 @@ export type GiftcardFieldProps = {
     getCardErrorMessage;
     focusedElement;
     setFocusOn;
+    label?: string;
 };

--- a/packages/lib/src/components/MealVoucherFR/components/MealVoucherFields.tsx
+++ b/packages/lib/src/components/MealVoucherFR/components/MealVoucherFields.tsx
@@ -6,6 +6,7 @@ import { GiftcardNumberField } from '../../Giftcard/components/GiftcardNumberFie
 
 export const MealVoucherFields = (props: GiftcardFieldsProps) => {
     const { setRootNode } = props;
+    const pinFieldProps = { ...props, label: props.i18n.get('creditCard.cvcField.title') };
     return (
         <div ref={setRootNode}>
             <GiftcardNumberField {...props} classNameModifiers={['100']} />
@@ -13,7 +14,7 @@ export const MealVoucherFields = (props: GiftcardFieldsProps) => {
             <div className="adyen-checkout__field-wrapper">
                 <MealVoucherExpiryField {...props} />
 
-                <GiftcardPinField {...props} classNameModifiers={['50']} />
+                <GiftcardPinField {...pinFieldProps} classNameModifiers={['50']} />
             </div>
         </div>
     );


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We need to change the label `PIN` to `Security Code` on the 3 meal voucher Sodexo, Apetiz, Up.


## Tested scenarios
- The pin field label for mealVoucher_FR_groupeup, mealVoucher_FR_natixis and mealVoucher_FR_sodexo is changed to 'Security code', the gift card pin label should NOT be changed.
- All tests passed


**Relates to ticket**:  COWEB-1226
