### PR TITLE
fix(gift-card): inconsistency custom logo display

### DIFF
--- a/.changeset/slimy-dots-sparkle.md
+++ b/.changeset/slimy-dots-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix inconsistency displaying custom brand logo for the gift card payment

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -1,11 +1,10 @@
 import { h } from 'preact';
 import PaymentMethodIcon from './PaymentMethodIcon';
-
 import useCoreContext from '../../../../core/Context/useCoreContext';
 import './OrderPaymentMethods.scss';
 import useImage from '../../../../core/Context/useImage';
 
-export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel }) => {
+export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLogoConfiguration }) => {
     const { i18n } = useCoreContext();
     const getImage = useImage();
 
@@ -19,7 +18,7 @@ export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel }) => {
                                 <PaymentMethodIcon
                                     altDescription={orderPaymentMethod.name}
                                     type={orderPaymentMethod.type}
-                                    src={getImage({})(orderPaymentMethod.type)}
+                                    src={brandLogoConfiguration[orderPaymentMethod.type] || getImage({})(orderPaymentMethod.type)}
                                 />
                                 •••• {orderPaymentMethod.lastFour}
                             </div>

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -8,6 +8,7 @@ import { Order, OrderStatus } from '../../../../types';
 import OrderPaymentMethods from './OrderPaymentMethods';
 import InstantPaymentMethods from './InstantPaymentMethods';
 import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useBrandLogoConfiguration } from './useBrandLogoConfiguration';
 
 interface PaymentMethodListProps {
     paymentMethods: UIElement[];
@@ -66,10 +67,17 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
             'adyen-checkout__payment-methods-list--loading': isLoading
         });
 
+        const brandLogoConfiguration = useBrandLogoConfiguration(paymentMethods);
+
         return (
             <Fragment>
                 {this.props.orderStatus && (
-                    <OrderPaymentMethods order={this.props.order} orderStatus={this.props.orderStatus} onOrderCancel={this.props.onOrderCancel} />
+                    <OrderPaymentMethods
+                        order={this.props.order}
+                        orderStatus={this.props.orderStatus}
+                        onOrderCancel={this.props.onOrderCancel}
+                        brandLogoConfiguration={brandLogoConfiguration}
+                    />
                 )}
 
                 {!!instantPaymentMethods.length && <InstantPaymentMethods paymentMethods={instantPaymentMethods} />}

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/useBrandLogoConfiguration.ts
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/useBrandLogoConfiguration.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'preact/hooks';
+import UIElement from '../../../UIElement';
+
+type BrandLogoConfiguration = {
+    [key: string]: string;
+};
+
+export function useBrandLogoConfiguration(paymentMethods: UIElement[]): BrandLogoConfiguration {
+    const [brandLogoConfiguration, setBrandLogoConfiguration] = useState<BrandLogoConfiguration>({});
+
+    useEffect(() => {
+        setBrandLogoConfiguration(
+            paymentMethods.reduce(
+                (accumulator, paymentMethod) => ({
+                    ...accumulator,
+                    ...(paymentMethod.props.brand && paymentMethod.icon && { [paymentMethod.props.brand]: paymentMethod.icon })
+                }),
+                {}
+            )
+        );
+    }, [paymentMethods]);
+
+    return brandLogoConfiguration;
+}

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -246,6 +246,7 @@ export interface Order {
 export interface OrderStatus {
     expiresAt: string;
     paymentMethods: {
+        amount?: PaymentAmount;
         lastFour: string;
         type: string;
     }[];


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
### What the issue?
A merchant replaced the icon for Givex in their paymentMethodsConfiguration but when their Sessions Drop-in creates an order to deal with insufficient gift card balance, the deducted balance part of the Drop-in still shows the default logo for Givex.
![image](https://github.com/Adyen/adyen-web/assets/31349885/a7795d98-987b-4b55-b230-b1bdfc499b18)

### Fix
We need to feed the correct custom brand logo information to the `OrderPaymentMethods.tsx` component.
Hence created `useBrandLogoConfiguration.ts` to gather such information, and use it in the `PaymentMethodList.tsx`

### How to test the fix?
In the playground `session.js`, setting `brandsConfiguration` for `givex` under `paymentMethodsConfiguration` when initiating `AdyenCheckout`: 

```javascript
        paymentMethodsConfiguration: {
            giftcard: {
                brandsConfiguration: {
                    givex: {
                        icon: 'https://upload.wikimedia.org/wikipedia/commons/7/70/Example.png',
                        name: 'givex Giftcard'
                    }
                }
            }
        }
```

We should be able to see the Givex renders custom logo in the payment list.
After we fill in a Givex card, and redeem, the order payment section should also show the custom logo.

## Tested scenarios
Dropin should display the custom logo in the order payment section:

<img width="633" alt="Screenshot 2023-06-08 at 16 07 02" src="https://github.com/Adyen/adyen-web/assets/31349885/06c4de0f-2363-47f8-9798-29dceaf0127a">



**Related Internal ticket**:  COWEB-1237