### PR TITLE
KlarnaWidget to use authorization token onComplete

### DIFF
--- a/.changeset/cyan-tools-love.md
+++ b/.changeset/cyan-tools-love.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Add `authorization_token` in the Klarna widget AdditionalDetails state data, so that we are aligned with the API specs.
+Improvements: add `authorization_token` in the Klarna widget AdditionalDetails state data, so that we are aligned with the API specs.

--- a/.changeset/cyan-tools-love.md
+++ b/.changeset/cyan-tools-love.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Add `authorization_token` in the Klarna widget AdditionalDetails state data, so that we are aligned with the API specs.

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -58,7 +58,9 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
                             data: {
                                 paymentData: props.paymentData,
                                 details: {
-                                    token: res.authorization_token
+                                    // For the backward compatibility we need to pass both 'token' and 'authorization_token'
+                                    token: res.authorization_token,
+                                    authorization_token: res.authorization_token
                                 }
                             }
                         });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Pass both `token` and `authorization_token`  in `KlarnaWidget` `onComplete` callback.

## Tested scenarios
Tested `authorization_token` separately in session and advanced flows. 
Tested both tokens in session and advanced flows.
Tested setting `useKlarnaWidget` to `true` in above scenarios.

**Fixed issue**:  COWEB-1280
