### PR TITLE
feat: add an ability to hide the amount labels in pay button

### DIFF
--- a/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
@@ -66,4 +66,37 @@ describe('PayButton', () => {
         expect(wrapper.text()).not.toContain(PAY_BTN_DIVIDER);
         expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
     });
+
+    test('Renders a pay button without an amount when amount.hideAmountLabel is true', () => {
+        const wrapper = getWrapper({ amount: { currency: 'USD', value: 1000, hideAmountLabel: true } });
+        expect(wrapper.text()).toBe('Pay');
+        expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
+    });
+
+    test('Renders a pay button without a secondary amount when secondaryAmount.hideAmountLabel is true', () => {
+        const wrapper = getWrapper({
+            amount: { currency: 'USD', value: 1000 },
+            secondaryAmount: { currency: 'HRK', value: 7534, hideAmountLabel: true }
+        });
+        expect(wrapper.text()).toBe('Pay $10.00');
+        expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
+    });
+
+    test('Renders a pay button without a any amount when both amount and secondaryAmount hideAmountLabel is true', () => {
+        const wrapper = getWrapper({
+            amount: { currency: 'USD', value: 1000, hideAmountLabel: true },
+            secondaryAmount: { currency: 'HRK', value: 7534, hideAmountLabel: true }
+        });
+        expect(wrapper.text()).toBe('Pay');
+        expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
+    });
+
+    test('Renders a pay button without a first amount when only amount.hideAmountLabel is true', () => {
+        const wrapper = getWrapper({
+            amount: { currency: 'USD', value: 1000, hideAmountLabel: true },
+            secondaryAmount: { currency: 'HRK', value: 7534 }
+        });
+        expect(wrapper.text().replace('\u00a0', ' ')).toBe('Pay / HRK 75.34');
+        expect(wrapper.getDOMNode().nodeName).toBe('BUTTON');
+    });
 });

--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -31,6 +31,7 @@ const PayButton = ({ amount, secondaryAmount, classNameModifiers = [], label, ..
      *  - we don't have a predefined label (i.e. redirect, qrcode, await based comps...), and
      *  - we do have an amount object (merchant might not be passing this in order to not show the amount on the button), and
      *  - we have a secondaryAmount object with some properties
+     *  - secondaryAmount.hideAmountLabel is not true
      */
     const secondaryLabel =
         !isZeroAuth && !label && amount && secondaryAmount && Object.keys(secondaryAmount).length

--- a/packages/lib/src/components/internal/PayButton/utils.ts
+++ b/packages/lib/src/components/internal/PayButton/utils.ts
@@ -1,16 +1,18 @@
 import Language from '../../../language';
 import { PaymentAmountExtended } from '../../../types';
 
-export const PAY_BTN_DIVIDER = '/ ';
+export const PAY_BTN_DIVIDER = ' / ';
 
-const amountLabel = (i18n, amount: PaymentAmountExtended) =>
-    !!amount?.value && !!amount?.currency ? i18n.amount(amount.value, amount.currency, { currencyDisplay: amount.currencyDisplay || 'symbol' }) : '';
+const amountLabel = (i18n: Language, amount: PaymentAmountExtended) =>
+    !amount?.hideAmountLabel && !!amount?.value && !!amount?.currency
+        ? i18n.amount(amount.value, amount.currency, { currencyDisplay: amount.currencyDisplay || 'symbol' })
+        : '';
 
-const payAmountLabel = (i18n: Language, amount: PaymentAmountExtended) => `${i18n.get('payButton')} ${amountLabel(i18n, amount)}`;
+const payAmountLabel = (i18n: Language, amount: PaymentAmountExtended) => `${i18n.get('payButton')} ${amountLabel(i18n, amount)}`.trimEnd();
 
 const secondaryAmountLabel = (i18n: Language, secondaryAmount: PaymentAmountExtended) => {
     const convertedSecondaryAmount =
-        secondaryAmount && !!secondaryAmount?.value && !!secondaryAmount?.currency
+        secondaryAmount && !secondaryAmount.hideAmountLabel && !!secondaryAmount.value && !!secondaryAmount.currency
             ? i18n.amount(secondaryAmount.value, secondaryAmount.currency, { currencyDisplay: secondaryAmount.currencyDisplay || 'symbol' })
             : '';
 

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -196,6 +196,10 @@ export interface PaymentAmountExtended extends PaymentAmount {
      * see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currencydisplay
      */
     currencyDisplay?: string;
+    /**
+     * In case you don't want to show the amount on the pay button, set this prop to true.
+     */
+    hideAmountLabel?: boolean;
 }
 
 export type ShopperDetails = {


### PR DESCRIPTION
## Summary
This pull request adds the ability to hide the amount and currency on for the payment button , addressing the requirement outlined in the GitHub issue (Created by myself) [#2229]

## Tested scenarios
Both Amount and Secondary Amount to support hiding the currency and amount

**Fixed issue**:  [#2229]
