### PR TITLE
Poc/component tree shaking no create fn

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -19,7 +19,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     protected static defaultProps = defaultProps;
 
     constructor(checkoutRef: Core, props: ApplePayElementProps) {
-        super(checkoutRef, { ...props, type: props?.type ?? ApplePayElement.type });
+        super(checkoutRef, props);
         this.startSession = this.startSession.bind(this);
         this.submit = this.submit.bind(this);
         this.validateMerchant = this.validateMerchant.bind(this);

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -18,12 +18,6 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     public static type = 'applepay';
     protected static defaultProps = defaultProps;
 
-    // constructor(props) {
-    //     super(props);
-    //     this.startSession = this.startSession.bind(this);
-    //     this.submit = this.submit.bind(this);
-    //     this.validateMerchant = this.validateMerchant.bind(this);
-    // }
     constructor(checkoutRef: Core, props: ApplePayElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? ApplePayElement.type });
         this.startSession = this.startSession.bind(this);

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -10,6 +10,7 @@ import { preparePaymentRequest } from './payment-request';
 import { resolveSupportedVersion, mapBrands } from './utils';
 import { ApplePayElementProps, ApplePayElementData, ApplePaySessionRequest, OnAuthorizedCallback } from './types';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
+import Core from '../../core';
 
 const latestSupportedVersion = 14;
 
@@ -17,8 +18,14 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     public static type = 'applepay';
     protected static defaultProps = defaultProps;
 
-    constructor(props) {
-        super(props);
+    // constructor(props) {
+    //     super(props);
+    //     this.startSession = this.startSession.bind(this);
+    //     this.submit = this.submit.bind(this);
+    //     this.validateMerchant = this.validateMerchant.bind(this);
+    // }
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, { ...props, type: props?.type ?? ApplePayElement.type });
         this.startSession = this.startSession.bind(this);
         this.submit = this.submit.bind(this);
         this.validateMerchant = this.validateMerchant.bind(this);

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -24,7 +24,7 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     //     this.submit = this.submit.bind(this);
     //     this.validateMerchant = this.validateMerchant.bind(this);
     // }
-    constructor(checkoutRef: Core, props) {
+    constructor(checkoutRef: Core, props: ApplePayElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? ApplePayElement.type });
         this.startSession = this.startSession.bind(this);
         this.submit = this.submit.bind(this);

--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -5,14 +5,9 @@ import RedirectButton from '../internal/RedirectButton';
 import { BankTransferProps, BankTransferState } from './types';
 import BankTransferResult from './components/BankTransferResult';
 import BankTransferInput from './components/BankTransferInput';
