### PR TITLE
[wip]Use expiresAt for QR payments

### DIFF
--- a/.changeset/slimy-pillows-wash.md
+++ b/.changeset/slimy-pillows-wash.md
@@ -1,0 +1,8 @@
+---
+"@adyen/adyen-web": minor
+---
+
+For the following QR based payments - `bcmc_mobile`, `duitnow`, `payme`, `paynow`, `pix`, `promptpay`, `swish` and `wechatpayQR`, we improved how we calculate the countdown time.
+
+Specifically, we calculate the QR countdown time based on the `expiresAt` timestamp from the `/payments` response if it is returned in the action object, otherwise we use merchant's frontend configuration. 
+If both are not presented, we fall back to the default value.

--- a/packages/lib/src/components/BcmcMobile/BcmcMobile.ts
+++ b/packages/lib/src/components/BcmcMobile/BcmcMobile.ts
@@ -3,17 +3,14 @@ import { STATUS_INTERVAL, COUNTDOWN_MINUTES } from './config';
 
 class BCMCMobileElement extends QRLoaderContainer {
     public static type = 'bcmc_mobile';
+    private static isMobile = window.matchMedia('(max-width: 768px)').matches && /Android|iPhone|iPod/.test(navigator.userAgent);
 
-    formatProps(props) {
-        const isMobile = window.matchMedia('(max-width: 768px)').matches && /Android|iPhone|iPod/.test(navigator.userAgent);
-
-        return super.formatProps({
-            delay: STATUS_INTERVAL,
-            countdownTime: COUNTDOWN_MINUTES,
-            buttonLabel: isMobile ? 'openApp' : 'generateQRCode',
-            ...props
-        });
-    }
+    protected static defaultProps = {
+        delay: STATUS_INTERVAL,
+        countdownTime: COUNTDOWN_MINUTES,
+        buttonLabel: BCMCMobileElement.isMobile ? 'openApp' : 'generateQRCode',
+        ...QRLoaderContainer.defaultProps
+    };
 }
 
 export default BCMCMobileElement;

--- a/packages/lib/src/components/BcmcMobile/BcmcMobile.ts
+++ b/packages/lib/src/components/BcmcMobile/BcmcMobile.ts
@@ -7,12 +7,12 @@ class BCMCMobileElement extends QRLoaderContainer {
     formatProps(props) {
         const isMobile = window.matchMedia('(max-width: 768px)').matches && /Android|iPhone|iPod/.test(navigator.userAgent);
 
-        return {
+        return super.formatProps({
             delay: STATUS_INTERVAL,
             countdownTime: COUNTDOWN_MINUTES,
             buttonLabel: isMobile ? 'openApp' : 'generateQRCode',
-            ...super.formatProps(props)
-        };
+            ...props
+        });
     }
 }
 

--- a/packages/lib/src/components/DuitNow/DuitNow.ts
+++ b/packages/lib/src/components/DuitNow/DuitNow.ts
@@ -4,9 +4,11 @@ import { delay, countdownTime } from './config';
 class DuitNowElement extends QRLoaderContainer {
     public static type = 'duitnow';
 
-    formatProps(props) {
-        return super.formatProps({ delay, countdownTime, ...props });
-    }
+    protected static defaultProps = {
+        countdownTime,
+        delay,
+        ...QRLoaderContainer.defaultProps
+    };
 }
 
 export default DuitNowElement;

--- a/packages/lib/src/components/DuitNow/DuitNow.ts
+++ b/packages/lib/src/components/DuitNow/DuitNow.ts
@@ -5,11 +5,7 @@ class DuitNowElement extends QRLoaderContainer {
     public static type = 'duitnow';
 
     formatProps(props) {
-        return {
-            delay,
-            countdownTime,
-            ...super.formatProps(props)
-        };
+        return super.formatProps({ delay, countdownTime, ...props });
     }
 }
 

