### PR TITLE
Add 'recurringProcessingModel' prop when making a storedPM payment ing API v70

### DIFF
--- a/packages/playground/src/services.js
+++ b/packages/playground/src/services.js
@@ -11,6 +11,11 @@ export const getPaymentMethods = configuration =>
         .catch(console.error);
 
 export const makePayment = (data, config = {}) => {
+    // Needed for storedPMs in v70 if a standalone comp, or, in Dropin, advanced flow. (Sessions, v70, works with or without this prop)
+    if (data.paymentMethod.storedPaymentMethodId) {
+        config = { recurringProcessingModel: 'CardOnFile', ...config };
+    }
+
     // NOTE: Merging data object. DO NOT do this in production.
     const paymentRequest = { ...paymentsConfig, ...config, ...data };
     if (paymentRequest.order) {


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Since API v70 a merchant, using a storedPM, needs to add `recurringProcessingModel: 'CardOnFile'` to the data sent to the backend when a `/payments` request is made.

This PR does this, in the Playground's `services.js` file, so that storedPM payments continue to work in the Playground when the API version is set to `v70`

## Tested scenarios
StoredPM payments work (tested across v69 & v70, in Dropin, with both `sessons` and `advanced flow`. Also with standalone storedCard component)

