### PR TITLE
Update sessionData after /setup call

### DIFF
--- a/.changeset/mean-glasses-happen.md
+++ b/.changeset/mean-glasses-happen.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+update sessionData after /setup call

--- a/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
+++ b/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
@@ -67,6 +67,10 @@ class Session {
                 this.configuration = { ...response.configuration };
             }
 
+            if (response.sessionData) {
+                this.updateSessionData(response.sessionData);
+            }
+
             return response;
         });
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We weren't updating our internal `sessionData` after a new `sessionData` blob is returned from the `/setup` call.
Although the original blob remains valid, best practice says that we should always use the _latest_ `sessionData` returned by the backend

## Tested scenarios
A `/payments` call made using the `sessionData` returned from the `/setup` call, instead of the one from the original `/session` call, succeeds in making a payment.

