### PR TITLE
refactor: sr panel and provider type definitions

### DIFF
--- a/.changeset/forty-geckos-sniff.md
+++ b/.changeset/forty-geckos-sniff.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Refactor the SRPanel type definition

--- a/packages/lib/src/core/Errors/SRPanelContext.ts
+++ b/packages/lib/src/core/Errors/SRPanelContext.ts
@@ -1,10 +1,17 @@
 import { createContext } from 'preact';
 import { SRPanel } from './SRPanel';
 import { SetSRMessagesReturnFn } from './SRPanelProvider';
+import { FieldTypeMappingFn } from './types';
+
+interface SetSRMessagesFromObjectsFnProps {
+    fieldTypeMappingFn?: FieldTypeMappingFn;
+}
+
+type SetSRMessagesFromObjectsFn = (props: SetSRMessagesFromObjectsFnProps) => SetSRMessagesReturnFn;
 
 export interface ISRPanelContext {
     srPanel: SRPanel;
-    setSRMessagesFromObjects: ({ fieldTypeMappingFn = null }) => SetSRMessagesReturnFn;
+    setSRMessagesFromObjects: SetSRMessagesFromObjectsFn;
     setSRMessagesFromStrings: (strs) => void;
     clearSRPanel: () => void;
     shouldMoveFocusSR: boolean;

--- a/packages/lib/src/core/Errors/SRPanelProvider.tsx
+++ b/packages/lib/src/core/Errors/SRPanelProvider.tsx
@@ -5,13 +5,23 @@ import { partial } from '../../components/internal/SecuredFields/lib/utilities/c
 import { setSRMessagesFromErrors } from './utils';
 import { SRPanel } from './SRPanel';
 import { SetSRMessagesReturnObject } from './types';
+import { StringObject } from '../../components/internal/Address/types';
 
 type SRPanelProviderProps = {
     srPanel: SRPanel;
     children: ComponentChildren;
 };
 
-export type SetSRMessagesReturnFn = ({ errors, isValidating, layout = null, countrySpecificLabels = null }) => SetSRMessagesReturnObject;
+interface SetSRMessagesReturnFnProps {
+    errors: {
+        [key: string]: any;
+    };
+    isValidating: boolean;
+    layout?: string[];
+    countrySpecificLabels?: StringObject;
+}
+
+export type SetSRMessagesReturnFn = (props: SetSRMessagesReturnFnProps) => SetSRMessagesReturnObject;
 
 const SRPanelProvider = ({ srPanel, children }: SRPanelProviderProps) => {
     const { i18n } = useCoreContext();

--- a/packages/lib/src/core/Errors/types.ts
+++ b/packages/lib/src/core/Errors/types.ts
@@ -14,12 +14,14 @@ export interface ValidationRuleErrorObj {
     [key: string]: ValidationRuleResult;
 }
 
+export type FieldTypeMappingFn = (key: string, i18n: Language, countrySpecificLabels: StringObject) => string;
+
 export interface SortErrorsObj {
     errors: ErrorObj;
     layout?: string[];
     i18n: Language;
     countrySpecificLabels?: StringObject;
-    fieldTypeMappingFn?: (key: string, i18n: Language, countrySpecificLabels: StringObject) => string;
+    fieldTypeMappingFn?: FieldTypeMappingFn;
 }
 
 export interface SortedErrorObject {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Created this separate PR because Storybook throws following errors:
```
4:25:20 AM [vite] Internal server error: Transform failed with 1 error:
/home/vagrant/workspace/adyen-web/packages/lib/src/core/Errors/SRPanelProvider.tsx:17:9: ERROR: Unexpected "="
  Plugin: vite:esbuild
  File: /home/vagrant/workspace/adyen-web/packages/lib/src/core/Errors/SRPanelProvider.tsx:14:67
  
  Unexpected "="
  15 |    errors,
  16 |    isValidating,
  17 |    layout = null,
     |           ^
  18 |    countrySpecificLabels = null
  19 |  }) => SetSRMessagesReturnObject;
  

``` 
```
/home/vagrant/workspace/adyen-web/packages/lib/src/core/Errors/SRPanelContext.ts:7:23: ERROR: Unexpected "="
  Plugin: vite:esbuild
  File: /home/vagrant/workspace/adyen-web/packages/lib/src/core/Errors/SRPanelContext.ts:7:51
  
  Unexpected "="
  5  |    srPanel: SRPanel;
  6  |    setSRMessagesFromObjects: ({
  7  |      fieldTypeMappingFn = null
     |                         ^
  8  |    }) => SetSRMessagesReturnFn;
  9  |    setSRMessagesFromStrings: (strs) => void;
  
      at failureErrorWithLog (/home/vagrant/workspace/adyen-web/node_modules/vite/node_modules/esbuild/lib/main.js:1653:15)

```
