### PR TITLE
Hide expiryDate field on storedCards when this info is not available

### DIFF
--- a/.changeset/good-camels-join.md
+++ b/.changeset/good-camels-join.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+For some storedCards it is not allowed to store the expiryDate, so when this info is not present in the storedCardData, we hide the readonly expiryDate field

--- a/packages/e2e/tests/_models/CardComponent.page.js
+++ b/packages/e2e/tests/_models/CardComponent.page.js
@@ -62,6 +62,8 @@ export default class CardPage extends BasePage {
         // The <span> that holds the error text
         this.dateErrorText = Selector(`${BASE_EL} .adyen-checkout__field__exp-date .adyen-checkout__error-text`);
 
+        this.storedCardExpiryDate = Selector(`${BASE_EL} .adyen-checkout__field--storedCard .adyen-checkout__card__exp-date__input--oneclick`);
+
         /**
          * CVC
          */

--- a/packages/e2e/tests/storedCard/general.test.js
+++ b/packages/e2e/tests/storedCard/general.test.js
@@ -17,6 +17,9 @@ test('#1 Can fill out the cvc fields in the stored card and make a successful pa
     // handler for alert that's triggered on successful payment
     await t.setNativeDialogHandler(() => true);
 
+    // expiry date field is readonly
+    await t.expect(cardPage.storedCardExpiryDate.withAttribute('readonly').exists).ok();
+
     await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
 
     // click pay
@@ -40,3 +43,23 @@ test('#2 Pressing pay without filling the cvc should generate a translated error
         .expect(cardPage.cvcErrorText.withExactText(EMPTY_FIELD).exists)
         .ok();
 });
+
+test('#3 A storedCard with no expiry date field still can be used for a successful payment', async t => {
+    // Wait for field to appear in DOM
+    await cardPage.cvcHolder();
+
+    // handler for alert that's triggered on successful payment
+    await t.setNativeDialogHandler(() => true);
+
+    // expiry date field is not visible
+    await t.expect(cardPage.storedCardExpiryDate.exists).notOk();
+
+    await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
+
+    // click pay
+    await t.click(cardPage.payButton).expect(cardPage.cvcLabelTextError.exists).notOk().wait(1000);
+
+    // Check the value of the alert text
+    const history = await t.getNativeDialogHistory();
+    await t.expect(history[0].text).eql('Authorised');
+}).clientScripts('./storedCard.noExpiry.clientScripts.js'); // N.B. the clientScript nullifies the expiryMonth & Year fields in the storedCardData

--- a/packages/e2e/tests/storedCard/storedCard.noExpiry.clientScripts.js
+++ b/packages/e2e/tests/storedCard/storedCard.noExpiry.clientScripts.js
@@ -1,0 +1,4 @@
+window.cardConfig = {
+    expiryMonth: null,
+    expiryYear: null
+};

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
@@ -21,15 +21,15 @@ describe('StoredCard', () => {
     test('Renders a StoredCard field, with readonly expiryDate and cvc field', () => {
         render(<StoredCardFields {...storedCardProps} />);
 
+        // Look for expiryDate elements
         /* eslint-disable-next-line */
         expect(screen.queryByText('Expiry date', { exact: false })).toBeTruthy(); // presence
-        /* eslint-disable-next-line */
-        expect(screen.queryByLabelText('Expiry date', { exact: true })).toBeTruthy(); // presence
-        /* eslint-disable-next-line */
-        expect(screen.queryByLabelText('Expiry date', { exact: true })).toHaveAttribute('readonly', '');
 
-        /* eslint-disable-next-line */
-        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getByLabelText('Expiry date', { exact: true })).toBeTruthy(); // presence
+        expect(screen.getByLabelText('Expiry date', { exact: true })).toHaveAttribute('readonly', '');
+
+        // Look for cvc field elements
+        expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
         expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
     });
 
@@ -43,8 +43,7 @@ describe('StoredCard', () => {
         /* eslint-disable-next-line */
         expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
 
-        /* eslint-disable-next-line */
-        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
         expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
     });
 
@@ -58,8 +57,7 @@ describe('StoredCard', () => {
         /* eslint-disable-next-line */
         expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
 
-        /* eslint-disable-next-line */
-        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
         expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
     });
 
@@ -73,8 +71,7 @@ describe('StoredCard', () => {
         /* eslint-disable-next-line */
         expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
 
-        /* eslint-disable-next-line */
-        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
         expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
     });
 });

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
@@ -1,0 +1,80 @@
+import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
+
+import { CVC_POLICY_REQUIRED } from '../../../../internal/SecuredFields/lib/configuration/constants';
+import StoredCardFields from './StoredCardFields';
+
+const storedCardProps = {
+    brand: 'visa',
+    expiryMonth: '03',
+    expiryYear: '2030',
+    lastFour: '1111',
+    hasCVC: true,
+    onFocusField: () => {},
+    errors: {},
+    valid: {},
+    cvcPolicy: CVC_POLICY_REQUIRED,
+    focusedElement: ''
+};
+
+describe('StoredCard', () => {
+    test('Renders a StoredCard field, with readonly expiryDate and cvc field', () => {
+        render(<StoredCardFields {...storedCardProps} />);
+
+        /* eslint-disable-next-line */
+        expect(screen.queryByText('Expiry date', { exact: false })).toBeTruthy(); // presence
+        /* eslint-disable-next-line */
+        expect(screen.queryByLabelText('Expiry date', { exact: true })).toBeTruthy(); // presence
+        /* eslint-disable-next-line */
+        expect(screen.queryByLabelText('Expiry date', { exact: true })).toHaveAttribute('readonly', '');
+
+        /* eslint-disable-next-line */
+        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+    });
+
+    test('Renders a StoredCard field, without expiryDate (relevant data is null); and with cvc field', () => {
+        const newStoredCardProps = { ...storedCardProps };
+        newStoredCardProps.expiryMonth = null;
+        newStoredCardProps.expiryYear = null;
+
+        render(<StoredCardFields {...newStoredCardProps} />);
+
+        /* eslint-disable-next-line */
+        expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
+
+        /* eslint-disable-next-line */
+        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+    });
+
+    test('Renders a StoredCard field, without expiryDate (relevant data is empty string); and with cvc field', () => {
+        const newStoredCardProps = { ...storedCardProps };
+        newStoredCardProps.expiryMonth = '';
+        newStoredCardProps.expiryYear = '';
+
+        render(<StoredCardFields {...newStoredCardProps} />);
+
+        /* eslint-disable-next-line */
+        expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
+
+        /* eslint-disable-next-line */
+        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+    });
+
+    test('Renders a StoredCard field, without expiryDate (relevant data is missing); and with cvc field', () => {
+        const newStoredCardProps = { ...storedCardProps };
+        delete newStoredCardProps.expiryMonth;
+        delete newStoredCardProps.expiryYear;
+
+        render(<StoredCardFields {...newStoredCardProps} />);
+
+        /* eslint-disable-next-line */
+        expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
+
+        /* eslint-disable-next-line */
+        expect(screen.queryAllByText('Security code', { exact: true })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+    });
+});

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
@@ -20,7 +20,9 @@ export default function StoredCardFields({
 }: StoredCardFieldsProps) {
     const { i18n } = useCoreContext();
     const storedCardDescription = i18n.get('creditCard.storedCard.description.ariaLabel').replace('%@', lastFour);
-    const ariaLabel = `${storedCardDescription} ${i18n.get('creditCard.expiryDateField.title')} ${expiryMonth}/${expiryYear}`;
+    const storedCardDescriptionSuffix =
+        expiryMonth && expiryYear ? ` ${i18n.get('creditCard.expiryDateField.title')} ${expiryMonth}/${expiryYear}` : '';
+    const ariaLabel = `${storedCardDescription}${storedCardDescriptionSuffix}`;
 
     const getError = (errors, fieldType) => {
         const errorMessage = errors[fieldType] ? i18n.get(errors[fieldType]) : null;
@@ -30,22 +32,24 @@ export default function StoredCardFields({
     return (
         <div className="adyen-checkout__card__form adyen-checkout__card__form--oneClick" aria-label={ariaLabel}>
             <div className="adyen-checkout__card__exp-cvc adyen-checkout__field-wrapper">
-                <Field
-                    label={i18n.get('creditCard.expiryDateField.title')}
-                    className="adyen-checkout__field--50"
-                    classNameModifiers={['storedCard']}
-                    name={'expiryDateField'}
-                    disabled
-                >
-                    <InputText
+                {expiryMonth && expiryYear && (
+                    <Field
+                        label={i18n.get('creditCard.expiryDateField.title')}
+                        className="adyen-checkout__field--50"
+                        classNameModifiers={['storedCard']}
                         name={'expiryDateField'}
-                        className={'adyen-checkout__input adyen-checkout__input--disabled adyen-checkout__card__exp-date__input--oneclick'}
-                        value={`${expiryMonth} / ${expiryYear}`}
-                        readonly={true}
-                        disabled={true}
-                        dir={'ltr'}
-                    />
-                </Field>
+                        disabled
+                    >
+                        <InputText
+                            name={'expiryDateField'}
+                            className={'adyen-checkout__input adyen-checkout__input--disabled adyen-checkout__card__exp-date__input--oneclick'}
+                            value={`${expiryMonth} / ${expiryYear}`}
+                            readonly={true}
+                            disabled={true}
+                            dir={'ltr'}
+                        />
+                    </Field>
+                )}
 
                 {hasCVC && (
                     <CVC
@@ -56,7 +60,7 @@ export default function StoredCardFields({
                         isValid={!!valid.encryptedSecurityCode}
                         label={i18n.get('creditCard.cvcField.title')}
                         onFocusField={onFocusField}
-                        className={'adyen-checkout__field--50'}
+                        {...(expiryMonth && expiryYear && { className: 'adyen-checkout__field--50' })}
                         classNameModifiers={['storedCard']}
                         frontCVC={brand === 'amex'}
                     />

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFieldsWrapper.tsx
@@ -34,7 +34,6 @@ export const StoredCardFieldsWrapper = ({
                 cvcPolicy={cvcPolicy}
                 onFocusField={setFocusOn}
                 focusedElement={focusedElement}
-                status={sfpState.status}
                 valid={sfpState.valid}
                 lastFour={lastFour}
                 expiryMonth={expiryMonth}

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -147,7 +147,6 @@ export interface StoredCardFieldsProps {
     lastFour?: string;
     onFocusField: any;
     valid: any;
-    // status: string;
 }
 
 export interface SfSpanProps {

--- a/packages/lib/src/components/Card/components/CardInput/components/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/components/types.ts
@@ -147,7 +147,7 @@ export interface StoredCardFieldsProps {
     lastFour?: string;
     onFocusField: any;
     valid: any;
-    status: string;
+    // status: string;
 }
 
 export interface SfSpanProps {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For some storedCards, in some regions, it is not allowed to store the expiryDate.
So when this info is not present in the `storedCardData`, we hide the readonly `expiryDate` field and send the cvc field to be full width

## Tested scenarios
Manually tested with `storedCardData` that has, and doesn't have, expiryDate info
new e2e tests added
new unit test added

**Fixed issue**:  COWEB-1270
