### PR TITLE
Fixes alt text for card brands

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import Img from '../../../../../internal/Img';
 import './AvailableBrands.scss';
 import { BrandConfiguration } from '../../../../types';
-import { BRAND_READABLE_NAME_MAP } from '../../../../../internal/SecuredFields/lib/configuration/constants';
+import { getFullBrandName } from '../../utils';
 
 type AvailableBrands = Array<BrandConfiguration>;
 
@@ -26,7 +26,7 @@ const AvailableBrands = ({ brands, activeBrand }: PaymentMethodBrandsProps) => {
         >
             {brands.map(({ name, icon }) => (
                 <span key={name} className="adyen-checkout__card__brands__brand-wrapper">
-                    <Img src={icon} alt={BRAND_READABLE_NAME_MAP[name]} />
+                    <Img src={icon} alt={getFullBrandName(name)} />
                 </span>
             ))}
         </span>

--- a/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { getCardImageUrl } from '../utils';
+import { getCardImageUrl, getFullBrandName } from '../utils';
 import useCoreContext from '../../../../../core/Context/useCoreContext';
 import { BrandIconProps } from './types';
 import styles from '../CardInput.module.scss';
@@ -16,7 +16,7 @@ export default function BrandIcon({ brand, brandsConfiguration = {} }: BrandIcon
         <img
             className={`${styles['card-input__icon']} adyen-checkout__card__cardNumber__brandIcon`}
             onError={handleError}
-            alt={brand}
+            alt={getFullBrandName(brand)}
             src={imageUrl}
         />
     );

--- a/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/DualBrandingIcon/DualBrandingIcon.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import styles from '../../CardInput.module.scss';
 import useCoreContext from '../../../../../../core/Context/useCoreContext';
-import { getCardImageUrl } from '../../utils';
+import { getCardImageUrl, getFullBrandName } from '../../utils';
 import { DualBrandingIconProps } from '../types';
 import './DualBrandingIcon.scss';
 
@@ -19,7 +19,7 @@ const DualBrandingIcon = ({ brand, onClick, dataValue, notSelected, brandsConfig
                 notSelected ? 'adyen-checkout__card__cardNumber__brandIcon--not-selected' : ''
             } adyen-checkout__card__cardNumber__brandIcon`}
             onError={handleError}
-            alt={brand}
+            alt={getFullBrandName(brand)}
             src={imageUrl}
             onClick={onClick}
             data-value={dataValue}

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -16,6 +16,7 @@ import { AddressSpecifications, StringObject } from '../../../internal/Address/t
 import { PARTIAL_ADDRESS_SCHEMA } from '../../../internal/Address/constants';
 import { InstallmentsObj } from './components/Installments/Installments';
 import { SFPProps } from '../../../internal/SecuredFields/SFP/types';
+import { BRAND_READABLE_NAME_MAP } from '../../../internal/SecuredFields/lib/configuration/constants';
 
 export const getCardImageUrl = (brand: string, loadingContext: string): string => {
     const imageOptions = {
@@ -172,4 +173,8 @@ export const handlePartialAddressMode = (addressMode: AddressModeOptions): Addre
 // Almost all errors are blur based, but some SF ones are not i.e. when an unsupported card is entered or the expiry date is out of range
 export function lookupBlurBasedErrors(errorCode) {
     return !['error.va.sf-cc-num.03', 'error.va.sf-cc-dat.01', 'error.va.sf-cc-dat.02', 'error.va.sf-cc-dat.03'].includes(errorCode);
+}
+
+export function getFullBrandName(brand) {
+    return BRAND_READABLE_NAME_MAP[brand] ?? brand;
 }

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/CompactView.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/CompactView.tsx
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import PaymentMethodIcon from '../PaymentMethodIcon';
 import { BrandConfiguration } from '../../../../Card/types';
+import { getFullBrandName } from '../../../../Card/components/CardInput/utils';
 
 interface CompactViewProps {
     allowedBrands: Array<BrandConfiguration>; // A set of brands filtered to exclude those that can never appear in the UI
@@ -24,7 +25,7 @@ const CompactView = ({ allowedBrands, isPaymentMethodSelected }: CompactViewProp
     return (
         <span className="adyen-checkout__payment-method__brands">
             {visibleBrands.map(brand => (
-                <PaymentMethodIcon key={brand.name} altDescription={brand.name} type={brand.name} src={brand.icon} />
+                <PaymentMethodIcon key={brand.name} altDescription={getFullBrandName(brand.name)} type={brand.name} src={brand.icon} />
             ))}
             {leftBrandsAmount !== 0 && <span className="adyen-checkout__payment-method__brand-number">+{leftBrandsAmount}</span>}
         </span>

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import PaymentMethodIcon from '../PaymentMethodIcon';
 import { BrandConfiguration } from '../../../../Card/types';
 import CompactView from './CompactView';
+import { getFullBrandName } from '../../../../Card/components/CardInput/utils';
 
 interface PaymentMethodBrandsProps {
     brands: Array<BrandConfiguration>;
@@ -23,7 +24,7 @@ const PaymentMethodBrands = ({ activeBrand, brands, excludedUIBrands, isPaymentM
             {allowedBrands.map(brand => (
                 <PaymentMethodIcon
                     key={brand.name}
-                    altDescription={brand.name}
+                    altDescription={getFullBrandName(brand.name)}
                     type={brand.name}
                     src={brand.icon}
                     disabled={activeBrand && activeBrand !== brand.name}

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -70,5 +70,6 @@ export const BRAND_READABLE_NAME_MAP = {
     jcb: 'JCB',
     diners: 'Diners Club',
     maestro: 'Maestro',
-    bcmc: 'Bancontact card'
+    bcmc: 'Bancontact card',
+    bijcard: 'de Bijenkorf Card'
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Fixes brands icons alt text to use hard coded values. Also add bijcard. 

## Tested scenarios
<!-- Description of tested scenarios -->

Checked BrandIcon, Dropin Card icons and Card Brand list. 


**Fixed issue**:  <!-- #-prefixed issue number -->
