### PR TITLE
Extra checks on dual branding selection

### DIFF
--- a/.changeset/smart-yaks-behave.md
+++ b/.changeset/smart-yaks-behave.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Perform extra checks that a valid value has been passed when a dual branding selection is made

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/extensions.ts
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/extensions.ts
@@ -119,15 +119,26 @@ export default function extensions(props, refs, states, hasPanLengthRef: Partial
                 value = target.getAttribute('data-value') || target.getAttribute('alt');
             }
 
-            setSelectedBrandValue(value);
+            // Check if we have a value and whether that value corresponds to a brandObject we can propagate
+            // If either are false then abandon the process
+            let brandObjArr: BrandObject[] = [];
+            if (value) {
+                // Find the brandObject with the matching brand value and place into an array
+                brandObjArr = dualBrandSelectElements.reduce((acc, item) => {
+                    if (item.brandObject.brand === value) {
+                        acc.push(item.brandObject);
+                    }
+                    return acc;
+                }, []);
 
-            // Find the brandObject with the matching brand value and place into an array
-            const brandObjArr: BrandObject[] = dualBrandSelectElements.reduce((acc, item) => {
-                if (item.brandObject.brand === value) {
-                    acc.push(item.brandObject);
+                if (!brandObjArr.length) {
+                    return; // no brand object associated with value was found
                 }
-                return acc;
-            }, []);
+            } else {
+                return; // no value passed
+            }
+
+            setSelectedBrandValue(value);
 
             // Pass brand object into SecuredFields
             sfp.current.processBinLookupResponse({


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Perform extra checks that a valid value has been passed when a dual branding selection is made

## Tested scenarios
An invalid value (i.e. a txvariant that doesn't match what has been returned in the `/binLookup` call) doesn't cause a fatal error

**Fixed issue**: #2319 
