### PR TITLE
fixing e2e tests now /binLookup and /paymentMethods response have change

### DIFF
--- a/packages/e2e/tests/cards/errorPanel/errorPanel.avsCard.test.js
+++ b/packages/e2e/tests/cards/errorPanel/errorPanel.avsCard.test.js
@@ -80,6 +80,8 @@ test('#2 Click pay with empty fields and error panel in avsCard is populated', a
     // no 9th element
     await t.expect(cardPage.errorPanelEls.nth(8).exists).notOk();
 
+    await t.wait(500);
+
     // Expect focus to be place on Card number field - since SRConfig for this card comp says we should move focus
     await t.expect(cardPage.numLabelWithFocus.exists).ok();
 });

--- a/packages/e2e/tests/cards/utils/constants.js
+++ b/packages/e2e/tests/cards/utils/constants.js
@@ -7,7 +7,7 @@ export const MAESTRO_CARD = '5000550000000029';
 export const BCMC_CARD = '6703444444444449'; // actually dual branded bcmc & maestro
 export const BCMC_DUAL_BRANDED_VISA = '4871049999999910'; // dual branded visa & bcmc
 export const UNKNOWN_BIN_CARD = '135410014004955'; // card that is not in the test DBs (uatp)
-export const UNKNOWN_VISA_CARD = '4111111111111111'; // card that is not in the test DBs (visa)
+export const UNKNOWN_VISA_CARD = '41111111'; // card is now in the test DBs (visa) - so keep it short to stop it firing binLookup
 export const AMEX_CARD = '370000000000002';
 
 export const DUAL_BRANDED_CARD_EXCLUDED = '4001230000000004'; // dual branded visa/star

--- a/packages/e2e/tests/issuerLists/ideal/ideal.test.js
+++ b/packages/e2e/tests/issuerLists/ideal/ideal.test.js
@@ -14,13 +14,14 @@ test('should make an iDeal payment', async t => {
         .expect(Selector('.adyen-checkout__dropdown__list').hasClass('adyen-checkout__dropdown__list--active'))
         .ok();
 
-    await t.click(Selector('.adyen-checkout__dropdown__list').child(0));
+    await t.click(Selector('.adyen-checkout__dropdown__list').child(1));
 
     const stateData = await getComponentData();
 
     await t.expect(stateData.paymentMethod).eql({
         type: 'ideal',
-        issuer: '1121'
+        issuer: '1121',
+        checkoutAttemptId: 'do-not-track'
     });
 
     await t.expect(stateData.clientStateDataIndicator).eql(true);
@@ -35,7 +36,8 @@ test('should make an iDeal payment using a highlighted issuer', async t => {
 
     await t.expect(stateData.paymentMethod).eql({
         type: 'ideal',
-        issuer: '1121'
+        issuer: '1121',
+        checkoutAttemptId: 'do-not-track'
     });
 
     await t.expect(stateData.clientStateDataIndicator).eql(true);

--- a/packages/e2e/tests/storedCard/general.test.js
+++ b/packages/e2e/tests/storedCard/general.test.js
@@ -6,7 +6,7 @@ const cardPage = new CardComponentPage('.stored-card-field', {}, 'storedcards');
 
 const EMPTY_FIELD = LANG['error.va.sf-cc-cvc.01'];
 
-fixture.only`Testing some general functionality and UI on the stored card component`.beforeEach(async t => {
+fixture`Testing some general functionality and UI on the stored card component`.beforeEach(async t => {
     await t.navigateTo(cardPage.pageUrl);
 });
 

--- a/packages/e2e/tests/storedCard/general.test.js
+++ b/packages/e2e/tests/storedCard/general.test.js
@@ -6,7 +6,7 @@ const cardPage = new CardComponentPage('.stored-card-field', {}, 'storedcards');
 
 const EMPTY_FIELD = LANG['error.va.sf-cc-cvc.01'];
 
-fixture`Testing some general functionality and UI on the stored card component`.beforeEach(async t => {
+fixture.only`Testing some general functionality and UI on the stored card component`.beforeEach(async t => {
     await t.navigateTo(cardPage.pageUrl);
 });
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The `/binLookup` and `/paymentMethods` response have changed - so some of the e2e tests needed to be adjusted

## Tested scenarios
(testcafe) e2e test all run

