### PR TITLE
PayPal - Adding isExpress flag

### DIFF
--- a/.changeset/strong-snakes-attack.md
+++ b/.changeset/strong-snakes-attack.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Added isExpress configuration to PayPal component

--- a/packages/lib/src/components/PayPal/Paypal.test.ts
+++ b/packages/lib/src/components/PayPal/Paypal.test.ts
@@ -6,6 +6,11 @@ describe('Paypal', () => {
         expect(paypal.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { subtype: 'sdk', type: 'paypal' } });
     });
 
+    test('should return subtype express if isExpress flag is set', () => {
+        const paypal = new Paypal({ isExpress: true });
+        expect(paypal.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { subtype: 'express', type: 'paypal' } });
+    });
+
     test('Is always valid', () => {
         const paypal = new Paypal({});
         expect(paypal.isValid).toBe(true);

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -49,10 +49,12 @@ class PaypalElement extends UIElement<PayPalElementProps> {
      * Formats the component data output
      */
     protected formatData() {
+        const { isExpress } = this.props;
+
         return {
             paymentMethod: {
                 type: PaypalElement.type,
-                subtype: PaypalElement.subtype
+                subtype: isExpress ? 'express' : PaypalElement.subtype
             }
         };
     }

--- a/packages/lib/src/components/PayPal/defaultProps.ts
+++ b/packages/lib/src/components/PayPal/defaultProps.ts
@@ -49,6 +49,8 @@ const defaultProps: PayPalElementProps = {
 
     blockPayPalVenmoButton: false,
 
+    isExpress: false,
+
     configuration: {
         /**
          * @see {@link https://developer.paypal.com/docs/checkout/reference/customize-sdk/#merchant-id}

--- a/packages/lib/src/components/PayPal/types.ts
+++ b/packages/lib/src/components/PayPal/types.ts
@@ -149,6 +149,12 @@ interface PayPalCommonProps {
      * @see {@link https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#onshippingchange}
      */
     onShippingChange?: (data, actions) => void;
+
+    /**
+     *  Identifies if the payment is Express.
+     *  @defaultValue false
+     */
+    isExpress?: boolean;
 }
 
 export interface PayPalConfig {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adding `isExpress` configuration property to PayPal component. 

If the flag is set, the `subtype` is set to `express`, which will trigger different behavior from the Backend when processing the /payments call.


## Tested scenarios
- Added unit test to ensure subtype is set
- Manual test
<!-- Description of tested scenarios -->


**Fixed issue**: COWEB-1241