### PR TITLE
Allow to select item when data-disabled equals to "false"

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -53,7 +53,7 @@ function Select({
         // If the target is not one of the list items, select the first list item
         const target: HTMLInputElement = selectListRef.current.contains(e.currentTarget) ? e.currentTarget : selectListRef.current.firstElementChild;
 
-        if (!target.getAttribute('data-disabled')) {
+        if (!target.getAttribute('data-disabled') || target.getAttribute('data-disabled') === 'false') {
             closeList();
             const value = target.getAttribute('data-value');
             onChange({ target: { value, name: name } });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For some reason `data-disable` attribute is stored as a string.
This is why it is not possible to select any item, since each of them has `data-disabled="false"`

![image](https://github.com/Adyen/adyen-web/assets/17749946/2f7bcf30-1ec3-4a2d-802f-b9d073540e2a)

In order to prevent this issue from happening I handled both boolean and string.

**Fixed issue**:  [2309](https://github.com/Adyen/adyen-web/issues/2309)
