### PR TITLE
Add 'redirectFromTop' config prop to allow top level redirect when Checkout loaded in an iframe

### DIFF
--- a/.changeset/forty-badgers-bow.md
+++ b/.changeset/forty-badgers-bow.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': minor
 ---
 
-Add 'redirectFromTop' config prop to allow top level redirect when Checkout loaded in an iframe
+Add 'redirectFromTopWhenInIframe' config prop to allow top level redirect when Checkout loaded in an iframe

--- a/.changeset/forty-badgers-bow.md
+++ b/.changeset/forty-badgers-bow.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Add 'redirectFromTop' config prop to allow top level redirect when Checkout loaded in an iframe

--- a/packages/lib/src/components/Redirect/Redirect.test.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.test.tsx
@@ -32,7 +32,7 @@ describe('Redirect', () => {
         test('Accepts a POST redirect status, setting target to _top, when the config prop tells it to', () => {
             window.HTMLFormElement.prototype.submit = jest.fn();
 
-            const wrapper = mount(<RedirectShopper url="http://www.adyen.com" method="POST" data={{}} redirectFromTop={true} />);
+            const wrapper = mount(<RedirectShopper url="http://www.adyen.com" method="POST" data={{}} redirectFromTopWhenInIframe={true} />);
 
             expect(wrapper.find('form')).toHaveLength(1);
             expect(wrapper.find('form').prop('target')).toBe('_top');

--- a/packages/lib/src/components/Redirect/Redirect.test.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.test.tsx
@@ -3,6 +3,12 @@ import { h } from 'preact';
 import Redirect from './Redirect';
 import RedirectShopper from './components/RedirectShopper';
 
+jest.mock('../../utils/detectInIframe', () => {
+    return jest.fn().mockImplementation(() => {
+        return true;
+    });
+});
+
 describe('Redirect', () => {
     describe('isValid', () => {
         test('Is always valid', () => {
@@ -19,6 +25,17 @@ describe('Redirect', () => {
 
             expect(wrapper.find('form')).toHaveLength(1);
             expect(wrapper.find('form').prop('action')).toBe('http://www.adyen.com');
+            expect(wrapper.find('form').prop('target')).toBe(undefined);
+            setTimeout(() => expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled(), 0);
+        });
+
+        test('Accepts a POST redirect status, setting target to _top, when the config prop tells it to', () => {
+            window.HTMLFormElement.prototype.submit = jest.fn();
+
+            const wrapper = mount(<RedirectShopper url="http://www.adyen.com" method="POST" data={{}} redirectFromTop={true} />);
+
+            expect(wrapper.find('form')).toHaveLength(1);
+            expect(wrapper.find('form').prop('target')).toBe('_top');
             setTimeout(() => expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled(), 0);
         });
     });

--- a/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
+++ b/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
@@ -1,10 +1,12 @@
 import { Component, h } from 'preact';
+import detectInIframe from '../../../../utils/detectInIframe';
 
 interface RedirectShopperProps {
     beforeRedirect: (resolve, reject, url) => Promise<void>;
     url: string;
     method: 'GET' | 'POST';
     data?: any;
+    redirectFromTop?: boolean;
 }
 
 class RedirectShopper extends Component<RedirectShopperProps> {
@@ -19,7 +21,12 @@ class RedirectShopper extends Component<RedirectShopperProps> {
             if (this.postForm) {
                 this.postForm.submit();
             } else {
-                window.location.assign(this.props.url);
+                if (this.props.redirectFromTop && detectInIframe()) {
+                    // if in an iframe and the config prop allows it - try to redirect from the top level window
+                    window.top.location.assign?.(this.props.url);
+                } else {
+                    window.location.assign(this.props.url);
+                }
             }
         };
 
@@ -44,6 +51,7 @@ class RedirectShopper extends Component<RedirectShopperProps> {
                     ref={ref => {
                         this.postForm = ref;
                     }}
+                    {...(this.props.redirectFromTop && detectInIframe() && { target: '_top' })}
                 >
                     {Object.keys(data).map(key => (
                         <input type="hidden" name={key} key={key} value={data[key]} />

--- a/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
+++ b/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
@@ -6,7 +6,7 @@ interface RedirectShopperProps {
     url: string;
     method: 'GET' | 'POST';
     data?: any;
-    redirectFromTop?: boolean;
+    redirectFromTopWhenInIframe?: boolean;
 }
 
 class RedirectShopper extends Component<RedirectShopperProps> {
@@ -21,7 +21,7 @@ class RedirectShopper extends Component<RedirectShopperProps> {
             if (this.postForm) {
                 this.postForm.submit();
             } else {
-                if (this.props.redirectFromTop && detectInIframe()) {
+                if (this.props.redirectFromTopWhenInIframe && detectInIframe()) {
                     // if in an iframe and the config prop allows it - try to redirect from the top level window
                     window.top.location.assign?.(this.props.url);
                 } else {
@@ -51,7 +51,7 @@ class RedirectShopper extends Component<RedirectShopperProps> {
                     ref={ref => {
                         this.postForm = ref;
                     }}
-                    {...(this.props.redirectFromTop && detectInIframe() && { target: '_top' })}
+                    {...(this.props.redirectFromTopWhenInIframe && detectInIframe() && { target: '_top' })}
                 >
                     {Object.keys(data).map(key => (
                         <input type="hidden" name={key} key={key} value={data[key]} />

--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -15,6 +15,7 @@ export const GENERIC_OPTIONS = [
     'session',
     'clientKey',
     'showPayButton',
+    'redirectFromTop',
     'installmentOptions',
 
     // Events

--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -15,7 +15,7 @@ export const GENERIC_OPTIONS = [
     'session',
     'clientKey',
     'showPayButton',
-    'redirectFromTop',
+    'redirectFromTopWhenInIframe',
     'installmentOptions',
 
     // Events

--- a/packages/lib/src/utils/detectInIframe.ts
+++ b/packages/lib/src/utils/detectInIframe.ts
@@ -1,0 +1,2 @@
+// Returns true if the page is being run in an iframe
+export default () => window.location !== window.parent.location;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
If the merchant is running their site within an iframe*, they can now specify a `redirectFromTopWhenInIframe ` boolean in the Checkout config. 
Then, if we end up with a `Redirect` action, we check for ourselves if the site is running in an iframe and, if it is, and `redirectFromTopWhenInIframe ` is set to `true`, then we will attempt to perform the redirect on the top level, parent, window rather than the window holding the iframe

**\*Caveat**:  We don't recommend the use of iframes for hosting Checkout. We cannot guarantee that all payment methods will work when inside an iframe (ApplePay, GooglePay etc). Nor can we guarantee that pages outside of our control e.g. Issuer created pages that are part of the 3DS2 process, will perform correctly.

## Tested scenarios
Manually tested that both `form` submits and `window.location.assign` happen on the top level window when checkout hosted in an iframe and `redirectFromTopWhenInIframe ` is set to true.
New unit test added.


**Fixed issue**:  #2316 