### PR TITLE
Populate Sepa data with initial values

### DIFF
--- a/.changeset/loud-vans-burn.md
+++ b/.changeset/loud-vans-burn.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Populate data with initial values (empty strings) for 'ibanNumber' and 'ownerName'

--- a/packages/lib/src/components/Sepa/Sepa.tsx
+++ b/packages/lib/src/components/Sepa/Sepa.tsx
@@ -15,6 +15,11 @@ class SepaElement extends UIElement {
         showFormInstruction: true
     };
 
+    constructor(props) {
+        super(props);
+        this.state = { ...this.state, ...{ data: { ibanNumber: '', ownerName: '' } } };
+    }
+
     /**
      * Formats props on construction time
      */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Populate data with initial values (empty strings) for `ibanNumber` and `ownerName`

## Tested scenarios
Trying to access `component.data` before the component has been interacted with no longer causes an error


**Fixed issue**:  COWEB-1113
