### PR TITLE
Adding safety check when initializing ApplePay 

### DIFF
--- a/.changeset/warm-crews-decide.md
+++ b/.changeset/warm-crews-decide.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixes issue which ApplePay crashes Drop-in when initialized within iframe

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -136,8 +136,12 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
             return Promise.reject(new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'clientKey was not provided'));
         }
 
-        if (window.ApplePaySession && ApplePaySession.canMakePayments() && ApplePaySession.supportsVersion(this.props.version)) {
-            return Promise.resolve(true);
+        try {
+            if (window.ApplePaySession && ApplePaySession.canMakePayments() && ApplePaySession.supportsVersion(this.props.version)) {
+                return Promise.resolve(true);
+            }
+        } catch (error) {
+            console.warn(error);
         }
 
         return Promise.reject(new AdyenCheckoutError('ERROR', 'Apple Pay is not available on this device'));

--- a/packages/lib/src/components/ApplePay/utils.ts
+++ b/packages/lib/src/components/ApplePay/utils.ts
@@ -1,10 +1,15 @@
-export function resolveSupportedVersion(latestVersion) {
+export function resolveSupportedVersion(latestVersion: number): number | null {
     const versions = [];
     for (let i = latestVersion; i > 0; i--) {
         versions.push(i);
     }
 
-    return versions.find(v => v && window.ApplePaySession && ApplePaySession.supportsVersion(v));
+    try {
+        return versions.find(v => v && window.ApplePaySession && ApplePaySession.supportsVersion(v));
+    } catch (error) {
+        console.warn(error);
+        return null;
+    }
 }
 
 export function mapBrands(brands) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
ApplePay isn't supported inside iframes. When checking for the ApplePaySession inside an iframe, the browser throws an exception which isn't handled properly.

This PR adds a safety check to not let Drop-in crash in case the browser does not manage to access `window.ApplePaySession` due to the iframe limitation.

**Side note:** A recent WebKit added support for it though (it seems to not be released yet) - the iframe  must contain `allow="payment"` attribute in order to let ApplePay show up.


**Fixed issue**:  #2149 
