### PR TITLE
chore: fix ts config

### DIFF
--- a/.changeset/brown-eels-hear.md
+++ b/.changeset/brown-eels-hear.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+chore: fix ts config

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -16,6 +16,7 @@
     "typings": "dist/types",
     "exports": {
         ".": {
+            "types": "./dist/types/index.d.ts",
             "import": "./dist/es/index.js",
             "require": "./dist/cjs/index.js"
         },


### PR DESCRIPTION
## Summary

The `types` field in `package.json` is no longer used if there is an `exports` field. Because of that `tsc` complains that it can not find a declaration file for the module.