--- a/packages/lib/src/components/PayMe/PayMe.ts
+++ b/packages/lib/src/components/PayMe/PayMe.ts
@@ -3,7 +3,7 @@ import Instructions from './Instructions';
 
 class PayMeElement extends QRLoaderContainer {
     public static type = 'payme';
-    private static defaultCountdown = 30; // min
+    private static defaultCountdown = 10; // min
     private static defaultDelay = 2000; // ms
 
     protected static defaultProps = {

--- a/packages/lib/src/components/PayMe/PayMe.ts
+++ b/packages/lib/src/components/PayMe/PayMe.ts
@@ -7,7 +7,7 @@ class PayMeElement extends QRLoaderContainer {
     private static defaultDelay = 2000; // ms
 
     formatProps(props) {
-        return {
+        return super.formatProps({
             delay: PayMeElement.defaultDelay,
             countdownTime: PayMeElement.defaultCountdown,
             redirectIntroduction: 'payme.openPayMeApp',
@@ -15,8 +15,8 @@ class PayMeElement extends QRLoaderContainer {
             timeToPay: 'payme.timeToPay',
             buttonLabel: 'payme.redirectButtonLabel',
             instructions: Instructions,
-            ...super.formatProps(props)
-        };
+            ...props
+        });
     }
 }
 

--- a/packages/lib/src/components/PayMe/PayMe.ts
+++ b/packages/lib/src/components/PayMe/PayMe.ts
@@ -3,21 +3,19 @@ import Instructions from './Instructions';
 
 class PayMeElement extends QRLoaderContainer {
     public static type = 'payme';
-    private static defaultCountdown = 10; // min
+    private static defaultCountdown = 30; // min
     private static defaultDelay = 2000; // ms
 
-    formatProps(props) {
-        return super.formatProps({
-            delay: PayMeElement.defaultDelay,
-            countdownTime: PayMeElement.defaultCountdown,
-            redirectIntroduction: 'payme.openPayMeApp',
-            introduction: 'payme.scanQrCode',
-            timeToPay: 'payme.timeToPay',
-            buttonLabel: 'payme.redirectButtonLabel',
-            instructions: Instructions,
-            ...props
-        });
-    }
+    protected static defaultProps = {
+        delay: PayMeElement.defaultDelay,
+        countdownTime: PayMeElement.defaultCountdown,
+        redirectIntroduction: 'payme.openPayMeApp',
+        introduction: 'payme.scanQrCode',
+        timeToPay: 'payme.timeToPay',
+        buttonLabel: 'payme.redirectButtonLabel',
+        instructions: Instructions,
+        ...QRLoaderContainer.defaultProps
+    };
 }
 
 export default PayMeElement;

--- a/packages/lib/src/components/PayNow/PayNow.ts
+++ b/packages/lib/src/components/PayNow/PayNow.ts
@@ -5,11 +5,7 @@ class PayNowElement extends QRLoaderContainer {
     public static type = 'paynow';
 
     formatProps(props) {
-        return {
-            delay,
-            countdownTime,
-            ...super.formatProps(props)
-        };
+        return super.formatProps({ delay, countdownTime, ...props });
     }
 }
 

--- a/packages/lib/src/components/PayNow/PayNow.ts
+++ b/packages/lib/src/components/PayNow/PayNow.ts
@@ -4,9 +4,11 @@ import { delay, countdownTime } from './config';
 class PayNowElement extends QRLoaderContainer {
     public static type = 'paynow';
 
-    formatProps(props) {
-        return super.formatProps({ delay, countdownTime, ...props });
-    }
+    protected static defaultProps = {
+        countdownTime,
+        delay,
+        ...QRLoaderContainer.defaultProps
+    };
 }
 
 export default PayNowElement;

--- a/packages/lib/src/components/PromptPay/PromptPay.ts
+++ b/packages/lib/src/components/PromptPay/PromptPay.ts
@@ -5,11 +5,7 @@ class PromptPayElement extends QRLoaderContainer {
     public static type = 'promptpay';
 
     formatProps(props) {
-        return {
-            delay,
-            countdownTime,
-            ...super.formatProps(props)
-        };
+        return super.formatProps({ delay, countdownTime, ...props });
     }
 }
 

--- a/packages/lib/src/components/PromptPay/PromptPay.ts
+++ b/packages/lib/src/components/PromptPay/PromptPay.ts
@@ -4,9 +4,11 @@ import { delay, countdownTime } from './config';
 class PromptPayElement extends QRLoaderContainer {
     public static type = 'promptpay';
 
-    formatProps(props) {
-        return super.formatProps({ delay, countdownTime, ...props });
-    }
+    protected static defaultProps = {
+        countdownTime,
+        delay,
+        ...QRLoaderContainer.defaultProps
+    };
 }
 
 export default PromptPayElement;

--- a/packages/lib/src/components/Swish/Swish.ts
+++ b/packages/lib/src/components/Swish/Swish.ts
@@ -2,13 +2,14 @@ import QRLoaderContainer from '../helpers/QRLoaderContainer';
 
 class SwishElement extends QRLoaderContainer {
     public static type = 'swish';
+
     formatProps(props) {
-        return {
+        return super.formatProps({
             delay: 2000, // ms
             countdownTime: 3, // min
             instructions: 'swish.pendingMessage',
-            ...super.formatProps(props)
-        };
+            ...props
+        });
     }
 }
 

--- a/packages/lib/src/components/Swish/Swish.ts
+++ b/packages/lib/src/components/Swish/Swish.ts
@@ -3,14 +3,12 @@ import QRLoaderContainer from '../helpers/QRLoaderContainer';
 class SwishElement extends QRLoaderContainer {
     public static type = 'swish';
 
-    formatProps(props) {
-        return super.formatProps({
-            delay: 2000, // ms
-            countdownTime: 3, // min
-            instructions: 'swish.pendingMessage',
-            ...props
-        });
-    }
+    protected static defaultProps = {
+        delay: 2000, // ms
+        countdownTime: 3, // min
+        instructions: 'swish.pendingMessage',
+        ...QRLoaderContainer.defaultProps
+    };
 }
 
 export default SwishElement;

--- a/packages/lib/src/components/WeChat/WeChat.test.ts
+++ b/packages/lib/src/components/WeChat/WeChat.test.ts
@@ -41,15 +41,4 @@ describe('WeChat', () => {
             expect(wechat.render()).toBe(null);
         });
     });
-
-    describe('formatProps', () => {
-        describe('countdownTime', () => {
-            test('should calculate the time difference if expiresAt is provided', () => {});
-            test('should return the default countdown time if expiresAt is not provided', () => {});
-            test('should return the default countdown time if there are errors calculating the time difference', () => {});
-        });
-        describe('other props', () => {
-            test('should return the correct values for other props', () => {});
-        });
-    });
 });

