### PR TITLE
Feature: Use backend label for stored Blik

### DIFF
--- a/packages/lib/src/components/Blik/Blik.test.tsx
+++ b/packages/lib/src/components/Blik/Blik.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/preact';
+import AdyenCheckout from '../../index';
+
+describe('Blik', () => {
+    const createDropin = async paymentMethodsResponse => {
+        const checkout = await AdyenCheckout({
+            environment: 'test',
+            clientKey: 'test_123456',
+            analytics: { enabled: false },
+            paymentMethodsResponse: paymentMethodsResponse
+        });
+        return checkout.create('dropin');
+    };
+
+    describe('in Dropin display correct payment method name', () => {
+        test('display only blik if it is not stored', async () => {
+            const blik = await createDropin({ paymentMethods: [{ type: 'blik', name: 'Blik' }] });
+            render(blik.render());
+
+            const blikText = await screen.findByText('Blik');
+
+            expect(blikText).toBeInTheDocument();
+        });
+
+        test('display blik payment method name and label', async () => {
+            const blik = await createDropin({
+                storedPaymentMethods: [
+                    {
+                        id: 'X8CN3VMB6XXZTX43',
+                        label: 'mBank PMM',
+                        name: 'Blik',
+                        supportedRecurringProcessingModels: ['CardOnFile'],
+                        supportedShopperInteractions: ['Ecommerce'],
+                        type: 'blik'
+                    }
+                ]
+            });
+            render(blik.render());
+
+            const blikText = await screen.findByText('Blik');
+            const storedPaymentMethodLabel = await screen.findByText('mBank PMM');
+
+            expect(blikText).toBeInTheDocument();
+            expect(storedPaymentMethodLabel).toBeInTheDocument();
+        });
+    });
+});

--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -37,6 +37,19 @@ class BlikElement extends UIElement {
         return !!this.state.isValid;
     }
 
+    get displayName() {
+        if (this.props.storedPaymentMethodId && this.props.label) {
+            return this.props.label;
+        }
+        return this.props.name;
+    }
+
+    get additionalInfo() {
+        if (this.props.storedPaymentMethodId && this.props.label) {
+            return this.props.name;
+        }
+    }
+
     /**
      * NOTE: for future reference:
      *  this.props.onComplete (which is called from this.onComplete) equates to the merchant defined onAdditionalDetails callback


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

For Blik we want to display a backend label to distinguish between stored payment methods.

## Tested scenarios
<!-- Description of tested scenarios -->
See tests.

**Fixed issue**:  <!-- #-prefixed issue number -->
