### PR TITLE
fix: Clear timeouts on SecuredFieldsProvider when unmounting the component

### DIFF
--- a/.changeset/smooth-jars-buy.md
+++ b/.changeset/smooth-jars-buy.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+fix: Clear timeouts on SecuredFieldsProvider when unmounting the component

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -137,6 +137,8 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
 
     public componentWillUnmount(): void {
         this.csf = null;
+        clearTimeout(this.csfLoadFailTimeout);
+        clearTimeout(this.csfConfigFailTimeout);
     }
 
     private initializeCSF(root: HTMLElement): void {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
SecuredFieldsProvider uses timeouts to check whether SecureFields are loaded properly. Those timeouts are not cleared when the component unmounts which causes issues if the fields have already been unmounted. This triggers the onError handler in cases where it should not.

## Tested scenarios
Mounting and almost immediately unmounting adyen drop-in triggers the onError handler.

