### PR TITLE
Fix: Klarna widget to make drop-in clickable after loaded

### DIFF
--- a/.changeset/spicy-crews-worry.md
+++ b/.changeset/spicy-crews-worry.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix Klarna widget blocks drop-in to be clickable on loaded.

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -33,7 +33,7 @@ describe('KlarnaPayments', () => {
         // @ts-ignore to test
         await waitFor(() => KlarnaPaymentsEle.componentRef);
         // @ts-ignore to test
-        KlarnaPaymentsEle.componentRef.props.onReady();
+        KlarnaPaymentsEle.componentRef.props.onLoaded();
         expect(spy).toHaveBeenCalled();
     });
 

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/preact';
+import KlarnaPayments from './KlarnaPayments';
+import DropinElement from '../Dropin';
+
+describe('KlarnaPayments', () => {
+    const coreProps = { name: 'Klarna', i18n: global.i18n, loadingContext: 'test', modules: { resources: global.resources } };
+    const renderKlarna = props => {
+        const KlarnaPaymentsEle = new KlarnaPayments({
+            ...coreProps,
+            ...props
+        });
+        render(KlarnaPaymentsEle.render());
+    };
+
+    test('should show the pay button if sets to true', async () => {
+        renderKlarna({ paymentData: '', paymentMethodType: '', sdkData: undefined, useKlarnaWidget: false, showPayButton: true });
+        expect(await screen.findByRole('button', { name: 'Continue to Klarna' })).toBeTruthy();
+    });
+
+    test('should hide pay button if sets to false', () => {
+        renderKlarna({ paymentData: '', paymentMethodType: '', sdkData: undefined, useKlarnaWidget: false, showPayButton: false });
+        expect(screen.queryByRole('button', { name: 'Continue to Pay By Bank' })).toBeFalsy();
+    });
+
+    test('should call setStatus if elementRef is a drop-in', async () => {
+        const KlarnaPaymentsEle = new KlarnaPayments({
+            ...coreProps,
+            ...{ paymentData: '', paymentMethodType: '', sdkData: undefined, useKlarnaWidget: false, showPayButton: false }
+        });
+        KlarnaPaymentsEle.elementRef = new DropinElement({ paymentMethods: [] });
+        render(KlarnaPaymentsEle.render());
+        const spy = jest.spyOn(KlarnaPaymentsEle.elementRef, 'setStatus');
+        // @ts-ignore to test
+        await waitFor(() => KlarnaPaymentsEle.componentRef);
+        // @ts-ignore to test
+        KlarnaPaymentsEle.componentRef.props.onReady();
+        expect(spy).toHaveBeenCalled();
+    });
+
+    test('should call handleAdditionalDetails onComplete', async () => {
+        const onAdditionalDetailsMock = jest.fn(() => {});
+
+        const KlarnaPaymentsEle = new KlarnaPayments({
+            ...coreProps,
+            ...{
+                paymentData: '',
+                paymentMethodType: '',
+                sdkData: undefined,
+                useKlarnaWidget: false,
+                showPayButton: false,
+                onAdditionalDetails: onAdditionalDetailsMock
+            }
+        });
+        render(KlarnaPaymentsEle.render());
+        // @ts-ignore to test
+        await waitFor(() => KlarnaPaymentsEle.componentRef);
+        // @ts-ignore to test
+        KlarnaPaymentsEle.componentRef.props.onComplete();
+        expect(onAdditionalDetailsMock).toHaveBeenCalled();
+    });
+});

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -5,6 +5,7 @@ import { KlarnaPaymentsProps } from './types';
 import PayButton from '../internal/PayButton';
 import { KlarnaContainer } from './components/KlarnaContainer/KlarnaContainer';
 import { PaymentAction } from '../../types';
+import DropinElement from '../Dropin';
 
 class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
     public static type = 'klarna';
