### PR TITLE
Change the pay button and status text for zero auth transactions

### DIFF
--- a/.changeset/mean-sheep-matter.md
+++ b/.changeset/mean-sheep-matter.md
@@ -1,0 +1,6 @@
+---
+"@adyen/adyen-web": patch
+---
+
+For the regular card payment, in case of a zero-auth transaction, the pay button label is changed to `Save details`, and the `Save for my next payment` checkbox is removed.
+The drop-in component shows `Details saved` as the success message for such transaction.

--- a/packages/lib/src/components/Card/Card.test.tsx
+++ b/packages/lib/src/components/Card/Card.test.tsx
@@ -1,4 +1,9 @@
+import { h } from 'preact';
 import { CardElement } from './Card';
+import { render, screen } from '@testing-library/preact';
+import CoreProvider from '../../core/Context/CoreProvider';
+import Language from '../../language';
+import { Resources } from '../../core/Context/Resources';
 
 describe('Card', () => {
     describe('formatProps', function () {
@@ -10,6 +15,40 @@ describe('Card', () => {
         test('should format countryCode to lowerCase', () => {
             const card = new CardElement({ countryCode: 'KR' });
             expect(card.props.countryCode).toEqual('kr');
+        });
+
+        test('should return false for enableStoreDetails in case of zero-auto transaction', () => {
+            const card = new CardElement({ amount: { value: 0 }, enableStoreDetails: true });
+            expect(card.props.enableStoreDetails).toEqual(false);
+        });
+    });
+
+    describe('payButton', () => {
+        describe('Zero auth transaction', () => {
+            const i18n = new Language();
+            const props = { amount: { value: 0 }, enableStoreDetails: true, i18n };
+            const customRender = (ui: h.JSX.Element) => {
+                return render(
+                    // @ts-ignore ignore
+                    <CoreProvider i18n={i18n} loadingContext="test" resources={new Resources()}>
+                        {ui}
+                    </CoreProvider>
+                );
+            };
+
+            test('should show the label "Save details" for the regular card', async () => {
+                const card = new CardElement(props);
+                // @ts-ignore ignore
+                customRender(card.payButton());
+                expect(await screen.findByRole('button', { name: 'Save details' })).toBeTruthy();
+            });
+
+            test('should show the label "Confirm preauthorization" for the stored card', async () => {
+                const card = new CardElement({ ...props, storedPaymentMethodId: 'test' });
+                // @ts-ignore ignore
+                customRender(card.payButton());
+                expect(await screen.findByRole('button', { name: 'Confirm preauthorization' })).toBeTruthy();
+            });
         });
     });
 

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -121,7 +121,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
 
         switch (status.type) {
             case 'success':
-                return <Status.Success message={status.props?.message} />;
+                return <Status.Success message={props?.amount?.value === 0 ? 'resultMessages.preauthorized' : status.props?.message} />;
 
             case 'error':
                 return <Status.Error message={status.props?.message} />;

--- a/packages/lib/src/language/locales/ar.json
+++ b/packages/lib/src/language/locales/ar.json
@@ -2,6 +2,7 @@
     "payButton": "دفع",
     "payButton.redirecting": "جارِ إعادة التوجيه...",
     "payButton.with": "ادفع %{value} باستخدام %{maskedData}",
+    "payButton.saveDetails": "حفظ التفاصيل",
     "close": "إغلاق",
     "storeDetails": "حفظ لمدفوعاتي القادمة",
     "readMore": "اقرأ المزيد",

--- a/packages/lib/src/language/locales/ar.json
+++ b/packages/lib/src/language/locales/ar.json
@@ -120,6 +120,7 @@
     "donateButton": "التبرع",
     "notNowButton": "ليس الآن",
     "thanksForYourSupport": "شكرًا على دعمك!",
+    "resultMessages.preauthorized": "تم حفظ التفاصيل",
     "preauthorizeWith": "تفويض مسبق باستخدام",
     "confirmPreauthorization": "تأكيد التفويض المسبق",
     "confirmPurchase": "تأكيد الشراء",

--- a/packages/lib/src/language/locales/cs-CZ.json
+++ b/packages/lib/src/language/locales/cs-CZ.json
@@ -2,6 +2,7 @@
     "payButton": "Zaplatit",
     "payButton.redirecting": "Přesměrování...",
     "payButton.with": "Zaplatit %{value} pomocí %{maskedData}",
+    "payButton.saveDetails": "Uložit podrobnosti",
     "close": "Zavřít",
     "storeDetails": "Uložit pro příští platby",
     "readMore": "Přečtěte si více",

--- a/packages/lib/src/language/locales/cs-CZ.json
+++ b/packages/lib/src/language/locales/cs-CZ.json
@@ -120,6 +120,7 @@
     "donateButton": "Přispět",
     "notNowButton": "Teď ne",
     "thanksForYourSupport": "Děkujeme vám za podporu!",
+    "resultMessages.preauthorized": "Uložené podrobnosti",
     "preauthorizeWith": "Předautorizovat pomocí",
     "confirmPreauthorization": "Potvrdit předautorizaci",
     "confirmPurchase": "Potvrdit nákup",

--- a/packages/lib/src/language/locales/da-DK.json
+++ b/packages/lib/src/language/locales/da-DK.json
@@ -121,6 +121,7 @@
     "donateButton": "Giv et bidrag",
     "notNowButton": "Ikke nu",
     "thanksForYourSupport": "Tak for din støtte!",
+    "resultMessages.preauthorized": "Oplysningerne er gemt",
     "preauthorizeWith": "Forhåndsgodkend med",
     "confirmPreauthorization": "Bekræft forhåndsgodkendelse",
     "confirmPurchase": "Bekræft køb",

--- a/packages/lib/src/language/locales/da-DK.json
+++ b/packages/lib/src/language/locales/da-DK.json
@@ -2,6 +2,7 @@
     "payButton": "Betal",
     "payButton.redirecting": "Omdirigerer...",
     "payButton.with": "Betal %{value} med %{maskedData}",
+    "payButton.saveDetails": "Gem oplysninger",
     "close": "Luk",
     "storeDetails": "Gem til min næste betaling",
     "readMore": "Læs mere",

--- a/packages/lib/src/language/locales/de-DE.json
+++ b/packages/lib/src/language/locales/de-DE.json
@@ -2,6 +2,7 @@
     "payButton": "Zahle",
     "payButton.redirecting": "Umleiten…",
     "payButton.with": "%{value} mit %{maskedData} zahlen",
+    "payButton.saveDetails": "Angaben speichern",
     "close": "Schließen",
     "storeDetails": "Für zukünftige Zahlvorgänge speichern",
     "readMore": "Mehr lesen",

--- a/packages/lib/src/language/locales/de-DE.json
+++ b/packages/lib/src/language/locales/de-DE.json
@@ -120,6 +120,7 @@
     "donateButton": "Spenden",
     "notNowButton": "Nicht jetzt",
     "thanksForYourSupport": "Danke für Ihre Unterstützung!",
+    "resultMessages.preauthorized": "Angaben gespeichert",
     "preauthorizeWith": "Vorautorisieren mit",
     "confirmPreauthorization": "Vorautorisierung bestätigen",
     "confirmPurchase": "Kauf bestätigen",

--- a/packages/lib/src/language/locales/el-GR.json
+++ b/packages/lib/src/language/locales/el-GR.json
@@ -2,6 +2,7 @@
     "payButton": "Πληρωμή",
     "payButton.redirecting": "Ανακατεύθυνση...",
     "payButton.with": "Πληρωμή %{value} με %{maskedData}",
+    "payButton.saveDetails": "Αποθήκευση στοιχείων",
     "close": "Κλείσιμο",
     "storeDetails": "Αποθήκευση για την επόμενη πληρωμή μου",
     "readMore": "Ανάγνωση περισσότερων",

--- a/packages/lib/src/language/locales/el-GR.json
+++ b/packages/lib/src/language/locales/el-GR.json
@@ -120,6 +120,7 @@
     "donateButton": "Δωρεά",
     "notNowButton": "Όχι τώρα",
     "thanksForYourSupport": "Σας ευχαριστούμε για την υποστήριξη!",
+    "resultMessages.preauthorized": "Τα στοιχεία αποθηκεύτηκαν",
     "preauthorizeWith": "Προεξουσιοδότηση με",
     "confirmPreauthorization": "Επιβεβαίωση προεξουσιοδότησης",
     "confirmPurchase": "Επιβεβαίωση αγοράς",

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -121,6 +121,7 @@
     "donateButton": "Donate",
     "notNowButton": "Not now",
     "thanksForYourSupport": "Thanks for your support!",
+    "resultMessages.preauthorized": "Details saved",
     "preauthorizeWith": "Preauthorize with",
     "confirmPreauthorization": "Confirm preauthorization",
     "confirmPurchase": "Confirm purchase",

--- a/packages/lib/src/language/locales/en-US.json
+++ b/packages/lib/src/language/locales/en-US.json
@@ -2,6 +2,7 @@
     "payButton": "Pay",
     "payButton.redirecting": "Redirecting...",
     "payButton.with": "Pay %{value} with %{maskedData}",
+    "payButton.saveDetails": "Save details",
     "close": "Close",
     "storeDetails": "Save for my next payment",
     "readMore": "Read more",

--- a/packages/lib/src/language/locales/es-ES.json
+++ b/packages/lib/src/language/locales/es-ES.json
@@ -2,6 +2,7 @@
     "payButton": "Pagar",
     "payButton.redirecting": "Redirigiendo...",
     "payButton.with": "Pague %{value} con %{maskedData}",
+    "payButton.saveDetails": "Guardar los detalles",
     "close": "Cerrar",
     "storeDetails": "Recordar para mi próximo pago",
     "readMore": "Leer más",

--- a/packages/lib/src/language/locales/es-ES.json
+++ b/packages/lib/src/language/locales/es-ES.json
@@ -118,6 +118,7 @@
     "donateButton": "Donar",
     "notNowButton": "Ahora no",
     "thanksForYourSupport": "¡Gracias por su contribución!",
+    "resultMessages.preauthorized": "Se han guardado los detalles",
     "preauthorizeWith": "Preautorizar con",
     "confirmPreauthorization": "Confirmar preautorización",
     "confirmPurchase": "Confirmar compra",

--- a/packages/lib/src/language/locales/fi-FI.json
+++ b/packages/lib/src/language/locales/fi-FI.json
@@ -2,6 +2,7 @@
     "payButton": "Maksa",
     "payButton.redirecting": "Uudelleenohjataan...",
     "payButton.with": "Maksa %{value} käyttäen maksutapaa %{maskedData}",
+    "payButton.saveDetails": "Tallenna tiedot",
     "close": "Sulje",
     "storeDetails": "Tallenna seuraavaa maksuani varten",
     "readMore": "Lue lisää",

--- a/packages/lib/src/language/locales/fi-FI.json
+++ b/packages/lib/src/language/locales/fi-FI.json
@@ -120,6 +120,7 @@
     "donateButton": "Lahjoita",
     "notNowButton": "Ei nyt",
     "thanksForYourSupport": "Kiitos tuestasi!",
+    "resultMessages.preauthorized": "Tiedot tallennettu",
     "preauthorizeWith": "Ennkkolupa käyttäjän kanssa",
     "confirmPreauthorization": "Vahvista ennakkolupa",
     "confirmPurchase": "Vahvista hankinta",

--- a/packages/lib/src/language/locales/fr-FR.json
+++ b/packages/lib/src/language/locales/fr-FR.json
@@ -120,6 +120,7 @@
     "donateButton": "Faire un don",
     "notNowButton": "Pas maintenant",
     "thanksForYourSupport": "Merci de votre soutien !",
+    "resultMessages.preauthorized": "Détails enregistrés",
     "preauthorizeWith": "Pré-autoriser avec",
     "confirmPreauthorization": "Confirmer la pré-autorisation",
     "confirmPurchase": "Confirmer l'achat",

--- a/packages/lib/src/language/locales/fr-FR.json
+++ b/packages/lib/src/language/locales/fr-FR.json
@@ -2,6 +2,7 @@
     "payButton": "Payer",
     "payButton.redirecting": "Redirection...",
     "payButton.with": "Payer %{value} avec %{maskedData}",
+    "payButton.saveDetails": "Enregistrer les détails",
     "close": "Fermer",
     "storeDetails": "Sauvegarder pour mon prochain paiement",
     "readMore": "Lire la suite",

--- a/packages/lib/src/language/locales/hr-HR.json
+++ b/packages/lib/src/language/locales/hr-HR.json
@@ -2,6 +2,7 @@
     "payButton": "Platiti",
     "payButton.redirecting": "Preusmjeravanje...",
     "payButton.with": "Platite iznos od %{value} uporabom stavke %{maskedData}",
+    "payButton.saveDetails": "Spremi pojedinosti",
     "close": "Zatvori",
     "storeDetails": "Pohrani za moje sljedeće plaćanje",
     "readMore": "Opširnije",

--- a/packages/lib/src/language/locales/hr-HR.json
+++ b/packages/lib/src/language/locales/hr-HR.json
@@ -120,6 +120,7 @@
     "donateButton": "Doniraj",
     "notNowButton": "Ne sada",
     "thanksForYourSupport": "Hvala na podršci!",
+    "resultMessages.preauthorized": "Spremljeni podatci",
     "preauthorizeWith": "Prethodno odobri s",
     "confirmPreauthorization": "Potvrdite prethodno odobrenje",
     "confirmPurchase": "Potvrdite kupnju",

--- a/packages/lib/src/language/locales/hu-HU.json
+++ b/packages/lib/src/language/locales/hu-HU.json
@@ -2,6 +2,7 @@
     "payButton": "Fizetés",
     "payButton.redirecting": "Átirányítás...",
     "payButton.with": "%{value} fizetése a következővel: %{maskedData}",
+    "payButton.saveDetails": "Részletek mentése",
     "close": "Bezárás",
     "storeDetails": "Mentés a következő fizetéshez",
     "readMore": "Bővebben",

--- a/packages/lib/src/language/locales/hu-HU.json
+++ b/packages/lib/src/language/locales/hu-HU.json
@@ -120,6 +120,7 @@
     "donateButton": "Adományozás",
     "notNowButton": "Most nem",
     "thanksForYourSupport": "Köszönjük a támogatását!",
+    "resultMessages.preauthorized": "Részletek mentve",
     "preauthorizeWith": "Előzetes meghatalmazás a következővel:",
     "confirmPreauthorization": "Előzetes meghatalmazás jóváhagyása",
     "confirmPurchase": "Fizetés jóváhagyása",

--- a/packages/lib/src/language/locales/it-IT.json
+++ b/packages/lib/src/language/locales/it-IT.json
@@ -118,6 +118,7 @@
     "donateButton": "Dona",
     "notNowButton": "Non ora",
     "thanksForYourSupport": "Grazie per il tuo sostegno!",
+    "resultMessages.preauthorized": "Dettagli salvati",
     "preauthorizeWith": "Preautorizza con",
     "confirmPreauthorization": "Conferma preautorizzazione",
     "confirmPurchase": "Conferma acquisto",

--- a/packages/lib/src/language/locales/it-IT.json
+++ b/packages/lib/src/language/locales/it-IT.json
@@ -2,6 +2,7 @@
     "payButton": "Paga",
     "payButton.redirecting": "Reindirizzamento...",
     "payButton.with": "Paga %{value} con %{maskedData}",
+    "payButton.saveDetails": "Salva dettagli",
     "close": "Chiudi",
     "storeDetails": "Salva per il prossimo pagamento",
     "readMore": "Leggi di più",

--- a/packages/lib/src/language/locales/ja-JP.json
+++ b/packages/lib/src/language/locales/ja-JP.json
@@ -120,6 +120,7 @@
     "donateButton": "寄付する",
     "notNowButton": "今はしない",
     "thanksForYourSupport": "ご支援いただきありがとうございます。",
+    "resultMessages.preauthorized": "詳細が保存されました",
     "preauthorizeWith": "次で事前認証する：",
     "confirmPreauthorization": "事前承認を確認する",
     "confirmPurchase": "購入を確認する",

--- a/packages/lib/src/language/locales/ja-JP.json
+++ b/packages/lib/src/language/locales/ja-JP.json
@@ -2,6 +2,7 @@
     "payButton": "支払う",
     "payButton.redirecting": "リダイレクトしています...",
     "payButton.with": "%{value}を%{maskedData}で支払う",
+    "payButton.saveDetails": "詳細を保存",
     "close": "終了",
     "storeDetails": "次回のお支払いのため詳細を保存",
     "readMore": "詳細を確認",

--- a/packages/lib/src/language/locales/ko-KR.json
+++ b/packages/lib/src/language/locales/ko-KR.json
@@ -120,6 +120,7 @@
     "donateButton": "기부하기",
     "notNowButton": "다음에 하기",
     "thanksForYourSupport": "도와주셔서 감사합니다!",
+    "resultMessages.preauthorized": "세부 정보 저장됨",
     "preauthorizeWith": "사전 승인 방법:",
     "confirmPreauthorization": "사전 승인 확인",
     "confirmPurchase": "구매 확인",

--- a/packages/lib/src/language/locales/ko-KR.json
+++ b/packages/lib/src/language/locales/ko-KR.json
@@ -2,6 +2,7 @@
     "payButton": "결제",
     "payButton.redirecting": "리디렉션 중...",
     "payButton.with": "%{maskedData}(으)로 %{value} 결제",
+    "payButton.saveDetails": "세부 정보 저장",
     "close": "닫기",
     "storeDetails": "다음 결제를 위해 이 수단 저장",
     "readMore": "자세히 보기",

--- a/packages/lib/src/language/locales/nl-NL.json
+++ b/packages/lib/src/language/locales/nl-NL.json
@@ -2,6 +2,7 @@
     "payButton": "Betaal",
     "payButton.redirecting": "U wordt doorverwezen...",
     "payButton.with": "Betaal %{value} met %{maskedData}",
+    "payButton.saveDetails": "Gegevens opslaan",
     "close": "Sluiten",
     "storeDetails": "Bewaar voor mijn volgende betaling",
     "readMore": "Verder lezen",

--- a/packages/lib/src/language/locales/nl-NL.json
+++ b/packages/lib/src/language/locales/nl-NL.json
@@ -120,6 +120,7 @@
     "donateButton": "Doneren",
     "notNowButton": "Niet nu",
     "thanksForYourSupport": "Bedankt voor uw donatie!",
+    "resultMessages.preauthorized": "Gegevens opgeslagen",
     "preauthorizeWith": "Preautorisatie uitvoeren met",
     "confirmPreauthorization": "Preautorisatie bevestigen",
     "confirmPurchase": "Aankoop bevestigen",

--- a/packages/lib/src/language/locales/no-NO.json
+++ b/packages/lib/src/language/locales/no-NO.json
@@ -2,6 +2,7 @@
     "payButton": "Betal",
     "payButton.redirecting": "Omdirigerer...",
     "payButton.with": "Betal %{value} med %{maskedData}",
+    "payButton.saveDetails": "Lagre detaljer",
     "close": "Lukk",
     "storeDetails": "Lagre til min neste betaling",
     "readMore": "Les mer",

--- a/packages/lib/src/language/locales/no-NO.json
+++ b/packages/lib/src/language/locales/no-NO.json
@@ -120,6 +120,7 @@
     "donateButton": "Donér",
     "notNowButton": "Ikke nå",
     "thanksForYourSupport": "Takk for din støtte!",
+    "resultMessages.preauthorized": "Detaljer lagret",
     "preauthorizeWith": "Forhåndsgodkjenn med",
     "confirmPreauthorization": "Bekreft forhåndsgodkjenning",
     "confirmPurchase": "Bekreft kjøp",

--- a/packages/lib/src/language/locales/pl-PL.json
+++ b/packages/lib/src/language/locales/pl-PL.json
@@ -120,6 +120,7 @@
     "donateButton": "Przekaż darowiznę",
     "notNowButton": "Nie teraz",
     "thanksForYourSupport": "Dziękujemy za wsparcie!",
+    "resultMessages.preauthorized": "Zapisano dane",
     "preauthorizeWith": "Autoryzuj wstępnie za pomocą:",
     "confirmPreauthorization": "Potwierdź autoryzację wstępną",
     "confirmPurchase": "Potwierdź zakup",

--- a/packages/lib/src/language/locales/pl-PL.json
+++ b/packages/lib/src/language/locales/pl-PL.json
@@ -2,6 +2,7 @@
     "payButton": "Zapłać",
     "payButton.redirecting": "Przekierowywanie...",
     "payButton.with": "Zapłać %{value} za pomocą %{maskedData}",
+    "payButton.saveDetails": "Zapisz dane",
     "close": "Zamknij",
     "storeDetails": "Zapisz na potrzeby następnej płatności",
     "readMore": "Czytaj więcej",

--- a/packages/lib/src/language/locales/pt-BR.json
+++ b/packages/lib/src/language/locales/pt-BR.json
@@ -118,6 +118,7 @@
     "donateButton": "Doar",
     "notNowButton": "Agora não",
     "thanksForYourSupport": "Obrigado pelo apoio!",
+    "resultMessages.preauthorized": "Informações salvas",
     "preauthorizeWith": "Pré-autorizar com",
     "confirmPreauthorization": "Confirmar pré-autorização",
     "confirmPurchase": "Confirmar compra",

--- a/packages/lib/src/language/locales/pt-BR.json
+++ b/packages/lib/src/language/locales/pt-BR.json
@@ -2,6 +2,7 @@
     "payButton": "Pagar",
     "payButton.redirecting": "Redirecionando...",
     "payButton.with": "Pague %{value} com %{maskedData}",
+    "payButton.saveDetails": "Salvar informações",
     "close": "Fechar",
     "storeDetails": "Salvar para meu próximo pagamento",
     "readMore": "Leia mais",

--- a/packages/lib/src/language/locales/pt-PT.json
+++ b/packages/lib/src/language/locales/pt-PT.json
@@ -121,6 +121,7 @@
     "donateButton": "Doar",
     "notNowButton": "Agora não",
     "thanksForYourSupport": "Obrigado pelo seu apoio!",
+    "resultMessages.preauthorized": "Detalhes guardados",
     "preauthorizeWith": "Pré-autorizar com",
     "confirmPreauthorization": "Confirmar pré-autorização",
     "confirmPurchase": "Confirmar compra",

--- a/packages/lib/src/language/locales/pt-PT.json
+++ b/packages/lib/src/language/locales/pt-PT.json
@@ -2,6 +2,7 @@
     "payButton": "Pagar",
     "payButton.redirecting": "Redirecionar...",
     "payButton.with": "Pagar %{value} com %{maskedData}",
+    "payButton.saveDetails": "Guardar detalhes",
     "close": "Fechar",
     "storeDetails": "Guardar para o meu próximo pagamento",
     "readMore": "Ler mais",

--- a/packages/lib/src/language/locales/ro-RO.json
+++ b/packages/lib/src/language/locales/ro-RO.json
@@ -2,6 +2,7 @@
     "payButton": "Plătiți",
     "payButton.redirecting": "Se redirecționează...",
     "payButton.with": "Plătiți %{value} cu %{maskedData}",
+    "payButton.saveDetails": "Salvați detaliile",
     "close": "Închidere",
     "storeDetails": "Salvează pentru următoarea mea plată",
     "readMore": "Citiți mai mult",

--- a/packages/lib/src/language/locales/ro-RO.json
+++ b/packages/lib/src/language/locales/ro-RO.json
@@ -120,6 +120,7 @@
     "donateButton": "Donați",
     "notNowButton": "Nu acum",
     "thanksForYourSupport": "Vă mulțumim pentru sprijin!",
+    "resultMessages.preauthorized": "Detalii salvate",
     "preauthorizeWith": "Preautorizare cu",
     "confirmPreauthorization": "Confirmați preautorizarea",
     "confirmPurchase": "Confirmați achiziția",

--- a/packages/lib/src/language/locales/ru-RU.json
+++ b/packages/lib/src/language/locales/ru-RU.json
@@ -2,6 +2,7 @@
     "payButton": "Заплатить",
     "payButton.redirecting": "Перенаправление...",
     "payButton.with": "Оплатить %{value} %{maskedData}",
+    "payButton.saveDetails": "Сохранить данные",
     "close": "Закрыть",
     "storeDetails": "Сохранить для следующего платежа",
     "readMore": "Подробнее",

--- a/packages/lib/src/language/locales/ru-RU.json
+++ b/packages/lib/src/language/locales/ru-RU.json
@@ -120,6 +120,7 @@
     "donateButton": "Пожертвовать",
     "notNowButton": "Позже",
     "thanksForYourSupport": "Благодарим за поддержку!",
+    "resultMessages.preauthorized": "Данные сохранены",
     "preauthorizeWith": "Предавторизация в",
     "confirmPreauthorization": "Подтвердить предавторизацию",
     "confirmPurchase": "Подтвердить покупку",

--- a/packages/lib/src/language/locales/sk-SK.json
+++ b/packages/lib/src/language/locales/sk-SK.json
@@ -120,6 +120,7 @@
     "donateButton": "Prispieť",
     "notNowButton": "Teraz nie",
     "thanksForYourSupport": "Ďakujeme za podporu!",
+    "resultMessages.preauthorized": "Údaje boli uložené",
     "preauthorizeWith": "Predbežne autorizovať pomocou",
     "confirmPreauthorization": "Potvrďte predbežnú autorizáciu",
     "confirmPurchase": "Potvrďte nákup",

--- a/packages/lib/src/language/locales/sk-SK.json
+++ b/packages/lib/src/language/locales/sk-SK.json
@@ -2,6 +2,7 @@
     "payButton": "Zaplatiť",
     "payButton.redirecting": "Prebieha presmerovanie...",
     "payButton.with": "Zaplatiť %{value} pomocou %{maskedData}",
+    "payButton.saveDetails": "Uložiť údaje",
     "close": "Zavrieť",
     "storeDetails": "Uložiť pre moju ďalšiu platbu",
     "readMore": "Prečítajte si viac",

--- a/packages/lib/src/language/locales/sl-SI.json
+++ b/packages/lib/src/language/locales/sl-SI.json
@@ -120,6 +120,7 @@
     "donateButton": "Donirajte",
     "notNowButton": "Ne zdaj",
     "thanksForYourSupport": "Zahvaljujemo se vam za podporo!",
+    "resultMessages.preauthorized": "Podrobnosti so shranjene",
     "preauthorizeWith": "Predhodna odobritev s/z:",
     "confirmPreauthorization": "Potrdi predhodno odobritev",
     "confirmPurchase": "Potrditev nakupa",

--- a/packages/lib/src/language/locales/sl-SI.json
+++ b/packages/lib/src/language/locales/sl-SI.json
@@ -2,6 +2,7 @@
     "payButton": "Plačilo",
     "payButton.redirecting": "Preusmerjanje...",
     "payButton.with": "Plačajte %{value} z %{maskedData}",
+    "payButton.saveDetails": "Shrani podrobnosti",
     "close": "Zapri",
     "storeDetails": "Shrani za moje naslednje plačilo",
     "readMore": "Preberi več",

--- a/packages/lib/src/language/locales/sv-SE.json
+++ b/packages/lib/src/language/locales/sv-SE.json
@@ -2,6 +2,7 @@
     "payButton": "Betala",
     "payButton.redirecting": "Omdirigerar…",
     "payButton.with": "Betala %{value} med %{maskedData}",
+    "payButton.saveDetails": "Spara information",
     "close": "Stäng",
     "storeDetails": "Spara till min nästa betalning",
     "readMore": "Läs mer",

--- a/packages/lib/src/language/locales/sv-SE.json
+++ b/packages/lib/src/language/locales/sv-SE.json
@@ -120,6 +120,7 @@
     "donateButton": "Donera",
     "notNowButton": "Inte nu",
     "thanksForYourSupport": "Tack för ditt stöd!",
+    "resultMessages.preauthorized": "Information sparad",
     "preauthorizeWith": "Förauktorisera med",
     "confirmPreauthorization": "Bekräfta förauktorisering",
     "confirmPurchase": "Bekräfta köp",

--- a/packages/lib/src/language/locales/zh-CN.json
+++ b/packages/lib/src/language/locales/zh-CN.json
@@ -120,6 +120,7 @@
     "donateButton": "捐赠",
     "notNowButton": "暂不",
     "thanksForYourSupport": "感谢您的支持！",
+    "resultMessages.preauthorized": "详情已保存",
     "preauthorizeWith": "预先授权",
     "confirmPreauthorization": "确认预先授权",
     "confirmPurchase": "确认购买",

--- a/packages/lib/src/language/locales/zh-CN.json
+++ b/packages/lib/src/language/locales/zh-CN.json
@@ -2,6 +2,7 @@
     "payButton": "支付",
     "payButton.redirecting": "正在重定向...",
     "payButton.with": "使用 %{maskedData} 支付 %{value}",
+    "payButton.saveDetails": "保存详情",
     "close": "关闭",
     "storeDetails": "保存以便下次支付使用",
     "readMore": "阅读更多",

--- a/packages/lib/src/language/locales/zh-TW.json
+++ b/packages/lib/src/language/locales/zh-TW.json
@@ -2,6 +2,7 @@
     "payButton": "支付",
     "payButton.redirecting": "重新導向中......",
     "payButton.with": "用 %{maskedData} 支付 %{value}",
+    "payButton.saveDetails": "儲存詳細資料",
     "close": "關閉",
     "storeDetails": "儲存以供下次付款使用",
     "readMore": "閱讀全文",

--- a/packages/lib/src/language/locales/zh-TW.json
+++ b/packages/lib/src/language/locales/zh-TW.json
@@ -120,6 +120,7 @@
     "donateButton": "捐贈",
     "notNowButton": "稍後再說",
     "thanksForYourSupport": "感謝您的支持！",
+    "resultMessages.preauthorized": "已儲存詳細資料",
     "preauthorizeWith": "透過以下方式進行預先授權：",
     "confirmPreauthorization": "確認預先授權",
     "confirmPurchase": "確認購買",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For the regular card payment, in case of a zero-auth transaction, the pay button label is changed to `Save details`, and the `Save for my next payment` checkbox is removed.
The drop-in component shows `Details saved` as the success message for such transaction.

## Tested scenarios
Unit tests passed


**Internal ticket**:  COWEB-1188