### PR TITLE
Typescript - Disabling stripInternal feature

### DIFF
--- a/.changeset/wet-zebras-switch.md
+++ b/.changeset/wet-zebras-switch.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Removing tsconfig stripInternals from lib package

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -15,7 +15,6 @@
         "noImplicitAny": false,
         "strictPropertyInitialization": false,
         "suppressImplicitAnyIndexErrors": true,
-        "stripInternal": false,
 
         "importHelpers": true,
 

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -15,7 +15,7 @@
         "noImplicitAny": false,
         "strictPropertyInitialization": false,
         "suppressImplicitAnyIndexErrors": true,
-        "stripInternal": true,
+        "stripInternal": false,
 
         "importHelpers": true,
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We use JSDoc `@internal` annotation in some places to document that certain types are internal types, but we still want to keep those types in the exported type definition files.  This PR tweaks the tsconfig to not strip these types from the final build

**Fixed issue**: #2209 
