### PR TITLE
Feature/detect unsupported sf fields

### DIFF
--- a/.changeset/mighty-ladybugs-worry.md
+++ b/.changeset/mighty-ladybugs-worry.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Detect when the value of a data-cse attribute is not supported, and don't create a SF for it

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createCardSecuredFields.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createCardSecuredFields.test.ts
@@ -47,7 +47,7 @@ describe("Testing setupSecuredField's createCardSecuredFields functionality", ()
         SecuredFieldMock.mockClear();
     });
 
-    test("setupSecuredField's createCardSecuredFields function should call the onBrand callback", async () => {
+    test("setupSecuredField's createCardSecuredFields function, as a single-branded card, should call the onBrand callback", async () => {
         myCSF.state.type = 'mc';
         myCSF.isSingleBrandedCard = true;
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -6,7 +6,8 @@ import {
     DATA_ENCRYPTED_FIELD_ATTR,
     DATA_INFO,
     DATA_UID,
-    SF_CONFIG_TIMEOUT
+    SF_CONFIG_TIMEOUT,
+    ALL_SECURED_FIELDS
 } from '../../configuration/constants';
 import { existy } from '../../utilities/commonUtils';
 import cardType from '../utils/cardType';
@@ -22,8 +23,17 @@ import AdyenCheckoutError from '../../../../../../core/Errors/AdyenCheckoutError
 export function createSecuredFields(): number {
     this.encryptedAttrName = DATA_ENCRYPTED_FIELD_ATTR;
 
-    // Detect DOM elements that qualify as securedField holders
-    const securedFields: HTMLElement[] = select(this.props.rootNode, `[${this.encryptedAttrName}]`);
+    // Detect DOM elements that qualify as securedField holders & filter them for valid types
+    const securedFields: HTMLElement[] = select(this.props.rootNode, `[${this.encryptedAttrName}]`).filter(field => {
+        const fieldType: string = getAttribute(field, this.encryptedAttrName);
+        const isValidType = ALL_SECURED_FIELDS.includes(fieldType);
+        if (!isValidType) {
+            console.warn(
+                `WARNING: '${fieldType}' is not a valid type for the '${this.encryptedAttrName}' attribute. A SecuredField will not be created for this element.`
+            );
+        }
+        return isValidType;
+    });
 
     /**
      * cvcPolicy - 'required' | 'optional' | 'hidden'

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -8,7 +8,7 @@ import '../../style.scss';
 import { MockReactApp } from './MockReactApp';
 import { searchFunctionExample } from '../../utils';
 
-const onlyShowCard = true;
+const onlyShowCard = false;
 
 const showComps = {
     clickToPay: true,
@@ -53,7 +53,7 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
     // Stored Card
     if (!onlyShowCard && showComps.storedCard) {
         if (checkout.paymentMethodsResponse.storedPaymentMethods && checkout.paymentMethodsResponse.storedPaymentMethods.length > 0) {
-            const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[2];
+            const storedCardData = checkout.paymentMethodsResponse.storedPaymentMethods[0];
             window.storedCard = checkout
                 .create('card', {
                     ...storedCardData,

--- a/packages/playground/src/pages/SecuredFields/SecuredFields.js
+++ b/packages/playground/src/pages/SecuredFields/SecuredFields.js
@@ -227,7 +227,7 @@ function handlePaymentResult(result, component) {
 function startPayment(component) {
     if (!component.isValid) return component.showValidation();
 
-    const allow3DS2 = paymentsConfig.additionalData.allow3DS2 || false;
+    const allow3DS2 = paymentsConfig.additionalData?.allow3DS2 || false;
 
     const riskdata = checkout.modules.risk.data;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Detects when an element that is supposed to contain a securedField has an unsupported value for its `data-cse` attribute.
This is most commonly a scenario for the CustomCard component.
Now when this situation arises we will not even try to make a secureField for this element, and we will create a `console.warn` stating the `data-cse` attribute has an incorrect value

## Tested scenarios
Manually tested
Added new unit test