--- a/packages/lib/src/components/WeChat/WeChat.test.ts
+++ b/packages/lib/src/components/WeChat/WeChat.test.ts
@@ -1,7 +1,25 @@
 import WeChat from './WeChat';
+import * as utils from '../../utils/getTimeDiffInMinutesFromNow';
+import { countdownTime } from './config';
+
+const calculateTimeDiffMock = jest.spyOn(utils, 'getTimeDiffInMinutesFromNow').mockImplementation(() => 5);
 
 describe('WeChat', () => {
-    describe('formatProps', () => {});
+    describe('formatProps', () => {
+        test('should calculate the time difference if expiresAt exists', () => {
+            const expiresAt = '2024-01-15T14:00:48.321283089Z';
+            const wechat = new WeChat({ expiresAt });
+            expect(calculateTimeDiffMock).toHaveBeenCalledWith(expiresAt, wechat.props.delay);
+        });
+        test('should use the countdownTime from the props if it exists', () => {
+            const wechat = new WeChat({ countdownTime: 3 });
+            expect(wechat.props.countdownTime).toBe(3);
+        });
+        test('should use the default countdownTime if neither expiresAt nor countdownTime value exists', () => {
+            const wechat = new WeChat({});
+            expect(wechat.props.countdownTime).toBe(countdownTime);
+        });
+    });
 
     describe('isValid', () => {
         test('should be always true', () => {
@@ -21,6 +39,17 @@ describe('WeChat', () => {
         test('does not render anything by default', () => {
             const wechat = new WeChat({});
             expect(wechat.render()).toBe(null);
+        });
+    });
+
+    describe('formatProps', () => {
+        describe('countdownTime', () => {
+            test('should calculate the time difference if expiresAt is provided', () => {});
+            test('should return the default countdown time if expiresAt is not provided', () => {});
+            test('should return the default countdown time if there are errors calculating the time difference', () => {});
+        });
+        describe('other props', () => {
+            test('should return the correct values for other props', () => {});
         });
     });
 });

--- a/packages/lib/src/components/WeChat/WeChat.ts
+++ b/packages/lib/src/components/WeChat/WeChat.ts
@@ -4,15 +4,11 @@ import { delay, countdownTime } from './config';
 class WeChatPayElement extends QRLoaderContainer {
     public static type = 'wechatpayQR';
 
-    public static defaultProps = {
+    protected static defaultProps = {
         countdownTime,
         delay,
         ...QRLoaderContainer.defaultProps
     };
-
-    /*    formatProps(props) {
-        return super.formatProps({ delay, countdownTime, ...props });
-    }*/
 }
 
 export default WeChatPayElement;

--- a/packages/lib/src/components/WeChat/WeChat.ts
+++ b/packages/lib/src/components/WeChat/WeChat.ts
@@ -1,35 +1,18 @@
 import QRLoaderContainer from '../helpers/QRLoaderContainer';
-import { delay, countdownTime as defaultCountdownTime } from './config';
-import Instructions from '../PayMe/Instructions';
-import { getTimeDiffInMinutesFromNow } from '../../utils/getTimeDiffInMinutesFromNow';
+import { delay, countdownTime } from './config';
 
 class WeChatPayElement extends QRLoaderContainer {
     public static type = 'wechatpayQR';
 
-    formatProps(props) {
-        return {
-            delay,
-            redirectIntroduction: 'payme.openPayMeApp',
-            introduction: 'payme.scanQrCode',
-            timeToPay: 'payme.timeToPay',
-            buttonLabel: 'payme.redirectButtonLabel',
-            instructions: Instructions,
-            ...super.formatProps(props),
-            countdownTime: this.getCountDownTime(props)
-        };
-    }
+    public static defaultProps = {
+        countdownTime,
+        delay,
+        ...QRLoaderContainer.defaultProps
+    };
 
-    getCountDownTime(props): number {
-        try {
-            const { expiresAt, delay } = props;
-            if (expiresAt) {
-                return getTimeDiffInMinutesFromNow(expiresAt, delay);
-            }
-        } catch (e) {
-            console.error(e);
-            return props.countdownTime ?? defaultCountdownTime;
-        }
-    }
+    /*    formatProps(props) {
+        return super.formatProps({ delay, countdownTime, ...props });
+    }*/
 }
 
 export default WeChatPayElement;

--- a/packages/lib/src/components/WeChat/WeChat.ts
+++ b/packages/lib/src/components/WeChat/WeChat.ts
@@ -1,5 +1,7 @@
 import QRLoaderContainer from '../helpers/QRLoaderContainer';
-import { delay, countdownTime } from './config';
+import { delay, countdownTime as defaultCountdownTime } from './config';
+import Instructions from '../PayMe/Instructions';
+import { getTimeDiffInMinutesFromNow } from '../../utils/getTimeDiffInMinutesFromNow';
 
 class WeChatPayElement extends QRLoaderContainer {
     public static type = 'wechatpayQR';
@@ -7,9 +9,26 @@ class WeChatPayElement extends QRLoaderContainer {
     formatProps(props) {
         return {
             delay,
-            countdownTime,
-            ...super.formatProps(props)
+            redirectIntroduction: 'payme.openPayMeApp',
+            introduction: 'payme.scanQrCode',
+            timeToPay: 'payme.timeToPay',
+            buttonLabel: 'payme.redirectButtonLabel',
+            instructions: Instructions,
+            ...super.formatProps(props),
+            countdownTime: this.getCountDownTime(props)
         };
+    }
+
+    getCountDownTime(props): number {
+        try {
+            const { expiresAt, delay } = props;
+            if (expiresAt) {
+                return getTimeDiffInMinutesFromNow(expiresAt, delay);
+            }
+        } catch (e) {
+            console.error(e);
+            return props.countdownTime ?? defaultCountdownTime;
+        }
     }
 }
 

--- a/packages/lib/src/components/WeChat/config.ts
+++ b/packages/lib/src/components/WeChat/config.ts
@@ -1,4 +1,4 @@
-export const countdownTime = 15; // min
+export const countdownTime = 8; // min
 export const delay = 2000; // ms
 
 export default {

--- a/packages/lib/src/components/WeChat/config.ts
+++ b/packages/lib/src/components/WeChat/config.ts
@@ -1,4 +1,4 @@
-export const countdownTime = 8; // min
+export const countdownTime = 15; // min
 export const delay = 2000; // ms
 
 export default {

--- a/packages/lib/src/utils/getTimeDiffInMinutesFromNow.test.ts
+++ b/packages/lib/src/utils/getTimeDiffInMinutesFromNow.test.ts
@@ -1,0 +1,21 @@
+import { getTimeDiffInMinutesFromNow } from './getTimeDiffInMinutesFromNow';
+
+describe('getTimeDiffInMinutesFromNow', () => {
+    test('should return the time difference in minutes without delay', () => {
+        const fiveMinutes = 5;
+        const delay = 1000 * 60 * fiveMinutes;
+        const futureTime = new Date(Date.now() + delay);
+        expect(getTimeDiffInMinutesFromNow(futureTime.toISOString())).toEqual(fiveMinutes);
+    });
+
+    test('should return the time difference in minutes with delay', () => {
+        const fiveMinutes = 5;
+        const delay = 1000 * 60 * fiveMinutes;
+        const futureTime = new Date(Date.now() + delay);
+        expect(getTimeDiffInMinutesFromNow(futureTime.toISOString(), delay)).toEqual(0);
+    });
+
+    test('should throw an error when the time duration cannot be calculated', () => {
+        expect(() => getTimeDiffInMinutesFromNow('wrong datetime')).toThrow();
+    });
+});

--- a/packages/lib/src/utils/getTimeDiffInMinutesFromNow.test.ts
+++ b/packages/lib/src/utils/getTimeDiffInMinutesFromNow.test.ts
@@ -3,12 +3,11 @@ import { getTimeDiffInMinutesFromNow } from './getTimeDiffInMinutesFromNow';
 describe('getTimeDiffInMinutesFromNow', () => {
     test('should return the time difference in minutes without delay', () => {
         const fiveMinutes = 5;
-        const delay = 1000 * 60 * fiveMinutes;
-        const futureTime = new Date(Date.now() + delay);
+        const futureTime = new Date(Date.now() + 1000 * 60 * fiveMinutes);
         expect(getTimeDiffInMinutesFromNow(futureTime.toISOString())).toEqual(fiveMinutes);
     });
 
-    test('should return the time difference in minutes with delay', () => {
+    test('should return the time difference in minutes with a delay', () => {
         const fiveMinutes = 5;
         const delay = 1000 * 60 * fiveMinutes;
         const futureTime = new Date(Date.now() + delay);

--- a/packages/lib/src/utils/getTimeDiffInMinutesFromNow.ts
+++ b/packages/lib/src/utils/getTimeDiffInMinutesFromNow.ts
@@ -1,6 +1,6 @@
 /**
- * Calculate the time difference in minutes, between the future time and the current time (plus delay).
- * @param futureTime - string in utc datetime format
+ * Calculate the time difference in minutes, between the future UTC time and the current time (plus delay).
+ * @param futureTime - UTC date time string in the ISO 8601 format
  * @param delayFromNow - milliseconds delay from now
  */
 export function getTimeDiffInMinutesFromNow(futureTime: string, delayFromNow = 0) {

--- a/packages/lib/src/utils/getTimeDiffInMinutesFromNow.ts
+++ b/packages/lib/src/utils/getTimeDiffInMinutesFromNow.ts
@@ -5,9 +5,9 @@
  */
 export function getTimeDiffInMinutesFromNow(futureTime: string, delayFromNow = 0) {
     const future = new Date(futureTime);
-    const localDate = new Date();
-    localDate.setTime(localDate.getTime() + delayFromNow);
-    const diff = (future.getTime() - localDate.getTime()) / 60000;
+    const now = new Date();
+    now.setTime(now.getTime() + delayFromNow);
+    const diff = (future.getTime() - now.getTime()) / 60000;
     if (Number.isNaN(diff) || diff < 0) {
         throw new Error('Invalid countdown duration. A default one will be used.');
     }

--- a/packages/lib/src/utils/getTimeDiffInMinutesFromNow.ts
+++ b/packages/lib/src/utils/getTimeDiffInMinutesFromNow.ts
@@ -1,0 +1,15 @@
+/**
+ * Calculate the time difference in minutes, between the future time and the current time (plus delay).
+ * @param futureTime - string in utc datetime format
+ * @param delayFromNow - milliseconds delay from now
+ */
+export function getTimeDiffInMinutesFromNow(futureTime: string, delayFromNow = 0) {
+    const future = new Date(futureTime);
+    const localDate = new Date();
+    localDate.setTime(localDate.getTime() + delayFromNow);
+    const diff = (future.getTime() - localDate.getTime()) / 60000;
+    if (Number.isNaN(diff) || diff < 0) {
+        throw new Error('Invalid countdown duration. A default one will be used.');
+    }
+    return diff;
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For the following QR based payments - `bcmc_mobile`, `duitnow`, `payme`, `paynow`, `pix`, `promptpay`, `swish` and `wechatpayQR`, we improved how we calculate the countdown time.

Specifically, we calculate the QR countdown time based on the `expiresAt` timestamp from the `/payments` response if it is returned in the action object, otherwise we use merchant's frontend configuration. 
If both are not presented, we fall back to the default value.

## Tested scenarios
Added tests and all unit tests passed.
Tested on my device with different timezones, the wechat QR pay shows a 30mins count down (taking the value from `expiresAt`)


**Internal ticket**:  COWEB-1258