### PR TITLE
Feat/add default value props for card store payment method

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -94,7 +94,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
     // Keeps the value of the country set initially by the merchant, before the Address Component mutates it
     const partialAddressCountry = useRef<string>(partialAddressSchema && props.data?.billingAddress?.country);
 
-    const [storePaymentMethod, setStorePaymentMethod] = useState(false);
+    const [storePaymentMethod, setStorePaymentMethod] = useState(props.enableStoreDetails && props.storePaymentMethod ? true : false);
     const [billingAddress, setBillingAddress] = useState<AddressData>(showBillingAddress ? props.data.billingAddress : null);
     const [showSocialSecurityNumber, setShowSocialSecurityNumber] = useState(false);
     const [socialSecurityNumber, setSocialSecurityNumber] = useState('');

--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -10,6 +10,7 @@ export default {
     hasHolderName: false,
     holderNameRequired: false,
     enableStoreDetails: false,
+    storePaymentMethod: false,
     hasCVC: true,
     showBrandIcon: true,
     showBrandsUnderCardNumber: true,

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -73,6 +73,7 @@ export interface CardInputProps {
     data?: CardInputDataState;
     disableIOSArrowKeys?: boolean;
     enableStoreDetails?: boolean;
+    storePaymentMethod?: boolean;
     expiryMonth?: string;
     expiryYear?: string;
     forceCompat?: boolean;

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -117,6 +117,7 @@ export const extractPropsForCardFields = (props: CardInputProps) => {
         billingAddressAllowedCountries: props.billingAddressAllowedCountries,
         brandsConfiguration: props.brandsConfiguration,
         enableStoreDetails: props.enableStoreDetails,
+        storePaymentMethod: props.storePaymentMethod,
         hasCVC: props.hasCVC,
         hasHolderName: props.hasHolderName,
         holderNameRequired: props.holderNameRequired,

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -73,6 +73,12 @@ export interface CardElementProps extends UIElementProps {
     /** Show/hide the "store details" checkbox */
     enableStoreDetails?: boolean;
 
+    /**
+     * Set default value for the "store details" checkbox
+     * @defaultValue `false`
+     */
+    storePaymentMethod?: boolean;
+
     /** Show/hide the CVC field - merchant set config option */
     hideCVC?: boolean;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
There's now a prop for CardInput component to set default value for `storePaymentMethod`

## Tested scenarios
<!-- Description of tested scenarios -->
Please advice on how I can test locally, thanks! 
It's a UI change

**Fixed issue**:  <!-- #-prefixed issue number -->
#2337 