### PR TITLE
Bumping sf version to 4.8.0

### DIFF
--- a/.changeset/light-pianos-join.md
+++ b/.changeset/light-pianos-join.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Bumping sf version to 4.8.0 which includes a more comprehensive startup log (to help with debugging)

--- a/packages/e2e/tests/cards/errorPanel/errorPanel.avsCard.test.js
+++ b/packages/e2e/tests/cards/errorPanel/errorPanel.avsCard.test.js
@@ -30,7 +30,7 @@ test('#1 avsCard error fields and inputs should have correct aria attributes', a
     await t.switchToMainWindow().switchToIframe(cardPage.iframeSelector.nth(0));
     const adb = await getInputSelector('encryptedCardNumber', true).getAttribute('aria-describedby');
     await t.expect(adb).contains('adyen-checkout-encryptedCardNumber-');
-    await t.expect(adb).contains('-ariaError');
+    await t.expect(adb).contains('-ariaContext');
     await t.switchToMainWindow();
 
     // Address input's error field should have correct aria attrs

--- a/packages/e2e/tests/utils/commonUtils.js
+++ b/packages/e2e/tests/utils/commonUtils.js
@@ -17,7 +17,7 @@ export const getInputSelector = (fieldType, withSelector = false) => {
 };
 
 export const getAriaErrorField = (fieldType, withSelector = false) => {
-    const selStr = `#${fieldType}-ariaError`;
+    const selStr = `#${fieldType}-ariaContext`;
     return withSelector ? Selector(selStr) : selStr;
 };
 
@@ -68,6 +68,7 @@ export const deleteDigitsFromIFrame = async (t, iframeSelector, iFrameNum, iFram
 };
 
 export const checkIframeInputContainsValue = async (t, iframeSelector, iFrameNum, iFrameInputSelector, valueToCheck) => {
+    // prettier-ignore
     return t
         .switchToMainWindow()
         .switchToIframe(iframeSelector.nth(iFrameNum))

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '4.5.1';
+export const SF_VERSION = '4.8.0';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Bumping sf version to `4.8.0` which includes a more comprehensive startup log (to help with debugging)

## Tested scenarios
All e2e & unit tests pass

