### PR TITLE
Klarna B2B - Fixing logo on Drop-in

### DIFF
--- a/.changeset/khaki-fireants-scream.md
+++ b/.changeset/khaki-fireants-scream.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed Klarna B2B logo for Drop-in

--- a/packages/lib/src/components/Doku/Doku.tsx
+++ b/packages/lib/src/components/Doku/Doku.tsx
@@ -27,10 +27,6 @@ export class DokuElement extends UIElement {
         };
     }
 
-    get icon() {
-        return this.resources.getImage()(this.props.type);
-    }
-
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>

--- a/packages/lib/src/components/Econtext/Econtext.tsx
+++ b/packages/lib/src/components/Econtext/Econtext.tsx
@@ -41,10 +41,6 @@ export class EcontextElement extends UIElement<EcontextElementProps> {
         };
     }
 
-    get icon() {
-        return this.resources.getImage()(this.props.type);
-    }
-
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -41,10 +41,6 @@ class RedirectElement extends UIElement {
         return true;
     }
 
-    get icon() {
-        return this.resources.getImage()(this.props.type);
-    }
-
     render() {
         if (this.props.url && this.props.method) {
             return <RedirectShopper {...this.props} />;

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -85,10 +85,6 @@ export class SecuredFieldsElement extends UIElement {
         return !!this.state.isValid;
     }
 
-    get icon() {
-        return this.resources.getImage()(this.props.type);
-    }
-
     get browserInfo() {
         return collectBrowserInfo();
     }

--- a/packages/lib/src/components/UIElement.test.ts
+++ b/packages/lib/src/components/UIElement.test.ts
@@ -2,11 +2,35 @@ import UIElement from './UIElement';
 import AdyenCheckout from '../index';
 import ThreeDS2DeviceFingerprint from './ThreeDS2/ThreeDS2DeviceFingerprint';
 import ThreeDS2Challenge from './ThreeDS2/ThreeDS2Challenge';
+import { mock } from 'jest-mock-extended';
+import { Resources } from '../core/Context/Resources';
 
 const submitMock = jest.fn();
 (global as any).HTMLFormElement.prototype.submit = () => submitMock;
 
 describe('UIElement', () => {
+    describe('icon()', () => {
+        test.only('should generate the icon URL by getting the tx variant from type() getter', () => {
+            const resources = mock<Resources>();
+            resources.getImage.mockReturnValue((icon: string) => `https://checkout-adyen.com/${icon}`);
+
+            const txVariant = 'klarna_b2b';
+
+            const uiElement = new UIElement({
+                type: txVariant,
+                modules: {
+                    resources
+                }
+            });
+
+            const typeSpy = jest.spyOn(uiElement, 'type', 'get');
+            const iconUrl = uiElement.icon;
+
+            expect(typeSpy).toHaveBeenCalledTimes(1);
+            expect(iconUrl).toBe(`https://checkout-adyen.com/${txVariant}`);
+        });
+    });
+
     describe('onComplete', () => {
         test('calls the passed onComplete function', () => {
             const onComplete = jest.fn();

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -239,7 +239,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
      * Get the element icon URL for the current environment
      */
     get icon(): string {
-        return this.props.icon ?? this.resources.getImage()(this.constructor['type']);
+        return this.props.icon ?? this.resources.getImage()(this.type);
     }
 
     /**


### PR DESCRIPTION

## Summary
The logo on UIElement currently is being build using the `this.constructor[type]` . This implies that it will always use the main tx variant defined in the Component, although there are components that have multiple TxVariants (for ex: Klarna, DragonPay, etc).

So instead of getting the main tx variant to use as icon, we are now pulling the tx variant from the `type()` getter which will decide if we take from the `type` property or from the `this.constructor[type]`.

## Tested scenarios
- Proper icon is rendered
- Unit test added to make sure the `icon` method pulls the txVariant from `type` getter
