### PR TITLE
Adjusting paymentMethodConfiguration type to support txVariants not mapped internally

### DIFF
--- a/.changeset/good-boxes-taste.md
+++ b/.changeset/good-boxes-taste.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix Typescript definition for paymentMethodsConfiguration, allowing usage of Tx variants that are not defined in the codebase

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -3,7 +3,7 @@ import { PaymentMethods, PaymentMethodOptions, PaymentActionsType, PaymentAmount
 import { AnalyticsOptions } from './Analytics/types';
 import { PaymentMethodsResponse } from './ProcessResponse/PaymentMethodsResponse/types';
 import { RiskModuleOptions } from './RiskModule/RiskModule';
-import { ActionHandledReturnObject, OnPaymentCompletedData, PaymentData } from '../components/types';
+import { ActionHandledReturnObject, OnPaymentCompletedData, PaymentData, UIElementProps } from '../components/types';
 import UIElement from '../components/UIElement';
 import AdyenCheckoutError from './Errors/AdyenCheckoutError';
 import { GiftCardElementData } from '../components/Giftcard/types';
@@ -174,5 +174,5 @@ export type PaymentMethodsConfiguration =
           [key in PaymentActionsType]?: any;
       }
     | {
-          [key: string]: any;
+          [key: string]: UIElementProps;
       };

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -172,4 +172,7 @@ export type PaymentMethodsConfiguration =
       }
     | {
           [key in PaymentActionsType]?: any;
+      }
+    | {
+          [key: string]: any;
       };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`paymentMethodConfiguration` typescript definition does not support tx variants that are not mapped internally. If they are set, the linter will complain. This PR fixes this problem.

## Tested scenarios
- Checked that following code does not trigger TS complains:

```js
 paymentMethodsConfiguration: {
    directEbanking: {
        name: 'Sofort Klarna'
    },
}
```

**Fixed issue**:  #2320 
