### PR TITLE
fix: Core update function also updates payment methods list

### DIFF
--- a/.changeset/kind-flies-know.md
+++ b/.changeset/kind-flies-know.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix Core `update` should also update payment methods list.

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -242,6 +242,7 @@ describe('Core', () => {
                 environment: 'test',
                 clientKey: 'xxxx'
             });
+            await checkout.initialize();
             const paymentMethodsResponse = { paymentMethods: [{ name: 'Credit Card', type: 'scheme', brands: ['visa'] }] };
             expect(checkout.paymentMethodsResponse).toHaveProperty('paymentMethods', []);
             await checkout.update({ paymentMethodsResponse });

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -236,5 +236,16 @@ describe('Core', () => {
 
             expect(spy).toHaveBeenCalled();
         });
+
+        test('should update the payment method list for the advanced flow', async () => {
+            const checkout = new AdyenCheckout({
+                environment: 'test',
+                clientKey: 'xxxx'
+            });
+            const paymentMethodsResponse = { paymentMethods: [{ name: 'Credit Card', type: 'scheme', brands: ['visa'] }] };
+            expect(checkout.paymentMethodsResponse).toHaveProperty('paymentMethods', []);
+            await checkout.update({ paymentMethodsResponse });
+            expect(checkout.paymentMethodsResponse).toHaveProperty('paymentMethods', paymentMethodsResponse.paymentMethods);
+        });
     });
 });

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -80,6 +80,10 @@ class Core {
 
         this.createCoreModules();
 
+        if (!this.paymentMethodsResponse?.paymentMethods?.length) {
+            this.createPaymentMethodsList();
+        }
+
         return Promise.resolve(this);
     }
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -38,7 +38,6 @@ class Core {
         this.createFromAction = this.createFromAction.bind(this);
 
         this.setOptions(props);
-        this.createPaymentMethodsList();
 
         this.loadingContext = resolveEnvironment(this.options.environment);
         this.cdnContext = resolveCDNEnvironment(this.options.resourceEnvironment || this.options.environment);
@@ -80,9 +79,7 @@ class Core {
 
         this.createCoreModules();
 
-        if (!this.paymentMethodsResponse?.paymentMethods?.length) {
-            this.createPaymentMethodsList();
-        }
+        this.createPaymentMethodsList();
 
         return Promise.resolve(this);
     }
@@ -360,7 +357,9 @@ class Core {
 
     private createCoreModules(): void {
         if (this.modules) {
-            console.warn('Core: Core modules are already created.');
+            if (process.env.NODE_ENV === 'development') {
+                console.warn('Core: Core modules are already created.');
+            }
             return;
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
It's related to the drop-in advanced flow.

There is a use case that merchants feed `paymentMethodsResponse` via the `update` function instead of passing it  while initiating the `AdyenCheckout`.

Fix the issue so that we are backward compatible.

## Tested scenarios
Tested in the playground drop-in manual flow.

Pass the `paymentMethodsResponse` in the `update` function. The drop-in should render the payment methods list.

```javascript
checkout.update({ paymentMethodsResponse: await getPaymentMethods({ amount, shopperLocale }) });
```

