### PR TITLE
Feature/render iframe labels as divs

### DIFF
--- a/env.default
+++ b/env.default
@@ -18,7 +18,9 @@ CLIENT_KEY=
 CLIENT_ENV=
 
 ####################
-#SecuredFields.html src - Comment in if loading securedFields from local node server
+# SecuredFields.html src
+# - Comment in if loading securedFields from local node server
+# - If commenting in - also make sure IS_HTTPS=false
 ####################
 #SF_ENV=http://localhost:8011/
 

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -12,6 +12,7 @@ import {
     ENCRYPTED_SECURITY_CODE
 } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import DataSfSpan from './DataSfSpan';
+import { alternativeLabelContent } from './IframeLabelAlternative';
 
 export default function CVC(props: CVCProps) {
     const {
@@ -60,6 +61,8 @@ export default function CVC(props: CVCProps) {
             name={ENCRYPTED_SECURITY_CODE}
             i18n={i18n}
             errorVisibleToScreenReader={false}
+            useLabelElement={false}
+            renderAlternativeToLabel={alternativeLabelContent}
         >
             <DataSfSpan encryptedFieldType={ENCRYPTED_SECURITY_CODE} className={cvcClassnames} />
 

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -8,6 +8,7 @@ import { CardNumberProps } from './types';
 import styles from '../CardInput.module.scss';
 import DataSfSpan from './DataSfSpan';
 import { ENCRYPTED_CARD_NUMBER } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import { alternativeLabelContent } from './IframeLabelAlternative';
 
 export default function CardNumber(props: CardNumberProps) {
     const { i18n } = useCoreContext();
@@ -27,6 +28,8 @@ export default function CardNumber(props: CardNumberProps) {
             showValidIcon={false}
             i18n={i18n}
             errorVisibleToScreenReader={false} // securedFields have their own, internal, aria-describedby element
+            useLabelElement={false}
+            renderAlternativeToLabel={alternativeLabelContent}
         >
             <DataSfSpan
                 encryptedFieldType={ENCRYPTED_CARD_NUMBER}

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -13,6 +13,7 @@ import {
     ENCRYPTED_EXPIRY_DATE
 } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import useImage from '../../../../../core/Context/useImage';
+import { alternativeLabelContent } from './IframeLabelAlternative';
 
 export default function ExpirationDate(props: ExpirationDateProps) {
     const { label, focused, filled, onFocusField, className = '', error = '', isValid = false, expiryDatePolicy = DATE_POLICY_REQUIRED } = props;
@@ -41,6 +42,8 @@ export default function ExpirationDate(props: ExpirationDateProps) {
             name={'encryptedExpiryDate'}
             i18n={i18n}
             errorVisibleToScreenReader={false}
+            useLabelElement={false}
+            renderAlternativeToLabel={alternativeLabelContent}
         >
             <DataSfSpan
                 encryptedFieldType={ENCRYPTED_EXPIRY_DATE}

--- a/packages/lib/src/components/Card/components/CardInput/components/IframeLabelAlternative.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/IframeLabelAlternative.tsx
@@ -1,0 +1,9 @@
+import { h } from 'preact';
+
+export const alternativeLabelContent = (defaultWrapperProps, children) => {
+    return (
+        <div {...defaultWrapperProps} aria-hidden={'true'}>
+            {children}
+        </div>
+    );
+};


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Following a recent meeting with our a11y consultants, it was agreed that since the iframes in the Credit Card have an `input` that has an `aria-label` attribute, the actual `<label>` element that exists within Checkout is semantically meaningless, and can be replaced by a `<div aria-hidden="true">`

This should help prevent automated HTML validators from complaining about label elements that don't have a `for` attribute

## Tested scenarios
All unit tests pass

