### PR TITLE
feat: export types from Adyen Web

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -15,3 +15,5 @@ async function AdyenCheckout(props: CoreOptions): Promise<Checkout> {
 }
 
 export default AdyenCheckout;
+
+export * from './types';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This PR simply exports every type from `types` directory to make it available for consumers. I haven't had chance to test it manually.

## Expected behavior

I am able to:
```ts
import type { CoreOptions } from "@adyen/adyen-web";
import type { DropinElementProps } from "@adyen/adyen-web";
```
Instead of:
```ts
import type { CoreOptions } from "@adyen/adyen-web/dist/types/core/types";
import type { DropinElementProps } from "@adyen/adyen-web/dist/types/components/Dropin/types";
```


**Fixed issue**:  #363 