### PR TITLE
card_stop adding credit/debit class to non-cards

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.tsx
@@ -71,11 +71,13 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
             return null;
         }
 
+        const isCard = paymentMethod.props.type === 'card' || paymentMethod.props.type === 'scheme';
+
         const paymentMethodClassnames = classNames({
             'adyen-checkout__payment-method': true,
             [styles['adyen-checkout__payment-method']]: true,
             [`adyen-checkout__payment-method--${paymentMethod.props.type}`]: true,
-            [`adyen-checkout__payment-method--${paymentMethod.props.fundingSource ?? 'credit'}`]: true,
+            ...(isCard && { [`adyen-checkout__payment-method--${paymentMethod.props.fundingSource ?? 'credit'}`]: true }),
             'adyen-checkout__payment-method--selected': isSelected,
             [styles['adyen-checkout__payment-method--selected']]: isSelected,
             'adyen-checkout__payment-method--loading': isLoading,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For all `PaymentMethodItems` we were adding a class `adyen-checkout__payment-method--{fundingSource}` (where `fundingSource` was either "credit" or "debit")

This is meant to be a Card PM specific class to indicate, in the paymentMethods list, whether the card is a credit or debit card.

## Tested scenarios
`adyen-checkout__payment-method--credit` no longer added to non-card PMs
