### PR TITLE
feat: remove threeDSServerTransID check in challenge component

### DIFF
--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -85,22 +85,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                             this.props.onError(errorCodeObject);
                         }
 
-                        // This is the response we were looking for
-                        if (challenge.threeDSServerTransID === challengeData.cReqData.threeDSServerTransID) {
-                            // Proceed with call to onAdditionalDetails
-                            this.setStatusComplete(challenge.result);
-                        } else {
-                            /**
-                             * We suspect there is a scenario where the cRes is empty the first time causing the shopper to try to pay again, from the same
-                             * browser window. But due to a suboptimal implementation by the merchant - the first set of 3DS2 components has not been properly removed.
-                             * This means that for the second, successful challenge, there are a double set of listeners, leading to double callbacks, leading to
-                             * double /details calls (one that will fail, one that will succeed).
-                             *
-                             * So here we detect that this is not the response we are looking for, and this time round, unmount this set of 3DS2 comps
-                             */
-                            console.debug('### PrepareChallenge3DS2::threeDSServerTransID:: ids do not match');
-                            this.props.onComplete(null); // Send null so parent will unmount without calling onComplete
-                        }
+                        this.setStatusComplete(challenge.result);
                     }}
                     onErrorChallenge={(challenge: ThreeDS2FlowObject) => {
                         /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR reverts the changes of [this PR](https://github.com/Adyen/adyen-web/pull/2081/files).
This validation is too strict and causes issues with conversion since sometimes the threeDSServerTransID's might not match due to ACS or other reasons. 

