### PR TITLE
fix(sr-panel): remove existing SR panel container when initiating SRPanel

### DIFF
--- a/.changeset/neat-llamas-build.md
+++ b/.changeset/neat-llamas-build.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Remove existing SR panel container when initiating SRPanel, as a result all checkout instances share one SR panel.

--- a/packages/lib/src/core/Errors/SRPanel.tsx
+++ b/packages/lib/src/core/Errors/SRPanel.tsx
@@ -43,10 +43,15 @@ export class SRPanel extends BaseElement<SRPanelProps> {
         if (this.props.enabled) {
             this._enabled = true;
             if (document.querySelector(this.props.node)) {
+                const containers = document.getElementsByClassName('sr-panel-holder');
+                if (Array.from(containers).length) {
+                    Array.from(containers).forEach(ele => {
+                        ele.remove();
+                    });
+                }
                 this.srPanelContainer = document.createElement('div');
                 this.srPanelContainer.className = 'sr-panel-holder';
                 this.srPanelContainer.id = this.id;
-
                 document.querySelector(this.props.node).appendChild(this.srPanelContainer);
                 this.mount(this.srPanelContainer);
             } else {

--- a/packages/lib/src/core/Errors/SRPanel.tsx
+++ b/packages/lib/src/core/Errors/SRPanel.tsx
@@ -43,6 +43,15 @@ export class SRPanel extends BaseElement<SRPanelProps> {
         if (this.props.enabled) {
             this._enabled = true;
             if (document.querySelector(this.props.node)) {
+                /*
+                We want to remove the sr panel container from the DOM after the checkout instance destroyed.
+                SRPanel extends from BaseElement which is not a preact component,
+                there is no way to know when component unmounts.
+                Hence, we remove all sr panel container elements during the initializing phase.
+                A 'side effect' to this approach - if there are multiple adyen checkout instances,
+                there will be only one sr panel which belongs to the last instance.
+                Usually there is only one checkout instance.
+                 */
                 const containers = document.getElementsByClassName('sr-panel-holder');
                 if (Array.from(containers).length) {
                     Array.from(containers).forEach(ele => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Remove existing SR panel containers (if there are) when initiating SRPanel, as a result all checkout instances share one SR panel.

Reusing the existing SR panel messes up (or loses the `SRMessages` reference) with the `SRMessages` reference, hence it's better to remove all SR panel containers and remount it again.

## Tested scenarios
Tested in `MyStoreDemo`, only one SR panel exists in the DOM when switching pages from the checkout to any other pages.

