### PR TITLE
Typescript: Fix type for paymentMethodsConfiguration

### DIFF
--- a/.changeset/pink-trains-stare.md
+++ b/.changeset/pink-trains-stare.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Typescript: Fixed types for paymentMethodsConfiguration object

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -166,13 +166,19 @@ export interface CoreOptions {
     loadingContext?: string;
 }
 
-export type PaymentMethodsConfiguration =
-    | {
-          [key in keyof PaymentMethods]?: Partial<PaymentMethodOptions<key>>;
-      }
-    | {
-          [key in PaymentActionsType]?: any;
-      }
-    | {
-          [key: string]: UIElementProps;
-      };
+type PaymentMethodsConfigurationMap = {
+    [key in keyof PaymentMethods]?: Partial<PaymentMethodOptions<key>>;
+};
+
+type PaymentActionTypesMap = {
+    [key in PaymentActionsType]?: Partial<UIElementProps>;
+};
+
+/**
+ * Type must be loose, otherwise it will take priority over the rest
+ */
+type NonMappedPaymentMethodsMap = {
+    [key: string]: any;
+};
+
+export type PaymentMethodsConfiguration = PaymentMethodsConfigurationMap & PaymentActionTypesMap & NonMappedPaymentMethodsMap;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We were using [discriminating union types](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#discriminating-unions) for the PaymentMethodsConfiguration object.

That means that, if merchant passes config like:

```ts
const config =  {
  card: {
    hideCVC: true,
  },
  directEbanking: {
    name: 'Sofort'
  }
};
```

The type inference for the 'card' would not work, as it will be considered as `[key: string]: UIElementProps;` according to the  discriminated union type inferred by Typescript.

In this PR, we make a union type instead. And in order to properly map non-mapped TxVariants, we should use the `any` keyword, otherwise all entry-values will fallback to `[key: string]: UIElementProps;` type


**Fixed issue**: 
#2349 
#2320 