### PR TITLE
feature/add issuerlist feature to highlight all issuers and hide dropdown

### DIFF
--- a/.changeset/khaki-impalas-sin.md
+++ b/.changeset/khaki-impalas-sin.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": minor
+---
+
+Add issuerlist feature to highlight all issuers and hide dropdown

--- a/packages/lib/src/components/internal/IssuerList/IssuerList.test.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerList.test.tsx
@@ -126,4 +126,34 @@ describe('IssuerList', () => {
         expect(highlightedIssuerButton.text()).toBe(highlightedIssuerDropdownItem.text());
         expect(highlightedIssuerButton.prop('value')).toBe(highlightedIssuerDropdownItem.prop('data-value'));
     });
+
+    test('Highlight all issuers removes dropdown and renders all issuers regardless of highlightedIds', () => {
+        const items = [
+            { name: 'Issuer 1', id: '1' },
+            { name: 'Issuer 2', id: '2' },
+            { name: 'Issuer 3', id: '3' },
+            { name: 'Issuer 3', id: '4' },
+            { name: 'Issuer 5', id: '5' }
+        ];
+        const highlightedIds = ['3'];
+
+        const wrapper = mount(
+            <IssuerList
+                items={items}
+                highlightedIds={highlightedIds}
+                showPayButton={false}
+                onChange={jest.fn()}
+                payButton={props => <PayButton {...props} amount={{ value: 50, currency: 'USD' }} />}
+                highlightAllIssuersAndHideDropdown
+            />
+        );
+
+        const highlightedIssuers = wrapper.find('.adyen-checkout__issuer-button-group button');
+        const highlightedContentSeparator = wrapper.find('.adyen-checkout__content-separator');
+        const dropdownElement = wrapper.find('.adyen-checkout__field--issuer-list');
+
+        expect(highlightedContentSeparator.exists()).toBeFalsy();
+        expect(dropdownElement.exists()).toBeFalsy();
+        expect(highlightedIssuers).toHaveLength(5);
+    });
 });

--- a/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
@@ -100,7 +100,7 @@ function IssuerList({
 
             {!highlightAllIssuersAndHideDropdown && (
                 <Fragment>
-                    <ContentSeparator />
+                    {!!highlightedItems.length && <ContentSeparator />}
 
                     <Field errorMessage={getErrorMessage(errors.issuer)} classNameModifiers={['issuer-list']} name={'issuer'}>
                         <Select

--- a/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
@@ -36,7 +36,14 @@ enum IssuerListInputTypes {
     Dropdown
 }
 
-function IssuerList({ items, placeholder = 'idealIssuer.selectField.placeholder', issuer, highlightedIds = [], ...props }: IssuerListProps) {
+function IssuerList({
+    items,
+    placeholder = 'idealIssuer.selectField.placeholder',
+    issuer,
+    highlightedIds = [],
+    highlightAllIssuersAndHideDropdown = false,
+    ...props
+}: IssuerListProps) {
     const { i18n } = useCoreContext();
     const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm({
         schema,
@@ -77,13 +84,15 @@ function IssuerList({ items, placeholder = 'idealIssuer.selectField.placeholder'
         triggerValidation();
     };
 
-    const { highlightedItems } = items.reduce(
-        (memo, item) => {
-            if (highlightedIds.includes(item.id)) memo.highlightedItems.push({ ...item });
-            return memo;
-        },
-        { highlightedItems: [] }
-    );
+    const { highlightedItems } = highlightAllIssuersAndHideDropdown
+        ? { highlightedItems: items }
+        : items.reduce(
+              (memo, item) => {
+                  if (highlightedIds.includes(item.id)) memo.highlightedItems.push({ ...item });
+                  return memo;
+              },
+              { highlightedItems: [] }
+          );
 
     return (
         <div className="adyen-checkout__issuer-list">
@@ -94,20 +103,25 @@ function IssuerList({ items, placeholder = 'idealIssuer.selectField.placeholder'
                         items={highlightedItems}
                         onChange={handleInputChange(IssuerListInputTypes.ButtonGroup)}
                     />
-                    <ContentSeparator />
                 </Fragment>
             )}
 
-            <Field errorMessage={getErrorMessage(errors.issuer)} classNameModifiers={['issuer-list']} name={'issuer'}>
-                <Select
-                    items={items}
-                    selectedValue={inputType === IssuerListInputTypes.Dropdown ? data['issuer'] : null}
-                    placeholder={i18n.get(placeholder)}
-                    name={'issuer'}
-                    className={'adyen-checkout__issuer-list__dropdown'}
-                    onChange={handleInputChange(IssuerListInputTypes.Dropdown)}
-                />
-            </Field>
+            {!highlightAllIssuersAndHideDropdown && (
+                <Fragment>
+                    <ContentSeparator />
+
+                    <Field errorMessage={getErrorMessage(errors.issuer)} classNameModifiers={['issuer-list']} name={'issuer'}>
+                        <Select
+                            items={items}
+                            selectedValue={inputType === IssuerListInputTypes.Dropdown ? data['issuer'] : null}
+                            placeholder={i18n.get(placeholder)}
+                            name={'issuer'}
+                            className={'adyen-checkout__issuer-list__dropdown'}
+                            onChange={handleInputChange(IssuerListInputTypes.Dropdown)}
+                        />
+                    </Field>
+                </Fragment>
+            )}
 
             {props.termsAndConditions && (
                 <div className="adyen-checkout__issuer-list__termsAndConditions">

--- a/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
@@ -84,15 +84,7 @@ function IssuerList({
         triggerValidation();
     };
 
-    const { highlightedItems } = highlightAllIssuersAndHideDropdown
-        ? { highlightedItems: items }
-        : items.reduce(
-              (memo, item) => {
-                  if (highlightedIds.includes(item.id)) memo.highlightedItems.push({ ...item });
-                  return memo;
-              },
-              { highlightedItems: [] }
-          );
+    const highlightedItems = highlightAllIssuersAndHideDropdown ? items : items.filter(item => highlightedIds.includes(item.id));
 
     return (
         <div className="adyen-checkout__issuer-list">

--- a/packages/lib/src/components/internal/IssuerList/types.ts
+++ b/packages/lib/src/components/internal/IssuerList/types.ts
@@ -7,6 +7,7 @@ export interface IssuerListProps {
     payButton(props: Partial<PayButtonProps>): ComponentChildren;
     onChange(payload: any): void;
     highlightedIds?: string[];
+    highlightAllIssuersAndHideDropdown?: boolean;
     placeholder?: string;
     issuer?: string;
     termsAndConditions?: TermsAndConditions;


### PR DESCRIPTION
## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Hello! This is my first PR here, at my company we are going to slowly make use of the awesome drop-in payment method, so after setting drop-in up in my own codebase I also wanted to set it up locally here to have a look. I saw a scenario where you want all issuers to be highlighted, this is already technically possible by passing all issuer id's to the highlightedIssuers prop, but then the dropdown is also still there which is too much for this use case.

I want to propose this feature where all issuers will be highlighted by enabling the prop and it also hiding the dropdown and content separator.

![Screenshot 2023-08-23 at 12 56 56](https://github.com/Adyen/adyen-web/assets/22095656/3c1b5fc8-4989-4a2d-bbcf-e688beee98d6)


## Tested scenarios
I added an unit test to test the scenario where the highlightAllIssuersAndHideDropdown is set to true, the name is verbose but it also covers that the dropdown will also be hidden, which is new.

As mentioned, it's my first PR, so if things need to change please let me know :)