-// import Core from '../../core';
 
 export class BankTransferElement extends UIElement<BankTransferProps> {
     public static type = 'bankTransfer_IBAN';
-
-    // constructor(checkoutRef: Core, props: BankTransferProps) {
-    //     super(checkoutRef, { ...props, type: props?.type ?? BankTransferElement.type });
-    // }
 
     public static defaultProps = {
         showPayButton: true,

--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -5,9 +5,14 @@ import RedirectButton from '../internal/RedirectButton';
 import { BankTransferProps, BankTransferState } from './types';
 import BankTransferResult from './components/BankTransferResult';
 import BankTransferInput from './components/BankTransferInput';
+// import Core from '../../core';
 
 export class BankTransferElement extends UIElement<BankTransferProps> {
     public static type = 'bankTransfer_IBAN';
+
+    // constructor(checkoutRef: Core, props: BankTransferProps) {
+    //     super(checkoutRef, { ...props, type: props?.type ?? BankTransferElement.type });
+    // }
 
     public static defaultProps = {
         showPayButton: true,

--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -15,25 +15,21 @@ class BaseElement<P extends BaseElementProps> {
     public _node;
     public _component;
     public eventEmitter = new EventEmitter();
-    protected _parentInstance: Core;
+    protected readonly _parentInstance: Core;
 
     protected resources: Resources;
 
     protected constructor(checkoutRef: Core, props: P) {
-        // this._parentInstance = this.props._parentInstance;
+        this._parentInstance = checkoutRef;
+
         this._node = null;
         this.state = {};
 
-        this.init(checkoutRef, props);
+        this.init(props);
     }
 
-    protected init(checkoutRef, props) {
-        console.log('### BaseElement::init:: checkoutRef=', checkoutRef);
-
+    protected init(props: P) {
         this.props = this.formatProps({ ...this.constructor['defaultProps'], setStatusAutomatically: true, ...props });
-        this._parentInstance = this.props._parentInstance;
-
-        console.log('### BaseElement::init:: this._parentInstance=', this._parentInstance);
 
         this.resources = this.props.modules ? this.props.modules.resources : undefined;
     }

--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -15,15 +15,26 @@ class BaseElement<P extends BaseElementProps> {
     public _node;
     public _component;
     public eventEmitter = new EventEmitter();
-    protected readonly _parentInstance: Core;
+    protected _parentInstance: Core;
 
     protected resources: Resources;
 
-    protected constructor(props: P) {
-        this.props = this.formatProps({ ...this.constructor['defaultProps'], setStatusAutomatically: true, ...props });
-        this._parentInstance = this.props._parentInstance;
+    protected constructor(checkoutRef: Core, props: P) {
+        // this._parentInstance = this.props._parentInstance;
         this._node = null;
         this.state = {};
+
+        this.init(checkoutRef, props);
+    }
+
+    protected init(checkoutRef, props) {
+        console.log('### BaseElement::init:: checkoutRef=', checkoutRef);
+
+        this.props = this.formatProps({ ...this.constructor['defaultProps'], setStatusAutomatically: true, ...props });
+        this._parentInstance = this.props._parentInstance;
+
+        console.log('### BaseElement::init:: this._parentInstance=', this._parentInstance);
+
         this.resources = this.props.modules ? this.props.modules.resources : undefined;
     }
 

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -8,7 +8,7 @@ class BancontactElement extends CardElement {
     public static txVariants = ['bcmc'];
 
     constructor(checkout: Core, props?: CardElementProps) {
-        super(checkout, { ...props, type: BancontactElement.type });
+        super(checkout, props);
     }
 
     protected static defaultProps = {

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -7,10 +7,6 @@ class BancontactElement extends CardElement {
     public static type = 'bcmc';
     public static txVariants = ['bcmc'];
 
-    // constructor(props: CardElementProps) {
-    //     super(props);
-    // }
-
     constructor(checkout: Core, props?: CardElementProps) {
         super(checkout, { ...props, type: BancontactElement.type });
     }

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -1,13 +1,18 @@
 import { CardElement } from './Card';
 import { CardElementProps } from './types';
 import { CVC_POLICY_HIDDEN } from '../internal/SecuredFields/lib/configuration/constants';
+import Core from '../../core';
 
 class BancontactElement extends CardElement {
     public static type = 'bcmc';
     public static txVariants = ['bcmc'];
 
-    constructor(props: CardElementProps) {
-        super(props);
+    // constructor(props: CardElementProps) {
+    //     super(props);
+    // }
+
+    constructor(checkout: Core, props: CardElementProps) {
+        super(checkout, { ...props, type: BancontactElement.type });
     }
 
     protected static defaultProps = {

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -11,7 +11,7 @@ class BancontactElement extends CardElement {
     //     super(props);
     // }
 
-    constructor(checkout: Core, props: CardElementProps) {
+    constructor(checkout: Core, props?: CardElementProps) {
         super(checkout, { ...props, type: BancontactElement.type });
     }
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -20,7 +20,7 @@ import Core from '../../core';
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
     // public static txVariants = ['amex', 'card', 'diners', 'discover', 'jcb', 'kcp', 'maestro', 'mc', 'scheme', 'storedCard', 'visa'];
-    public static txVariants = ['card'];
+    public static txVariants = ['card']; // TODO - don't think we need even this
     public static dependencies = [ThreeDS2DeviceFingerprint, ThreeDS2Challenge, Redirect];
 
     private readonly clickToPayService: IClickToPayService | null;
@@ -43,6 +43,10 @@ export class CardElement extends UIElement<CardElementProps> {
     //     }
     // }
     constructor(checkoutRef: Core, props: CardElementProps) {
+        // console.log('\n### Card::constructor:: props.type=', props.type);
+        // props.type is specified in storedCards, Bancontact and when card is part of dropin
+        // but not for standalone card
+
         // UIElement does the calculating of props...
         super(checkoutRef, { ...props, type: props?.type ?? CardElement.type });
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -19,7 +19,8 @@ import Core from '../../core';
 
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
-    public static txVariants = ['amex', 'card', 'diners', 'discover', 'jcb', 'kcp', 'maestro', 'mc', 'scheme', 'storedCard', 'visa'];
+    // public static txVariants = ['amex', 'card', 'diners', 'discover', 'jcb', 'kcp', 'maestro', 'mc', 'scheme', 'storedCard', 'visa'];
+    public static txVariants = ['card'];
     public static dependencies = [ThreeDS2DeviceFingerprint, ThreeDS2Challenge, Redirect];
 
     private readonly clickToPayService: IClickToPayService | null;

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -42,24 +42,24 @@ export class CardElement extends UIElement<CardElementProps> {
     //         this.clickToPayService?.initialize();
     //     }
     // }
-    constructor(checkoutRef, props) {
+    constructor(checkoutRef: Core, props: CardElementProps) {
         if (!(checkoutRef instanceof Core)) {
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
         }
 
         // If UIElement does the calculating of props...
-        // super(checkoutRef, props, CardElement.type);
+        // super(checkoutRef, {...props, type: props?.type ?? CardElement.type } );
 
-        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: CardElement.type });
+        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? CardElement.type });
 
         super(calculatedProps);
         console.log('### Card::constructor:: calculatedProps=', calculatedProps);
 
         checkoutRef.storeComponentRef(this as UIElement);
 
-        // this.checkoutRef = checkoutRef;
+        // this.checkoutRef = checkoutRef;// TODO - Needed?
 
-        if (!props._disableClickToPay) {
+        if (props && !props._disableClickToPay) {
             this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);
             this.clickToPayService?.initialize();
         }

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -14,6 +14,8 @@ import ClickToPayWrapper from './components/ClickToPayWrapper';
 import { UIElementStatus } from '../types';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import { ThreeDS2Challenge, ThreeDS2DeviceFingerprint } from '../ThreeDS2';
+import Core from '../../core';
+import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
@@ -40,7 +42,9 @@ export class CardElement extends UIElement<CardElementProps> {
     //     }
     // }
     constructor(checkoutRef, props) {
-        // TODO - throw error if checkoutRef not defined
+        if (!(checkoutRef instanceof Core)) {
+            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
+        }
 
         // If UIElement does the calculating of props...
         // super(checkoutRef, props, CardElement.type);

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -27,8 +27,32 @@ export class CardElement extends UIElement<CardElementProps> {
      */
     private clickToPayRef = null;
 
-    constructor(props) {
-        super(props);
+    // private checkoutRef;
+
+    // constructor(props) {
+    //     super(props);
+    //
+    //     console.log('### Card::constructor:: props=', props);
+    //
+    //     if (!props._disableClickToPay) {
+    //         this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);
+    //         this.clickToPayService?.initialize();
+    //     }
+    // }
+    constructor(checkoutRef, props) {
+        // TODO - throw error if checkoutRef not defined
+
+        // If UIElement does the calculating of props...
+        // super(checkoutRef, props, CardElement.type);
+
+        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: CardElement.type });
+
+        super(calculatedProps);
+        console.log('### Card::constructor:: calculatedProps=', calculatedProps);
+
+        checkoutRef.storeComponentRef(this as UIElement);
+
+        // this.checkoutRef = checkoutRef;
 
         if (!props._disableClickToPay) {
             this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -16,7 +16,6 @@ import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import { ThreeDS2Challenge, ThreeDS2DeviceFingerprint } from '../ThreeDS2';
 import Redirect from '../Redirect/Redirect';
 import Core from '../../core';
-import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
@@ -43,21 +42,17 @@ export class CardElement extends UIElement<CardElementProps> {
     //     }
     // }
     constructor(checkoutRef: Core, props: CardElementProps) {
-        if (!(checkoutRef instanceof Core)) {
-            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
-        }
+        // UIElement does the calculating of props...
+        super(checkoutRef, { ...props, type: props?.type ?? CardElement.type });
 
-        // If UIElement does the calculating of props...
-        // super(checkoutRef, {...props, type: props?.type ?? CardElement.type } );
+        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? CardElement.type });
+        //
+        // super(calculatedProps);
+        // console.log('### Card::constructor:: calculatedProps=', calculatedProps);
 
-        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? CardElement.type });
-
-        super(calculatedProps);
-        console.log('### Card::constructor:: calculatedProps=', calculatedProps);
-
-        if (!props.isDropin) {
-            checkoutRef.storeComponentRef(this as UIElement);
-        }
+        // if (!props.isDropin) {
+        //     checkoutRef.storeComponentRef(this as UIElement);
+        // }
 
         // this.checkoutRef = checkoutRef;// TODO - Needed?
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -14,13 +14,14 @@ import ClickToPayWrapper from './components/ClickToPayWrapper';
 import { UIElementStatus } from '../types';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import { ThreeDS2Challenge, ThreeDS2DeviceFingerprint } from '../ThreeDS2';
+import Redirect from '../Redirect/Redirect';
 import Core from '../../core';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
     public static txVariants = ['amex', 'card', 'diners', 'discover', 'jcb', 'kcp', 'maestro', 'mc', 'scheme', 'storedCard', 'visa'];
-    public static dependencies = [ThreeDS2DeviceFingerprint, ThreeDS2Challenge];
+    public static dependencies = [ThreeDS2DeviceFingerprint, ThreeDS2Challenge, Redirect];
 
     private readonly clickToPayService: IClickToPayService | null;
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -36,7 +36,7 @@ export class CardElement extends UIElement<CardElementProps> {
         // but not for standalone card
 
         // UIElement does the calculating of props...
-        super(checkoutRef, { ...props, type: props?.type ?? CardElement.type });
+        super(checkoutRef, props);
 
         if (props && !props._disableClickToPay) {
             this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -55,7 +55,9 @@ export class CardElement extends UIElement<CardElementProps> {
         super(calculatedProps);
         console.log('### Card::constructor:: calculatedProps=', calculatedProps);
 
-        checkoutRef.storeComponentRef(this as UIElement);
+        if (!props.isDropin) {
+            checkoutRef.storeComponentRef(this as UIElement);
+        }
 
         // this.checkoutRef = checkoutRef;// TODO - Needed?
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -30,18 +30,6 @@ export class CardElement extends UIElement<CardElementProps> {
      */
     private clickToPayRef = null;
 
-    // private checkoutRef;
-
-    // constructor(props) {
-    //     super(props);
-    //
-    //     console.log('### Card::constructor:: props=', props);
-    //
-    //     if (!props._disableClickToPay) {
-    //         this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);
-    //         this.clickToPayService?.initialize();
-    //     }
-    // }
     constructor(checkoutRef: Core, props: CardElementProps) {
         // console.log('\n### Card::constructor:: props.type=', props.type);
         // props.type is specified in storedCards, Bancontact and when card is part of dropin
@@ -49,17 +37,6 @@ export class CardElement extends UIElement<CardElementProps> {
 
         // UIElement does the calculating of props...
         super(checkoutRef, { ...props, type: props?.type ?? CardElement.type });
-
-        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? CardElement.type });
-        //
-        // super(calculatedProps);
-        // console.log('### Card::constructor:: calculatedProps=', calculatedProps);
-
-        // if (!props.isDropin) {
-        //     checkoutRef.storeComponentRef(this as UIElement);
-        // }
-
-        // this.checkoutRef = checkoutRef;// TODO - Needed?
 
         if (props && !props._disableClickToPay) {
             this.clickToPayService = createClickToPayService(this.props.configuration, this.props.clickToPayConfiguration, this.props.environment);

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -18,8 +18,6 @@ export class CashAppPay extends UIElement<CashAppPayElementProps> {
 
     protected static defaultProps = defaultProps;
 
-    // constructor(props) {
-    //     super(props);
     constructor(checkoutRef: Core, props: CashAppPayElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? CashAppPay.type });
 

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -22,8 +22,8 @@ export class CashAppPay extends UIElement<CashAppPayElementProps> {
         super(checkoutRef, props);
     }
 
-    protected init(checkoutRef: Core, props: CashAppPayElementProps) {
-        super.init(checkoutRef, props);
+    protected init(props: CashAppPayElementProps) {
+        super.init(props);
 
         if (this.props.enableStoreDetails && this.props.storePaymentMethod) {
             console.warn(

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -9,6 +9,7 @@ import { ICashAppService } from './services/types';
 import defaultProps from './defaultProps';
 import RedirectButton from '../internal/RedirectButton';
 import { payAmountLabel } from '../internal/PayButton';
+import Core from '../../core';
 
 export class CashAppPay extends UIElement<CashAppPayElementProps> {
     public static type = 'cashapp';
@@ -17,8 +18,10 @@ export class CashAppPay extends UIElement<CashAppPayElementProps> {
 
     protected static defaultProps = defaultProps;
 
-    constructor(props) {
-        super(props);
+    // constructor(props) {
+    //     super(props);
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, { ...props, type: props?.type ?? CashAppPay.type });
 
         if (this.props.enableStoreDetails && this.props.storePaymentMethod) {
             console.warn(

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -14,12 +14,16 @@ import Core from '../../core';
 export class CashAppPay extends UIElement<CashAppPayElementProps> {
     public static type = 'cashapp';
 
-    private readonly cashAppService: ICashAppService | undefined;
+    private cashAppService: ICashAppService | undefined;
 
     protected static defaultProps = defaultProps;
 
     constructor(checkoutRef: Core, props: CashAppPayElementProps) {
-        super(checkoutRef, { ...props, type: props?.type ?? CashAppPay.type });
+        super(checkoutRef, props);
+    }
+
+    protected init(checkoutRef: Core, props: CashAppPayElementProps) {
+        super.init(checkoutRef, props);
 
         if (this.props.enableStoreDetails && this.props.storePaymentMethod) {
             console.warn(

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -20,7 +20,7 @@ export class CashAppPay extends UIElement<CashAppPayElementProps> {
 
     // constructor(props) {
     //     super(props);
-    constructor(checkoutRef: Core, props) {
+    constructor(checkoutRef: Core, props: CashAppPayElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? CashAppPay.type });
 
         if (this.props.enableStoreDetails && this.props.storePaymentMethod) {

--- a/packages/lib/src/components/ClickToPay/ClickToPay.tsx
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.tsx
@@ -22,8 +22,8 @@ export class ClickToPayElement extends UIElement<ClickToPayElementProps> {
         super(checkoutRef, props);
     }
 
-    protected init(checkoutRef, props) {
-        super.init(checkoutRef, props);
+    protected init(props: ClickToPayElementProps) {
+        super.init(props);
 
         this.ctpConfiguration = {
             shopperEmail: this.props.shopperEmail,

--- a/packages/lib/src/components/ClickToPay/ClickToPay.tsx
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.tsx
@@ -20,7 +20,7 @@ export class ClickToPayElement extends UIElement<ClickToPayElementProps> {
 
     // constructor(props) {
     //     super(props);
-    constructor(checkoutRef: Core, props) {
+    constructor(checkoutRef: Core, props: ClickToPayElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? ClickToPayElement.type });
 
         this.ctpConfiguration = {

--- a/packages/lib/src/components/ClickToPay/ClickToPay.tsx
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.tsx
@@ -10,6 +10,7 @@ import { CtpState } from '../internal/ClickToPay/services/ClickToPayService';
 import ClickToPayProvider from '../internal/ClickToPay/context/ClickToPayProvider';
 import ClickToPayComponent from '../internal/ClickToPay';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
+import Core from '../../core';
 
 export class ClickToPayElement extends UIElement<ClickToPayElementProps> {
     public static type = 'clicktopay';
@@ -17,8 +18,10 @@ export class ClickToPayElement extends UIElement<ClickToPayElementProps> {
     private readonly clickToPayService: IClickToPayService | null;
     private readonly ctpConfiguration: ClickToPayConfiguration;
 
-    constructor(props) {
-        super(props);
+    // constructor(props) {
+    //     super(props);
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, { ...props, type: props?.type ?? ClickToPayElement.type });
 
         this.ctpConfiguration = {
             shopperEmail: this.props.shopperEmail,

--- a/packages/lib/src/components/ClickToPay/ClickToPay.tsx
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.tsx
@@ -18,8 +18,6 @@ export class ClickToPayElement extends UIElement<ClickToPayElementProps> {
     private readonly clickToPayService: IClickToPayService | null;
     private readonly ctpConfiguration: ClickToPayConfiguration;
 
-    // constructor(props) {
-    //     super(props);
     constructor(checkoutRef: Core, props: ClickToPayElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? ClickToPayElement.type });
 

--- a/packages/lib/src/components/ClickToPay/ClickToPay.tsx
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.tsx
@@ -15,11 +15,15 @@ import Core from '../../core';
 export class ClickToPayElement extends UIElement<ClickToPayElementProps> {
     public static type = 'clicktopay';
 
-    private readonly clickToPayService: IClickToPayService | null;
-    private readonly ctpConfiguration: ClickToPayConfiguration;
+    private clickToPayService: IClickToPayService | null;
+    private ctpConfiguration: ClickToPayConfiguration;
 
     constructor(checkoutRef: Core, props: ClickToPayElementProps) {
-        super(checkoutRef, { ...props, type: props?.type ?? ClickToPayElement.type });
+        super(checkoutRef, props);
+    }
+
+    protected init(checkoutRef, props) {
+        super.init(checkoutRef, props);
 
         this.ctpConfiguration = {
             shopperEmail: this.props.shopperEmail,

--- a/packages/lib/src/components/Donation/Donation.tsx
+++ b/packages/lib/src/components/Donation/Donation.tsx
@@ -10,11 +10,6 @@ import Core from '../../core';
 class DonationElement extends UIElement {
     public static type = 'donation';
 
-    // constructor(props) {
-    //     super(props);
-    //     this.donate = this.donate.bind(this);
-    // }
-
     constructor(checkoutRef: Core, props) {
         super(checkoutRef, { ...props, type: props?.type ?? DonationElement.type });
         this.donate = this.donate.bind(this);

--- a/packages/lib/src/components/Donation/Donation.tsx
+++ b/packages/lib/src/components/Donation/Donation.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import UIElement from '../UIElement';
 import CoreProvider from '../../core/Context/CoreProvider';
 import DonationComponent from './components/DonationComponent';
+import Core from '../../core';
 
 /**
  * DonationElement
@@ -9,8 +10,13 @@ import DonationComponent from './components/DonationComponent';
 class DonationElement extends UIElement {
     public static type = 'donation';
 
-    constructor(props) {
-        super(props);
+    // constructor(props) {
+    //     super(props);
+    //     this.donate = this.donate.bind(this);
+    // }
+
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, { ...props, type: props?.type ?? DonationElement.type });
         this.donate = this.donate.bind(this);
     }
 

--- a/packages/lib/src/components/Donation/Donation.tsx
+++ b/packages/lib/src/components/Donation/Donation.tsx
@@ -11,7 +11,7 @@ class DonationElement extends UIElement {
     public static type = 'donation';
 
     constructor(checkoutRef: Core, props) {
-        super(checkoutRef, { ...props, type: props?.type ?? DonationElement.type });
+        super(checkoutRef, props);
         this.donate = this.donate.bind(this);
     }
 

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -11,7 +11,6 @@ import createInstantPaymentElements from './elements/createInstantPaymentElement
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import { PaymentResponse } from '../types';
 import Core from '../../core';
-import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 
 const SUPPORTED_INSTANT_PAYMENTS = ['paywithgoogle', 'googlepay', 'applepay'];
 
@@ -25,7 +24,7 @@ class DropinElement extends UIElement<DropinElementProps> {
      */
     public componentFromAction?: UIElement;
 
-    private checkoutRef;
+    // private checkoutRef;
 
     // constructor(props) {
     //     super(props);
@@ -33,20 +32,15 @@ class DropinElement extends UIElement<DropinElementProps> {
     //     this.handleAction = this.handleAction.bind(this);
     // }
 
-    constructor(checkoutRef, props) {
-        if (!(checkoutRef instanceof Core)) {
-            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
-        }
+    constructor(checkoutRef: Core, props) {
+        // UIElement does the calculating of props...
+        super(checkoutRef, { ...props, type: DropinElement.type });
 
-        // If UIElement does the calculating of props...
-        // super(checkoutRef, props, DropinElement.type);
+        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: DropinElement.type });
+        //
+        // super(calculatedProps);
 
-        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: DropinElement.type });
-
-        super(calculatedProps);
-        console.log('### Dropin::constructor:: calculatedProps=', calculatedProps);
-
-        this.checkoutRef = checkoutRef;
+        // this.checkoutRef = checkoutRef;
 
         this.submit = this.submit.bind(this);
         this.handleAction = this.handleAction.bind(this);

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -25,7 +25,7 @@ class DropinElement extends UIElement<DropinElementProps> {
     public componentFromAction?: UIElement;
 
     constructor(checkoutRef: Core, props: DropinElementProps) {
-        super(checkoutRef, { ...props, type: DropinElement.type });
+        super(checkoutRef, props);
 
         this.submit = this.submit.bind(this);
         this.handleAction = this.handleAction.bind(this);

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -24,23 +24,8 @@ class DropinElement extends UIElement<DropinElementProps> {
      */
     public componentFromAction?: UIElement;
 
-    // private checkoutRef;
-
-    // constructor(props) {
-    //     super(props);
-    //     this.submit = this.submit.bind(this);
-    //     this.handleAction = this.handleAction.bind(this);
-    // }
-
     constructor(checkoutRef: Core, props: DropinElementProps) {
-        // UIElement does the calculating of props...
         super(checkoutRef, { ...props, type: DropinElement.type });
-
-        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: DropinElement.type });
-        //
-        // super(calculatedProps);
-
-        // this.checkoutRef = checkoutRef;
 
         this.submit = this.submit.bind(this);
         this.handleAction = this.handleAction.bind(this);
@@ -119,13 +104,10 @@ class DropinElement extends UIElement<DropinElementProps> {
 
         const commonProps = getCommonProps({ ...this.props, elementRef: this.elementRef });
 
-        // const storedElements = showStoredPaymentMethods ? createStoredElements(storedPaymentMethods, commonProps, this._parentInstance.create) : [];
         const storedElements = showStoredPaymentMethods ? createStoredElements(storedPaymentMethods, commonProps, this._parentInstance) : [];
 
-        // const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance.create) : [];
         const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance) : [];
 
-        // const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, commonProps, this._parentInstance.create);
         const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, commonProps, this._parentInstance);
 
         return [storedElements, elements, instantPaymentElements];

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -23,8 +23,27 @@ class DropinElement extends UIElement<DropinElementProps> {
      */
     public componentFromAction?: UIElement;
 
-    constructor(props) {
-        super(props);
+    private checkoutRef;
+
+    // constructor(props) {
+    //     super(props);
+    //     this.submit = this.submit.bind(this);
+    //     this.handleAction = this.handleAction.bind(this);
+    // }
+
+    constructor(checkoutRef, props) {
+        // TODO - throw error if checkoutRef is not instance of AdyenCheckout
+
+        // If UIElement does the calculating of props...
+        // super(checkoutRef, props, DropinElement.type);
+
+        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: DropinElement.type });
+
+        super(calculatedProps);
+        console.log('### Dropin::constructor:: calculatedProps=', calculatedProps);
+
+        this.checkoutRef = checkoutRef;
+
         this.submit = this.submit.bind(this);
         this.handleAction = this.handleAction.bind(this);
     }
@@ -103,7 +122,8 @@ class DropinElement extends UIElement<DropinElementProps> {
         const commonProps = getCommonProps({ ...this.props, elementRef: this.elementRef });
 
         const storedElements = showStoredPaymentMethods ? createStoredElements(storedPaymentMethods, commonProps, this._parentInstance.create) : [];
-        const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance.create) : [];
+        // const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance.create) : [];
+        const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this.checkoutRef) : [];
         const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, commonProps, this._parentInstance.create);
 
         return [storedElements, elements, instantPaymentElements];

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -10,6 +10,8 @@ import { createElements, createStoredElements } from './elements';
 import createInstantPaymentElements from './elements/createInstantPaymentElements';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import { PaymentResponse } from '../types';
+import Core from '../../core';
+import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 
 const SUPPORTED_INSTANT_PAYMENTS = ['paywithgoogle', 'googlepay', 'applepay'];
 
@@ -32,7 +34,9 @@ class DropinElement extends UIElement<DropinElementProps> {
     // }
 
     constructor(checkoutRef, props) {
-        // TODO - throw error if checkoutRef is not instance of AdyenCheckout
+        if (!(checkoutRef instanceof Core)) {
+            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
+        }
 
         // If UIElement does the calculating of props...
         // super(checkoutRef, props, DropinElement.type);

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -131,7 +131,8 @@ class DropinElement extends UIElement<DropinElementProps> {
         // const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance.create) : [];
         const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance) : [];
 
-        const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, commonProps, this._parentInstance.create);
+        // const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, commonProps, this._parentInstance.create);
+        const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, commonProps, this._parentInstance);
 
         return [storedElements, elements, instantPaymentElements];
     };

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -125,9 +125,12 @@ class DropinElement extends UIElement<DropinElementProps> {
 
         const commonProps = getCommonProps({ ...this.props, elementRef: this.elementRef });
 
-        const storedElements = showStoredPaymentMethods ? createStoredElements(storedPaymentMethods, commonProps, this._parentInstance.create) : [];
+        // const storedElements = showStoredPaymentMethods ? createStoredElements(storedPaymentMethods, commonProps, this._parentInstance.create) : [];
+        const storedElements = showStoredPaymentMethods ? createStoredElements(storedPaymentMethods, commonProps, this._parentInstance) : [];
+
         // const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance.create) : [];
-        const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this.checkoutRef) : [];
+        const elements = showPaymentMethods ? createElements(paymentMethods, commonProps, this._parentInstance) : [];
+
         const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, commonProps, this._parentInstance.create);
 
         return [storedElements, elements, instantPaymentElements];

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -32,7 +32,7 @@ class DropinElement extends UIElement<DropinElementProps> {
     //     this.handleAction = this.handleAction.bind(this);
     // }
 
-    constructor(checkoutRef: Core, props) {
+    constructor(checkoutRef: Core, props: DropinElementProps) {
         // UIElement does the calculating of props...
         super(checkoutRef, { ...props, type: DropinElement.type });
 

--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -13,7 +13,7 @@ const createElements = (components: PaymentMethod[] = [], props, checkout) => {
             console.log('\n### createElements:::: c=', c);
 
             // OPT A: core generates props and initialises PM
-            const pm = checkout.generateUIElementForDropin(c, props);
+            const pm = checkout.createUIElementForDropin(c, props);
             console.log('### createElements:::: pm=', pm);
             return pm;
         })

--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -10,11 +10,11 @@ import { PaymentMethod } from '../../../types';
 const createElements = (components: PaymentMethod[] = [], props, checkout) => {
     const elements = components
         .map(c => {
-            console.log('\n### createElements:::: c=', c);
+            // console.log('\n### createElements:::: c=', c);// TODO - keep for now, for debugging
 
             // OPT A: core generates props and initialises PM
             const pm = checkout.createUIElementForDropin(c, props);
-            console.log('### createElements:::: pm=', pm);
+            // console.log('### createElements:::: pm=', pm);// TODO - keep for now, for debugging
             return pm;
         })
         .filter(filterPresent)

--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -7,9 +7,23 @@ import { PaymentMethod } from '../../../types';
  * @param props - High level props to be passed through to every component (as defined in utils/getCommonProps)
  * @param create - Reference to the main instance `Core#create` method
  */
-const createElements = (components: PaymentMethod[] = [], props, create) => {
+// const createElements = (components: PaymentMethod[] = [], props, create) => {
+const createElements = (components: PaymentMethod[] = [], props, checkout) => {
     const elements = components
-        .map(c => create(c, props))
+        .map(c => {
+            console.log('### createElements:::: c=', c);
+            // const pm = create(c, props);
+
+            // OPT A: core generates props and initialises PM
+            const pm = checkout.generateUIElementForDropin(c, props);
+            console.log('### createElements:::: pm=', pm);
+            return pm;
+
+            // OPT B: core generates props, but we initialise the PM here
+            // const PaymentMethod = checkout.getComponentFromRegistry(c.type);
+            // const generatedProps = checkout.generateUIElementForDropin(c, props);
+            // return new PaymentMethod(checkout, generatedProps);
+        })
         .filter(filterPresent)
         .filter(filterUnsupported);
 

--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -7,22 +7,15 @@ import { PaymentMethod } from '../../../types';
  * @param props - High level props to be passed through to every component (as defined in utils/getCommonProps)
  * @param create - Reference to the main instance `Core#create` method
  */
-// const createElements = (components: PaymentMethod[] = [], props, create) => {
 const createElements = (components: PaymentMethod[] = [], props, checkout) => {
     const elements = components
         .map(c => {
             console.log('\n### createElements:::: c=', c);
-            // const pm = create(c, props);
 
             // OPT A: core generates props and initialises PM
             const pm = checkout.generateUIElementForDropin(c, props);
             console.log('### createElements:::: pm=', pm);
             return pm;
-
-            // OPT B: core generates props, but we initialise the PM here
-            // const PaymentMethod = checkout.getComponentFromRegistry(c.type);
-            // const generatedProps = checkout.generateUIElementForDropin(c, props);
-            // return new PaymentMethod(checkout, generatedProps);
         })
         .filter(filterPresent)
         .filter(filterUnsupported);

--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -11,7 +11,7 @@ import { PaymentMethod } from '../../../types';
 const createElements = (components: PaymentMethod[] = [], props, checkout) => {
     const elements = components
         .map(c => {
-            console.log('### createElements:::: c=', c);
+            console.log('\n### createElements:::: c=', c);
             // const pm = create(c, props);
 
             // OPT A: core generates props and initialises PM

--- a/packages/lib/src/components/Dropin/elements/createInstantPaymentElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createInstantPaymentElements.ts
@@ -8,8 +8,6 @@ import UIElement from '../../UIElement';
  * @param props - Props to be passed through to every paymentMethod
  * @param create - Reference to the main instance `Core#create` method
  */
-// const createInstantPaymentElements = (paymentMethods: PaymentMethod[] = [], props, create): Promise<UIElement[]> | [] =>
-//     paymentMethods.length ? createElements(paymentMethods, { ...props, isInstantPayment: true, showPayButton: true }, create) : [];
 const createInstantPaymentElements = (paymentMethods: PaymentMethod[] = [], props, checkout): Promise<UIElement[]> | [] =>
     paymentMethods.length ? createElements(paymentMethods, { ...props, isInstantPayment: true, showPayButton: true }, checkout) : [];
 

--- a/packages/lib/src/components/Dropin/elements/createInstantPaymentElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createInstantPaymentElements.ts
@@ -8,7 +8,9 @@ import UIElement from '../../UIElement';
  * @param props - Props to be passed through to every paymentMethod
  * @param create - Reference to the main instance `Core#create` method
  */
-const createInstantPaymentElements = (paymentMethods: PaymentMethod[] = [], props, create): Promise<UIElement[]> | [] =>
-    paymentMethods.length ? createElements(paymentMethods, { ...props, isInstantPayment: true, showPayButton: true }, create) : [];
+// const createInstantPaymentElements = (paymentMethods: PaymentMethod[] = [], props, create): Promise<UIElement[]> | [] =>
+//     paymentMethods.length ? createElements(paymentMethods, { ...props, isInstantPayment: true, showPayButton: true }, create) : [];
+const createInstantPaymentElements = (paymentMethods: PaymentMethod[] = [], props, checkout): Promise<UIElement[]> | [] =>
+    paymentMethods.length ? createElements(paymentMethods, { ...props, isInstantPayment: true, showPayButton: true }, checkout) : [];
 
 export default createInstantPaymentElements;

--- a/packages/lib/src/components/Dropin/elements/createStoredElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createStoredElements.ts
@@ -7,7 +7,9 @@ import { StoredPaymentMethod } from '../../../types';
  * @param props - Props to be passed through to every paymentMethod
  * @param create - Reference to the main instance `create` method
  */
-const createStoredElements = (paymentMethods: StoredPaymentMethod[] = [], props, create) =>
-    createElements(paymentMethods, { ...props, oneClick: true }, create);
+// const createStoredElements = (paymentMethods: StoredPaymentMethod[] = [], props, create) =>
+//     createElements(paymentMethods, { ...props, oneClick: true }, create);
+const createStoredElements = (paymentMethods: StoredPaymentMethod[] = [], props, checkout) =>
+    createElements(paymentMethods, { ...props, oneClick: true }, checkout);
 
 export default createStoredElements;

--- a/packages/lib/src/components/Dropin/elements/createStoredElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createStoredElements.ts
@@ -7,8 +7,6 @@ import { StoredPaymentMethod } from '../../../types';
  * @param props - Props to be passed through to every paymentMethod
  * @param create - Reference to the main instance `create` method
  */
-// const createStoredElements = (paymentMethods: StoredPaymentMethod[] = [], props, create) =>
-//     createElements(paymentMethods, { ...props, oneClick: true }, create);
 const createStoredElements = (paymentMethods: StoredPaymentMethod[] = [], props, checkout) =>
     createElements(paymentMethods, { ...props, oneClick: true }, checkout);
 

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -15,8 +15,6 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
         useKlarnaWidget: false
     };
 
-    // constructor(props: KlarnaPaymentsProps) {
-    //     super(props);
     constructor(checkoutRef: Core, props: KlarnaPaymentsProps) {
         super(checkoutRef, { ...props, type: props?.type ?? KlarnaPayments.type });
 

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -5,6 +5,7 @@ import { KlarnaPaymentsProps } from './types';
 import PayButton from '../internal/PayButton';
 import { KlarnaContainer } from './components/KlarnaContainer/KlarnaContainer';
 import { PaymentAction } from '../../types';
+import Core from '../../core';
 
 class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
     public static type = 'klarna';
@@ -14,8 +15,10 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
         useKlarnaWidget: false
     };
 
-    constructor(props: KlarnaPaymentsProps) {
-        super(props);
+    // constructor(props: KlarnaPaymentsProps) {
+    //     super(props);
+    constructor(checkoutRef: Core, props: KlarnaPaymentsProps) {
+        super(checkoutRef, { ...props, type: props?.type ?? KlarnaPayments.type });
 
         this.onComplete = this.onComplete.bind(this);
         this.updateWithAction = this.updateWithAction.bind(this);

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -6,10 +6,12 @@ import PayButton from '../internal/PayButton';
 import { KlarnaContainer } from './components/KlarnaContainer/KlarnaContainer';
 import { PaymentAction } from '../../types';
 import Core from '../../core';
+import Redirect from '../Redirect/Redirect';
 
 class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
     public static type = 'klarna';
     public static txVariants = ['klarna', 'klarna_account', 'klarna_paynow'];
+    public static dependencies = [Redirect];
 
     protected static defaultProps = {
         useKlarnaWidget: false

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -18,7 +18,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
     };
 
     constructor(checkoutRef: Core, props?: KlarnaPaymentsProps) {
-        super(checkoutRef, { ...props, type: props?.type ?? KlarnaPayments.type });
+        super(checkoutRef, props);
 
         this.onComplete = this.onComplete.bind(this);
         this.updateWithAction = this.updateWithAction.bind(this);

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -15,7 +15,7 @@ class KlarnaPayments extends UIElement<KlarnaPaymentsProps> {
         useKlarnaWidget: false
     };
 
-    constructor(checkoutRef: Core, props: KlarnaPaymentsProps) {
+    constructor(checkoutRef: Core, props?: KlarnaPaymentsProps) {
         super(checkoutRef, { ...props, type: props?.type ?? KlarnaPayments.type });
 
         this.onComplete = this.onComplete.bind(this);

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -5,9 +5,14 @@ import CoreProvider from '../../core/Context/CoreProvider';
 import config from './components/MBWayAwait/config';
 import Await from '../../components/internal/Await';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
+// import Core from '../../core';
 
 export class MBWayElement extends UIElement {
     public static type = 'mbway';
+
+    // constructor(checkoutRef: Core, props?) {
+    //     super(checkoutRef, { ...props, type: props?.type ?? MBWayElement.type });
+    // }
 
     formatProps(props) {
         const { data = {}, placeholders = {} } = props;

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -5,14 +5,9 @@ import CoreProvider from '../../core/Context/CoreProvider';
 import config from './components/MBWayAwait/config';
 import Await from '../../components/internal/Await';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
-// import Core from '../../core';
 
 export class MBWayElement extends UIElement {
     public static type = 'mbway';
-
-    // constructor(checkoutRef: Core, props?) {
-    //     super(checkoutRef, { ...props, type: props?.type ?? MBWayElement.type });
-    // }
 
     formatProps(props) {
         const { data = {}, placeholders = {} } = props;

--- a/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
+++ b/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
@@ -1,16 +1,27 @@
 import GiftcardElement from '../Giftcard/Giftcard';
 import { MealVoucherFields } from './components/MealVoucherFields';
+import Core from '../../core';
 
 export class MealVoucherFRElement extends GiftcardElement {
     public static type = 'mealVoucher_FR';
     public static txVariants = ['mealVoucher_FR_natixis', 'mealVoucher_FR_sodexo', 'mealVoucher_FR_groupeup'];
 
-    constructor(props) {
-        super({
+    // constructor(props) {
+    //     super({
+    //         ...props,
+    //         pinRequired: true,
+    //         expiryDateRequired: true,
+    //         fieldsLayoutComponent: MealVoucherFields
+    //     });
+    // }
+
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, {
             ...props,
             pinRequired: true,
             expiryDateRequired: true,
-            fieldsLayoutComponent: MealVoucherFields
+            fieldsLayoutComponent: MealVoucherFields,
+            type: props?.type ?? MealVoucherFRElement.type
         });
     }
 

--- a/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
+++ b/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
@@ -6,15 +6,6 @@ export class MealVoucherFRElement extends GiftcardElement {
     public static type = 'mealVoucher_FR';
     public static txVariants = ['mealVoucher_FR_natixis', 'mealVoucher_FR_sodexo', 'mealVoucher_FR_groupeup'];
 
-    // constructor(props) {
-    //     super({
-    //         ...props,
-    //         pinRequired: true,
-    //         expiryDateRequired: true,
-    //         fieldsLayoutComponent: MealVoucherFields
-    //     });
-    // }
-
     constructor(checkoutRef: Core, props) {
         super(checkoutRef, {
             ...props,

--- a/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
+++ b/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
@@ -11,8 +11,7 @@ export class MealVoucherFRElement extends GiftcardElement {
             ...props,
             pinRequired: true,
             expiryDateRequired: true,
-            fieldsLayoutComponent: MealVoucherFields,
-            type: props?.type ?? MealVoucherFRElement.type
+            fieldsLayoutComponent: MealVoucherFields
         });
     }
 

--- a/packages/lib/src/components/OnlinebankingPL/OnlineBankingPL.tsx
+++ b/packages/lib/src/components/OnlinebankingPL/OnlineBankingPL.tsx
@@ -1,4 +1,5 @@
 import IssuerListContainer from '../helpers/IssuerListContainer';
+import Core from '../../core';
 
 class OnlineBankingPL extends IssuerListContainer {
     public static type = 'onlineBanking_PL';
@@ -13,8 +14,8 @@ class OnlineBankingPL extends IssuerListContainer {
         urls: [OnlineBankingPL.disclaimerUrlsMap.regulation, OnlineBankingPL.disclaimerUrlsMap.obligation]
     };
 
-    constructor(props) {
-        super({ ...props, termsAndConditions: OnlineBankingPL.termsAndConditions });
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, { ...props, termsAndConditions: OnlineBankingPL.termsAndConditions });
     }
 }
 

--- a/packages/lib/src/components/OnlinebankingPL/OnlineBankingPL.tsx
+++ b/packages/lib/src/components/OnlinebankingPL/OnlineBankingPL.tsx
@@ -14,7 +14,7 @@ class OnlineBankingPL extends IssuerListContainer {
         urls: [OnlineBankingPL.disclaimerUrlsMap.regulation, OnlineBankingPL.disclaimerUrlsMap.obligation]
     };
 
-    constructor(checkoutRef: Core, props) {
+    constructor(checkoutRef: Core, props?) {
         super(checkoutRef, { ...props, termsAndConditions: OnlineBankingPL.termsAndConditions });
     }
 }

--- a/packages/lib/src/components/PayByBank/PayByBank.tsx
+++ b/packages/lib/src/components/PayByBank/PayByBank.tsx
@@ -1,9 +1,11 @@
 import IssuerListContainer from '../helpers/IssuerListContainer';
+import Core from '../../core';
 
 class PayByBank extends IssuerListContainer {
     public static type = 'paybybank';
-    constructor(props) {
-        super({ ...props, showPaymentMethodItemImages: true });
+
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, { ...props, showPaymentMethodItemImages: true, type: props?.type ?? PayByBank.type });
     }
 }
 

--- a/packages/lib/src/components/PayByBank/PayByBank.tsx
+++ b/packages/lib/src/components/PayByBank/PayByBank.tsx
@@ -5,7 +5,7 @@ class PayByBank extends IssuerListContainer {
     public static type = 'paybybank';
 
     constructor(checkoutRef: Core, props) {
-        super(checkoutRef, { ...props, showPaymentMethodItemImages: true, type: props?.type ?? PayByBank.type });
+        super(checkoutRef, { ...props, showPaymentMethodItemImages: true });
     }
 }
 

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -21,7 +21,7 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     protected static defaultProps = defaultProps;
 
     constructor(checkoutRef: Core, props: PayPalElementProps) {
-        super(checkoutRef, { ...props, type: props?.type ?? PaypalElement.type });
+        super(checkoutRef, props);
         this.handleSubmit = this.handleSubmit.bind(this);
     }
 

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -9,6 +9,7 @@ import CoreProvider from '../../core/Context/CoreProvider';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { ERRORS } from './constants';
 import { createShopperDetails } from './utils/create-shopper-details';
+import Core from '../../core';
 
 class PaypalElement extends UIElement<PayPalElementProps> {
     public static type = 'paypal';
@@ -19,8 +20,12 @@ class PaypalElement extends UIElement<PayPalElementProps> {
 
     protected static defaultProps = defaultProps;
 
-    constructor(props) {
-        super(props);
+    // constructor(props) {
+    //     super(props);
+    //     this.handleSubmit = this.handleSubmit.bind(this);
+    // }
+    constructor(checkoutRef: Core, props) {
+        super(checkoutRef, { ...props, type: props?.type ?? PaypalElement.type });
         this.handleSubmit = this.handleSubmit.bind(this);
     }
 

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -20,10 +20,6 @@ class PaypalElement extends UIElement<PayPalElementProps> {
 
     protected static defaultProps = defaultProps;
 
-    // constructor(props) {
-    //     super(props);
-    //     this.handleSubmit = this.handleSubmit.bind(this);
-    // }
     constructor(checkoutRef: Core, props: PayPalElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? PaypalElement.type });
         this.handleSubmit = this.handleSubmit.bind(this);

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -24,7 +24,7 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     //     super(props);
     //     this.handleSubmit = this.handleSubmit.bind(this);
     // }
-    constructor(checkoutRef: Core, props) {
+    constructor(checkoutRef: Core, props: PayPalElementProps) {
         super(checkoutRef, { ...props, type: props?.type ?? PaypalElement.type });
         this.handleSubmit = this.handleSubmit.bind(this);
     }

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -4,6 +4,9 @@ import UIElement from '../UIElement';
 import CoreProvider from '../../core/Context/CoreProvider';
 import RedirectShopper from './components/RedirectShopper';
 import RedirectButton from '../internal/RedirectButton';
+import Core from '../../core';
+import { CardElementProps } from '../Card/types';
+import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 
 /**
  * RedirectElement
@@ -15,6 +18,24 @@ class RedirectElement extends UIElement {
         type: RedirectElement.type,
         showPayButton: true
     };
+
+    constructor(checkoutRef: Core, props: CardElementProps) {
+        if (!(checkoutRef instanceof Core)) {
+            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
+        }
+
+        // If UIElement does the calculating of props...
+        // super(checkoutRef, {...props, type: props?.type ?? CardElement.type } );
+
+        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? RedirectElement.type });
+
+        super(calculatedProps);
+        console.log('### RedirectElement::constructor:: calculatedProps=', calculatedProps);
+
+        if (!props.isDropin) {
+            checkoutRef.storeComponentRef(this as UIElement);
+        }
+    }
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -4,9 +4,6 @@ import UIElement from '../UIElement';
 import CoreProvider from '../../core/Context/CoreProvider';
 import RedirectShopper from './components/RedirectShopper';
 import RedirectButton from '../internal/RedirectButton';
-import Core from '../../core';
-import { CardElementProps } from '../Card/types';
-import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 
 /**
  * RedirectElement
@@ -18,24 +15,6 @@ class RedirectElement extends UIElement {
         type: RedirectElement.type,
         showPayButton: true
     };
-
-    constructor(checkoutRef: Core, props: CardElementProps) {
-        if (!(checkoutRef instanceof Core)) {
-            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
-        }
-
-        // If UIElement does the calculating of props...
-        // super(checkoutRef, {...props, type: props?.type ?? CardElement.type } );
-
-        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? RedirectElement.type });
-
-        super(calculatedProps);
-        console.log('### RedirectElement::constructor:: calculatedProps=', calculatedProps);
-
-        if (!props.isDropin) {
-            checkoutRef.storeComponentRef(this as UIElement);
-        }
-    }
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -41,12 +41,15 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without specifying a type');
         }
 
-        // Calculating the props...
-        const calculatedProps = checkoutRef.generateUIElementProps(props);
-        super(calculatedProps);
-        console.log('### UIElement::constructor:: type', props.type, 'calculatedProps', calculatedProps);
+        const type = ['this'].constructor['type'];
+        console.log('### UIElement::constructor:: type=', type);
 
-        if (!calculatedProps.isDropin) {
+        // Retrieve props...
+        const generatedProps = checkoutRef.generateUIElementProps(props);
+        super(generatedProps);
+        console.log('### UIElement::constructor:: type', props.type, 'generatedProps', generatedProps);
+
+        if (!generatedProps.isDropin) {
             checkoutRef.storeComponentRef(this as UIElement);
         }
 

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -29,7 +29,7 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
      */
     public static dependencies: any[] = []; // FIX type
 
-    constructor(checkoutRef: Core, props: P) {
+    constructor(checkoutRef: Core, props?: P) {
         // constructor(props: P) {
         // super(props);
 
@@ -37,15 +37,16 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
         }
 
-        // if (!hasOwnProperty(props, 'type')) {
-        //     throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without specifying a type');
-        // }
+        if (!hasOwnProperty(props, 'type')) {
+            console.warn(
+                'You are trying to initialise a component without specifying a props.type.\nIf this component relies on retrieving data from the /paymentMethodsResponse, or from the top level paymentMethodsConfiguration object, it will not be able to do so.'
+            );
+        } // TODO turn to warning - no "type", no way to retrieve pmResponse objects
 
         // Retrieve props...
         const generatedProps = checkoutRef.generateUIElementProps(props);
-        // const generatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? ['this'].constructor['type'] });
         super(generatedProps);
-        // super(checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? ['this'].constructor['type'] }));
+
         console.log('### UIElement::constructor:: type', props?.type, 'generatedProps', generatedProps);
 
         if (!generatedProps.isDropin) {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -33,7 +33,8 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
         // constructor(props: P) {
         // super(props);
 
-        if (!(checkoutRef instanceof Core)) {
+        // Check for some expected methods on checkoutRef. Would like to use "if(!checkoutRef instanceof Core)" but that creates circular dependencies in the build process
+        if (!hasOwnProperty(checkoutRef, 'createFromAction') || !hasOwnProperty(checkoutRef, 'update')) {
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
         }
 

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -36,10 +36,10 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
         }
 
         if (!hasOwnProperty(props, 'type')) {
-            console.warn(
+            console.debug(
                 'You are trying to initialise a component without specifying a props.type.\nIf this component relies on retrieving data from the /paymentMethodsResponse, or from the top level paymentMethodsConfiguration object, it will not be able to do so.'
             );
-        } // TODO turn to warning - no "type", no way to retrieve pmResponse objects
+        }
 
         // Retrieve props...
         const generatedProps = checkoutRef.generateUIElementProps(props);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -29,15 +29,23 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
      */
     public static dependencies: any[] = []; // FIX type
 
-    // constructor(checkoutRef, props: P) {
-    constructor(props: P) {
-        // If UIElement does the calculating of props...
-        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props.type });
-        //
-        // super(calculatedProps);
-        // console.log('### UIElement::constructor:: type', type, 'calculatedProps', calculatedProps);
+    constructor(checkoutRef, props: P) {
+        // constructor(props: P) {
 
-        super(props);
+        if (!(checkoutRef instanceof Core)) {
+            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
+        }
+
+        // Calculating the props...
+        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props.type });
+        super(calculatedProps);
+        console.log('### UIElement::constructor:: type', props.type, 'calculatedProps', calculatedProps);
+
+        if (!calculatedProps.isDropin) {
+            checkoutRef.storeComponentRef(this as UIElement);
+        }
+
+        // super(props);
         this.submit = this.submit.bind(this);
         this.setState = this.setState.bind(this);
         this.onValid = this.onValid.bind(this);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -37,17 +37,16 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
         }
 
-        if (!hasOwnProperty(props, 'type')) {
-            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without specifying a type');
-        }
-
-        const type = ['this'].constructor['type'];
-        console.log('### UIElement::constructor:: type=', type);
+        // if (!hasOwnProperty(props, 'type')) {
+        //     throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without specifying a type');
+        // }
 
         // Retrieve props...
         const generatedProps = checkoutRef.generateUIElementProps(props);
+        // const generatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? ['this'].constructor['type'] });
         super(generatedProps);
-        console.log('### UIElement::constructor:: type', props.type, 'generatedProps', generatedProps);
+        // super(checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? ['this'].constructor['type'] }));
+        console.log('### UIElement::constructor:: type', props?.type, 'generatedProps', generatedProps);
 
         if (!generatedProps.isDropin) {
             checkoutRef.storeComponentRef(this as UIElement);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -53,7 +53,7 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
              * So... do we issue a "warning" like below or do we write constructors for those PMs that extend UIElement but don't have their own constructor
              *  e.g. Ach, AmazonPay, Bacs, MBWay, etc, etc?
              *
-             * NOTE: everything that extends UIElement now has a static type (with the exceptions of QRLoader-, OpenInvoice-, and IssuerList-Container)
+             * NOTE: everything that extends UIElement now has a static type (with the exceptions of QRLoader-, OpenInvoice-, and IssuerList-Container - which have their own subclasses with a static type)
              * - so retrieving the type for the constructor is not an issue.
              */
             if (!hasOwnProperty(props, 'type')) {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -35,12 +35,6 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
         }
 
-        if (!hasOwnProperty(props, 'type')) {
-            console.debug(
-                'You are trying to initialise a component without specifying a props.type.\nIf this component relies on retrieving data from the /paymentMethodsResponse, or from the top level paymentMethodsConfiguration object, it will not be able to do so.'
-            );
-        }
-
         // Retrieve props...
         const generatedProps = checkoutRef.generateUIElementProps(props);
         super(generatedProps);
@@ -49,6 +43,24 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
 
         if (!generatedProps.isDropin) {
             checkoutRef.storeComponentRef(this as UIElement);
+
+            /**
+             * TODO - decide what to do...
+             * If a PM can be instantiated as a *standalone* component, it needs a constructor that can pass on it's type if it wants to retrieve
+             *  anything from the paymentMethodsResponse or paymentMethodsConfiguration.
+             * However, not all PMs need to collect anything from the paymentMethodsResponse or paymentMethodsConfiguration e.g. MBWay
+             *
+             * So... do we issue a "warning" like below or do we write constructors for those PMs that extend UIElement but don't have their own constructor
+             *  e.g. Ach, AmazonPay, Bacs, MBWay, etc, etc?
+             *
+             * NOTE: everything that extends UIElement now has a static type (with the exceptions of QRLoader-, OpenInvoice-, and IssuerList-Container)
+             * - so retrieving the type for the constructor is not an issue.
+             */
+            if (!hasOwnProperty(props, 'type')) {
+                console.debug(
+                    'You are trying to initialise a component without specifying a props.type.\nIf this component relies on retrieving data from the /paymentMethodsResponse, or from the top level paymentMethodsConfiguration object, it will not be able to do so.'
+                );
+            }
         }
 
         this.submit = this.submit.bind(this);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -52,7 +52,7 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
 
     protected init(props: P) {
         // Retrieve props...
-        const generatedProps = this._parentInstance.generateUIElementProps({ ...props, type: props?.type ?? this.constructor['type'] });
+        const generatedProps = this._parentInstance.generatePropsForUIElement({ ...props, type: props?.type ?? this.constructor['type'] });
         super.init(generatedProps);
 
         console.log('### UIElement::constructor:: type', props?.type ?? this.constructor['type'], 'generatedProps', generatedProps);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -29,7 +29,14 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
      */
     public static dependencies: any[] = []; // FIX type
 
+    // constructor(checkoutRef, props: P, type) {
     constructor(props: P) {
+        // If UIElement does the calculating of props...
+        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: type });
+        //
+        // super(calculatedProps);
+        // console.log('### UIElement::constructor:: type', type, 'calculatedProps', calculatedProps);
+
         super(props);
         this.submit = this.submit.bind(this);
         this.setState = this.setState.bind(this);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -29,8 +29,9 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
      */
     public static dependencies: any[] = []; // FIX type
 
-    constructor(checkoutRef, props: P) {
+    constructor(checkoutRef: Core, props: P) {
         // constructor(props: P) {
+        // super(props);
 
         if (!(checkoutRef instanceof Core)) {
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
@@ -45,7 +46,6 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
             checkoutRef.storeComponentRef(this as UIElement);
         }
 
-        // super(props);
         this.submit = this.submit.bind(this);
         this.setState = this.setState.bind(this);
         this.onValid = this.onValid.bind(this);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -50,17 +50,15 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
         this.elementRef = (props && props.elementRef) || this;
     }
 
-    protected init(checkoutRef, props) {
-        console.log('### UIElement::constructor:: props.type', props?.type);
-
+    protected init(props: P) {
         // Retrieve props...
-        const generatedProps = checkoutRef.generateUIElementProps({ ...props, type: props?.type ?? this.constructor['type'] });
-        super.init(checkoutRef, generatedProps);
+        const generatedProps = this._parentInstance.generateUIElementProps({ ...props, type: props?.type ?? this.constructor['type'] });
+        super.init(generatedProps);
 
         console.log('### UIElement::constructor:: type', props?.type ?? this.constructor['type'], 'generatedProps', generatedProps);
 
         if (!generatedProps.isDropin) {
-            checkoutRef.storeComponentRef(this as UIElement);
+            this._parentInstance.storeComponentRef(this as UIElement);
         }
     }
 

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -55,7 +55,7 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
         const generatedProps = this._parentInstance.generatePropsForUIElement({ ...props, type: props?.type ?? this.constructor['type'] });
         super.init(generatedProps);
 
-        console.log('### UIElement::constructor:: type', props?.type ?? this.constructor['type'], 'generatedProps', generatedProps);
+        // console.log('### UIElement::constructor:: type', props?.type ?? this.constructor['type'], 'generatedProps', generatedProps); // TODO - keep for now, for debugging
 
         if (!generatedProps.isDropin) {
             this._parentInstance.storeComponentRef(this as UIElement);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -30,9 +30,6 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
     public static dependencies: any[] = []; // FIX type
 
     constructor(checkoutRef: Core, props?: P) {
-        // constructor(props: P) {
-        // super(props);
-
         // Check for some expected methods on checkoutRef. Would like to use "if(!checkoutRef instanceof Core)" but that creates circular dependencies in the build process
         if (!hasOwnProperty(checkoutRef, 'createFromAction') || !hasOwnProperty(checkoutRef, 'update')) {
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -29,10 +29,10 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
      */
     public static dependencies: any[] = []; // FIX type
 
-    // constructor(checkoutRef, props: P, type) {
+    // constructor(checkoutRef, props: P) {
     constructor(props: P) {
         // If UIElement does the calculating of props...
-        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: type });
+        // const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props.type });
         //
         // super(calculatedProps);
         // console.log('### UIElement::constructor:: type', type, 'calculatedProps', calculatedProps);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -37,8 +37,12 @@ export abstract class UIElement<P extends UIElementProps = any> extends BaseElem
             throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without a reference to an instance of Checkout');
         }
 
+        if (!hasOwnProperty(props, 'type')) {
+            throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'Trying to initialise a component without specifying a type');
+        }
+
         // Calculating the props...
-        const calculatedProps = checkoutRef.generateUIElementProps({ ...props, type: props.type });
+        const calculatedProps = checkoutRef.generateUIElementProps(props);
         super(calculatedProps);
         console.log('### UIElement::constructor:: type', props.type, 'calculatedProps', calculatedProps);
 

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -36,6 +36,10 @@ class IssuerListContainer extends UIElement<IssuerListContainerProps> {
 
     constructor(checkoutRef: Core, props: IssuerListContainerProps) {
         super(checkoutRef, props); // Not possible to add a default type. It must be specified in props.
+    }
+
+    protected init(checkoutRef: Core, props: IssuerListContainerProps) {
+        super.init(checkoutRef, props);
 
         if (this.props.showImage) {
             const getIssuerIcon = getIssuerImageUrl({ loadingContext: this.props.loadingContext }, this.constructor['type']);

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -34,7 +34,7 @@ interface IssuerListData {
 class IssuerListContainer extends UIElement<IssuerListContainerProps> {
     public static dependencies = [Redirect];
 
-    constructor(checkoutRef: Core, props: IssuerListContainerProps) {
+    constructor(checkoutRef: Core, props?: IssuerListContainerProps) {
         super(checkoutRef, props);
     }
 

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -37,7 +37,9 @@ class IssuerListContainer extends UIElement<IssuerListContainerProps> {
     // constructor(props: IssuerListContainerProps) {
     //     super(props);
     constructor(checkoutRef: Core, props: IssuerListContainerProps) {
-        super(checkoutRef, { ...props, type: props?.type ?? 'issuerList' });
+        console.log('### IssuerListContainer::constructor:: props.type', props.type);
+        // super(checkoutRef, { ...props, type: props?.type ?? 'issuerList' });
+        super(checkoutRef, props); // Not possible to add a default type. It must be specified in props.
 
         if (this.props.showImage) {
             const getIssuerIcon = getIssuerImageUrl({ loadingContext: this.props.loadingContext }, this.constructor['type']);

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -34,11 +34,7 @@ interface IssuerListData {
 class IssuerListContainer extends UIElement<IssuerListContainerProps> {
     public static dependencies = [Redirect];
 
-    // constructor(props: IssuerListContainerProps) {
-    //     super(props);
     constructor(checkoutRef: Core, props: IssuerListContainerProps) {
-        console.log('### IssuerListContainer::constructor:: props.type', props.type);
-        // super(checkoutRef, { ...props, type: props?.type ?? 'issuerList' });
         super(checkoutRef, props); // Not possible to add a default type. It must be specified in props.
 
         if (this.props.showImage) {

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -10,6 +10,7 @@ import { IssuerItem, TermsAndConditions } from '../internal/IssuerList/types';
 import RedirectButton from '../internal/RedirectButton';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import Redirect from '../Redirect';
+import Core from '../../core';
 
 interface IssuerListContainerProps extends UIElementProps {
     showImage?: boolean;
@@ -33,8 +34,10 @@ interface IssuerListData {
 class IssuerListContainer extends UIElement<IssuerListContainerProps> {
     public static dependencies = [Redirect];
 
-    constructor(props: IssuerListContainerProps) {
-        super(props);
+    // constructor(props: IssuerListContainerProps) {
+    //     super(props);
+    constructor(checkoutRef: Core, props: IssuerListContainerProps) {
+        super(checkoutRef, { ...props, type: props?.type ?? 'issuerList' });
 
         if (this.props.showImage) {
             const getIssuerIcon = getIssuerImageUrl({ loadingContext: this.props.loadingContext }, this.constructor['type']);

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -35,11 +35,11 @@ class IssuerListContainer extends UIElement<IssuerListContainerProps> {
     public static dependencies = [Redirect];
 
     constructor(checkoutRef: Core, props: IssuerListContainerProps) {
-        super(checkoutRef, props); // Not possible to add a default type. It must be specified in props.
+        super(checkoutRef, props);
     }
 
-    protected init(checkoutRef: Core, props: IssuerListContainerProps) {
-        super.init(checkoutRef, props);
+    protected init(props: IssuerListContainerProps) {
+        super.init(props);
 
         if (this.props.showImage) {
             const getIssuerIcon = getIssuerImageUrl({ loadingContext: this.props.loadingContext }, this.constructor['type']);

--- a/packages/lib/src/core/Errors/SRPanel.tsx
+++ b/packages/lib/src/core/Errors/SRPanel.tsx
@@ -34,7 +34,7 @@ export class SRPanel extends BaseElement<SRPanelProps> {
     private componentRef: SRMessagesRef;
 
     constructor(props: SRPanelProps) {
-        super(props);
+        super(null, props);
         this.id = this.props.id;
         this.showPanel = process.env.NODE_ENV !== 'production' ? this.props.showPanel : false;
         this._enabled = false;

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/PaymentAction.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/PaymentAction.ts
@@ -2,11 +2,11 @@ import actionTypes from './actionTypes';
 import { PaymentAction } from '../../../types';
 import type { IRegistry } from '../../core.registry';
 
-export function getComponentForAction(registry: IRegistry, action: PaymentAction, props = {}) {
+export function getComponentForAction(checkout, registry: IRegistry, action: PaymentAction, props = {}) {
     const nextAction = actionTypes[action.type];
 
     if (nextAction && typeof nextAction === 'function') {
-        return nextAction(registry, action, props);
+        return nextAction(checkout, registry, action, props);
     }
 
     throw new Error('Invalid Action');

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -8,16 +8,18 @@ const createComponent = (checkout, registry: IRegistry, componentType, props) =>
     return new Element(checkout, { ...props, id: `${componentType}-${uuid()}` });
 };
 
-const getActionHandler = statusType => (checkout, registry: IRegistry, action: PaymentAction, props) => {
-    const config = {
-        ...props,
-        ...action,
-        onComplete: props.onAdditionalDetails,
-        onError: props.onError,
-        statusType
-    };
+const getActionHandler = statusType => {
+    return (checkout, registry: IRegistry, action: PaymentAction, props) => {
+        const config = {
+            ...props,
+            ...action,
+            onComplete: props.onAdditionalDetails,
+            onError: props.onError,
+            statusType
+        };
 
-    return createComponent(checkout, registry, action.paymentMethodType, config);
+        return createComponent(checkout, registry, action.paymentMethodType, config);
+    };
 };
 
 const actionTypes = {

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -3,12 +3,12 @@ import { get3DS2FlowProps } from '../../../components/ThreeDS2/components/utils'
 import uuid from '../../../utils/uuid';
 import type { IRegistry } from '../../core.registry';
 
-const createComponent = (registry: IRegistry, componentType, props) => {
+const createComponent = (checkout, registry: IRegistry, componentType, props) => {
     const Element = registry.getComponent(componentType);
-    return new Element({ ...props, id: `${componentType}-${uuid()}` });
+    return new Element(checkout, { ...props, id: `${componentType}-${uuid()}` });
 };
 
-const getActionHandler = statusType => (registry: IRegistry, action: PaymentAction, props) => {
+const getActionHandler = statusType => (checkout, registry: IRegistry, action: PaymentAction, props) => {
     const config = {
         ...props,
         ...action,
@@ -17,21 +17,21 @@ const getActionHandler = statusType => (registry: IRegistry, action: PaymentActi
         statusType
     };
 
-    return createComponent(registry, action.paymentMethodType, config);
+    return createComponent(checkout, registry, action.paymentMethodType, config);
 };
 
 const actionTypes = {
-    redirect: (registry, action: PaymentAction, props) => {
+    redirect: (checkout, registry, action: PaymentAction, props) => {
         const config = {
             ...props,
             ...action,
             statusType: 'redirect'
         };
 
-        return createComponent(registry, 'redirect', config);
+        return createComponent(checkout, registry, 'redirect', config);
     },
 
-    threeDS2Fingerprint: (registry, action: PaymentAction, props) => {
+    threeDS2Fingerprint: (checkout, registry, action: PaymentAction, props) => {
         const config = {
             createFromAction: props.createFromAction,
             token: action.token,
@@ -46,10 +46,10 @@ const actionTypes = {
             useOriginalFlow: true
         };
 
-        return createComponent(registry, 'threeDS2DeviceFingerprint', config);
+        return createComponent(checkout, registry, 'threeDS2DeviceFingerprint', config);
     },
 
-    threeDS2Challenge: (registry, action: PaymentAction, props) => {
+    threeDS2Challenge: (checkout, registry, action: PaymentAction, props) => {
         const config = {
             ...props,
             token: action.token,
@@ -63,10 +63,10 @@ const actionTypes = {
             useOriginalFlow: true
         };
 
-        return createComponent(registry, 'threeDS2Challenge', config);
+        return createComponent(checkout, registry, 'threeDS2Challenge', config);
     },
 
-    threeDS2: (registry, action: PaymentAction, props) => {
+    threeDS2: (checkout, registry, action: PaymentAction, props) => {
         const componentType = action.subtype === 'fingerprint' ? 'threeDS2DeviceFingerprint' : 'threeDS2Challenge';
         const paymentData = action.subtype === 'fingerprint' ? action.paymentData : action.authorisationToken;
 
@@ -88,7 +88,7 @@ const actionTypes = {
             ...get3DS2FlowProps(action.subtype, props)
         };
 
-        return createComponent(registry, componentType, config);
+        return createComponent(checkout, registry, componentType, config);
     },
 
     voucher: getActionHandler('custom'),

--- a/packages/lib/src/core/RiskModule/RiskModule.tsx
+++ b/packages/lib/src/core/RiskModule/RiskModule.tsx
@@ -33,7 +33,7 @@ export default class RiskElement extends BaseElement<RiskModuleProps> {
     private nodeRiskContainer = null;
 
     constructor(props) {
-        super(props);
+        super(null, props);
 
         // Populate state with null values
         const riskElements = {

--- a/packages/lib/src/core/core.registry.ts
+++ b/packages/lib/src/core/core.registry.ts
@@ -26,7 +26,7 @@ function createComponentsMap(components: (new (props) => UIElement)[]) {
                 [dependency.type]: dependency
             };
         });
-
+        // console.log('### core.registry:::: memo', memo);
         return memo;
     }, {});
 }

--- a/packages/lib/src/core/core.registry.ts
+++ b/packages/lib/src/core/core.registry.ts
@@ -4,7 +4,7 @@ function assertIsTypeofUIElement(item: any): item is typeof UIElement {
     return typeof UIElement === typeof item;
 }
 
-function createComponentsMap(components: (new (props) => UIElement)[]) {
+function createComponentsMap(components: (new (checkout, props) => UIElement)[]) {
     return components.reduce((memo, component) => {
         const isValid = assertIsTypeofUIElement(component);
         if (!isValid) {
@@ -32,15 +32,15 @@ function createComponentsMap(components: (new (props) => UIElement)[]) {
 }
 
 export interface IRegistry {
-    add(...items: (new (props) => UIElement)[]): void;
-    getComponent(type: string): new (props) => UIElement;
+    add(...items: (new (checkout, props) => UIElement)[]): void;
+    getComponent(type: string): new (checkout, props) => UIElement;
 }
 
 class Registry implements IRegistry {
-    public components: (new (props) => UIElement)[] = [];
-    public componentsMap: Record<string, new (props) => UIElement> = {};
+    public components: (new (checkout, props) => UIElement)[] = [];
+    public componentsMap: Record<string, new (checkout, props) => UIElement> = {};
 
-    public add(...items: (new (props) => UIElement)[]) {
+    public add(...items: (new (checkout, props) => UIElement)[]) {
         this.components = [...items];
         this.componentsMap = createComponentsMap(this.components);
     }

--- a/packages/lib/src/core/core.registry.ts
+++ b/packages/lib/src/core/core.registry.ts
@@ -4,7 +4,9 @@ function assertIsTypeofUIElement(item: any): item is typeof UIElement {
     return typeof UIElement === typeof item;
 }
 
-function createComponentsMap(components: (new (checkout, props) => UIElement)[]) {
+export type NewableComponent = new (checkout, props) => UIElement;
+
+function createComponentsMap(components: NewableComponent[]) {
     return components.reduce((memo, component) => {
         const isValid = assertIsTypeofUIElement(component);
         if (!isValid) {
@@ -32,15 +34,15 @@ function createComponentsMap(components: (new (checkout, props) => UIElement)[])
 }
 
 export interface IRegistry {
-    add(...items: (new (checkout, props) => UIElement)[]): void;
-    getComponent(type: string): new (checkout, props) => UIElement;
+    add(...items: NewableComponent[]): void;
+    getComponent(type: string): NewableComponent;
 }
 
 class Registry implements IRegistry {
-    public components: (new (checkout, props) => UIElement)[] = [];
-    public componentsMap: Record<string, new (checkout, props) => UIElement> = {};
+    public components: NewableComponent[] = [];
+    public componentsMap: Record<string, NewableComponent> = {};
 
-    public add(...items: (new (checkout, props) => UIElement)[]) {
+    public add(...items: NewableComponent[]) {
         this.components = [...items];
         this.componentsMap = createComponentsMap(this.components);
     }

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -13,7 +13,7 @@ import { hasOwnProperty } from '../utils/hasOwnProperty';
 import { Resources } from './Context/Resources';
 import { SRPanel } from './Errors/SRPanel';
 import registry, { NewableComponent } from './core.registry';
-// import AdyenCheckoutError from "./Errors/AdyenCheckoutError";
+import AdyenCheckoutError from './Errors/AdyenCheckoutError';
 import type { PaymentMethods, PaymentMethodOptions } from '../components/type-new';
 
 class Core {
@@ -121,11 +121,13 @@ class Core {
      * @returns new UIElement
      */
     public create<T extends keyof PaymentMethods>(paymentMethod: T, options?: PaymentMethodOptions<T>): UIElement {
-        /** TODO - Ideally we would have some way to distinguish UMD users from npm users and throw this error if npm users try to call checkout.create */
-        // throw new AdyenCheckoutError(
-        //     'IMPLEMENTATION_ERROR',
-        //     'Since v6 the create method is no longer how you instantiate a Payment Method component. You should now import the component directly and instantiate it with the "new" operator e.g. new Card(checkout, ...)'
-        // );
+        /** Distinguish UMD users from npm users and throw this error if npm users try to call checkout.create */
+        if (!window['AdyenCheckout']) {
+            throw new AdyenCheckoutError(
+                'IMPLEMENTATION_ERROR',
+                'Since v6 the create method is no longer how you instantiate a Payment Method component. You should now import the component directly and instantiate it with the "new" operator e.g. new Card(checkout, props)'
+            );
+        }
 
         const PaymentMethod: NewableComponent = registry.getComponent(paymentMethod);
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -13,7 +13,8 @@ import { hasOwnProperty } from '../utils/hasOwnProperty';
 import { Resources } from './Context/Resources';
 import { SRPanel } from './Errors/SRPanel';
 import registry, { NewableComponent } from './core.registry';
-// import type { PaymentMethods, PaymentMethodOptions } from '../components/type-new';
+// import AdyenCheckoutError from "./Errors/AdyenCheckoutError";
+import type { PaymentMethods, PaymentMethodOptions } from '../components/type-new';
 
 class Core {
     public session: Session;
@@ -106,6 +107,33 @@ class Core {
                     this.options.onError?.(error);
                 });
         }
+    }
+
+    /**
+     * TODO - check if UMD users can also use the 'new' operator
+     * ONLY NEEDED(??) for UMD users of Checkout i.e. merchants who load adyen.js
+     *
+     * Instantiates a new UIElement component ready to be mounted
+     *
+     * @param paymentMethod - Name of the paymentMethod - a string corresponding to a txVariant
+     * @param options - the merchant defined config object passed when a component is created via checkout.create
+     *
+     * @returns new UIElement
+     */
+    public create<T extends keyof PaymentMethods>(paymentMethod: T, options?: PaymentMethodOptions<T>): UIElement {
+        /** TODO - Ideally we would have some way to distinguish UMD users from npm users and throw this error if npm users try to call checkout.create */
+        // throw new AdyenCheckoutError(
+        //     'IMPLEMENTATION_ERROR',
+        //     'Since v6 the create method is no longer how you instantiate a Payment Method component. You should now import the component directly and instantiate it with the "new" operator e.g. new Card(checkout, ...)'
+        // );
+
+        const PaymentMethod: NewableComponent = registry.getComponent(paymentMethod);
+
+        if (!PaymentMethod) {
+            return this.handleCreateError(PaymentMethod);
+        }
+
+        return new PaymentMethod(this, options);
     }
 
     /**

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -397,7 +397,6 @@ class Core {
 
         const calculatedUIElementProps = { ...PaymentMethodObject, ...options, ...paymentMethodsConfiguration };
 
-        // re. OPT A in Dropin/elements/createElements.ts - initialise the PM here
         let PaymentMethod = registry.getComponent(PaymentMethodObject.type);
 
         /**
@@ -409,15 +408,7 @@ class Core {
         }
 
         return new PaymentMethod(this, calculatedUIElementProps);
-
-        // re. OPT B in Dropin/elements/createElements.ts - createElements will initialise the PM. In which case this fn should be called generateUIElementPropsForDropin
-        // return calculatedUIElementProps;
     }
-
-    // Needed for OPT B in Dropin/elements/createElements.ts
-    // public getComponentFromRegistry(type: string) {
-    //     return registry.getComponent(type);
-    // }
 
     /**
      * @internal

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -227,8 +227,7 @@ class Core {
             session: this.session,
             loadingContext: this.loadingContext,
             cdnContext: this.cdnContext,
-            createFromAction: this.createFromAction,
-            _parentInstance: this
+            createFromAction: this.createFromAction
         };
     }
 
@@ -244,7 +243,7 @@ class Core {
         const needsPMData = needsConfigData && !supportedShopperInteractions;
 
         /**
-         * We only need to populate the objects under certain circumstances.
+         * We only need to populate the paymentMethodsDetails & paymentMethodsConfiguration objects under certain circumstances.
          * (If we're creating a Dropin or a PM within the Dropin - then the relevant paymentMethods response & paymentMethodsConfiguration props
          * are already merged into the passed options object; whilst a standalone stored card just needs the paymentMethodsConfiguration props)
          * So:
@@ -388,7 +387,7 @@ class Core {
     }
 
     public generateUIElementForDropin(PaymentMethodObject, options) {
-        console.log('\n### core::generateUIElementForDropin:: ');
+        console.log('### core::generateUIElementForDropin:: ');
         const paymentMethodsConfiguration = getComponentConfiguration(
             PaymentMethodObject.type,
             this.options.paymentMethodsConfiguration,

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -238,7 +238,7 @@ class Core {
         };
     }
 
-    public generateUIElementProps(options: any) {
+    public generatePropsForUIElement(options: any) {
         const props = this.getPropsForComponent(options);
 
         const { type, isDropin, supportedShopperInteractions, storedPaymentMethodId } = props;
@@ -268,11 +268,11 @@ class Core {
 
         const calculatedOptions = { ...globalOptions, ...paymentMethodsDetails, ...paymentMethodsConfiguration, ...props };
 
-        console.log('\n### core::generateUIElementProps:: props.type', type);
-        console.log('### core::generateUIElementProps:: props.isDropin', isDropin);
-        console.log('### core::generateUIElementProps:: props.supportedShopperInteractions', supportedShopperInteractions);
-        console.log('### core::generateUIElementProps:: needsConfigData', needsConfigData);
-        console.log('### core::generateUIElementProps:: needsPMData', needsPMData);
+        console.log('\n### core::generatePropsForUIElement:: props.type', type);
+        console.log('### core::generatePropsForUIElement:: props.isDropin', isDropin);
+        console.log('### core::generatePropsForUIElement:: props.supportedShopperInteractions', supportedShopperInteractions);
+        console.log('### core::generatePropsForUIElement:: needsConfigData', needsConfigData);
+        console.log('### core::generatePropsForUIElement:: needsPMData', needsPMData);
 
         return calculatedOptions;
     }
@@ -281,8 +281,8 @@ class Core {
         this.components.push(component);
     }
 
-    public generateUIElementForDropin(PaymentMethodObject, options) {
-        console.log('### core::generateUIElementForDropin:: ');
+    public createUIElementForDropin(PaymentMethodObject, options) {
+        console.log('### core::createUIElementForDropin:: ');
         const paymentMethodsConfiguration = getComponentConfiguration(
             PaymentMethodObject.type,
             this.options.paymentMethodsConfiguration,

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -385,7 +385,16 @@ class Core {
         const calculatedUIElementProps = { ...PaymentMethodObject, ...options, ...paymentMethodsConfiguration };
 
         // re. OPT A in Dropin/elements/createElements.ts - initialise the PM here
-        const PaymentMethod = registry.getComponent(PaymentMethodObject.type);
+        let PaymentMethod = registry.getComponent(PaymentMethodObject.type);
+
+        /**
+         * If we are trying to create a payment method that is in the paymentMethods response but does not explicitly
+         * implement a component (i.e. no matching entry in the 'paymentMethods' components map), it will default to a Redirect component
+         */
+        if (!PaymentMethod) {
+            PaymentMethod = registry.getComponent('redirect');
+        }
+
         return new PaymentMethod(this, calculatedUIElementProps);
 
         // re. OPT B in Dropin/elements/createElements.ts - createElements will initialise the PM. In which case this fn should be called generateUIElementPropsForDropin

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -33,7 +33,7 @@ class Core {
 
     public static registry = registry;
 
-    public static register(...items: (new (props) => UIElement)[]) {
+    public static register(...items: (new (checkout, props) => UIElement)[]) {
         registry.add(...items);
     }
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -155,7 +155,7 @@ class Core {
                 ...this.getPropsForComponent(options)
             };
 
-            return getComponentForAction(registry, action, props);
+            return getComponentForAction(this, registry, action, props);
         }
 
         return this.handleCreateError();

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -391,7 +391,7 @@ class Core {
          * If we are trying to create a payment method that is in the paymentMethods response but does not explicitly
          * implement a component (i.e. no matching entry in the 'paymentMethods' components map), it will default to a Redirect component
          */
-        if (!PaymentMethod) {
+        if (!PaymentMethod && this.paymentMethodsResponse.has(PaymentMethodObject.type)) {
             PaymentMethod = registry.getComponent('redirect');
         }
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -121,7 +121,10 @@ class Core {
      * @returns new UIElement
      */
     public create<T extends keyof PaymentMethods>(paymentMethod: T, options?: PaymentMethodOptions<T>): UIElement {
-        /** Distinguish UMD users from npm users and throw this error if npm users try to call checkout.create */
+        /**
+         * Distinguish UMD users from npm users and throw this error if npm users try to call checkout.create
+         * TODO - decide if this is a reliable check and whether an error is too strong & it should just be a warning
+         */
         if (!window['AdyenCheckout']) {
             throw new AdyenCheckoutError(
                 'IMPLEMENTATION_ERROR',
@@ -270,11 +273,12 @@ class Core {
 
         const calculatedOptions = { ...globalOptions, ...paymentMethodsDetails, ...paymentMethodsConfiguration, ...props };
 
-        console.log('\n### core::generatePropsForUIElement:: props.type', type);
-        console.log('### core::generatePropsForUIElement:: props.isDropin', isDropin);
-        console.log('### core::generatePropsForUIElement:: props.supportedShopperInteractions', supportedShopperInteractions);
-        console.log('### core::generatePropsForUIElement:: needsConfigData', needsConfigData);
-        console.log('### core::generatePropsForUIElement:: needsPMData', needsPMData);
+        // TODO - keep for now, for debugging
+        // console.log('\n### core::generatePropsForUIElement:: props.type', type);
+        // console.log('### core::generatePropsForUIElement:: props.isDropin', isDropin);
+        // console.log('### core::generatePropsForUIElement:: props.supportedShopperInteractions', supportedShopperInteractions);
+        // console.log('### core::generatePropsForUIElement:: needsConfigData', needsConfigData);
+        // console.log('### core::generatePropsForUIElement:: needsPMData', needsPMData);
 
         return calculatedOptions;
     }
@@ -284,7 +288,7 @@ class Core {
     }
 
     public createUIElementForDropin(PaymentMethodObject, options) {
-        console.log('### core::createUIElementForDropin:: ');
+        // console.log('### core::createUIElementForDropin:: ');// TODO - keep for now, for debugging
         const paymentMethodsConfiguration = getComponentConfiguration(
             PaymentMethodObject.type,
             this.options.paymentMethodsConfiguration,

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -12,7 +12,7 @@ import Session from './CheckoutSession';
 import { hasOwnProperty } from '../utils/hasOwnProperty';
 import { Resources } from './Context/Resources';
 import { SRPanel } from './Errors/SRPanel';
-import registry from './core.registry';
+import registry, { NewableComponent } from './core.registry';
 // import type { PaymentMethods, PaymentMethodOptions } from '../components/type-new';
 
 class Core {
@@ -33,7 +33,7 @@ class Core {
 
     public static registry = registry;
 
-    public static register(...items: (new (checkout, props) => UIElement)[]) {
+    public static register(...items: NewableComponent[]) {
         registry.add(...items);
     }
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,8 +1,7 @@
-import UIElement from './components/UIElement';
-
 export * from './components';
 export * from './AdyenCheckout';
 
 import * as elements from './components';
+import { NewableComponent } from './core/core.registry';
 
-export const components: (new (checkout, props) => UIElement)[] = Object.keys(elements).map(key => elements[key]);
+export const components: NewableComponent[] = Object.keys(elements).map(key => elements[key]);

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -5,4 +5,4 @@ export * from './AdyenCheckout';
 
 import * as elements from './components';
 
-export const components: (new (props) => UIElement)[] = Object.keys(elements).map(key => elements[key]);
+export const components: (new (checkout, props) => UIElement)[] = Object.keys(elements).map(key => elements[key]);

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -68,6 +68,9 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
                 ...storedCardData,
                 disclaimerMessage
             }).mount('.storedcard-field');
+            // window.card = new Card(checkout, {
+            //     brands: ['visa']
+            // }).mount('.storedcard-field');
         }
     }
 

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -28,8 +28,6 @@ const disclaimerMessage = {
 getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse => {
     AdyenCheckout.register(Card, Bancontact);
 
-    console.log('### Cards:::: AdyenCheckout=', AdyenCheckout);
-
     window.checkout = await AdyenCheckout({
         amount,
         resourceEnvironment: 'https://checkoutshopper-beta.adyen.com/checkoutshopper/',

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -11,7 +11,7 @@ import { MockReactApp } from './MockReactApp';
 
 const showComps = {
     clickToPay: false,
-    storedCard: false,
+    storedCard: true,
     card: true,
     cardInReact: false,
     bcmcCard: true,

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -7,14 +7,14 @@ import { amount, shopperLocale } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
 import { MockReactApp } from './MockReactApp';
-import { searchFunctionExample } from '../../utils';
+// import { searchFunctionExample } from '../../utils';
 
 const showComps = {
     clickToPay: false,
-    storedCard: false,
+    storedCard: true,
     card: true,
     cardInReact: false,
-    bcmcCard: false,
+    bcmcCard: true,
     avsCard: false,
     avsPartialCard: false,
     kcpCard: false
@@ -45,10 +45,13 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
             card: {
                 hasHolderName: true,
                 holderNameRequired: true
-            },
-            storedCard: {
-                hideCVC: true
             }
+            // storedCard: {
+            //     hideCVC: true
+            // },
+            // bcmc: {
+            //     brands: ['bcmc', 'visa']
+            // }
         }
     });
 
@@ -56,13 +59,12 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     if (showComps.storedCard) {
         if (checkout.paymentMethodsResponse.storedPaymentMethods && checkout.paymentMethodsResponse.storedPaymentMethods.length > 0) {
             const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[2];
-            // window.card = new Card(checkout, {
-            window.storedCard = checkout
-                .create('card', {
-                    ...storedCardData,
-                    disclaimerMessage
-                })
-                .mount('.storedcard-field');
+            window.card = new Card(checkout, {
+                // window.storedCard = checkout
+                //     .create('card', {
+                ...storedCardData,
+                disclaimerMessage
+            }).mount('.storedcard-field');
         }
     }
 
@@ -105,7 +107,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
 
     // Bancontact card
     if (showComps.bcmcCard) {
-        window.bancontact = checkout.create('bcmc').mount('.bancontact-field');
+        window.bancontact = new Bancontact(checkout).mount('.bancontact-field');
+        // window.bancontact = checkout.create('bcmc').mount('.bancontact-field');
     }
 
     // Credit card with AVS

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -119,71 +119,71 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
 
     // Credit card with AVS
     if (showComps.avsCard) {
-        window.cardAvs = checkout
-            .create('card', {
-                type: 'scheme',
-                brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-                enableStoreDetails: true,
+        // window.cardAvs = checkout
+        //     .create('card', {
+        window.cardAvs = new Card(checkout, {
+            // type: 'scheme',
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+            enableStoreDetails: true,
 
-                // holderName config:
-                hasHolderName: true,
-                holderNameRequired: true,
+            // holderName config:
+            hasHolderName: true,
+            holderNameRequired: true,
+            holderName: 'J. Smith',
+            positionHolderNameOnTop: true,
+
+            // billingAddress config:
+            billingAddressRequired: true,
+            billingAddressAllowedCountries: ['US', 'CA', 'GB'],
+            // billingAddressRequiredFields: ['postalCode', 'country'],
+
+            // data:
+            data: {
                 holderName: 'J. Smith',
-                positionHolderNameOnTop: true,
-
-                // billingAddress config:
-                billingAddressRequired: true,
-                billingAddressAllowedCountries: ['US', 'CA', 'GB'],
-                // billingAddressRequiredFields: ['postalCode', 'country'],
-
-                // data:
-                data: {
-                    holderName: 'J. Smith',
-                    billingAddress: {
-                        street: 'Infinite Loop',
-                        postalCode: '95014',
-                        city: 'Cupertino',
-                        houseNumberOrName: '1',
-                        country: 'US',
-                        stateOrProvince: 'CA'
-                    }
-                },
-                onError: objdobj => {
-                    console.log('component level merchant defined error handler for Card objdobj=', objdobj);
+                billingAddress: {
+                    street: 'Infinite Loop',
+                    postalCode: '95014',
+                    city: 'Cupertino',
+                    houseNumberOrName: '1',
+                    country: 'US',
+                    stateOrProvince: 'CA'
                 }
-            })
-            .mount('.card-avs-field');
+            },
+            onError: objdobj => {
+                console.log('component level merchant defined error handler for Card objdobj=', objdobj);
+            }
+        }).mount('.card-avs-field');
     }
 
     if (showComps.avsPartialCard) {
-        window.avsPartialCard = checkout
-            .create('card', {
-                type: 'scheme',
-                brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-                // billingAddress config:
-                billingAddressRequired: true,
-                billingAddressMode: 'partial',
-                onError: objdobj => {
-                    console.log('component level merchant defined error handler for Card objdobj=', objdobj);
-                }
-            })
-            .mount('.card-avs-partial-field');
+        // window.avsPartialCard = checkout
+        //     .create('card', {
+        window.avsPartialCard = new Card(checkout, {
+            // type: 'scheme',
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+            // billingAddress config:
+            billingAddressRequired: true,
+            billingAddressMode: 'partial',
+            onError: objdobj => {
+                console.log('component level merchant defined error handler for Card objdobj=', objdobj);
+            }
+        }).mount('.card-avs-partial-field');
     }
 
     // Credit card with KCP Authentication
     if (showComps.kcpCard) {
-        window.kcpCard = checkout
-            .create('card', {
-                type: 'scheme',
-                brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro', 'korean_local_card'],
-                // Set koreanAuthenticationRequired AND countryCode so KCP fields show at start
-                // Just set koreanAuthenticationRequired if KCP fields should only show if korean_local_card entered
-                configuration: {
-                    koreanAuthenticationRequired: true
-                },
-                countryCode: 'KR'
-            })
-            .mount('.card-kcp-field');
+        // window.kcpCard = checkout
+        //     .create('card', {
+        window.kcpCard = new Card(checkout, {
+            // type: 'scheme',
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro', 'korean_local_card'],
+            // Set koreanAuthenticationRequired AND countryCode so KCP fields show at start
+            // Just set koreanAuthenticationRequired if KCP fields should only show if korean_local_card entered
+            configuration: {
+                koreanAuthenticationRequired: true
+            },
+            countryCode: 'KR'
+        }).mount('.card-kcp-field');
     }
 
     if (showComps.clickToPay) {

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -52,6 +52,9 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
             // bcmc: {
             //     brands: ['bcmc', 'visa']
             // }
+        },
+        risk: {
+            enabled: false
         }
     });
 

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -61,11 +61,11 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         if (checkout.paymentMethodsResponse.storedPaymentMethods && checkout.paymentMethodsResponse.storedPaymentMethods.length > 0) {
             const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[2];
             window.card = new Card(checkout, {
-                // window.storedCard = checkout
-                //     .create('card', {
                 ...storedCardData,
                 disclaimerMessage
             }).mount('.storedcard-field');
+
+            // A "single branded" card
             // window.card = new Card(checkout, {
             //     brands: ['visa']
             // }).mount('.storedcard-field');
@@ -75,8 +75,6 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     // Credit card with installments
     if (showComps.card) {
         window.card = new Card(checkout, {
-            // window.card = checkout
-            //     .create('card', {
             brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
             // installmentOptions: {
             //     mc: {
@@ -105,20 +103,18 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
 
     // Card mounted in a React app
     if (showComps.cardInReact) {
-        window.cardReact = checkout.create('card', {});
+        window.cardReact = new Card(checkout, {});
+
         MockReactApp(window, 'cardReact', document.querySelector('.react-card-field'), false);
     }
 
     // Bancontact card
     if (showComps.bcmcCard) {
         window.bancontact = new Bancontact(checkout).mount('.bancontact-field');
-        // window.bancontact = checkout.create('bcmc').mount('.bancontact-field');
     }
 
     // Credit card with AVS
     if (showComps.avsCard) {
-        // window.cardAvs = checkout
-        //     .create('card', {
         window.cardAvs = new Card(checkout, {
             // type: 'scheme',
             brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
@@ -154,8 +150,6 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     }
 
     if (showComps.avsPartialCard) {
-        // window.avsPartialCard = checkout
-        //     .create('card', {
         window.avsPartialCard = new Card(checkout, {
             // type: 'scheme',
             brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
@@ -170,8 +164,6 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
 
     // Credit card with KCP Authentication
     if (showComps.kcpCard) {
-        // window.kcpCard = checkout
-        //     .create('card', {
         window.kcpCard = new Card(checkout, {
             // type: 'scheme',
             brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro', 'korean_local_card'],
@@ -189,20 +181,18 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
          * Make sure that the initialization values are being set in the /paymentMethods response,
          * as part of the 'scheme' configuration object
          */
-        window.ctpCard = checkout
-            .create('card', {
-                type: 'scheme',
-                brands: ['mc', 'visa'],
-                configuration: {
-                    mcDpaId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1_dpa2',
-                    mcSrcClientId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1'
-                },
-                clickToPayConfiguration: {
-                    disableOtpAutoFocus: true,
-                    shopperEmail: 'gui.ctp@adyen.com',
-                    merchantDisplayName: 'Adyen Merchant Name '
-                }
-            })
-            .mount('.card-ctp-field');
+        window.ctpCard = new Card(checkout, {
+            // type: 'scheme',
+            brands: ['mc', 'visa'],
+            configuration: {
+                mcDpaId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1_dpa2',
+                mcSrcClientId: '6d41d4d6-45b1-42c3-a5d0-a28c0e69d4b1'
+            },
+            clickToPayConfiguration: {
+                disableOtpAutoFocus: true,
+                shopperEmail: 'gui.ctp@adyen.com',
+                merchantDisplayName: 'Adyen Merchant Name '
+            }
+        }).mount('.card-ctp-field');
     }
 });

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -14,7 +14,7 @@ const showComps = {
     storedCard: false,
     card: true,
     cardInReact: false,
-    bcmcCard: false,
+    bcmcCard: true,
     avsCard: false,
     avsPartialCard: false,
     kcpCard: false

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -2,7 +2,7 @@ import { AdyenCheckout, Card, Bancontact } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
 
 import { getPaymentMethods } from '../../services';
-import { handleSubmit, handleAdditionalDetails, handleError, handleChange } from '../../handlers';
+import { handleSubmit, handleAdditionalDetails, handleError } from '../../handlers';
 import { amount, shopperLocale } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
@@ -10,14 +10,14 @@ import { MockReactApp } from './MockReactApp';
 import { searchFunctionExample } from '../../utils';
 
 const showComps = {
-    clickToPay: true,
-    storedCard: true,
+    clickToPay: false,
+    storedCard: false,
     card: true,
-    cardInReact: true,
-    bcmcCard: true,
-    avsCard: true,
-    avsPartialCard: true,
-    kcpCard: true
+    cardInReact: false,
+    bcmcCard: false,
+    avsCard: false,
+    avsPartialCard: false,
+    kcpCard: false
 };
 const disclaimerMessage = {
     message: 'By continuing you accept the %{linkText} of MyStore',
@@ -27,6 +27,8 @@ const disclaimerMessage = {
 
 getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse => {
     AdyenCheckout.register(Card, Bancontact);
+
+    console.log('### Cards:::: AdyenCheckout=', AdyenCheckout);
 
     window.checkout = await AdyenCheckout({
         amount,
@@ -39,11 +41,13 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         onSubmit: handleSubmit,
         onAdditionalDetails: handleAdditionalDetails,
         onError: handleError,
-        onChange: handleChange,
         paymentMethodsConfiguration: {
             card: {
                 hasHolderName: true,
                 holderNameRequired: true
+            },
+            storedCard: {
+                hideCVC: true
             }
         }
     });
@@ -51,7 +55,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     // Stored Card
     if (showComps.storedCard) {
         if (checkout.paymentMethodsResponse.storedPaymentMethods && checkout.paymentMethodsResponse.storedPaymentMethods.length > 0) {
-            const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[0];
+            const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[2];
+            // window.card = new Card(checkout, {
             window.storedCard = checkout
                 .create('card', {
                     ...storedCardData,
@@ -63,33 +68,33 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
 
     // Credit card with installments
     if (showComps.card) {
-        window.card = checkout
-            .create('card', {
-                brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
-                installmentOptions: {
-                    mc: {
-                        values: [1, 2],
-                        preselectedValue: 2
-                    },
-                    visa: {
-                        values: [1, 2, 3, 4],
-                        plans: ['regular', 'revolving'],
-                        preselectedValue: 4
-                    }
-                },
-                disclaimerMessage,
-                showBrandsUnderCardNumber: true,
-                showInstallmentAmounts: true,
-                onError: obj => {
-                    console.log('### Cards::onError:: obj=', obj);
-                },
-                onBinLookup: obj => {
-                    console.log('### Cards::onBinLookup:: obj=', obj);
-                },
-                billingAddressRequired: true,
-                onAddressLookup: searchFunctionExample
-            })
-            .mount('.card-field');
+        window.card = new Card(checkout, {
+            // window.card = checkout
+            //     .create('card', {
+            brands: ['mc', 'visa', 'amex', 'bcmc', 'maestro'],
+            // installmentOptions: {
+            //     mc: {
+            //         values: [1, 2],
+            //         preselectedValue: 2
+            //     },
+            //     visa: {
+            //         values: [1, 2, 3, 4],
+            //         plans: ['regular', 'revolving'],
+            //         preselectedValue: 4
+            //     }
+            // },
+            disclaimerMessage,
+            showBrandsUnderCardNumber: true,
+            showInstallmentAmounts: true,
+            onError: obj => {
+                console.log('### Cards::onError:: obj=', obj);
+            },
+            onBinLookup: obj => {
+                console.log('### Cards::onBinLookup:: obj=', obj);
+            },
+            // billingAddressRequired: true,
+            onAddressLookup: null //searchFunctionExample
+        }).mount('.card-field');
     }
 
     // Card mounted in a React app

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -11,10 +11,10 @@ import { MockReactApp } from './MockReactApp';
 
 const showComps = {
     clickToPay: false,
-    storedCard: true,
+    storedCard: false,
     card: true,
     cardInReact: false,
-    bcmcCard: true,
+    bcmcCard: false,
     avsCard: false,
     avsPartialCard: false,
     kcpCard: false
@@ -54,6 +54,9 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         risk: {
             enabled: false
         }
+        // srConfig: {
+        //     enabled: false
+        // }
     });
 
     // Stored Card

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -11,7 +11,7 @@ import { MockReactApp } from './MockReactApp';
 
 const showComps = {
     clickToPay: false,
-    storedCard: true,
+    storedCard: false,
     card: true,
     cardInReact: false,
     bcmcCard: true,

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -75,8 +75,6 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         }
     }).mount('.ach-field');
 
-    return;
-
     // SEPA Direct Debit
     window.sepa = checkout
         .create('sepadirectdebit', {

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -53,30 +53,29 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     // Klarna Widget
     window.klarnaButton = new Klarna(checkout, { useKlarnaWidget: true }).mount('.klarna-field');
 
-    return;
     // ACH
-    window.ach = checkout
-        .create('ach', {
-            // holderNameRequired: false,
-            // hasHolderName: false,
-            //            onConfigSuccess: obj => {
-            //                console.log('### Components::onConfigSuccess:: obj', obj);
-            //            },
-            // billingAddressRequired: false,
-            // billingAddressAllowedCountries: ['US', 'PR'],
-            data: {
-                // holderName: 'B. Fish',
-                billingAddress: {
-                    street: 'Infinite Loop',
-                    postalCode: '95014',
-                    city: 'Cupertino',
-                    houseNumberOrName: '1',
-                    country: 'US',
-                    stateOrProvince: 'CA'
-                }
+    window.ach = new Ach(checkout, {
+        // holderNameRequired: false,
+        // hasHolderName: false,
+        //            onConfigSuccess: obj => {
+        //                console.log('### Components::onConfigSuccess:: obj', obj);
+        //            },
+        // billingAddressRequired: false,
+        // billingAddressAllowedCountries: ['US', 'PR'],
+        data: {
+            // holderName: 'B. Fish',
+            billingAddress: {
+                street: 'Infinite Loop',
+                postalCode: '95014',
+                city: 'Cupertino',
+                houseNumberOrName: '1',
+                country: 'US',
+                stateOrProvince: 'CA'
             }
-        })
-        .mount('.ach-field');
+        }
+    }).mount('.ach-field');
+
+    return;
 
     // SEPA Direct Debit
     window.sepa = checkout

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -29,7 +29,9 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     });
 
     // // SEPA Bank Transfer
-    window.bankTransfer = checkout.create('bankTransfer_IBAN').mount('.bankTransfer-field');
+    // window.bankTransfer = checkout.create('bankTransfer_IBAN').mount('.bankTransfer-field');
+    // window.bankTransfer = new BankTransfer(checkout, { type: 'bankTransfer_IBAN' }).mount('.bankTransfer-field');// BankTransfer doesn't need constructor
+    window.bankTransfer = new BankTransfer(checkout).mount('.bankTransfer-field'); // BankTransfer needs constructor
     window.bankTransferResult = checkout
         .createFromAction({
             paymentMethodType: 'bankTransfer_IBAN',
@@ -47,8 +49,10 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         .mount('.bankTransfer-result-field');
     //
     // MBWay
-    window.mbway = checkout.create('mbway').mount('.mbway-field');
-
+    // window.mbway = checkout.create('mbway').mount('.mbway-field');
+    // window.mbway = new MBWay(checkout, { type: 'mbway' }).mount('.mbway-field');
+    window.mbway = new MBWay(checkout).mount('.mbway-field');
+    return;
     // Klarna Widget
     window.klarnaButton = checkout.create('klarna').mount('.klarna-field');
 

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -75,6 +75,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         }
     }).mount('.ach-field');
 
+    return;
+
     // SEPA Direct Debit
     window.sepa = checkout
         .create('sepadirectdebit', {

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -25,7 +25,10 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         onActionHandled: rtnObj => {
             console.log('onActionHandled', rtnObj);
         },
-        showPayButton: true
+        showPayButton: true,
+        klarna: {
+            useKlarnaWidget: true
+        }
     });
 
     // // SEPA Bank Transfer
@@ -49,13 +52,14 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         .mount('.bankTransfer-result-field');
     //
     // MBWay
-    // window.mbway = checkout.create('mbway').mount('.mbway-field');
     // window.mbway = new MBWay(checkout, { type: 'mbway' }).mount('.mbway-field');
     window.mbway = new MBWay(checkout).mount('.mbway-field');
-    return;
-    // Klarna Widget
-    window.klarnaButton = checkout.create('klarna').mount('.klarna-field');
 
+    // Klarna Widget
+    // window.klarnaButton = checkout.create('klarna').mount('.klarna-field');
+    window.klarnaButton = new Klarna(checkout).mount('.klarna-field');
+
+    return;
     // ACH
     window.ach = checkout
         .create('ach', {

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -25,14 +25,10 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         onActionHandled: rtnObj => {
             console.log('onActionHandled', rtnObj);
         },
-        showPayButton: true,
-        klarna: {
-            useKlarnaWidget: true
-        }
+        showPayButton: true
     });
 
     // // SEPA Bank Transfer
-    // window.bankTransfer = checkout.create('bankTransfer_IBAN').mount('.bankTransfer-field');
     // window.bankTransfer = new BankTransfer(checkout, { type: 'bankTransfer_IBAN' }).mount('.bankTransfer-field');// BankTransfer doesn't need constructor
     window.bankTransfer = new BankTransfer(checkout).mount('.bankTransfer-field'); // BankTransfer needs constructor
     window.bankTransferResult = checkout
@@ -52,12 +48,10 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         .mount('.bankTransfer-result-field');
     //
     // MBWay
-    // window.mbway = new MBWay(checkout, { type: 'mbway' }).mount('.mbway-field');
     window.mbway = new MBWay(checkout).mount('.mbway-field');
 
     // Klarna Widget
-    // window.klarnaButton = checkout.create('klarna').mount('.klarna-field');
-    window.klarnaButton = new Klarna(checkout).mount('.klarna-field');
+    window.klarnaButton = new Klarna(checkout, { useKlarnaWidget: true }).mount('.klarna-field');
 
     return;
     // ACH

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,7 +20,7 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        allowPaymentMethods: ['scheme', 'bcmc'],
+        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -21,7 +21,7 @@ export async function initManual() {
             }
         },
         // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard'],
-        // allowPaymentMethods: ['paysafecard'],
+        // allowPaymentMethods: ['ideal'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -80,12 +80,12 @@ export async function initManual() {
             paywithgoogle: {
                 buttonType: 'plain'
             },
-            storedCard: {
-                hideCVC: true
-            }
-            // klarna: {
-            //     useKlarnaWidget: true
+            // storedCard: {
+            //     hideCVC: true
             // }
+            klarna: {
+                useKlarnaWidget: true
+            }
         }
     });
 
@@ -147,8 +147,8 @@ export async function initManual() {
     }
 
     const dropin = new Dropin(checkout, {
-        instantPaymentTypes: ['googlepay'],
-        showStoredPaymentMethods: false
+        instantPaymentTypes: ['googlepay']
+        // showStoredPaymentMethods: false
     }).mount('#dropin-container');
 
     handleRedirectResult();

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,7 +20,8 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay'],
+        // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay'],
+        allowPaymentMethods: ['paysafecard'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,7 +20,7 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard'],
+        // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard'],
         // allowPaymentMethods: ['paysafecard'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,7 +20,7 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard', 'mbway'],
+        // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard', 'mbway'],
         // allowPaymentMethods: ['onlineBanking_PL'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
@@ -79,10 +79,10 @@ export async function initManual() {
             },
             paywithgoogle: {
                 buttonType: 'plain'
+            },
+            storedCard: {
+                hideCVC: true
             }
-            // storedCard: {
-            //     hideCVC: true
-            // }
         }
     });
 
@@ -144,10 +144,8 @@ export async function initManual() {
     }
 
     const dropin = new Dropin(checkout, {
-        // const dropin = checkout
-        //     .create('dropin', {
-        instantPaymentTypes: ['googlepay'],
-        showStoredPaymentMethods: false
+        instantPaymentTypes: ['googlepay']
+        // showStoredPaymentMethods: false
     }).mount('#dropin-container');
 
     handleRedirectResult();

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,7 +20,7 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard', 'mbway'],
+        // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard', 'mbway', 'klarna'],
         // allowPaymentMethods: ['onlineBanking_PL'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
@@ -83,6 +83,9 @@ export async function initManual() {
             storedCard: {
                 hideCVC: true
             }
+            // klarna: {
+            //     useKlarnaWidget: true
+            // }
         }
     });
 
@@ -144,8 +147,8 @@ export async function initManual() {
     }
 
     const dropin = new Dropin(checkout, {
-        instantPaymentTypes: ['googlepay']
-        // showStoredPaymentMethods: false
+        instantPaymentTypes: ['googlepay'],
+        showStoredPaymentMethods: false
     }).mount('#dropin-container');
 
     handleRedirectResult();

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,8 +20,8 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay'],
-        allowPaymentMethods: ['paysafecard'],
+        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard'],
+        // allowPaymentMethods: ['paysafecard'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -1,4 +1,5 @@
 import AdyenCheckout from '@adyen/adyen-web/auto';
+import { Dropin } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
 import { getPaymentMethods, makePayment, checkBalance, createOrder, cancelOrder, makeDetailsCall } from '../../services';
 import { amount, shopperLocale, countryCode, returnUrl } from '../../config/commonConfig';
@@ -6,6 +7,8 @@ import { getSearchParameters } from '../../utils';
 
 export async function initManual() {
     const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
+    console.log('### manual::initManual:: AdyenCheckout', AdyenCheckout);
+    console.log('### manual::initManual:: Dropin', Dropin);
     window.checkout = await AdyenCheckout({
         amount,
         countryCode,
@@ -18,6 +21,7 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
+        allowPaymentMethods: ['scheme'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
 
@@ -39,9 +43,9 @@ export async function initManual() {
                 handleFinalState(result.resultCode, component);
             }
         },
-        onChange: state => {
-            console.log('onChange', state);
-        },
+        // onChange: state => {
+        //     console.log('onChange', state);
+        // },
         onAdditionalDetails: async (state, component) => {
             const result = await makeDetailsCall(state.data);
 
@@ -69,7 +73,7 @@ export async function initManual() {
         },
         paymentMethodsConfiguration: {
             card: {
-                enableStoreDetails: false,
+                enableStoreDetails: true,
                 hasHolderName: true,
                 holderNameRequired: true
             },
@@ -136,11 +140,12 @@ export async function initManual() {
         return Promise.resolve(true);
     }
 
-    const dropin = checkout
-        .create('dropin', {
-            instantPaymentTypes: ['googlepay']
-        })
-        .mount('#dropin-container');
+    const dropin = new Dropin(checkout, {
+        // const dropin = checkout
+        //     .create('dropin', {
+        instantPaymentTypes: ['googlepay'],
+        showStoredPaymentMethods: false
+    }).mount('#dropin-container');
 
     handleRedirectResult();
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -7,8 +7,7 @@ import { getSearchParameters } from '../../utils';
 
 export async function initManual() {
     const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
-    console.log('### manual::initManual:: AdyenCheckout', AdyenCheckout);
-    console.log('### manual::initManual:: Dropin', Dropin);
+
     window.checkout = await AdyenCheckout({
         amount,
         countryCode,
@@ -80,6 +79,9 @@ export async function initManual() {
             paywithgoogle: {
                 buttonType: 'plain'
             }
+            // storedCard: {
+            //     hideCVC: true
+            // }
         }
     });
 
@@ -143,8 +145,8 @@ export async function initManual() {
     const dropin = new Dropin(checkout, {
         // const dropin = checkout
         //     .create('dropin', {
-        instantPaymentTypes: ['googlepay'],
-        showStoredPaymentMethods: false
+        instantPaymentTypes: ['googlepay']
+        // showStoredPaymentMethods: false
     }).mount('#dropin-container');
 
     handleRedirectResult();

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,7 +20,7 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard'],
+        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard', 'mbway'],
         // allowPaymentMethods: ['onlineBanking_PL'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
@@ -146,8 +146,8 @@ export async function initManual() {
     const dropin = new Dropin(checkout, {
         // const dropin = checkout
         //     .create('dropin', {
-        instantPaymentTypes: ['googlepay']
-        // showStoredPaymentMethods: false
+        instantPaymentTypes: ['googlepay'],
+        showStoredPaymentMethods: false
     }).mount('#dropin-container');
 
     handleRedirectResult();

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,8 +20,8 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        // allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard'],
-        // allowPaymentMethods: ['ideal'],
+        allowPaymentMethods: ['scheme', 'bcmc', 'googlepay', 'paysafecard'],
+        // allowPaymentMethods: ['onlineBanking_PL'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -20,7 +20,7 @@ export async function initManual() {
                 values: [1, 2, 3, 4]
             }
         },
-        allowPaymentMethods: ['scheme'],
+        allowPaymentMethods: ['scheme', 'bcmc'],
         onSubmit: async (state, component) => {
             const result = await makePayment(state.data);
 

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -1,4 +1,5 @@
 import AdyenCheckout from '@adyen/adyen-web/auto';
+import { Dropin } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
 import { createSession } from '../../services';
 import { amount, shopperLocale, shopperReference, countryCode, returnUrl } from '../../config/commonConfig';
@@ -50,10 +51,10 @@ export async function initSession() {
         }
     });
 
-    const dropin = checkout
-        .create('dropin', {
-            instantPaymentTypes: ['googlepay']
-        })
-        .mount('#dropin-container');
+    // const dropin = checkout
+    //     .create('dropin', {
+    const dropin = new Dropin(checkout, {
+        instantPaymentTypes: ['googlepay']
+    }).mount('#dropin-container');
     return [checkout, dropin];
 }

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -51,8 +51,6 @@ export async function initSession() {
         }
     });
 
-    // const dropin = checkout
-    //     .create('dropin', {
     const dropin = new Dropin(checkout, {
         instantPaymentTypes: ['googlepay']
     }).mount('#dropin-container');

--- a/packages/playground/src/pages/Helpers/Helpers.js
+++ b/packages/playground/src/pages/Helpers/Helpers.js
@@ -26,80 +26,74 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     });
 
     // Adyen Giving
-    window.donation = checkout
-        .create('donation', {
-            onDonate: (state, component) => {
-                console.log({ state, component });
-                setTimeout(() => component.setStatus('ready'), 1000);
-            },
-            url: 'https://example.org',
-            amounts: {
-                currency: 'EUR',
-                values: [50, 199, 300]
-            },
-            disclaimerMessage: {
-                message: 'By donating you agree to the %{linkText} ',
-                linkText: 'terms and conditions',
-                link: 'https://www.adyen.com'
-            },
-            backgroundUrl:
-                'https://www.patagonia.com/static/on/demandware.static/-/Library-Sites-PatagoniaShared/default/dwb396273f/content-banners/100-planet-hero-desktop.jpg',
-            description: 'Lorem ipsum...',
-            logoUrl: 'https://i.ebayimg.com/images/g/aTwAAOSwfu9dfX4u/s-l300.jpg',
-            name: 'Test Charity',
-            onCancel(data) {
-                console.log(data);
-            }
-        })
-        .mount('.donation-field');
+    window.donation = new Donation(checkout, {
+        onDonate: (state, component) => {
+            console.log({ state, component });
+            setTimeout(() => component.setStatus('ready'), 1000);
+        },
+        url: 'https://example.org',
+        amounts: {
+            currency: 'EUR',
+            values: [50, 199, 300]
+        },
+        disclaimerMessage: {
+            message: 'By donating you agree to the %{linkText} ',
+            linkText: 'terms and conditions',
+            link: 'https://www.adyen.com'
+        },
+        backgroundUrl:
+            'https://www.patagonia.com/static/on/demandware.static/-/Library-Sites-PatagoniaShared/default/dwb396273f/content-banners/100-planet-hero-desktop.jpg',
+        description: 'Lorem ipsum...',
+        logoUrl: 'https://i.ebayimg.com/images/g/aTwAAOSwfu9dfX4u/s-l300.jpg',
+        name: 'Test Charity',
+        onCancel(data) {
+            console.log(data);
+        }
+    }).mount('.donation-field');
 
     // Personal details
-    window.personalDetails = checkout
-        .create('personal_details', {
-            onChange: console.log
-        })
-        .mount('.personalDetails-field');
+    window.personalDetails = new PersonalDetails(checkout, {
+        onChange: console.log
+    }).mount('.personalDetails-field');
 
     // Address
-    window.address = checkout
-        .create('address', {
-            onAddressLookup: searchFunctionExample,
-            onChange: console.log,
-            validationRules: {
-                postalCode: {
-                    validate: (value, context) => {
-                        const selectedCountry = context.state?.data?.country;
-                        const isOptional = selectedCountry === 'IN';
-                        return isOptional || (value && value.length > 0);
-                    },
-                    modes: ['blur']
+    window.address = new Address(checkout, {
+        onAddressLookup: searchFunctionExample,
+        onChange: console.log,
+        validationRules: {
+            postalCode: {
+                validate: (value, context) => {
+                    const selectedCountry = context.state?.data?.country;
+                    const isOptional = selectedCountry === 'IN';
+                    return isOptional || (value && value.length > 0);
                 },
-                // Example of overwriting the default validation rule (which doesn't consider an empty field to be in error, unless the whole form is being validated)
-                // with a new rule that will throw an error on a field if you click into it and then click out again leaving it empty
-                default: {
-                    validate: value => value && value.length > 0,
-                    modes: ['blur']
-                }
+                modes: ['blur']
             },
-            specifications: {
-                IN: {
-                    hasDataset: false,
-                    optionalFields: ['postalCode'],
-                    labels: {
-                        postalCode: 'pin',
-                        street: 'addressTown'
-                    },
-                    schema: [
-                        'country',
-                        'street',
-                        'houseNumberOrName',
-                        [
-                            ['city', 70],
-                            ['postalCode', 30]
-                        ]
-                    ]
-                }
+            // Example of overwriting the default validation rule (which doesn't consider an empty field to be in error, unless the whole form is being validated)
+            // with a new rule that will throw an error on a field if you click into it and then click out again leaving it empty
+            default: {
+                validate: value => value && value.length > 0,
+                modes: ['blur']
             }
-        })
-        .mount('.address-field');
+        },
+        specifications: {
+            IN: {
+                hasDataset: false,
+                optionalFields: ['postalCode'],
+                labels: {
+                    postalCode: 'pin',
+                    street: 'addressTown'
+                },
+                schema: [
+                    'country',
+                    'street',
+                    'houseNumberOrName',
+                    [
+                        ['city', 70],
+                        ['postalCode', 30]
+                    ]
+                ]
+            }
+        }
+    }).mount('.address-field');
 });

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.js
@@ -57,7 +57,9 @@ import '../../style.scss';
     });
 
     // iDEAL
-    window.ideal = checkout.create('ideal').mount('.ideal-field');
+    // window.ideal = checkout.create('ideal').mount('.ideal-field');
+    window.ideal = new Ideal(checkout).mount('.ideal-field');
+    return;
 
     // BillDesk Online
     window.billdesk_online = checkout.create('billdesk_online').mount('.billdesk_online-field');

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.js
@@ -57,12 +57,12 @@ import '../../style.scss';
     });
 
     // iDEAL
-    // window.ideal = checkout.create('ideal').mount('.ideal-field');
     window.ideal = new Ideal(checkout).mount('.ideal-field');
     return;
 
     // BillDesk Online
-    window.billdesk_online = checkout.create('billdesk_online').mount('.billdesk_online-field');
+    window.billdesk_online = new BillDeskOnline(checkout).mount('.billdesk_online-field');
+    // return;
 
     //  BillDesk Wallet
     window.billdesk_wallet = checkout.create('billdesk_wallet').mount('.billdesk_wallet-field');
@@ -77,7 +77,7 @@ import '../../style.scss';
     window.dotpay = checkout.create('dotpay').mount('.dotpay-field');
 
     // Online banking PL
-    window.onlineBanking_PL = checkout.create('onlineBanking_PL').mount('.onlinebanking_PL-field');
+    window.onlineBanking_PL = new OnlineBankingPL(checkout).mount('.onlinebanking_PL-field');
 
     // Entercash
     window.entercash = checkout.create('entercash').mount('.entercash-field');

--- a/packages/playground/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/playground/src/pages/IssuerLists/IssuerLists.js
@@ -58,33 +58,32 @@ import '../../style.scss';
 
     // iDEAL
     window.ideal = new Ideal(checkout).mount('.ideal-field');
-    return;
 
     // BillDesk Online
     window.billdesk_online = new BillDeskOnline(checkout).mount('.billdesk_online-field');
     // return;
 
     //  BillDesk Wallet
-    window.billdesk_wallet = checkout.create('billdesk_wallet').mount('.billdesk_wallet-field');
+    window.billdesk_wallet = new BillDeskWallet(checkout).mount('.billdesk_wallet-field');
 
     // PayU CashCard
-    window.payu_cashcard = checkout.create('payu_IN_cashcard').mount('.payu_cc-field');
+    window.payu_cashcard = new PayuCashcard(checkout).mount('.payu_cc-field');
 
     //  PayU NetBanking
-    window.payu_nb = checkout.create('payu_IN_nb').mount('.payu_nb-field');
+    window.payu_nb = new PayuNetBanking(checkout).mount('.payu_nb-field');
 
     // Dotpay
-    window.dotpay = checkout.create('dotpay').mount('.dotpay-field');
+    window.dotpay = new Dotpay(checkout).mount('.dotpay-field');
 
     // Online banking PL
     window.onlineBanking_PL = new OnlineBankingPL(checkout).mount('.onlinebanking_PL-field');
 
     // Entercash
-    window.entercash = checkout.create('entercash').mount('.entercash-field');
+    window.entercash = new Entercash(checkout).mount('.entercash-field');
 
     // Molpay MY
-    window.molpay = checkout.create('molpay_ebanking_fpx_MY').mount('.molpay-field');
+    window.molpay = new MolPayEBankingMY(checkout).mount('.molpay-field');
 
     // Pay By Bank
-    window.paybybank_NL = checkout.create('paybybank').mount('.paybybank_NL-field');
+    window.paybybank_NL = new PayByBank(checkout).mount('.paybybank_NL-field');
 })();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
PoC to remove the `checkout.create` function as the means to initialise a component (`checkout.create('card'...`)

Instead components are initialised with the `new` operator (`new Card(...`)

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
