### PR TITLE
feat: add klarna b2b tx_variant

### DIFF
--- a/.changeset/tough-fishes-exercise.md
+++ b/.changeset/tough-fishes-exercise.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Add `klarna_b2b` tx variant so that Billie (klarna_b2b) is supported.

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -195,6 +195,7 @@ const componentsMap = {
 
     /** Klarna */
     klarna: Klarna,
+    klarna_b2b: Klarna,
     klarna_account: Klarna,
     klarna_paynow: Klarna,
     /** Klarna */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Add `klarna_b2b` tx variant in the `componentsMap`.

## Tested scenarios
Tested `klarna_b2b` for country code DE, use MyStoreDemoCOM merchant account. 


**Fixed issue**:  COWEB-1277