### PR TITLE
Feature: Adds onAddressSelected to address lookup functionality

### DIFF
--- a/.changeset/fifty-parrots-collect.md
+++ b/.changeset/fifty-parrots-collect.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': minor
 ---
 
-feature: adds onAddressSelected callback
+feature: adds new onAddressSelected to fill data when an item is selected in AddressSearch

--- a/.changeset/fifty-parrots-collect.md
+++ b/.changeset/fifty-parrots-collect.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': minor
 ---
 
-feature: adds onAddresSelected callback
+feature: adds onAddressSelected callback

--- a/.changeset/fifty-parrots-collect.md
+++ b/.changeset/fifty-parrots-collect.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+feature: adds onAddresSelected callback

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -493,6 +493,8 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
                             partialAddressSchema={partialAddressSchema}
                             handleAddress={handleAddress}
                             onAddressLookup={props.onAddressLookup}
+                            onAddressSelected={props.onAddressSelected}
+                            addressSearchDebounceMs={props.addressSearchDebounceMs}
                             //
                             iOSFocusedField={iOSFocusedField}
                         />

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
@@ -45,6 +45,8 @@ export const CardFieldsWrapper = ({
     setAddressRef,
     partialAddressSchema,
     onAddressLookup,
+    onAddressSelected,
+    addressSearchDebounceMs,
     // For this comp (props passed through from CardInput)
     amount,
     billingAddressRequired,
@@ -159,6 +161,8 @@ export const CardFieldsWrapper = ({
                     specifications={partialAddressSchema}
                     iOSFocusedField={iOSFocusedField}
                     onAddressLookup={onAddressLookup}
+                    onAddressSelected={onAddressSelected}
+                    addressSearchDebounceMs={addressSearchDebounceMs}
                 />
             )}
 

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -109,7 +109,7 @@ export interface CardInputProps {
     onLoad?: () => {};
     onAddressLookup?: OnAddressLookupType;
     onAddressSelected?: OnAddressSelectedType;
-    addressSearchDebounceMs: number;
+    addressSearchDebounceMs?: number;
     payButton?: (obj) => {};
     placeholders?: Placeholders;
     positionHolderNameOnTop?: boolean;

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -13,7 +13,7 @@ import Analytics from '../../../../core/Analytics';
 import RiskElement from '../../../../core/RiskModule';
 import { ComponentMethodsRef } from '../../../types';
 import { DisclaimerMsgObject } from '../../../internal/DisclaimerMessage/DisclaimerMessage';
-import { OnAddressLookupType } from '../../../internal/Address/components/AddressSearch';
+import { OnAddressLookupType, OnAddressSelectedType } from '../../../internal/Address/components/AddressSearch';
 
 export interface CardInputValidState {
     holderName?: boolean;
@@ -108,6 +108,8 @@ export interface CardInputProps {
     onFocus?: (e) => {};
     onLoad?: () => {};
     onAddressLookup?: OnAddressLookupType;
+    onAddressSelected?: OnAddressSelectedType;
+    addressSearchDebounceMs: number;
     payButton?: (obj) => {};
     placeholders?: Placeholders;
     positionHolderNameOnTop?: boolean;

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -1,5 +1,5 @@
 import { Fragment, h } from 'preact';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import Fieldset from '../FormFields/Fieldset';
 import ReadOnlyAddress from './components/ReadOnlyAddress';
 import { getAddressValidationRules } from './validate';
@@ -49,22 +49,25 @@ export default function Address(props: AddressProps) {
         formatters: addressFormatters
     });
 
-    const setSearchData = selectedAddress => {
-        const propsKeysToProcess = ADDRESS_SCHEMA;
-        propsKeysToProcess.forEach(propKey => {
-            // Make sure the data provided by the merchant is always strings
-            const providedValue = selectedAddress[propKey];
-            if (providedValue === null || providedValue === undefined) return;
-            // Cast everything to string
-            setData(propKey, String(providedValue));
-            triggerValidation();
-        });
-        setHasSelectedAddress(true);
-    };
+    const setSearchData = useCallback(
+        selectedAddress => {
+            const propsKeysToProcess = ADDRESS_SCHEMA;
+            propsKeysToProcess.forEach(propKey => {
+                // Make sure the data provided by the merchant is always strings
+                const providedValue = selectedAddress[propKey];
+                if (providedValue === null || providedValue === undefined) return;
+                // Cast everything to string
+                setData(propKey, String(providedValue));
+                triggerValidation();
+            });
+            setHasSelectedAddress(true);
+        },
+        [setHasSelectedAddress, triggerValidation, setData]
+    );
 
-    const onManualAddress = () => {
+    const onManualAddress = useCallback(() => {
         setUseManualAddress(true);
-    };
+    }, []);
 
     // Expose method expected by (parent) Address.tsx
     addressRef.current.showValidation = () => {

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -50,7 +50,7 @@ export default function Address(props: AddressProps) {
     });
 
     const setSearchData = useCallback(
-        selectedAddress => {
+        (selectedAddress: AddressData) => {
             const propsKeysToProcess = ADDRESS_SCHEMA;
             propsKeysToProcess.forEach(propKey => {
                 // Make sure the data provided by the merchant is always strings

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -58,8 +58,8 @@ export default function Address(props: AddressProps) {
                 if (providedValue === null || providedValue === undefined) return;
                 // Cast everything to string
                 setData(propKey, String(providedValue));
-                triggerValidation();
             });
+            triggerValidation();
             setHasSelectedAddress(true);
         },
         [setHasSelectedAddress, triggerValidation, setData]

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -172,6 +172,7 @@ export default function Address(props: AddressProps) {
                 {showAddressSearch && (
                     <AddressSearch
                         onAddressLookup={props.onAddressLookup}
+                        onAddressSelected={props.onAddressSelected}
                         onSelect={setSearchData}
                         onManualAddress={onManualAddress}
                         externalErrorMessage={searchErrorMessage}

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -180,6 +180,7 @@ export default function Address(props: AddressProps) {
                         onManualAddress={onManualAddress}
                         externalErrorMessage={searchErrorMessage}
                         hideManualButton={showAddressFields}
+                        addressSearchDebounceMs={props.addressSearchDebounceMs}
                     />
                 )}
                 {showAddressFields && (

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
@@ -1,0 +1,191 @@
+import { h } from 'preact';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/preact';
+import AddressSearch from './AddressSearch';
+
+const ADDRESS_LOOKUP_RESULT = [
+    {
+        id: 1,
+        name: 'Road 1, 2000, UK',
+        street: 'Road 1'
+    },
+    {
+        id: 2,
+        name: 'Road 2, 2500, UK',
+        street: 'Road 2'
+    },
+    {
+        id: 3,
+        name: 'Road 3, 3000, UK',
+        street: 'Road 3'
+    }
+];
+
+const ADDRESS_SELECT_RESULT = {
+    id: 1,
+    name: 'Road 1, 2000, UK',
+    street: 'Road 1',
+    city: 'London',
+    houseNumberOrName: '1',
+    postalCode: '2000',
+    country: 'GB',
+    raw: {
+        id: 1,
+        raw: 'RAW_DATA_MOCK'
+    }
+};
+const onAddressLookupMockFn = async (value, { resolve }) => {
+    resolve(ADDRESS_LOOKUP_RESULT);
+};
+const onAddressSelectMockFn = async (value, { resolve }) => {
+    resolve(ADDRESS_SELECT_RESULT);
+};
+
+const onAddressSelectMockFnReject =
+    rejectReason =>
+    async (value, { reject }) => {
+        reject(rejectReason);
+    };
+
+test('onAddressLookupMock should be triggered when typing', async () => {
+    const user = userEvent.setup({ delay: 100 });
+
+    const onAddressLookupMock = jest.fn(onAddressLookupMockFn);
+
+    render(
+        <AddressSearch
+            onSelect={() => {}}
+            onManualAddress={() => {}}
+            externalErrorMessage={'failed'}
+            onAddressLookup={onAddressLookupMock}
+            hideManualButton={true}
+            addressSearchDebounceMs={0}
+        />
+    );
+
+    // Helps to make sure all tests ran
+    expect.assertions(5);
+
+    // Get the input
+    const searchBar = screen.getByRole('combobox');
+    await user.click(searchBar);
+    expect(searchBar).toHaveFocus();
+
+    await user.keyboard('Test');
+    expect(searchBar).toHaveValue('Test');
+
+    // Test if onAddressLookup is called with the correct values
+    await waitFor(() => expect(onAddressLookupMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(onAddressLookupMock.mock.lastCall[0]).toBe('Test'));
+    // Test if the return of the function is displayed
+    const resultList = screen.getByRole('listbox');
+    expect(resultList).toHaveTextContent('Road 1, 2000, UK');
+});
+
+test('onSelect is triggered with correct data', async () => {
+    const user = userEvent.setup({ delay: 100 });
+
+    const onAddressLookupMock = jest.fn(onAddressLookupMockFn);
+    const onAddressSelectMock = jest.fn(onAddressSelectMockFn);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const internalSetDataMock = jest.fn(data => {});
+
+    render(
+        <AddressSearch
+            onSelect={internalSetDataMock}
+            onManualAddress={() => {}}
+            externalErrorMessage={'failed'}
+            onAddressLookup={onAddressLookupMock}
+            onAddressSelected={onAddressSelectMock}
+            hideManualButton={true}
+            addressSearchDebounceMs={0}
+        />
+    );
+    const searchBar = screen.getByRole('combobox');
+
+    await user.click(searchBar);
+    await user.keyboard('Test');
+
+    // Move down with the keyboard and select the first option
+    await user.keyboard('[ArrowDown][Enter]');
+    await waitFor(() => expect(onAddressSelectMock).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+        expect(onAddressSelectMock.mock.lastCall[0]).toStrictEqual({
+            id: 1,
+            name: 'Road 1, 2000, UK',
+            street: 'Road 1'
+        })
+    );
+
+    // CHeck if the parents select function is called with full data
+    await waitFor(() => expect(internalSetDataMock.mock.lastCall[0]).toStrictEqual(ADDRESS_SELECT_RESULT));
+});
+
+test('rejecting onAddressLookupMock should not trigger error', async () => {
+    const user = userEvent.setup({ delay: 100 });
+
+    const onAddressLookupMock = jest.fn(onAddressSelectMockFnReject({}));
+
+    render(
+        <AddressSearch
+            onSelect={() => {}}
+            onManualAddress={() => {}}
+            externalErrorMessage={'failed'}
+            onAddressLookup={onAddressLookupMock}
+            hideManualButton={true}
+            addressSearchDebounceMs={0}
+        />
+    );
+
+    // Helps to make sure all tests ran
+    expect.assertions(4);
+
+    // Get the input
+    const searchBar = screen.getByRole('combobox');
+    await user.click(searchBar);
+    await user.keyboard('Test');
+
+    // Still test if correct values are being called
+    await waitFor(() => expect(onAddressLookupMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(onAddressLookupMock.mock.lastCall[0]).toBe('Test'));
+
+    // Test if no options are displayed
+    const resultList = screen.getByRole('listbox');
+    expect(resultList).toHaveTextContent('No options found');
+
+    // TODO fix this
+    // const resultError = screen.getByText('failed');
+    // expect(resultError).not.toBeVisible();
+});
+
+test('rejecting onAddressLookupMock with errorMessage displays error and message', async () => {
+    const user = userEvent.setup({ delay: 100 });
+
+    const onAddressLookupMock = jest.fn(onAddressSelectMockFnReject({ errorMessage: 'Refused Mock' }));
+
+    render(
+        <AddressSearch
+            onSelect={() => {}}
+            onManualAddress={() => {}}
+            externalErrorMessage={'failed'}
+            onAddressLookup={onAddressLookupMock}
+            hideManualButton={true}
+            addressSearchDebounceMs={0}
+        />
+    );
+
+    // Helps to make sure all tests ran
+    expect.assertions(3);
+
+    // Get the input
+    const searchBar = screen.getByRole('combobox');
+    await user.click(searchBar);
+    await user.keyboard('Test');
+
+    await waitFor(() => expect(onAddressLookupMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(onAddressLookupMock.mock.lastCall[0]).toBe('Test'));
+
+    // Test if no options are displayed
+    const resultError = screen.getByText('Refused Mock');
+    expect(resultError).toBeVisible();
+});

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
@@ -138,7 +138,7 @@ test('rejecting onAddressLookupMock should not trigger error', async () => {
     );
 
     // Helps to make sure all tests ran
-    expect.assertions(4);
+    expect.assertions(3);
 
     // Get the input
     const searchBar = screen.getByRole('combobox');

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -31,7 +31,7 @@ interface AddressSearchProps {
     onManualAddress: any;
     externalErrorMessage: string;
     hideManualButton: boolean;
-    addressSearchDebounceMs: number;
+    addressSearchDebounceMs?: number;
 }
 
 export default function AddressSearch({

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -1,7 +1,7 @@
 import Field from '../../FormFields/Field';
 import { Fragment, h } from 'preact';
 import { AddressLookupItem } from '../types';
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState, useMemo } from 'preact/hooks';
 import './AddressSearch.scss';
 import useCoreContext from '../../../../core/Context/useCoreContext';
 import { debounce } from '../utils';
@@ -49,9 +49,9 @@ export default function AddressSearch({
     const mapDataToSelect = data => data.map(({ id, name }) => ({ id, name }));
 
     const onInput = useCallback(
-        async event => {
+        async (inputValue: string) => {
             new Promise<Array<AddressLookupItem>>((resolve, reject) => {
-                onAddressLookup(event, { resolve, reject });
+                onAddressLookup(inputValue, { resolve, reject });
             })
                 .then(data => {
                     setOriginalData(data);
@@ -98,7 +98,7 @@ export default function AddressSearch({
             });
     };
 
-    const debounceInputHandler = useCallback(() => debounce(onInput), []);
+    const debounceInputHandler = useMemo(() => debounce(onInput), []);
 
     return (
         <Fragment>

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -1,5 +1,5 @@
 import Field from '../../FormFields/Field';
-import { Fragment, h } from 'preact';
+import { h } from 'preact';
 import { AddressLookupItem } from '../types';
 import { useCallback, useEffect, useState, useMemo } from 'preact/hooks';
 import './AddressSearch.scss';
@@ -46,7 +46,7 @@ export default function AddressSearch({
     externalErrorMessage,
     hideManualButton,
     addressSearchDebounceMs
-}: AddressSearchProps) {
+}: Readonly<AddressSearchProps>) {
     const [formattedData, setFormattedData] = useState([]);
     const [originalData, setOriginalData] = useState([]);
 
@@ -56,7 +56,7 @@ export default function AddressSearch({
     const mapDataToSelect = data => data.map(({ id, name }) => ({ id, name }));
 
     const handlePromiseReject = useCallback((reason: RejectionReason) => {
-        if (reason && reason.errorMessage) {
+        if (reason?.errorMessage) {
             setErrorMessage(reason.errorMessage);
         }
     }, []);
@@ -102,7 +102,6 @@ export default function AddressSearch({
             .then(fullData => {
                 onSelect(fullData);
                 setFormattedData([]);
-                return;
             })
             .catch(reason => handlePromiseReject(reason));
     };
@@ -110,32 +109,30 @@ export default function AddressSearch({
     const debounceInputHandler = useMemo(() => debounce(onTextInput, addressSearchDebounceMs), []);
 
     return (
-        <Fragment>
-            <div className={'adyen-checkout__address-search adyen-checkout__field-group'}>
-                <Field label={i18n.get('address')} classNameModifiers={['address-search']} errorMessage={errorMessage} name={'address-search'}>
-                    <Select
-                        name={'address-search'}
-                        className={'adyen-checkout__address-search__dropdown'}
-                        //placeholder={i18n.get('address.placeholder')}
-                        onInput={debounceInputHandler}
-                        items={formattedData}
-                        onChange={onSelectItem}
-                        disableTextFilter={true}
-                        blurOnClose={true}
-                    />
-                </Field>
-                {!hideManualButton && (
-                    <span className="adyen-checkout__address-search__manual-add">
-                        <button
-                            type="button"
-                            className="adyen-checkout__button adyen-checkout__button--inline adyen-checkout__button--link adyen-checkout__address-search__manual-add__button"
-                            onClick={onManualAddress}
-                        >
-                            {'+ ' + i18n.get('address.enterManually')}
-                        </button>
-                    </span>
-                )}
-            </div>
-        </Fragment>
+        <div className={'adyen-checkout__address-search adyen-checkout__field-group'}>
+            <Field label={i18n.get('address')} classNameModifiers={['address-search']} errorMessage={errorMessage} name={'address-search'}>
+                <Select
+                    name={'address-search'}
+                    className={'adyen-checkout__address-search__dropdown'}
+                    //placeholder={i18n.get('address.placeholder')}
+                    onInput={debounceInputHandler}
+                    items={formattedData}
+                    onChange={onSelectItem}
+                    disableTextFilter={true}
+                    blurOnClose={true}
+                />
+            </Field>
+            {!hideManualButton && (
+                <span className="adyen-checkout__address-search__manual-add">
+                    <button
+                        type="button"
+                        className="adyen-checkout__button adyen-checkout__button--inline adyen-checkout__button--link adyen-checkout__address-search__manual-add__button"
+                        onClick={onManualAddress}
+                    >
+                        {'+ ' + i18n.get('address.enterManually')}
+                    </button>
+                </span>
+            )}
+        </div>
     );
 }

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -114,7 +114,6 @@ export default function AddressSearch({
                 <Select
                     name={'address-search'}
                     className={'adyen-checkout__address-search__dropdown'}
-                    //placeholder={i18n.get('address.placeholder')}
                     onInput={debounceInputHandler}
                     items={formattedData}
                     onChange={onSelectItem}

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -31,6 +31,7 @@ interface AddressSearchProps {
     onManualAddress: any;
     externalErrorMessage: string;
     hideManualButton: boolean;
+    addressSearchDebounceMs: number;
 }
 
 export default function AddressSearch({
@@ -39,7 +40,8 @@ export default function AddressSearch({
     onSelect,
     onManualAddress,
     externalErrorMessage,
-    hideManualButton
+    hideManualButton,
+    addressSearchDebounceMs
 }: AddressSearchProps) {
     const [formattedData, setFormattedData] = useState([]);
     const [originalData, setOriginalData] = useState([]);
@@ -99,7 +101,7 @@ export default function AddressSearch({
             });
     };
 
-    const debounceInputHandler = useMemo(() => debounce(onInput), []);
+    const debounceInputHandler = useMemo(() => debounce(onInput, addressSearchDebounceMs), []);
 
     return (
         <Fragment>

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -1,7 +1,7 @@
 import Field from '../../FormFields/Field';
 import { Fragment, h } from 'preact';
 import { AddressLookupItem } from '../types';
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 import './AddressSearch.scss';
 import useCoreContext from '../../../../core/Context/useCoreContext';
 import { debounce } from '../utils';
@@ -98,7 +98,7 @@ export default function AddressSearch({
             });
     };
 
-    const debounceInputHandler = useMemo(() => debounce(onInput), []);
+    const debounceInputHandler = useCallback(() => debounce(onInput), []);
 
     return (
         <Fragment>

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -6,6 +6,7 @@ import './AddressSearch.scss';
 import useCoreContext from '../../../../core/Context/useCoreContext';
 import { debounce } from '../utils';
 import Select from '../../FormFields/Select';
+import { AddressData } from '../../../../types';
 
 export type OnAddressLookupType = (
     value: string,
@@ -26,7 +27,7 @@ export type OnAddressSelectedType = (
 interface AddressSearchProps {
     onAddressLookup?: OnAddressLookupType;
     onAddressSelected?: OnAddressSelectedType;
-    onSelect: any; //TODO
+    onSelect: (addressItem: AddressData) => void;
     onManualAddress: any;
     externalErrorMessage: string;
     hideManualButton: boolean;
@@ -112,6 +113,7 @@ export default function AddressSearch({
                         items={formattedData}
                         onChange={onChange}
                         disableTextFilter={true}
+                        blurOnClose={true}
                     />
                 </Field>
                 {!hideManualButton && (

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -2,7 +2,7 @@ import { AddressField, AddressData } from '../../../types';
 import Specifications from './Specifications';
 import { ValidatorRules } from '../../../utils/Validator/types';
 import { ValidationRuleResult } from '../../../utils/Validator/ValidationRuleResult';
-import { OnAddressLookupType } from './components/AddressSearch';
+import { OnAddressLookupType, OnAddressSelectedType } from './components/AddressSearch';
 
 // Describes an object with unknown keys whose value is always a string
 export type StringObject = {
@@ -16,6 +16,7 @@ export interface AddressProps {
     label?: string;
     onChange: (newState) => void;
     onAddressLookup?: OnAddressLookupType;
+    onAddressSelected?: OnAddressSelectedType;
     requiredFields?: string[];
     ref?: any;
     specifications?: AddressSpecifications;

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -17,7 +17,7 @@ export interface AddressProps {
     onChange: (newState) => void;
     onAddressLookup?: OnAddressLookupType;
     onAddressSelected?: OnAddressSelectedType;
-    addressSearchDebounceMs: number;
+    addressSearchDebounceMs?: number;
     requiredFields?: string[];
     ref?: any;
     specifications?: AddressSpecifications;

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -17,6 +17,7 @@ export interface AddressProps {
     onChange: (newState) => void;
     onAddressLookup?: OnAddressLookupType;
     onAddressSelected?: OnAddressSelectedType;
+    addressSearchDebounceMs: number;
     requiredFields?: string[];
     ref?: any;
     specifications?: AddressSpecifications;

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -27,7 +27,8 @@ function Select({
     uniqueId,
     disabled,
     disableTextFilter,
-    clearOnSelect
+    clearOnSelect,
+    blurOnClose
 }: SelectProps) {
     const filterInputRef = useRef(null);
     const selectContainerRef = useRef(null);
@@ -75,6 +76,8 @@ function Select({
      * Closes the selectList, empties the text filter and focuses the button element
      */
     const closeList = () => {
+        //blurs the field when the list is closed, makes for a better UX for most users, needs more testing
+        blurOnClose && filterInputRef.current.blur();
         setShowList(false);
     };
 

--- a/packages/lib/src/components/internal/FormFields/Select/types.ts
+++ b/packages/lib/src/components/internal/FormFields/Select/types.ts
@@ -32,6 +32,7 @@ export interface SelectProps {
     disabled?: boolean;
     disableTextFilter?: boolean;
     clearOnSelect?: boolean;
+    blurOnClose?: boolean;
 }
 
 export interface SelectButtonProps {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

The objective of this PR is to add `onAddressSelected` callback. This callback works to provide a point of integration with Address completion services that require a second callback to access additional information, such is the case of Google Place Autocomplete API.

## Tested scenarios
<!-- Description of tested scenarios -->

- [X] onAddressSelected is called with the full Address data
- [X] on success: the new data is used in the address component
- [X] on failure: nothing is selected

**Fixed issue**:  <!-- #-prefixed issue number -->