@@ -44,7 +45,9 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
 
     onReady() {
         // When action/widget is loaded, set the 'drop-in' back to ready
-        this.elementRef?.setStatus('ready');
+        if (this.elementRef instanceof DropinElement) {
+            this.elementRef.setStatus('ready');
+        }
     }
 
     render() {

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -5,7 +5,6 @@ import { KlarnaPaymentsProps } from './types';
 import PayButton from '../internal/PayButton';
 import { KlarnaContainer } from './components/KlarnaContainer/KlarnaContainer';
 import { PaymentAction } from '../../types';
-import DropinElement from '../Dropin';
 
 class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
     public static type = 'klarna';
@@ -45,9 +44,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
 
     onLoaded() {
         // When action/widget is loaded, set the 'drop-in' back to ready
-        if (this.elementRef instanceof DropinElement) {
-            this.elementRef.setStatus('ready');
-        }
+        this.setElementStatus('ready');
     }
 
     render() {

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -18,6 +18,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
         this.onComplete = this.onComplete.bind(this);
         this.updateWithAction = this.updateWithAction.bind(this);
         this.submit = this.submit.bind(this);
+        this.onReady = this.onReady.bind(this);
     }
     get isValid() {
         return true;
@@ -41,6 +42,11 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
         this.componentRef.setAction(action);
     }
 
+    onReady() {
+        // When action/widget is loaded, set the 'drop-in' back to ready
+        this.elementRef?.setStatus('ready');
+    }
+
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
@@ -53,6 +59,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
                     onComplete={state => this.handleAdditionalDetails(state)}
                     onError={this.props.onError}
                     payButton={this.payButton}
+                    onReady={this.onReady}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -19,7 +19,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
         this.onComplete = this.onComplete.bind(this);
         this.updateWithAction = this.updateWithAction.bind(this);
         this.submit = this.submit.bind(this);
-        this.onReady = this.onReady.bind(this);
+        this.onLoaded = this.onLoaded.bind(this);
     }
     get isValid() {
         return true;
@@ -43,7 +43,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
         this.componentRef.setAction(action);
     }
 
-    onReady() {
+    onLoaded() {
         // When action/widget is loaded, set the 'drop-in' back to ready
         if (this.elementRef instanceof DropinElement) {
             this.elementRef.setStatus('ready');
@@ -62,7 +62,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
                     onComplete={state => this.handleAdditionalDetails(state)}
                     onError={this.props.onError}
                     payButton={this.payButton}
-                    onReady={this.onReady}
+                    onLoaded={this.onLoaded}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
@@ -22,7 +22,7 @@ export function KlarnaContainer(props) {
                 payButton={props.payButton}
                 onComplete={props.onComplete}
                 onError={props.onError}
-                onReady={props.onReady}
+                onLoaded={props.onLoaded}
             />
         );
     }

--- a/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
@@ -22,6 +22,7 @@ export function KlarnaContainer(props) {
                 payButton={props.payButton}
                 onComplete={props.onComplete}
                 onError={props.onError}
+                onReady={props.onReady}
             />
         );
     }

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -37,7 +37,7 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
                 if (!res.show_form || !!res.error) {
                     handleError();
                 } else {
-                    props.onReady();
+                    props.onLoaded();
                 }
             }
         );

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -36,6 +36,8 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
                 // based on Klarna’s pre-assessment.
                 if (!res.show_form || !!res.error) {
                     handleError();
+                } else {
+                    props.onReady();
                 }
             }
         );

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -34,7 +34,7 @@ export interface KlarnaWidgetProps extends KlarnaPaymentsShared {
     /** @internal */
     payButton: (options) => any;
     /** @internal */
-    onReady: () => void;
+    onLoaded: () => void;
 
     onComplete: (detailsData) => void;
     onError: (error) => void;

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -33,6 +33,8 @@ interface KlarnaPaymentsShared {
 export interface KlarnaWidgetProps extends KlarnaPaymentsShared {
     /** @internal */
     payButton: (options) => any;
+    /** @internal */
+    onReady: () => void;
 
     onComplete: (detailsData) => void;
     onError: (error) => void;

--- a/packages/lib/storybook/stories/components/Klarna.stories.tsx
+++ b/packages/lib/storybook/stories/components/Klarna.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from '@storybook/preact';
+import { PaymentMethodStoryProps } from '../types';
+import { getStoryContextCheckout } from '../../utils/get-story-context-checkout';
+import { Container } from '../Container';
+import { KlarnaPaymentsProps } from '../../../src/components/Klarna/types';
+
+type KlarnaStory = StoryObj<PaymentMethodStoryProps<Partial<KlarnaPaymentsProps>>>;
+
+const meta: Meta<PaymentMethodStoryProps<KlarnaPaymentsProps>> = {
+    title: 'Components/Klarna'
+};
+
+const createComponent = (args, context) => {
+    const checkout = getStoryContextCheckout(context);
+    return <Container type={'klarna'} componentConfiguration={args.componentConfiguration} checkout={checkout} />;
+};
+
+export const Klarna: KlarnaStory = {
+    render: createComponent,
+    args: {
+        countryCode: 'NL',
+        componentConfiguration: { useKlarnaWidget: true }
+    }
+};
+
+export default meta;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When Klarna widget is loaded inside the drop-in, the drop-in is still in 'loading' status, we need to tell dropin to be 'ready' - clikable.

## Tested scenarios
When we set the following config to the checkout, the Klarna widget renders inside the drop-in and it should not block the drop-in to be clickable after loaded.
 
```javascript
paymentMethodsConfiguration: {
         klarna: { 
               useKlarnaWidget: true 
         }
 };
```

**Internal ticket id**:  COWEB-1251
