### PR TITLE
Feature/indicate when analytics disabled

### DIFF
--- a/.changeset/neat-pandas-mix.md
+++ b/.changeset/neat-pandas-mix.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Send 'do-not-track' as value for checkoutAttemptId when analytics is disabled

--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -56,7 +56,8 @@ class BaseElement<P extends BaseElementProps> {
      */
     get data(): PaymentData | RiskData {
         const clientData = getProp(this.props, 'modules.risk.data');
-        const checkoutAttemptId = getProp(this.props, 'modules.analytics.checkoutAttemptId');
+        const useAnalytics = !!getProp(this.props, 'modules.analytics.props.enabled');
+        const checkoutAttemptId = useAnalytics ? getProp(this.props, 'modules.analytics.checkoutAttemptId') : 'do-not-track';
         const order = this.state.order || this.props.order;
 
         const componentData = this.formatData();

--- a/packages/lib/src/components/PayPal/Paypal.test.ts
+++ b/packages/lib/src/components/PayPal/Paypal.test.ts
@@ -3,12 +3,18 @@ import Paypal from './Paypal';
 describe('Paypal', () => {
     test('Returns a data object', () => {
         const paypal = new Paypal({});
-        expect(paypal.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { subtype: 'sdk', type: 'paypal' } });
+        expect(paypal.data).toEqual({
+            clientStateDataIndicator: true,
+            paymentMethod: { subtype: 'sdk', type: 'paypal', checkoutAttemptId: 'do-not-track' }
+        });
     });
 
     test('should return subtype express if isExpress flag is set', () => {
         const paypal = new Paypal({ isExpress: true });
-        expect(paypal.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { subtype: 'express', type: 'paypal' } });
+        expect(paypal.data).toEqual({
+            clientStateDataIndicator: true,
+            paymentMethod: { subtype: 'express', type: 'paypal', checkoutAttemptId: 'do-not-track' }
+        });
     });
 
     test('Is always valid', () => {

--- a/packages/lib/src/components/Pix/Pix.test.ts
+++ b/packages/lib/src/components/Pix/Pix.test.ts
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 test('should return only payment type if personalDetails is not required', async () => {
     const pixElement = new Pix({});
-    expect(pixElement.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { type: 'pix' } });
+    expect(pixElement.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { type: 'pix', checkoutAttemptId: 'do-not-track' } });
 });
 
 test('should show personal details form if enabled', async () => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In order to gain visibility for Drop-in and Components merchants who opt-out from the internal telemetry 
\- if `analytics.enabled` is set to `false` then, when we make a `/payments` request, we send in `'do-not-track'` as the value for `checkoutAttemptId` (in the `paymentMethod` data object)

## Tested scenarios
Tested with both `analytics.enabled:true` & `analytics.enabled:false` to see that the correct value is set for `checkoutAttemptId`


**Fixed issue**: COWEB-1265
