### PR TITLE
fix: put the NODE_ENV back in package.json

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -33,9 +33,9 @@
     },
     "scripts": {
         "start": "npm run dev-server",
-        "dev-server": "cross-env rollup --watch --config config/rollup.dev.config.js",
+        "dev-server": "cross-env NODE_ENV=development rollup --watch --config config/rollup.dev.config.js",
         "docs:generate": "typedoc --out docs src --exclude \"**/*+(index|.test).ts\"",
-        "build": "rm -rf dist/ && npm run type-check-generate && cross-env rollup --config config/rollup.config.js",
+        "build": "rm -rf dist/ && npm run type-check-generate && cross-env NODE_ENV=production rollup --config config/rollup.config.js",
         "build:analyze": "rm -rf dist/ && cross-env NODE_ENV=analyze rollup --config config/rollup.config.js",
         "test": "jest --config config/jest.config.js",
         "test:watch": "npm run test -- --watchAll",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Putting the NODE_ENV back as we need to set the process.env.NODE_ENV and use it in the code

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
