### PR TITLE
fix(address): pass undefined to maxLength to omit the property being set

### DIFF
--- a/.changeset/hungry-tigers-reflect.md
+++ b/.changeset/hungry-tigers-reflect.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix the address `maxLength` by passing `undefined` to omit the property being set.

--- a/packages/lib/src/utils/validator-utils.ts
+++ b/packages/lib/src/utils/validator-utils.ts
@@ -7,10 +7,11 @@ export const getMaxLengthByFieldAndCountry = (
     field: string,
     country: string,
     ignoreIfFormatterExists: boolean
-): number | null => {
+): number | undefined => {
     // In ignoreIfFormatterExists is true we expect the formatter function to also act to limit length
     if (ignoreIfFormatterExists && formattingRules[country]?.[field]?.formatterFn) {
-        return null;
+        // maxLength={undefined} will not set the maxlength
+        return undefined;
     }
     const maxLength = formattingRules[country]?.[field]?.maxlength;
     return maxLength ? maxLength : MAX_LENGTH;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix the address `maxLength` by passing `undefined` to omit the property being set.

## Tested scenarios
For `Card` billingAddressMode full mode, when choose country 'United States' or 'United Kingdom', the postal code max length should not be set. The validation should be done via `formatterFn` in `validate.formats.ts`, which also checks the max length. 

**Fixed issue**:  <!-- #-prefixed issue number -->
