### PR TITLE
fix: remove inline style applied to iframe due to CSP

### DIFF
--- a/.changeset/dirty-bugs-rush.md
+++ b/.changeset/dirty-bugs-rush.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+fix: remove inline style applied to iframe

--- a/packages/lib/src/components/internal/IFrame/Iframe.scss
+++ b/packages/lib/src/components/internal/IFrame/Iframe.scss
@@ -1,0 +1,3 @@
+.adyen-checkout__iframe{
+    border: 0;
+}

--- a/packages/lib/src/components/internal/IFrame/Iframe.tsx
+++ b/packages/lib/src/components/internal/IFrame/Iframe.tsx
@@ -1,5 +1,6 @@
 import { Component, h } from 'preact';
 import classNames from 'classnames';
+import './Iframe.scss';
 
 interface IframeProps {
     width?: string;
@@ -75,7 +76,6 @@ class Iframe extends Component<IframeProps> {
                 src={src}
                 width={width}
                 height={height}
-                style={{ border: 0 }}
                 frameBorder="0"
                 title={title}
                 /* eslint-disable react/no-unknown-property */

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.scss
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.scss
@@ -1,4 +1,4 @@
-.adyen-checkout-js-iframe {
+.js-iframe {
     border: none;
     height: 100%;
     width: 100%;

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.scss
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.scss
@@ -1,0 +1,6 @@
+.adyen-checkout-js-iframe {
+    border: none;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+}

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
@@ -28,6 +28,7 @@ import { processAriaConfig } from './utils/processAriaConfig';
 import { processPlaceholders } from './utils/processPlaceholders';
 import Language from '../../../../../language/Language';
 import { hasOwnProperty } from '../../../../../utils/hasOwnProperty';
+import './SecuredField.scss';
 
 const logPostMsg = false;
 const doLog = false;

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/createIframe.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/createIframe.ts
@@ -1,12 +1,7 @@
-export default function createIframe({
-    src,
-    title = 'iframe element',
-    policy = 'origin',
-    styleStr = 'border: none; height:100%; width:100%; overflow:hidden;'
-}) {
+export default function createIframe({ src, title = 'iframe element', policy = 'origin' }) {
     const iframeEl = document.createElement('iframe');
     iframeEl.setAttribute('src', src);
-    iframeEl.setAttribute('class', 'js-iframe');
+    iframeEl.classList.add('adyen-checkout-js-iframe');
     // For a11y some merchants want to be able to remove the title element on the iframe - seeing the info it carries as extraneous for the screenreader
     if (title === '' || title.trim().length === 0 || title === 'none') {
         iframeEl.setAttribute('role', 'presentation');
@@ -15,7 +10,6 @@ export default function createIframe({
     }
 
     iframeEl.setAttribute('allowtransparency', 'true');
-    iframeEl.setAttribute('style', styleStr);
     iframeEl.setAttribute('referrerpolicy', policy); // Necessary for ClientKey to work
     // Commenting out stops the "The devicemotion events are blocked by feature policy" warning in Chrome >=66 that some merchant experienced
     // Commenting in stops the same warnings in development (??)

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/createIframe.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/createIframe.ts
@@ -1,7 +1,7 @@
 export default function createIframe({ src, title = 'iframe element', policy = 'origin' }) {
     const iframeEl = document.createElement('iframe');
     iframeEl.setAttribute('src', src);
-    iframeEl.classList.add('adyen-checkout-js-iframe');
+    iframeEl.classList.add('js-iframe');
     // For a11y some merchants want to be able to remove the title element on the iframe - seeing the info it carries as extraneous for the screenreader
     if (title === '' || title.trim().length === 0 || title === 'none') {
         iframeEl.setAttribute('role', 'presentation');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This ticket solves the problem when the nonce attribute is set on the `<style>` tag, some of the inline styles set to the iframe are blocked.

The changes include subtracting those styles in a separate scss file.

## Tested scenarios
How to reproduce the issue:
- Checkout the `main` branch, modify the style-loader config in the `packages/playground/config/webpack.dev.js`. This step is to allow the webpack dev server to add nonce value to style sheets (playground + adyen-web styles) 
```javascript
                            {
                                loader: 'style-loader',
                                options: {
                                    attributes: {
                                        nonce: 'dummy-nonce'
                                    }
                                }
                            },
```
- Add the following to the `<head>` section in the `packages/playground/src/pages/Dropin/Dropin.html`
```html
<meta
            http-equiv="Content-Security-Policy"
            content="
            script-src 'unsafe-inline' https://*.adyen.com https://*.payments-amazon.com https://*.paypal.com https://*.google.com https://*.mastercard.com https://*.visa.com 'self';
            style-src https://*.adyen.com https://*.media-amazon.com https://*.paypal.com https://*.google.com 'self' 'nonce-dummy-nonce';
            img-src https://*.adyen.com https://*.media-amazon.com https://*.paypal.com https://*.gstatic.com 'self';
        "
        />
```
- Check the developer tool, we should see `Refused to apply inline style because it violates the following Content Security Policy directive` for google pay `pay.js` and `createIframe.ts`
- Switch to the branch `fix-csp-issue-due-to-inline-style`, restart the playground, wait for development build.. We shouldn't see browser throwing issues for `createIframe.ts` file. (The `pay.js` from Google pay remains.)
- Remove the whole `<meta>` tag, the dropin should render and function correctly.

**Fixed issue**:  #2336

Note:
This ticket doesn't solve Google pay when enabling CSP nonce, merchants can follow the Google's CSP advice.
