### PR TITLE
Checkoutanalytics mvp with 3DS2 events

### DIFF
--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -102,16 +102,20 @@ class BaseElement<P extends BaseElementProps> {
             throw new Error('Component could not mount. Root node was not found.');
         }
 
+        const setupAnalytics = !this._node;
+
         if (this._node) {
             this.unmount(); // new, if this._node exists then we are "remounting" so we first need to unmount if it's not already been done
         }
+
+        this._node = node;
 
         this._component = this.render();
 
         render(this._component, node);
 
         // Set up analytics (once, since this._node is currently undefined) now that we have mounted and rendered
-        if (!this._node) {
+        if (setupAnalytics) {
             if (this.props.modules && this.props.modules.analytics) {
                 this.setUpAnalytics({
                     containerWidth: node && (node as HTMLElement).offsetWidth,
@@ -127,8 +131,6 @@ class BaseElement<P extends BaseElementProps> {
                 });
             }
         }
-
-        this._node = node;
 
         return this;
     }

--- a/packages/lib/src/components/BaseElement.ts
+++ b/packages/lib/src/components/BaseElement.ts
@@ -6,7 +6,7 @@ import Core from '../core';
 import { BaseElementProps, PaymentData } from './types';
 import { RiskData } from '../core/RiskModule/RiskModule';
 import { Resources } from '../core/Context/Resources';
-import { AnalyticsInitialEvent } from '../core/Analytics/types';
+import { AnalyticsInitialEvent, SendAnalyticsObject } from '../core/Analytics/types';
 import { ANALYTICS_RENDERED_STR } from '../core/Analytics/constants';
 
 class BaseElement<P extends BaseElementProps> {
@@ -54,7 +54,7 @@ class BaseElement<P extends BaseElementProps> {
     }
 
     /* eslint-disable-next-line */
-    protected submitAnalytics(analyticsObj?: any) {
+    protected submitAnalytics(analyticsObj?: SendAnalyticsObject) {
         return null;
     }
 

--- a/packages/lib/src/components/Card/Card.Analytics.test.tsx
+++ b/packages/lib/src/components/Card/Card.Analytics.test.tsx
@@ -1,0 +1,170 @@
+import { CardElement } from './Card';
+import Analytics from '../../core/Analytics';
+
+const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
+
+let card;
+
+import {
+    ANALYTICS_CONFIGURED_STR,
+    ANALYTICS_EVENT_INFO,
+    ANALYTICS_EVENT_LOG,
+    ANALYTICS_FOCUS_STR,
+    ANALYTICS_RENDERED_STR,
+    ANALYTICS_SUBMIT_STR,
+    ANALYTICS_UNFOCUS_STR,
+    ANALYTICS_VALIDATION_ERROR_STR
+} from '../../core/Analytics/constants';
+
+describe('Card: calls that generate "info" analytics should produce objects with the expected shapes ', () => {
+    beforeEach(() => {
+        console.log = jest.fn(() => {});
+
+        card = new CardElement({
+            modules: {
+                analytics: analyticsModule
+            }
+        });
+
+        analyticsModule.createAnalyticsEvent = jest.fn(obj => {
+            console.log('### analyticsPreProcessor.test:::: obj=', obj);
+        });
+    });
+
+    test('Analytics should produce an "info" event, of type "rendered", for a card PM', () => {
+        card.submitAnalytics({
+            type: ANALYTICS_RENDERED_STR
+        });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_INFO,
+            data: { component: card.constructor['type'], type: ANALYTICS_RENDERED_STR }
+        });
+    });
+
+    test('Analytics should produce an "info" event, of type "rendered", for a storedCard PM', () => {
+        card.submitAnalytics({
+            type: ANALYTICS_RENDERED_STR,
+            isStoredPaymentMethod: true,
+            brand: 'mc'
+        });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_INFO,
+            data: { component: card.constructor['type'], type: ANALYTICS_RENDERED_STR, isStoredPaymentMethod: true, brand: 'mc' }
+        });
+    });
+
+    test('Analytics should produce an "info" event, of type "configured", for a card PM', () => {
+        card.submitAnalytics({
+            type: ANALYTICS_CONFIGURED_STR
+        });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_INFO,
+            data: { component: card.constructor['type'], type: ANALYTICS_CONFIGURED_STR }
+        });
+    });
+
+    test('Analytics should produce an "info" event, of type "configured", for a storedCard PM', () => {
+        card.submitAnalytics({
+            type: ANALYTICS_CONFIGURED_STR,
+            isStoredPaymentMethod: true,
+            brand: 'mc'
+        });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_INFO,
+            data: { component: card.constructor['type'], type: ANALYTICS_CONFIGURED_STR, isStoredPaymentMethod: true, brand: 'mc' }
+        });
+    });
+
+    test('Analytics should produce an "info" event, of type "focus" with the target value correctly formed', () => {
+        card.onFocus({
+            fieldType: 'encryptedCardNumber',
+            event: {
+                action: 'focus',
+                focus: true,
+                numChars: 0,
+                fieldType: 'encryptedCardNumber',
+                rootNode: {},
+                type: 'card',
+                currentFocusObject: 'encryptedCardNumber'
+            }
+        });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_INFO,
+            data: { component: card.constructor['type'], type: ANALYTICS_FOCUS_STR, target: 'card_number' }
+        });
+    });
+
+    test('Analytics should produce an "info" event, of type "unfocus" with the target value correctly formed', () => {
+        card.onBlur({
+            fieldType: 'encryptedCardNumber',
+            event: {
+                action: 'focus',
+                focus: false,
+                numChars: 1,
+                fieldType: 'encryptedCardNumber',
+                rootNode: {},
+                type: 'card',
+                currentFocusObject: null
+            }
+        });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_INFO,
+            data: { component: card.constructor['type'], type: ANALYTICS_UNFOCUS_STR, target: 'card_number' }
+        });
+    });
+
+    test('Analytics should produce an "info" event, of type "validationError", with the expected properties', () => {
+        card.onErrorAnalytics({
+            fieldType: 'encryptedCardNumber',
+            errorCode: 'error.va.sf-cc-num.04',
+            errorMessage: 'Enter the complete card number-sr'
+        });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_INFO,
+            data: {
+                component: card.constructor['type'],
+                type: ANALYTICS_VALIDATION_ERROR_STR,
+                target: 'card_number',
+                validationErrorCode: 'error.va.sf-cc-num.04',
+                validationErrorMessage: 'Enter the complete card number-sr'
+            }
+        });
+    });
+});
+
+describe('Card: calls that generate "log" analytics should produce objects with the expected shapes ', () => {
+    beforeEach(() => {
+        console.log = jest.fn(() => {});
+
+        card = new CardElement({
+            modules: {
+                analytics: analyticsModule
+            }
+        });
+
+        analyticsModule.createAnalyticsEvent = jest.fn(obj => {
+            console.log('### analyticsPreProcessor.test:::: obj=', obj);
+        });
+    });
+
+    test('Analytics should produce an "log" event, of type "submit", for a card PM', () => {
+        card.submitAnalytics({ type: ANALYTICS_SUBMIT_STR });
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_LOG,
+            data: {
+                component: card.constructor['type'],
+                type: ANALYTICS_SUBMIT_STR,
+                target: 'pay_button',
+                message: 'Shopper clicked pay'
+            }
+        });
+    });
+});

--- a/packages/lib/src/components/Card/Card.Analytics.test.tsx
+++ b/packages/lib/src/components/Card/Card.Analytics.test.tsx
@@ -162,7 +162,6 @@ describe('Card: calls that generate "log" analytics should produce objects with 
             data: {
                 component: card.constructor['type'],
                 type: ANALYTICS_SUBMIT_STR,
-                target: 'pay_button',
                 message: 'Shopper clicked pay'
             }
         });

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import CoreProvider from '../../core/Context/CoreProvider';
 import collectBrowserInfo from '../../utils/browserInfo';
 import { BinLookupResponse, CardElementData, CardElementProps } from './types';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';
-import { CbObjOnBinLookup, CbObjOnFocus } from '../internal/SecuredFields/lib/types';
+import { CbObjOnBinLookup, CbObjOnConfigSuccess, CbObjOnFocus } from '../internal/SecuredFields/lib/types';
 import { reject } from '../internal/SecuredFields/utils';
 import { hasValidInstallmentsObject } from './components/CardInput/utils';
 import createClickToPayService from '../internal/ClickToPay/services/create-clicktopay-service';
@@ -14,7 +14,7 @@ import ClickToPayWrapper from './components/ClickToPayWrapper';
 import { ComponentFocusObject, PayButtonFunctionProps, UIElementStatus } from '../types';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import PayButton from '../internal/PayButton';
-import { ANALYTICS_FOCUS_STR, ANALYTICS_UNFOCUS_STR, ANALYTICS_VALIDATION_ERROR_STR } from '../../core/Analytics/constants';
+import { ANALYTICS_FOCUS_STR, ANALYTICS_CONFIGURED_STR, ANALYTICS_UNFOCUS_STR, ANALYTICS_VALIDATION_ERROR_STR } from '../../core/Analytics/constants';
 import { ALL_SECURED_FIELDS, ENCRYPTED } from '../internal/SecuredFields/lib/configuration/constants';
 import { camelCaseToSnakeCase } from '../../utils/textUtils';
 import { FieldErrorAnalyticsObject } from '../../core/Analytics/types';
@@ -175,6 +175,14 @@ export class CardElement extends UIElement<CardElementProps> {
         return str;
     }
 
+    private onConfigSuccess = (obj: CbObjOnConfigSuccess) => {
+        this.submitAnalytics({
+            type: ANALYTICS_CONFIGURED_STR
+        });
+
+        this.props.onConfigSuccess?.(obj);
+    };
+
     private onFocus = (obj: ComponentFocusObject) => {
         // console.log('### Card::onFocus:: fieldType', obj.fieldType, 'target', this.fieldTypeToSnakeCase(obj.fieldType));
         this.submitAnalytics({
@@ -293,6 +301,7 @@ export class CardElement extends UIElement<CardElementProps> {
                 onFocus={this.onFocus}
                 onBlur={this.onBlur}
                 onErrorAnalytics={this.onErrorAnalytics}
+                onConfigSuccess={this.onConfigSuccess}
             />
         );
     }

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -6,7 +6,7 @@ import collectBrowserInfo from '../../utils/browserInfo';
 import { BinLookupResponse, CardElementData, CardElementProps } from './types';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';
 import { CbObjOnBinLookup, CbObjOnConfigSuccess, CbObjOnFocus } from '../internal/SecuredFields/lib/types';
-import { reject } from '../internal/SecuredFields/utils';
+import { fieldTypeToSnakeCase, reject } from '../internal/SecuredFields/utils';
 import { hasValidInstallmentsObject } from './components/CardInput/utils';
 import createClickToPayService from '../internal/ClickToPay/services/create-clicktopay-service';
 import { ClickToPayCheckoutPayload, IClickToPayService } from '../internal/ClickToPay/services/types';
@@ -21,8 +21,7 @@ import {
     ANALYTICS_VALIDATION_ERROR_STR,
     ANALYTICS_RENDERED_STR
 } from '../../core/Analytics/constants';
-import { ALL_SECURED_FIELDS, ENCRYPTED } from '../internal/SecuredFields/lib/configuration/constants';
-import { camelCaseToSnakeCase } from '../../utils/textUtils';
+import { ALL_SECURED_FIELDS } from '../internal/SecuredFields/lib/configuration/constants';
 import { FieldErrorAnalyticsObject, SendAnalyticsObject } from '../../core/Analytics/types';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 
@@ -189,15 +188,6 @@ export class CardElement extends UIElement<CardElementProps> {
         super.submitAnalytics(analyticsObj);
     }
 
-    private fieldTypeToSnakeCase(fieldType) {
-        let str = camelCaseToSnakeCase(fieldType);
-        // SFs need their fieldType mapped to what the endpoint expects
-        if (ALL_SECURED_FIELDS.includes(fieldType)) {
-            str = str.substring(ENCRYPTED.length + 1); // strip 'encrypted_' off the string
-        }
-        return str;
-    }
-
     private onConfigSuccess = (obj: CbObjOnConfigSuccess) => {
         this.submitAnalytics({
             type: ANALYTICS_CONFIGURED_STR
@@ -207,10 +197,9 @@ export class CardElement extends UIElement<CardElementProps> {
     };
 
     private onFocus = (obj: ComponentFocusObject) => {
-        // console.log('### Card::onFocus:: fieldType', obj.fieldType, 'target', this.fieldTypeToSnakeCase(obj.fieldType));
         this.submitAnalytics({
             type: ANALYTICS_FOCUS_STR,
-            target: this.fieldTypeToSnakeCase(obj.fieldType)
+            target: fieldTypeToSnakeCase(obj.fieldType)
         });
 
         // Call merchant defined callback
@@ -224,7 +213,7 @@ export class CardElement extends UIElement<CardElementProps> {
     private onBlur = (obj: ComponentFocusObject) => {
         this.submitAnalytics({
             type: ANALYTICS_UNFOCUS_STR,
-            target: this.fieldTypeToSnakeCase(obj.fieldType)
+            target: fieldTypeToSnakeCase(obj.fieldType)
         });
 
         // Call merchant defined callback
@@ -238,7 +227,7 @@ export class CardElement extends UIElement<CardElementProps> {
     private onErrorAnalytics = (obj: FieldErrorAnalyticsObject) => {
         this.submitAnalytics({
             type: ANALYTICS_VALIDATION_ERROR_STR,
-            target: this.fieldTypeToSnakeCase(obj.fieldType),
+            target: fieldTypeToSnakeCase(obj.fieldType),
             validationErrorCode: obj.errorCode,
             validationErrorMessage: obj.errorMessage
         });

--- a/packages/lib/src/components/SecuredFields/SecuredFields.tsx
+++ b/packages/lib/src/components/SecuredFields/SecuredFields.tsx
@@ -4,9 +4,10 @@ import SecuredFields from './SecuredFieldsInput';
 import CoreProvider from '../../core/Context/CoreProvider';
 import collectBrowserInfo from '../../utils/browserInfo';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';
-import { CbObjOnBinLookup } from '../internal/SecuredFields/lib/types';
+import { CbObjOnBinLookup, CbObjOnFocus } from '../internal/SecuredFields/lib/types';
 import { BrandObject } from '../Card/types';
-import { getCardImageUrl } from '../internal/SecuredFields/utils';
+import { fieldTypeToSnakeCase, getCardImageUrl } from '../internal/SecuredFields/utils';
+import { ANALYTICS_FOCUS_STR, ANALYTICS_UNFOCUS_STR } from '../../core/Analytics/constants';
 
 export class SecuredFieldsElement extends UIElement {
     public static type = 'scheme';
@@ -89,6 +90,16 @@ export class SecuredFieldsElement extends UIElement {
         return collectBrowserInfo();
     }
 
+    private onFocus = (obj: CbObjOnFocus) => {
+        this.submitAnalytics({
+            type: obj.focus === true ? ANALYTICS_FOCUS_STR : ANALYTICS_UNFOCUS_STR,
+            target: fieldTypeToSnakeCase(obj.fieldType)
+        });
+
+        // Call merchant defined callback
+        this.props.onFocus?.(obj);
+    };
+
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
@@ -103,6 +114,7 @@ export class SecuredFieldsElement extends UIElement {
                     onBinValue={this.onBinValue}
                     implementationType={'custom'}
                     resources={this.resources}
+                    onFocus={this.onFocus}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
@@ -35,7 +35,7 @@ describe('ThreeDS2Challenge: calls that generate analytics should produce object
     });
 
     test('ThreeDS2Challenge instantiated without paymentData should generate an analytics error', () => {
-        const renderedChall = challenge.render();
+        const view = challenge.render();
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
             event: ANALYTICS_EVENT_ERROR,
@@ -48,6 +48,6 @@ describe('ThreeDS2Challenge: calls that generate analytics should produce object
             }
         });
 
-        expect(renderedChall).toBe(null);
+        expect(view).toBe(null);
     });
 });

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
@@ -1,0 +1,53 @@
+import { ThreeDS2Challenge } from './index';
+import Analytics from '../../core/Analytics';
+import {
+    ANALYTICS_API_ERROR,
+    ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA,
+    ANALYTICS_EVENT_ERROR,
+    ANALYTICS_RENDERED_STR
+} from '../../core/Analytics/constants';
+import { THREEDS2_CHALLENGE_ERROR, THREEDS2_ERROR } from './config';
+
+const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
+
+describe('ThreeDS2Challenge: calls that generate analytics should produce objects with the expected shapes ', () => {
+    let challenge;
+    beforeEach(() => {
+        console.log = jest.fn(() => {});
+
+        challenge = new ThreeDS2Challenge({
+            onActionHandled: () => {},
+            modules: {
+                analytics: analyticsModule
+            },
+            onError: () => {}
+        });
+
+        analyticsModule.createAnalyticsEvent = jest.fn(obj => {
+            console.log('### analyticsPreProcessor.test:::: obj=', obj);
+        });
+    });
+
+    test('A call to ThreeDS2Challenge.submitAnalytics with an object with type "rendered" should not lead to an analytics event', () => {
+        challenge.submitAnalytics({ type: ANALYTICS_RENDERED_STR });
+
+        expect(analyticsModule.createAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    test('ThreeDS2Challenge instantiated without paymentData should generate an analytics error', () => {
+        const res = challenge.render();
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_ERROR,
+            data: {
+                component: challenge.constructor['type'],
+                type: THREEDS2_ERROR,
+                errorType: ANALYTICS_API_ERROR,
+                message: `${THREEDS2_CHALLENGE_ERROR}: Missing 'paymentData' property from threeDS2 action`,
+                code: ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA
+            }
+        });
+
+        expect(res).toBe(null);
+    });
+});

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
@@ -35,7 +35,7 @@ describe('ThreeDS2Challenge: calls that generate analytics should produce object
     });
 
     test('ThreeDS2Challenge instantiated without paymentData should generate an analytics error', () => {
-        const res = challenge.render();
+        const renderedChall = challenge.render();
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
             event: ANALYTICS_EVENT_ERROR,
@@ -48,6 +48,6 @@ describe('ThreeDS2Challenge: calls that generate analytics should produce object
             }
         });
 
-        expect(res).toBe(null);
+        expect(renderedChall).toBe(null);
     });
 });

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -48,7 +48,7 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
 
     render() {
         // existy used because threeds2InMDFlow will send empty string for paymentData and we should be allowed to proceed with this
-        if (existy(this.props.paymentData)) {
+        if (!existy(this.props.paymentData)) {
             /**
              *  One component is used for both old and new 3DS2 challenge flows
              *   - The presence of useOriginalFlow indicates the old flow which used paymentData from the 3DS2 action

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -2,11 +2,13 @@ import { h } from 'preact';
 import UIElement from '../UIElement';
 import PrepareChallenge from './components/Challenge';
 import { ErrorCodeObject } from './components/utils';
-import { DEFAULT_CHALLENGE_WINDOW_SIZE } from './config';
+import { DEFAULT_CHALLENGE_WINDOW_SIZE, THREEDS2_CHALLENGE_ERROR } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import Language from '../../language';
-import { ActionHandledReturnObject } from '../types';
+import { ActionHandledReturnObject, AnalyticsModule } from '../types';
+import { ANALYTICS_API_ERROR, ANALYTICS_EVENT_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
+import { ThreeDS2AnalyticsObject } from './types';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;
@@ -21,6 +23,7 @@ export interface ThreeDS2ChallengeProps {
     useOriginalFlow?: boolean;
     i18n?: Language;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
+    analytics?: AnalyticsModule;
 }
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
@@ -30,6 +33,10 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
         dataKey: 'threeDSResult',
         size: DEFAULT_CHALLENGE_WINDOW_SIZE,
         type: 'ChallengeShopper'
+    };
+
+    protected submitAnalytics = (aObj: ThreeDS2AnalyticsObject) => {
+        this.props.analytics.createAnalyticsEvent({ event: aObj.event, data: { component: ThreeDS2Challenge.type, ...aObj } });
     };
 
     onComplete(state) {
@@ -48,10 +55,18 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
             const dataTypeForError = hasOwnProperty(this.props, 'useOriginalFlow') ? 'paymentData' : 'authorisationToken';
 
             this.props.onError({ errorCode: 'threeds2.challenge', message: `No ${dataTypeForError} received. Challenge cannot proceed` });
+
+            this.submitAnalytics({
+                event: ANALYTICS_EVENT_ERROR,
+                code: ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA,
+                errorType: ANALYTICS_API_ERROR,
+                message: `${THREEDS2_CHALLENGE_ERROR}: Missing 'paymentData' property from threeDS2 action`
+            });
+
             return null;
         }
 
-        return <PrepareChallenge {...this.props} onComplete={this.onComplete} />;
+        return <PrepareChallenge {...this.props} onComplete={this.onComplete} onSubmitAnalytics={this.submitAnalytics} />;
     }
 }
 

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -7,7 +7,7 @@ import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import Language from '../../language';
 import { ActionHandledReturnObject, AnalyticsModule } from '../types';
-import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
+import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA, ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 
 export interface ThreeDS2ChallengeProps {
@@ -38,6 +38,8 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
 
     protected submitAnalytics = (aObj: SendAnalyticsObject) => {
         console.log('### ThreeDS2Challenge::submitAnalytics:: aObj', aObj);
+        if (aObj.type === ANALYTICS_RENDERED_STR) return; // suppress the rendered event (it will have the same timestamp as the "creq sent" event)
+
         super.submitAnalytics(aObj);
     };
 

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -23,7 +23,7 @@ export interface ThreeDS2ChallengeProps {
     useOriginalFlow?: boolean;
     i18n?: Language;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
-    analytics?: AnalyticsModule;
+    modules?: { analytics: AnalyticsModule };
 }
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
@@ -32,12 +32,10 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
     public static defaultProps = {
         dataKey: 'threeDSResult',
         size: DEFAULT_CHALLENGE_WINDOW_SIZE,
-        // type: 'ChallengeShopper'
         type: THREEDS2_CHALLENGE
     };
 
     protected submitAnalytics = (aObj: SendAnalyticsObject) => {
-        console.log('### ThreeDS2Challenge::submitAnalytics:: aObj', aObj);
         if (aObj.type === ANALYTICS_RENDERED_STR) return; // suppress the rendered event (it will have the same timestamp as the "creq sent" event)
 
         super.submitAnalytics(aObj);

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -2,13 +2,13 @@ import { h } from 'preact';
 import UIElement from '../UIElement';
 import PrepareChallenge from './components/Challenge';
 import { ErrorCodeObject } from './components/utils';
-import { DEFAULT_CHALLENGE_WINDOW_SIZE, THREEDS2_CHALLENGE_ERROR } from './config';
+import { DEFAULT_CHALLENGE_WINDOW_SIZE, THREEDS2_CHALLENGE, THREEDS2_CHALLENGE_ERROR, THREEDS2_ERROR } from './config';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import Language from '../../language';
 import { ActionHandledReturnObject, AnalyticsModule } from '../types';
-import { ANALYTICS_API_ERROR, ANALYTICS_EVENT_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
-import { ThreeDS2AnalyticsObject } from './types';
+import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
+import { SendAnalyticsObject } from '../../core/Analytics/types';
 
 export interface ThreeDS2ChallengeProps {
     token?: string;
@@ -32,11 +32,13 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
     public static defaultProps = {
         dataKey: 'threeDSResult',
         size: DEFAULT_CHALLENGE_WINDOW_SIZE,
-        type: 'ChallengeShopper'
+        // type: 'ChallengeShopper'
+        type: THREEDS2_CHALLENGE
     };
 
-    protected submitAnalytics = (aObj: ThreeDS2AnalyticsObject) => {
-        this.props.analytics.createAnalyticsEvent({ event: aObj.event, data: { component: ThreeDS2Challenge.type, ...aObj } });
+    protected submitAnalytics = (aObj: SendAnalyticsObject) => {
+        console.log('### ThreeDS2Challenge::submitAnalytics:: aObj', aObj);
+        super.submitAnalytics(aObj);
     };
 
     onComplete(state) {
@@ -46,7 +48,7 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
 
     render() {
         // existy used because threeds2InMDFlow will send empty string for paymentData and we should be allowed to proceed with this
-        if (!existy(this.props.paymentData)) {
+        if (existy(this.props.paymentData)) {
             /**
              *  One component is used for both old and new 3DS2 challenge flows
              *   - The presence of useOriginalFlow indicates the old flow which used paymentData from the 3DS2 action
@@ -57,7 +59,7 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeProps> {
             this.props.onError({ errorCode: 'threeds2.challenge', message: `No ${dataTypeForError} received. Challenge cannot proceed` });
 
             this.submitAnalytics({
-                event: ANALYTICS_EVENT_ERROR,
+                type: THREEDS2_ERROR,
                 code: ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA,
                 errorType: ANALYTICS_API_ERROR,
                 message: `${THREEDS2_CHALLENGE_ERROR}: Missing 'paymentData' property from threeDS2 action`

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
@@ -36,7 +36,7 @@ describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produc
     });
 
     test('ThreeDS2DeviceFingerprint instantiated without paymentData should generate an analytics error', () => {
-        const renderedFP = fingerprint.render();
+        const view = fingerprint.render();
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
             event: ANALYTICS_EVENT_ERROR,
@@ -49,6 +49,6 @@ describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produc
             }
         });
 
-        expect(renderedFP).toBe(null);
+        expect(view).toBe(null);
     });
 });

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
@@ -1,0 +1,53 @@
+import { ThreeDS2DeviceFingerprint } from './index';
+import Analytics from '../../core/Analytics';
+import {
+    ANALYTICS_API_ERROR,
+    ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA,
+    ANALYTICS_EVENT_ERROR,
+    ANALYTICS_RENDERED_STR
+} from '../../core/Analytics/constants';
+import { THREEDS2_ERROR, THREEDS2_FINGERPRINT_ERROR } from './config';
+
+const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
+
+describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produce objects with the expected shapes ', () => {
+    let fingerprint;
+    beforeEach(() => {
+        console.log = jest.fn(() => {});
+
+        fingerprint = new ThreeDS2DeviceFingerprint({
+            onActionHandled: () => {},
+            modules: {
+                analytics: analyticsModule
+            },
+            onError: () => {}
+        });
+
+        analyticsModule.createAnalyticsEvent = jest.fn(obj => {
+            console.log('### analyticsPreProcessor.test:::: obj=', obj);
+        });
+    });
+
+    test('A call to ThreeDS2DeviceFingerprint.submitAnalytics with an object with type "rendered" should not lead to an analytics event', () => {
+        fingerprint.submitAnalytics({ type: ANALYTICS_RENDERED_STR });
+
+        expect(analyticsModule.createAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    test('ThreeDS2DeviceFingerprint instantiated without paymentData should generate an analytics error', () => {
+        const res = fingerprint.render();
+
+        expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
+            event: ANALYTICS_EVENT_ERROR,
+            data: {
+                component: fingerprint.constructor['type'],
+                type: THREEDS2_ERROR,
+                errorType: ANALYTICS_API_ERROR,
+                message: `${THREEDS2_FINGERPRINT_ERROR}: Missing 'paymentData' property from threeDS2 action`,
+                code: ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA
+            }
+        });
+
+        expect(res).toBe(null);
+    });
+});

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
@@ -36,7 +36,7 @@ describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produc
     });
 
     test('ThreeDS2DeviceFingerprint instantiated without paymentData should generate an analytics error', () => {
-        const res = fingerprint.render();
+        const renderedFP = fingerprint.render();
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
             event: ANALYTICS_EVENT_ERROR,
@@ -49,6 +49,6 @@ describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produc
             }
         });
 
-        expect(res).toBe(null);
+        expect(renderedFP).toBe(null);
     });
 });

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
@@ -20,7 +20,8 @@ describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produc
             modules: {
                 analytics: analyticsModule
             },
-            onError: () => {}
+            onError: () => {},
+            showSpinner: null
         });
 
         analyticsModule.createAnalyticsEvent = jest.fn(obj => {

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -10,19 +10,19 @@ import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DAT
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 
 export interface ThreeDS2DeviceFingerprintProps {
-    dataKey: string;
-    token: string;
-    notificationURL: string;
-    onError: (error?: string | ErrorCodeObject) => void;
-    paymentData: string;
-    showSpinner: boolean;
-    type: string;
+    dataKey?: string;
+    token?: string;
+    notificationURL?: string;
+    onError?: (error?: string | ErrorCodeObject) => void;
+    paymentData?: string;
+    showSpinner?: boolean;
+    type?: string;
     useOriginalFlow?: boolean;
     loadingContext?: string;
     clientKey?: string;
     elementRef?: UIElement;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
-    analytics?: AnalyticsModule;
+    modules?: { analytics: AnalyticsModule };
 }
 
 class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps> {
@@ -30,14 +30,12 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
 
     public static defaultProps = {
         dataKey: 'fingerprintResult',
-        // type: 'IdentifyShopper'
         type: THREEDS2_FINGERPRINT
     };
 
     private callSubmit3DS2Fingerprint = callSubmit3DS2Fingerprint.bind(this); // New 3DS2 flow
 
     protected submitAnalytics = (aObj: SendAnalyticsObject) => {
-        console.log('### ThreeDS2DeviceFingerprint::submitAnalytics:: aObj', aObj);
         if (aObj.type === ANALYTICS_RENDERED_STR) return; // suppress the rendered event (it will have the same timestamp as the "threeDSMethodData sent" event)
 
         super.submitAnalytics(aObj);

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -15,7 +15,7 @@ export interface ThreeDS2DeviceFingerprintProps {
     notificationURL?: string;
     onError?: (error?: string | ErrorCodeObject) => void;
     paymentData?: string;
-    showSpinner?: boolean;
+    showSpinner: boolean;
     type?: string;
     useOriginalFlow?: boolean;
     loadingContext?: string;

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -5,9 +5,9 @@ import { ErrorCodeObject } from './components/utils';
 import callSubmit3DS2Fingerprint from './callSubmit3DS2Fingerprint';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { ActionHandledReturnObject, AnalyticsModule } from '../types';
-import { THREEDS2_FINGERPRINT_ERROR } from './config';
-import { ANALYTICS_EVENT_ERROR, ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
-import { ThreeDS2AnalyticsObject } from './types';
+import { THREEDS2_ERROR, THREEDS2_FINGERPRINT, THREEDS2_FINGERPRINT_ERROR } from './config';
+import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
+import { SendAnalyticsObject } from '../../core/Analytics/types';
 
 export interface ThreeDS2DeviceFingerprintProps {
     dataKey: string;
@@ -30,18 +30,15 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
 
     public static defaultProps = {
         dataKey: 'fingerprintResult',
-        type: 'IdentifyShopper'
+        // type: 'IdentifyShopper'
+        type: THREEDS2_FINGERPRINT
     };
 
     private callSubmit3DS2Fingerprint = callSubmit3DS2Fingerprint.bind(this); // New 3DS2 flow
 
-    protected submitAnalytics = (aObj: ThreeDS2AnalyticsObject) => {
-        // {
-        //     "event": "log",
-        //     "type": "threeDS2",
-        //     "message": "3DS2 fingerprint iframe loaded"
-        // }
-        this.props.analytics.createAnalyticsEvent({ event: aObj.event, data: { component: ThreeDS2DeviceFingerprint.type, ...aObj } });
+    protected submitAnalytics = (aObj: SendAnalyticsObject) => {
+        console.log('### ThreeDS2DeviceFingerprint::submitAnalytics:: aObj', aObj);
+        super.submitAnalytics(aObj);
     };
 
     onComplete(state) {
@@ -62,7 +59,7 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
 
             // TODO - check logs to see if this *ever* happens
             this.submitAnalytics({
-                event: ANALYTICS_EVENT_ERROR,
+                type: THREEDS2_ERROR,
                 code: ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA,
                 errorType: ANALYTICS_API_ERROR,
                 message: `${THREEDS2_FINGERPRINT_ERROR}: Missing 'paymentData' property from threeDS2 action`

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -6,7 +6,7 @@ import callSubmit3DS2Fingerprint from './callSubmit3DS2Fingerprint';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
 import { ActionHandledReturnObject, AnalyticsModule } from '../types';
 import { THREEDS2_ERROR, THREEDS2_FINGERPRINT, THREEDS2_FINGERPRINT_ERROR } from './config';
-import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
+import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA, ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 
 export interface ThreeDS2DeviceFingerprintProps {
@@ -38,6 +38,8 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
 
     protected submitAnalytics = (aObj: SendAnalyticsObject) => {
         console.log('### ThreeDS2DeviceFingerprint::submitAnalytics:: aObj', aObj);
+        if (aObj.type === ANALYTICS_RENDERED_STR) return; // suppress the rendered event (it will have the same timestamp as the "threeDSMethodData sent" event)
+
         super.submitAnalytics(aObj);
     };
 

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -4,7 +4,10 @@ import PrepareFingerprint from './components/DeviceFingerprint';
 import { ErrorCodeObject } from './components/utils';
 import callSubmit3DS2Fingerprint from './callSubmit3DS2Fingerprint';
 import { existy } from '../internal/SecuredFields/lib/utilities/commonUtils';
-import { ActionHandledReturnObject } from '../types';
+import { ActionHandledReturnObject, AnalyticsModule } from '../types';
+import { THREEDS2_FINGERPRINT_ERROR } from './config';
+import { ANALYTICS_EVENT_ERROR, ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA } from '../../core/Analytics/constants';
+import { ThreeDS2AnalyticsObject } from './types';
 
 export interface ThreeDS2DeviceFingerprintProps {
     dataKey: string;
@@ -19,6 +22,7 @@ export interface ThreeDS2DeviceFingerprintProps {
     clientKey?: string;
     elementRef?: UIElement;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
+    analytics?: AnalyticsModule;
 }
 
 class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps> {
@@ -30,6 +34,15 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
     };
 
     private callSubmit3DS2Fingerprint = callSubmit3DS2Fingerprint.bind(this); // New 3DS2 flow
+
+    protected submitAnalytics = (aObj: ThreeDS2AnalyticsObject) => {
+        // {
+        //     "event": "log",
+        //     "type": "threeDS2",
+        //     "message": "3DS2 fingerprint iframe loaded"
+        // }
+        this.props.analytics.createAnalyticsEvent({ event: aObj.event, data: { component: ThreeDS2DeviceFingerprint.type, ...aObj } });
+    };
 
     onComplete(state) {
         super.onComplete(state);
@@ -46,6 +59,15 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
                 errorCode: ThreeDS2DeviceFingerprint.defaultProps.dataKey,
                 message: 'No paymentData received. Fingerprinting cannot proceed'
             });
+
+            // TODO - check logs to see if this *ever* happens
+            this.submitAnalytics({
+                event: ANALYTICS_EVENT_ERROR,
+                code: ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA,
+                errorType: ANALYTICS_API_ERROR,
+                message: `${THREEDS2_FINGERPRINT_ERROR}: Missing 'paymentData' property from threeDS2 action`
+            });
+
             return null;
         }
 
@@ -54,7 +76,13 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintProps
          * It means the call to create this component came from the old 'threeDS2Fingerprint' action and upon completion should call the /details endpoint
          * instead of the new /submitThreeDS2Fingerprint endpoint
          */
-        return <PrepareFingerprint {...this.props} onComplete={this.props.useOriginalFlow ? this.onComplete : this.callSubmit3DS2Fingerprint} />;
+        return (
+            <PrepareFingerprint
+                {...this.props}
+                onComplete={this.props.useOriginalFlow ? this.onComplete : this.callSubmit3DS2Fingerprint}
+                onSubmitAnalytics={this.submitAnalytics}
+            />
+        );
     }
 }
 

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -24,12 +24,16 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
          */
         const jsonStr = JSON.stringify(this.props.cReqData);
         const base64URLencodedData = encodeBase64URL(jsonStr);
-        this.state = { base64URLencodedData };
+        this.state = { base64URLencodedData, status: 'init' };
     }
 
     private iframeCallback = () => {
         this.setState({ status: 'iframeLoaded' });
-        this.props.onActionHandled({ componentType: '3DS2Challenge', actionDescription: 'challenge-iframe-loaded' });
+        // On Test - actually calls-back 3 times: once for challenge screen, once again as challenge.html reloads after the challenge is submitted, and once for redirect to threeDSNotificationURL.
+        // But for the purposes of calling the merchant defined onActionHandled callback - we only want to do it once
+        if (this.state.status === 'init') {
+            this.props.onActionHandled({ componentType: '3DS2Challenge', actionDescription: 'challenge-iframe-loaded' });
+        }
     };
 
     private get3DS2ChallengePromise(): Promise<any> {
@@ -64,7 +68,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
         window.removeEventListener('message', this.processMessageHandler);
     }
 
-    render({ acsURL, cReqData, iframeSizeArr }, { base64URLencodedData, status }) {
+    render({ acsURL, cReqData, iframeSizeArr, onFormSubmit }, { base64URLencodedData, status }) {
         const [width, height] = iframeSizeArr;
 
         return (
@@ -77,7 +81,14 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
                 {status !== 'iframeLoaded' && <Spinner />}
 
                 <Iframe name={iframeName} width={width} height={height} callback={this.iframeCallback} />
-                <ThreeDS2Form name={'cReqForm'} action={acsURL} target={iframeName} inputName={'creq'} inputValue={base64URLencodedData} />
+                <ThreeDS2Form
+                    name={'cReqForm'}
+                    action={acsURL}
+                    target={iframeName}
+                    inputName={'creq'}
+                    inputValue={base64URLencodedData}
+                    onFormSubmit={onFormSubmit}
+                />
             </div>
         );
     }

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -2,15 +2,15 @@ import { Component, h } from 'preact';
 import DoChallenge3DS2 from './DoChallenge3DS2';
 import { createChallengeResolveData, handleErrorCode, prepareChallengeData, createOldChallengeResolveData } from '../utils';
 import { PrepareChallenge3DS2Props, PrepareChallenge3DS2State } from './types';
-import { ChallengeData, ThreeDS2AnalyticsObject, ThreeDS2FlowObject } from '../../types';
+import { ChallengeData, ThreeDS2FlowObject } from '../../types';
 import '../../ThreeDS2.scss';
 import Img from '../../../internal/Img';
 import './challenge.scss';
 import { hasOwnProperty } from '../../../../utils/hasOwnProperty';
 import useImage from '../../../../core/Context/useImage';
 import { ActionHandledReturnObject } from '../../../types';
-import { ANALYTICS_EVENT_LOG } from '../../../../core/Analytics/constants';
 import { THREEDS2_FULL } from '../../config';
+import { SendAnalyticsObject } from '../../../../core/Analytics/types';
 
 class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareChallenge3DS2State> {
     public static defaultProps = {
@@ -56,23 +56,22 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
         }
     }
 
-    public submitAnalytics = (what: ThreeDS2AnalyticsObject) => {
-        console.log('### PrepareChallenge3DS2::submitAnalytics:: what=', what);
+    public submitAnalytics = (what: SendAnalyticsObject) => {
+        console.log('\n### PrepareChallenge3DS2::submitAnalytics:: what=', what);
         this.props.onSubmitAnalytics(what);
     };
 
     public onActionHandled = (rtnObj: ActionHandledReturnObject) => {
-        this.submitAnalytics({ event: ANALYTICS_EVENT_LOG, type: THREEDS2_FULL, message: rtnObj.actionDescription });
+        this.submitAnalytics({ type: THREEDS2_FULL, message: rtnObj.actionDescription });
 
         this.props.onActionHandled(rtnObj);
     };
 
     public onFormSubmit = (msg: string) => {
         this.submitAnalytics({
-            event: ANALYTICS_EVENT_LOG,
             type: THREEDS2_FULL,
             message: msg
-        } as ThreeDS2AnalyticsObject);
+        });
     };
 
     setStatusComplete(resultObj) {

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -56,19 +56,14 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
         }
     }
 
-    public submitAnalytics = (what: SendAnalyticsObject) => {
-        console.log('\n### PrepareChallenge3DS2::submitAnalytics:: what=', what);
-        this.props.onSubmitAnalytics(what);
-    };
-
     public onActionHandled = (rtnObj: ActionHandledReturnObject) => {
-        this.submitAnalytics({ type: THREEDS2_FULL, message: rtnObj.actionDescription });
+        this.props.onSubmitAnalytics({ type: THREEDS2_FULL, message: rtnObj.actionDescription });
 
         this.props.onActionHandled(rtnObj);
     };
 
     public onFormSubmit = (msg: string) => {
-        this.submitAnalytics({
+        this.props.onSubmitAnalytics({
             type: THREEDS2_FULL,
             message: msg
         });

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -2,12 +2,15 @@ import { Component, h } from 'preact';
 import DoChallenge3DS2 from './DoChallenge3DS2';
 import { createChallengeResolveData, handleErrorCode, prepareChallengeData, createOldChallengeResolveData } from '../utils';
 import { PrepareChallenge3DS2Props, PrepareChallenge3DS2State } from './types';
-import { ChallengeData, ThreeDS2FlowObject } from '../../types';
+import { ChallengeData, ThreeDS2AnalyticsObject, ThreeDS2FlowObject } from '../../types';
 import '../../ThreeDS2.scss';
 import Img from '../../../internal/Img';
 import './challenge.scss';
 import { hasOwnProperty } from '../../../../utils/hasOwnProperty';
 import useImage from '../../../../core/Context/useImage';
+import { ActionHandledReturnObject } from '../../../types';
+import { ANALYTICS_EVENT_LOG } from '../../../../core/Analytics/constants';
+import { THREEDS2_FULL } from '../../config';
 
 class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareChallenge3DS2State> {
     public static defaultProps = {
@@ -53,6 +56,25 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
         }
     }
 
+    public submitAnalytics = (what: ThreeDS2AnalyticsObject) => {
+        console.log('### PrepareChallenge3DS2::submitAnalytics:: what=', what);
+        this.props.onSubmitAnalytics(what);
+    };
+
+    public onActionHandled = (rtnObj: ActionHandledReturnObject) => {
+        this.submitAnalytics({ event: ANALYTICS_EVENT_LOG, type: THREEDS2_FULL, message: rtnObj.actionDescription });
+
+        this.props.onActionHandled(rtnObj);
+    };
+
+    public onFormSubmit = (msg: string) => {
+        this.submitAnalytics({
+            event: ANALYTICS_EVENT_LOG,
+            type: THREEDS2_FULL,
+            message: msg
+        } as ThreeDS2AnalyticsObject);
+    };
+
     setStatusComplete(resultObj) {
         this.setState({ status: 'complete' }, () => {
             /**
@@ -72,7 +94,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
         this.props.onError(errorInfoObj); // For some reason this doesn't fire if it's in a callback passed to the setState function
     }
 
-    render({ onActionHandled }, { challengeData }) {
+    render(_, { challengeData }) {
         const getImage = useImage();
         if (this.state.status === 'retrievingChallengeToken') {
             return (
@@ -99,7 +121,8 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                         }
                     }}
                     {...challengeData}
-                    onActionHandled={onActionHandled}
+                    onActionHandled={this.onActionHandled}
+                    onFormSubmit={this.onFormSubmit}
                 />
             );
         }

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -9,7 +9,7 @@ import './challenge.scss';
 import { hasOwnProperty } from '../../../../utils/hasOwnProperty';
 import useImage from '../../../../core/Context/useImage';
 import { ActionHandledReturnObject } from '../../../types';
-import { THREEDS2_FULL } from '../../config';
+import { THREEDS2_FULL, THREEDS2_NUM } from '../../config';
 import { SendAnalyticsObject } from '../../../../core/Analytics/types';
 
 class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareChallenge3DS2State> {
@@ -78,6 +78,16 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
              */
             const resolveDataFunction = this.props.useOriginalFlow ? createOldChallengeResolveData : createChallengeResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj.transStatus, this.props.paymentData);
+
+            // Create log object - the process is completed, one way or another
+            const analyticsObject: SendAnalyticsObject = {
+                type: THREEDS2_FULL,
+                message: `${THREEDS2_NUM} challenge has completed`,
+                metadata: { ...resultObj }
+            };
+
+            // Send log to analytics endpoint
+            this.props.onSubmitAnalytics(analyticsObject);
 
             this.props.onComplete(data); // (equals onAdditionalDetails - except for 3DS2InMDFlow)
         });

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
@@ -2,11 +2,13 @@ import { ChallengeData, ThreeDS2FlowObject } from '../../types';
 import { ChallengeResolveData } from '../utils';
 import { ThreeDS2ChallengeProps } from '../../ThreeDS2Challenge';
 import { ActionHandledReturnObject } from '../../../types';
+import { SendAnalyticsObject } from '../../../../core/Analytics/types';
 
 export interface DoChallenge3DS2Props extends ChallengeData {
     onCompleteChallenge: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorChallenge: (rejectObject: ThreeDS2FlowObject) => void;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
+    onFormSubmit: (msg: string) => void;
 }
 
 export interface DoChallenge3DS2State {
@@ -16,7 +18,7 @@ export interface DoChallenge3DS2State {
 
 export interface PrepareChallenge3DS2Props extends ThreeDS2ChallengeProps {
     onComplete?: (data: ChallengeResolveData) => void;
-    onSubmitAnalytics: (w) => void;
+    onSubmitAnalytics: (aObj: SendAnalyticsObject) => void;
 }
 
 export interface PrepareChallenge3DS2State {

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
@@ -7,6 +7,7 @@ export interface DoChallenge3DS2Props extends ChallengeData {
     onCompleteChallenge: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorChallenge: (rejectObject: ThreeDS2FlowObject) => void;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
+    onFormSubmit: (w) => void;
 }
 
 export interface DoChallenge3DS2State {
@@ -16,6 +17,7 @@ export interface DoChallenge3DS2State {
 
 export interface PrepareChallenge3DS2Props extends ThreeDS2ChallengeProps {
     onComplete?: (data: ChallengeResolveData) => void;
+    onSubmitAnalytics: (w) => void;
 }
 
 export interface PrepareChallenge3DS2State {

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
@@ -7,7 +7,6 @@ export interface DoChallenge3DS2Props extends ChallengeData {
     onCompleteChallenge: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorChallenge: (rejectObject: ThreeDS2FlowObject) => void;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
-    onFormSubmit: (w) => void;
 }
 
 export interface DoChallenge3DS2State {

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -4,7 +4,7 @@ import Spinner from '../../../internal/Spinner';
 import ThreeDS2Form from '../Form';
 import promiseTimeout from '../../../../utils/promiseTimeout';
 import getProcessMessageHandler from '../../../../utils/get-process-message-handler';
-import { THREEDS_METHOD_TIMEOUT, FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT } from '../../config';
+import { THREEDS_METHOD_TIMEOUT, FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT, THREEDS2_NUM } from '../../config';
 import { encodeBase64URL } from '../utils';
 import { DoFingerprint3DS2Props, DoFingerprint3DS2State } from './types';
 
@@ -73,7 +73,7 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
         window.removeEventListener('message', this.processMessageHandler);
     }
 
-    render({ threeDSMethodURL, onActionHandled }, { base64URLencodedData }) {
+    render({ threeDSMethodURL, onActionHandled, onFormSubmit }, { base64URLencodedData }) {
         return (
             <div className="adyen-checkout__3ds2-device-fingerprint">
                 {this.props.showSpinner && <Spinner />}
@@ -81,7 +81,8 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
                     <Iframe
                         name={iframeName}
                         callback={() => {
-                            onActionHandled({ componentType: '3DS2Fingerprint', actionDescription: 'fingerprint-iframe-loaded' });
+                            console.log('### DoFingerprint3DS2:::: iframe callback');
+                            onActionHandled({ componentType: '3DS2Fingerprint', actionDescription: `${THREEDS2_NUM} fingerprint iframe loaded` });
                         }}
                     />
                     <ThreeDS2Form
@@ -90,6 +91,7 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
                         target={iframeName}
                         inputName={'threeDSMethodData'}
                         inputValue={base64URLencodedData}
+                        onFormSubmit={onFormSubmit}
                     />
                 </div>
             </div>

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -81,7 +81,6 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
                     <Iframe
                         name={iframeName}
                         callback={() => {
-                            console.log('### DoFingerprint3DS2:::: iframe callback');
                             onActionHandled({ componentType: '3DS2Fingerprint', actionDescription: `${THREEDS2_NUM} fingerprint iframe loaded` });
                         }}
                     />

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.test.tsx
@@ -40,7 +40,7 @@ describe('ThreeDS2DeviceFingerprint', () => {
 
         HTMLFormElement.prototype.submit = jest.fn().mockImplementation(() => formResult);
 
-        mount(<PrepareFingerprint3DS2 {...propsMock} onError={errorFunction} onComplete={completeFunction} />);
+        mount(<PrepareFingerprint3DS2 {...propsMock} onError={errorFunction} onComplete={completeFunction} onSubmitAnalytics={() => {}} />);
         expect(errorFunction.mock.calls.length).toBe(0);
     });
 });

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -4,7 +4,7 @@ import { createFingerprintResolveData, createOldFingerprintResolveData, handleEr
 import { PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State } from './types';
 import { FingerPrintData, ResultObject } from '../../types';
 import { ActionHandledReturnObject } from '../../../types';
-import { THREEDS2_FULL } from '../../config';
+import { THREEDS2_FULL, THREEDS2_NUM } from '../../config';
 import { SendAnalyticsObject } from '../../../../core/Analytics/types';
 
 class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State> {
@@ -75,6 +75,16 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
              */
             const resolveDataFunction = this.props.useOriginalFlow ? createOldFingerprintResolveData : createFingerprintResolveData;
             const data = resolveDataFunction(this.props.dataKey, resultObj, this.props.paymentData);
+
+            /** The fingerprint process is completed, one way or another */
+            const analyticsObject: SendAnalyticsObject = {
+                type: THREEDS2_FULL,
+                message: `${THREEDS2_NUM} fingerprinting has completed`,
+                metadata: { ...resultObj }
+            };
+
+            // Send log to analytics endpoint
+            this.props.onSubmitAnalytics(analyticsObject);
 
             /**
              * For 'threeDS2' action = call to callSubmit3DS2Fingerprint

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -2,10 +2,10 @@ import { Component, h } from 'preact';
 import DoFingerprint3DS2 from './DoFingerprint3DS2';
 import { createFingerprintResolveData, createOldFingerprintResolveData, handleErrorCode, prepareFingerPrintData } from '../utils';
 import { PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State } from './types';
-import { FingerPrintData, ResultObject, ThreeDS2AnalyticsObject } from '../../types';
+import { FingerPrintData, ResultObject } from '../../types';
 import { ActionHandledReturnObject } from '../../../types';
-import { ANALYTICS_EVENT_LOG } from '../../../../core/Analytics/constants';
 import { THREEDS2_FULL } from '../../config';
+import { SendAnalyticsObject } from '../../../../core/Analytics/types';
 
 class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State> {
     public static type = 'scheme';
@@ -41,23 +41,22 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
         }
     }
 
-    public submitAnalytics = (what: ThreeDS2AnalyticsObject) => {
-        console.log('### PrepareFingerprint3DS2::submitAnalytics:: what', what);
+    public submitAnalytics = (what: SendAnalyticsObject) => {
+        console.log('\n### PrepareFingerprint3DS2::submitAnalytics:: what', what);
         this.props.onSubmitAnalytics(what);
     };
 
     public onActionHandled = (rtnObj: ActionHandledReturnObject) => {
         // Leads to an "iframe loaded" log action
-        this.submitAnalytics({ event: ANALYTICS_EVENT_LOG, type: THREEDS2_FULL, message: rtnObj.actionDescription });
+        this.submitAnalytics({ type: THREEDS2_FULL, message: rtnObj.actionDescription });
         this.props.onActionHandled(rtnObj);
     };
 
     public onFormSubmit = (msg: string) => {
         this.submitAnalytics({
-            event: ANALYTICS_EVENT_LOG,
             type: THREEDS2_FULL,
             message: msg
-        } as ThreeDS2AnalyticsObject);
+        });
     };
 
     componentDidMount() {

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -41,19 +41,14 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
         }
     }
 
-    public submitAnalytics = (what: SendAnalyticsObject) => {
-        console.log('\n### PrepareFingerprint3DS2::submitAnalytics:: what', what);
-        this.props.onSubmitAnalytics(what);
-    };
-
     public onActionHandled = (rtnObj: ActionHandledReturnObject) => {
         // Leads to an "iframe loaded" log action
-        this.submitAnalytics({ type: THREEDS2_FULL, message: rtnObj.actionDescription });
+        this.props.onSubmitAnalytics({ type: THREEDS2_FULL, message: rtnObj.actionDescription });
         this.props.onActionHandled(rtnObj);
     };
 
     public onFormSubmit = (msg: string) => {
-        this.submitAnalytics({
+        this.props.onSubmitAnalytics({
             type: THREEDS2_FULL,
             message: msg
         });

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
@@ -8,6 +8,7 @@ export interface DoFingerprint3DS2Props extends FingerPrintData {
     onErrorFingerprint: (rejectObject: ThreeDS2FlowObject) => void;
     showSpinner: boolean;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
+    onFormSubmit: (w) => void;
 }
 
 export interface DoFingerprint3DS2State {
@@ -16,6 +17,7 @@ export interface DoFingerprint3DS2State {
 
 export interface PrepareFingerprint3DS2Props extends ThreeDS2DeviceFingerprintProps {
     onComplete: (data: FingerprintResolveData) => void;
+    onSubmitAnalytics: (w) => void;
 }
 
 export interface PrepareFingerprint3DS2State {

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
@@ -8,7 +8,6 @@ export interface DoFingerprint3DS2Props extends FingerPrintData {
     onErrorFingerprint: (rejectObject: ThreeDS2FlowObject) => void;
     showSpinner: boolean;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
-    onFormSubmit: (w) => void;
 }
 
 export interface DoFingerprint3DS2State {

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/types.ts
@@ -2,12 +2,14 @@ import { ThreeDS2FlowObject, FingerPrintData } from '../../types';
 import { ThreeDS2DeviceFingerprintProps } from '../../ThreeDS2DeviceFingerprint';
 import { FingerprintResolveData } from '../utils';
 import { ActionHandledReturnObject } from '../../../types';
+import { SendAnalyticsObject } from '../../../../core/Analytics/types';
 
 export interface DoFingerprint3DS2Props extends FingerPrintData {
     onCompleteFingerprint: (resolveObject: ThreeDS2FlowObject) => void;
     onErrorFingerprint: (rejectObject: ThreeDS2FlowObject) => void;
     showSpinner: boolean;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
+    onFormSubmit: (msg: string) => void;
 }
 
 export interface DoFingerprint3DS2State {
@@ -16,7 +18,7 @@ export interface DoFingerprint3DS2State {
 
 export interface PrepareFingerprint3DS2Props extends ThreeDS2DeviceFingerprintProps {
     onComplete: (data: FingerprintResolveData) => void;
-    onSubmitAnalytics: (w) => void;
+    onSubmitAnalytics: (aObj: SendAnalyticsObject) => void;
 }
 
 export interface PrepareFingerprint3DS2State {

--- a/packages/lib/src/components/ThreeDS2/components/Form/ThreeDS2Form.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Form/ThreeDS2Form.test.tsx
@@ -16,7 +16,7 @@ const propsMock = {
 let wrapper;
 
 beforeEach(() => {
-    wrapper = shallow(<ThreeDS2Form {...propsMock} />);
+    wrapper = shallow(<ThreeDS2Form {...propsMock} onFormSubmit={() => {}} />);
 });
 
 describe('<ThreeDS2Form /> rendering', () => {

--- a/packages/lib/src/components/ThreeDS2/components/Form/ThreeDS2Form.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Form/ThreeDS2Form.tsx
@@ -7,6 +7,7 @@ interface ThreeDS2FormProps {
     target: string;
     inputName: string;
     inputValue: string;
+    onFormSubmit: (w) => void;
 }
 
 export default class ThreeDS2Form extends Component<ThreeDS2FormProps> {
@@ -14,6 +15,7 @@ export default class ThreeDS2Form extends Component<ThreeDS2FormProps> {
 
     componentDidMount() {
         this.formEl.submit();
+        this.props.onFormSubmit(`${this.props.inputName} sent`);
     }
 
     render({ name, action, target, inputName, inputValue }) {

--- a/packages/lib/src/components/ThreeDS2/components/Form/ThreeDS2Form.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Form/ThreeDS2Form.tsx
@@ -7,7 +7,7 @@ interface ThreeDS2FormProps {
     target: string;
     inputName: string;
     inputValue: string;
-    onFormSubmit: (w) => void;
+    onFormSubmit: (msg: string) => void;
 }
 
 export default class ThreeDS2Form extends Component<ThreeDS2FormProps> {

--- a/packages/lib/src/components/ThreeDS2/config.ts
+++ b/packages/lib/src/components/ThreeDS2/config.ts
@@ -1,11 +1,12 @@
 import { ThreeDS2FlowObject } from './types';
 
-export const THREEDS2_FINGERPRINT = '3DS2Fingerprint';
+export const THREEDS2_FINGERPRINT = 'threeDS2Fingerprint';
 export const THREEDS2_FINGERPRINT_ERROR = '3DS2Fingerprint_Error';
 export const THREEDS2_FINGERPRINT_SUBMIT = 'callSubmit3DS2Fingerprint_Response';
-export const THREEDS2_CHALLENGE = '3DS2Challenge';
+export const THREEDS2_CHALLENGE = 'threeDS2Challenge';
 export const THREEDS2_CHALLENGE_ERROR = '3DS2Challenge_Error';
 
+export const THREEDS2_ERROR = 'threeDS2Error';
 export const THREEDS2_FULL = 'threeDS2';
 export const THREEDS2_NUM = '3DS2';
 

--- a/packages/lib/src/components/ThreeDS2/config.ts
+++ b/packages/lib/src/components/ThreeDS2/config.ts
@@ -1,5 +1,16 @@
 import { ThreeDS2FlowObject } from './types';
 
+export const THREEDS2_FINGERPRINT = '3DS2Fingerprint';
+export const THREEDS2_FINGERPRINT_ERROR = '3DS2Fingerprint_Error';
+export const THREEDS2_FINGERPRINT_SUBMIT = 'callSubmit3DS2Fingerprint_Response';
+export const THREEDS2_CHALLENGE = '3DS2Challenge';
+export const THREEDS2_CHALLENGE_ERROR = '3DS2Challenge_Error';
+
+export const THREEDS2_FULL = 'threeDS2';
+export const THREEDS2_NUM = '3DS2';
+
+export const MISSING_TOKEN_IN_ACTION_MSG = 'Missing "token" property from threeDS2 action';
+
 export const DEFAULT_CHALLENGE_WINDOW_SIZE = '02';
 
 export const THREEDS_METHOD_TIMEOUT = 10000;

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -1,5 +1,3 @@
-import { ANALYTICS_EVENT, AnalyticsObject } from '../../core/Analytics/types';
-
 /**
  * See
  * https://docs.adyen.com/checkout/3d-secure/api-reference#threeds2result
@@ -80,8 +78,4 @@ type CheckoutThreeDS2Action = {
     token: string;
     subtype: string;
     authorisationToken: string;
-};
-
-export type ThreeDS2AnalyticsObject = Pick<AnalyticsObject, 'code' | 'errorType' | 'message' | 'type' | 'metadata'> & {
-    event: ANALYTICS_EVENT;
 };

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -18,6 +18,7 @@ export interface ChallengeData {
     cReqData: CReqData;
     iframeSizeArr: string[];
     postMessageDomain: string;
+    onFormSubmit: (msg: string) => void;
 }
 
 export interface ResultObject {
@@ -58,6 +59,7 @@ export interface FingerPrintData {
     threeDSMethodURL: string;
     threeDSMethodNotificationURL: string;
     postMessageDomain: string;
+    onFormSubmit: (msg: string) => void;
 }
 
 export type ThreeDS2FingerprintResponse = {

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -1,3 +1,5 @@
+import { ANALYTICS_EVENT, AnalyticsObject } from '../../core/Analytics/types';
+
 /**
  * See
  * https://docs.adyen.com/checkout/3d-secure/api-reference#threeds2result
@@ -78,4 +80,8 @@ type CheckoutThreeDS2Action = {
     token: string;
     subtype: string;
     authorisationToken: string;
+};
+
+export type ThreeDS2AnalyticsObject = Pick<AnalyticsObject, 'code' | 'errorType' | 'message' | 'type' | 'metadata'> & {
+    event: ANALYTICS_EVENT;
 };

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -59,7 +59,7 @@ export interface FingerPrintData {
     threeDSMethodURL: string;
     threeDSMethodNotificationURL: string;
     postMessageDomain: string;
-    onFormSubmit: (msg: string) => void;
+    onFormSubmit?: (msg: string) => void;
 }
 
 export type ThreeDS2FingerprintResponse = {

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -18,7 +18,6 @@ export interface ChallengeData {
     cReqData: CReqData;
     iframeSizeArr: string[];
     postMessageDomain: string;
-    onFormSubmit: (msg: string) => void;
 }
 
 export interface ResultObject {
@@ -59,7 +58,6 @@ export interface FingerPrintData {
     threeDSMethodURL: string;
     threeDSMethodNotificationURL: string;
     postMessageDomain: string;
-    onFormSubmit?: (msg: string) => void;
 }
 
 export type ThreeDS2FingerprintResponse = {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -11,7 +11,7 @@ import { hasOwnProperty } from '../utils/hasOwnProperty';
 import DropinElement from './Dropin';
 import { CoreOptions } from '../core/types';
 import Core from '../core';
-import { ANALYTICS_CONFIGURED_STR, ANALYTICS_RENDERED_STR, ANALYTICS_SUBMIT_STR } from '../core/Analytics/constants';
+import { ANALYTICS_SUBMIT_STR } from '../core/Analytics/constants';
 import { AnalyticsInitialEvent, SendAnalyticsObject } from '../core/Analytics/types';
 
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
@@ -74,18 +74,6 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         let component = this.constructor['analyticsType'];
         if (!component) {
             component = this.constructor['type'] === 'scheme' || this.constructor['type'] === 'bcmc' ? this.constructor['type'] : this.props.type;
-        }
-
-        const { type } = analyticsObj;
-
-        if (type === ANALYTICS_RENDERED_STR || type === ANALYTICS_CONFIGURED_STR) {
-            // Check if it's a storedCard
-            if (component === 'scheme') {
-                if (hasOwnProperty(this.props, 'supportedShopperInteractions')) {
-                    analyticsObj.isStoredPaymentMethod = true;
-                    analyticsObj.brand = this.props.brand;
-                }
-            }
         }
 
         this.props.modules?.analytics.sendAnalytics(component, analyticsObj);

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -11,7 +11,7 @@ import { hasOwnProperty } from '../utils/hasOwnProperty';
 import DropinElement from './Dropin';
 import { CoreOptions } from '../core/types';
 import Core from '../core';
-import { ANALYTICS_RENDERED_STR, ANALYTICS_SUBMIT_STR } from '../core/Analytics/constants';
+import { ANALYTICS_CONFIGURED_STR, ANALYTICS_RENDERED_STR, ANALYTICS_SUBMIT_STR } from '../core/Analytics/constants';
 import { AnalyticsInitialEvent, SendAnalyticsObject } from '../core/Analytics/types';
 
 export class UIElement<P extends UIElementProps = any> extends BaseElement<P> implements IUIElement {
@@ -78,8 +78,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
 
         const { type } = analyticsObj;
 
-        // let storedCardIndicator;
-        if (type === ANALYTICS_RENDERED_STR) {
+        if (type === ANALYTICS_RENDERED_STR || type === ANALYTICS_CONFIGURED_STR) {
             // Check if it's a storedCard
             if (component === 'scheme') {
                 if (hasOwnProperty(this.props, 'supportedShopperInteractions')) {

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -226,6 +226,7 @@ export function setupSecuredField(pItem: HTMLElement, cvcPolicy?: CVCPolicyType,
                 // One of our existing securedFields has just loaded new content!
                 if (this.state.iframeCount > this.state.numIframes) {
                     this.destroySecuredFields();
+                    // TODO send analytics about this error
                     throw new AdyenCheckoutError(
                         'ERROR',
                         `One or more securedFields has just loaded new content. This should never happen. securedFields have been removed.

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -7,7 +7,8 @@ import {
     DATA_INFO,
     DATA_UID,
     SF_CONFIG_TIMEOUT,
-    ALL_SECURED_FIELDS
+    ALL_SECURED_FIELDS,
+    ENCRYPTED_EXPIRY_MONTH
 } from '../../configuration/constants';
 import { existy } from '../../utilities/commonUtils';
 import cardType from '../utils/cardType';
@@ -26,6 +27,11 @@ export function createSecuredFields(): number {
     // Detect DOM elements that qualify as securedField holders & filter them for valid types
     const securedFields: HTMLElement[] = select(this.props.rootNode, `[${this.encryptedAttrName}]`).filter(field => {
         const fieldType: string = getAttribute(field, this.encryptedAttrName);
+
+        if (fieldType === ENCRYPTED_EXPIRY_MONTH) {
+            // TODO send analytics about separate date fields
+        }
+
         const isValidType = ALL_SECURED_FIELDS.includes(fieldType);
         if (!isValidType) {
             console.warn(

--- a/packages/lib/src/components/internal/SecuredFields/utils.ts
+++ b/packages/lib/src/components/internal/SecuredFields/utils.ts
@@ -9,10 +9,14 @@ import {
     ENCRYPTED_SECURITY_CODE_3_DIGITS,
     ENCRYPTED_SECURITY_CODE_4_DIGITS,
     ENCRYPTED_BANK_ACCNT_NUMBER_FIELD,
-    ENCRYPTED_BANK_LOCATION_FIELD
+    ENCRYPTED_BANK_LOCATION_FIELD,
+    ALL_SECURED_FIELDS,
+    ENCRYPTED
 } from './lib/configuration/constants';
 import { SFPlaceholdersObject } from './lib/securedField/AbstractSecuredField';
 import { Resources } from '../../../core/Context/Resources';
+import { camelCaseToSnakeCase } from '../../../utils/textUtils';
+import { isArray } from './lib/utilities/commonUtils';
 
 /**
  * Lookup translated values for the placeholders for the SecuredFields
@@ -58,24 +62,20 @@ export const getCardImageUrl = (brand, resources: Resources) => {
     return resources.getImage(imageOptions)(type);
 };
 
-// REGULAR "UTIL" UTILS
 /**
- * Checks if `prop` is classified as an `Array` primitive or object.
- * @internal
- * @param prop - The value to check.
- * @returns Returns `true` if `prop` is correctly classified, else `false`.
- * @example
- * ```
- * isArray([1, 2, 3]);
- * // => true
- *
- * isArray(1);
- * // => false
- * ```
+ * Used by Card.tsx & SecuredFields.tsx
+ * @param fieldType -
  */
-export function isArray(prop) {
-    return typeof prop === 'object' && prop !== null && Object.prototype.toString.call(prop) === '[object Array]';
-}
+export const fieldTypeToSnakeCase = (fieldType: string) => {
+    let str = camelCaseToSnakeCase(fieldType);
+    // SFs need their fieldType mapped to what the endpoint expects
+    if (ALL_SECURED_FIELDS.includes(fieldType)) {
+        str = str.substring(ENCRYPTED.length + 1); // strip 'encrypted_' off the string
+    }
+    return str;
+};
+
+// REGULAR "UTIL" UTILS
 
 /**
  * 'Destructures' properties from object - returns a new object only containing those properties that were asked for (including if those properties

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -50,6 +50,8 @@ describe('Analytics initialisation and event queue', () => {
         expect(analytics.getCheckoutAttemptId).not.toBe(null);
         expect(analytics.getEnabled).not.toBe(null);
         expect(analytics.getEnabled()).toBe(true);
+        expect(analytics.createAnalyticsEvent).not.toBe(null);
+        expect(analytics.sendAnalytics).not.toBe(null);
         expect(collectIdPromiseMock).toHaveLength(0);
     });
 

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -1,24 +1,12 @@
 import LogEvent from '../Services/analytics/log-event';
 import CollectId from '../Services/analytics/collect-id';
 import EventsQueue, { EventsQueueModule } from './EventsQueue';
-import { ANALYTICS_EVENT, AnalyticsInitialEvent, AnalyticsObject, AnalyticsProps, CreateAnalyticsEventObject, SendAnalyticsObject } from './types';
-import {
-    ANALYTICS_EVENT_ERROR,
-    ANALYTICS_EVENT_INFO,
-    ANALYTICS_EVENT_LOG,
-    ANALYTICS_FOCUS_STR,
-    ANALYTICS_INFO_TIMER_INTERVAL,
-    ANALYTICS_PATH,
-    ANALYTICS_RENDERED_STR,
-    ANALYTICS_SELECTED_STR,
-    ANALYTICS_SUBMIT_STR,
-    ANALYTICS_UNFOCUS_STR,
-    ANALYTICS_VALIDATION_ERROR_STR
-} from './constants';
+import { ANALYTICS_EVENT, AnalyticsInitialEvent, AnalyticsObject, AnalyticsProps, CreateAnalyticsEventObject } from './types';
+import { ANALYTICS_EVENT_ERROR, ANALYTICS_EVENT_INFO, ANALYTICS_EVENT_LOG, ANALYTICS_INFO_TIMER_INTERVAL, ANALYTICS_PATH } from './constants';
 import { debounce } from '../../components/internal/Address/utils';
 import { AnalyticsModule } from '../../components/types';
 import { createAnalyticsObject } from './utils';
-import { THREEDS2_ERROR, THREEDS2_FULL } from '../../components/ThreeDS2/config';
+import { analyticsPreProcessor } from './analyticsPreProcessor';
 
 let capturedCheckoutAttemptId = null;
 let hasLoggedPixel = false;
@@ -124,80 +112,10 @@ const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analy
 
         getEnabled: () => props.enabled,
 
-        sendAnalytics: (component: string, analyticsObj: SendAnalyticsObject) => {
-            const { type, target } = analyticsObj;
-
-            switch (type) {
-                // Called from BaseElement (when component mounted) or, from DropinComponent (after mounting, when it has finished resolving all the PM promises)
-                // &/or, from DropinComponent when a PM is selected
-                case ANALYTICS_RENDERED_STR: {
-                    const { isStoredPaymentMethod, brand } = analyticsObj;
-                    const data = { component, type, isStoredPaymentMethod, brand };
-
-                    // AnalyticsAction: action: 'event' type:'rendered'|'selected'
-                    anlModule.createAnalyticsEvent({
-                        event: 'info',
-                        data
-                    });
-                    break;
-                }
-
-                case ANALYTICS_SUBMIT_STR:
-                    // PM pay button pressed - AnalyticsAction: action: 'log' type:'submit'
-                    anlModule.createAnalyticsEvent({
-                        event: 'log',
-                        data: { component, type, target: 'pay_button', message: 'Shopper clicked pay' }
-                    });
-                    break;
-
-                case ANALYTICS_FOCUS_STR:
-                case ANALYTICS_UNFOCUS_STR:
-                    anlModule.createAnalyticsEvent({
-                        event: 'info',
-                        data: { component, type, target }
-                    });
-                    break;
-
-                case ANALYTICS_VALIDATION_ERROR_STR: {
-                    const { validationErrorCode, validationErrorMessage } = analyticsObj;
-                    anlModule.createAnalyticsEvent({
-                        event: 'info',
-                        data: { component, type, target, validationErrorCode, validationErrorMessage }
-                    });
-                    break;
-                }
-
-                case ANALYTICS_SELECTED_STR:
-                    anlModule.createAnalyticsEvent({
-                        event: 'info',
-                        data: { component, type, target }
-                    });
-                    break;
-
-                case THREEDS2_FULL: {
-                    const { message } = analyticsObj;
-                    anlModule.createAnalyticsEvent({
-                        event: 'log',
-                        data: { component, type, message }
-                    });
-                    break;
-                }
-
-                case THREEDS2_ERROR: {
-                    const { message, code, errorType } = analyticsObj;
-                    anlModule.createAnalyticsEvent({
-                        event: 'error',
-                        data: { component, type, message, code, errorType }
-                    });
-                    break;
-                }
-
-                default: {
-                    anlModule.createAnalyticsEvent(analyticsObj as CreateAnalyticsEventObject);
-                }
-            }
-        }
+        sendAnalytics: null
     };
+
+    anlModule.sendAnalytics = analyticsPreProcessor(anlModule);
 
     return anlModule;
 };

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -18,6 +18,7 @@ import {
 import { debounce } from '../../components/internal/Address/utils';
 import { AnalyticsModule } from '../../components/types';
 import { createAnalyticsObject } from './utils';
+import { THREEDS2_ERROR, THREEDS2_FULL } from '../../components/ThreeDS2/config';
 
 let capturedCheckoutAttemptId = null;
 let hasLoggedPixel = false;
@@ -172,6 +173,24 @@ const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analy
                         data: { component, type, target }
                     });
                     break;
+
+                case THREEDS2_FULL: {
+                    const { message } = analyticsObj;
+                    anlModule.createAnalyticsEvent({
+                        event: 'log',
+                        data: { component, type, message }
+                    });
+                    break;
+                }
+
+                case THREEDS2_ERROR: {
+                    const { message, code, errorType } = analyticsObj;
+                    anlModule.createAnalyticsEvent({
+                        event: 'error',
+                        data: { component, type, message, code, errorType }
+                    });
+                    break;
+                }
 
                 default: {
                     anlModule.createAnalyticsEvent(analyticsObj as CreateAnalyticsEventObject);

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -69,6 +69,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                 break;
             }
 
+            // General 3DS2 log events: "action handled" (i.e. iframe loaded), data sent, process completed
             case THREEDS2_FULL: {
                 const { message, metadata } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -1,6 +1,7 @@
 import { AnalyticsModule } from '../../components/types';
 import { CreateAnalyticsEventObject, SendAnalyticsObject } from './types';
 import {
+    ANALYTICS_ACTION_STR,
     ANALYTICS_FOCUS_STR,
     ANALYTICS_RENDERED_STR,
     ANALYTICS_SELECTED_STR,
@@ -11,6 +12,7 @@ import {
 import { THREEDS2_ERROR, THREEDS2_FULL } from '../../components/ThreeDS2/config';
 
 export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
+    // return function with an analyticsModule reference
     return (component: string, analyticsObj: SendAnalyticsObject) => {
         const { type, target } = analyticsObj;
 
@@ -21,7 +23,6 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                 const { isStoredPaymentMethod, brand } = analyticsObj;
                 const data = { component, type, isStoredPaymentMethod, brand };
 
-                // AnalyticsAction: action: 'event' type:'rendered'|'selected'
                 analyticsModule.createAnalyticsEvent({
                     event: 'info',
                     data
@@ -30,12 +31,20 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             }
 
             case ANALYTICS_SUBMIT_STR:
-                // PM pay button pressed - AnalyticsAction: action: 'log' type:'submit'
                 analyticsModule.createAnalyticsEvent({
                     event: 'log',
                     data: { component, type, target: 'pay_button', message: 'Shopper clicked pay' }
                 });
                 break;
+
+            case ANALYTICS_ACTION_STR: {
+                const { subtype, message } = analyticsObj;
+                analyticsModule.createAnalyticsEvent({
+                    event: 'log',
+                    data: { component, type, subtype, message }
+                });
+                break;
+            }
 
             case ANALYTICS_FOCUS_STR:
             case ANALYTICS_UNFOCUS_STR:

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -2,6 +2,7 @@ import { AnalyticsModule } from '../../components/types';
 import { CreateAnalyticsEventObject, SendAnalyticsObject } from './types';
 import {
     ANALYTICS_ACTION_STR,
+    ANALYTICS_CONFIGURED_STR,
     ANALYTICS_FOCUS_STR,
     ANALYTICS_RENDERED_STR,
     ANALYTICS_SELECTED_STR,
@@ -45,6 +46,13 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                 });
                 break;
             }
+
+            case ANALYTICS_CONFIGURED_STR:
+                analyticsModule.createAnalyticsEvent({
+                    event: 'info',
+                    data: { component, type }
+                });
+                break;
 
             case ANALYTICS_FOCUS_STR:
             case ANALYTICS_UNFOCUS_STR:

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -3,6 +3,9 @@ import { CreateAnalyticsEventObject, SendAnalyticsObject } from './types';
 import {
     ANALYTICS_ACTION_STR,
     ANALYTICS_CONFIGURED_STR,
+    ANALYTICS_EVENT_ERROR,
+    ANALYTICS_EVENT_INFO,
+    ANALYTICS_EVENT_LOG,
     ANALYTICS_FOCUS_STR,
     ANALYTICS_RENDERED_STR,
     ANALYTICS_SELECTED_STR,
@@ -20,12 +23,13 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
         switch (type) {
             // Called from BaseElement (when component mounted) or, from DropinComponent (after mounting, when it has finished resolving all the PM promises)
             // &/or, from DropinComponent when a PM is selected
-            case ANALYTICS_RENDERED_STR: {
+            case ANALYTICS_RENDERED_STR:
+            case ANALYTICS_CONFIGURED_STR: {
                 const { isStoredPaymentMethod, brand } = analyticsObj;
                 const data = { component, type, isStoredPaymentMethod, brand };
 
                 analyticsModule.createAnalyticsEvent({
-                    event: 'info',
+                    event: ANALYTICS_EVENT_INFO,
                     data
                 });
                 break;
@@ -33,7 +37,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
 
             case ANALYTICS_SUBMIT_STR:
                 analyticsModule.createAnalyticsEvent({
-                    event: 'log',
+                    event: ANALYTICS_EVENT_LOG,
                     data: { component, type, target: 'pay_button', message: 'Shopper clicked pay' }
                 });
                 break;
@@ -41,23 +45,17 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case ANALYTICS_ACTION_STR: {
                 const { subtype, message } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: 'log',
+                    event: ANALYTICS_EVENT_LOG,
                     data: { component, type, subtype, message }
                 });
                 break;
             }
 
-            case ANALYTICS_CONFIGURED_STR:
-                analyticsModule.createAnalyticsEvent({
-                    event: 'info',
-                    data: { component, type }
-                });
-                break;
-
             case ANALYTICS_FOCUS_STR:
             case ANALYTICS_UNFOCUS_STR:
+            case ANALYTICS_SELECTED_STR:
                 analyticsModule.createAnalyticsEvent({
-                    event: 'info',
+                    event: ANALYTICS_EVENT_INFO,
                     data: { component, type, target }
                 });
                 break;
@@ -65,23 +63,16 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case ANALYTICS_VALIDATION_ERROR_STR: {
                 const { validationErrorCode, validationErrorMessage } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: 'info',
+                    event: ANALYTICS_EVENT_INFO,
                     data: { component, type, target, validationErrorCode, validationErrorMessage }
                 });
                 break;
             }
 
-            case ANALYTICS_SELECTED_STR:
-                analyticsModule.createAnalyticsEvent({
-                    event: 'info',
-                    data: { component, type, target }
-                });
-                break;
-
             case THREEDS2_FULL: {
                 const { message, metadata } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: 'log',
+                    event: ANALYTICS_EVENT_LOG,
                     data: { component, type, message, metadata }
                 });
                 break;
@@ -90,7 +81,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case THREEDS2_ERROR: {
                 const { message, code, errorType } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: 'error',
+                    event: ANALYTICS_EVENT_ERROR,
                     data: { component, type, message, code, errorType }
                 });
                 break;

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -38,7 +38,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case ANALYTICS_SUBMIT_STR:
                 analyticsModule.createAnalyticsEvent({
                     event: ANALYTICS_EVENT_LOG,
-                    data: { component, type, target: 'pay_button', message: 'Shopper clicked pay' }
+                    data: { component, type, message: 'Shopper clicked pay' }
                 });
                 break;
 

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -79,10 +79,10 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                 break;
 
             case THREEDS2_FULL: {
-                const { message } = analyticsObj;
+                const { message, metadata } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
                     event: 'log',
-                    data: { component, type, message }
+                    data: { component, type, message, metadata }
                 });
                 break;
             }

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -1,0 +1,87 @@
+import { AnalyticsModule } from '../../components/types';
+import { CreateAnalyticsEventObject, SendAnalyticsObject } from './types';
+import {
+    ANALYTICS_FOCUS_STR,
+    ANALYTICS_RENDERED_STR,
+    ANALYTICS_SELECTED_STR,
+    ANALYTICS_SUBMIT_STR,
+    ANALYTICS_UNFOCUS_STR,
+    ANALYTICS_VALIDATION_ERROR_STR
+} from './constants';
+import { THREEDS2_ERROR, THREEDS2_FULL } from '../../components/ThreeDS2/config';
+
+export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
+    return (component: string, analyticsObj: SendAnalyticsObject) => {
+        const { type, target } = analyticsObj;
+
+        switch (type) {
+            // Called from BaseElement (when component mounted) or, from DropinComponent (after mounting, when it has finished resolving all the PM promises)
+            // &/or, from DropinComponent when a PM is selected
+            case ANALYTICS_RENDERED_STR: {
+                const { isStoredPaymentMethod, brand } = analyticsObj;
+                const data = { component, type, isStoredPaymentMethod, brand };
+
+                // AnalyticsAction: action: 'event' type:'rendered'|'selected'
+                analyticsModule.createAnalyticsEvent({
+                    event: 'info',
+                    data
+                });
+                break;
+            }
+
+            case ANALYTICS_SUBMIT_STR:
+                // PM pay button pressed - AnalyticsAction: action: 'log' type:'submit'
+                analyticsModule.createAnalyticsEvent({
+                    event: 'log',
+                    data: { component, type, target: 'pay_button', message: 'Shopper clicked pay' }
+                });
+                break;
+
+            case ANALYTICS_FOCUS_STR:
+            case ANALYTICS_UNFOCUS_STR:
+                analyticsModule.createAnalyticsEvent({
+                    event: 'info',
+                    data: { component, type, target }
+                });
+                break;
+
+            case ANALYTICS_VALIDATION_ERROR_STR: {
+                const { validationErrorCode, validationErrorMessage } = analyticsObj;
+                analyticsModule.createAnalyticsEvent({
+                    event: 'info',
+                    data: { component, type, target, validationErrorCode, validationErrorMessage }
+                });
+                break;
+            }
+
+            case ANALYTICS_SELECTED_STR:
+                analyticsModule.createAnalyticsEvent({
+                    event: 'info',
+                    data: { component, type, target }
+                });
+                break;
+
+            case THREEDS2_FULL: {
+                const { message } = analyticsObj;
+                analyticsModule.createAnalyticsEvent({
+                    event: 'log',
+                    data: { component, type, message }
+                });
+                break;
+            }
+
+            case THREEDS2_ERROR: {
+                const { message, code, errorType } = analyticsObj;
+                analyticsModule.createAnalyticsEvent({
+                    event: 'error',
+                    data: { component, type, message, code, errorType }
+                });
+                break;
+            }
+
+            default: {
+                analyticsModule.createAnalyticsEvent(analyticsObj as CreateAnalyticsEventObject);
+            }
+        }
+    };
+};

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -15,6 +15,8 @@ export const ANALYTICS_VALIDATION_ERROR_STR = 'validationError';
 export const ANALYTICS_FOCUS_STR = 'focus';
 export const ANALYTICS_UNFOCUS_STR = 'unfocus';
 
+export const ANALYTICS_CONFIGURED_STR = 'configured';
+
 export const ANALYTICS_IMPLEMENTATION_ERROR = 'ImplementationError';
 export const ANALYTICS_API_ERROR = 'APIError';
 

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -81,7 +81,7 @@ export type CreateAnalyticsEventObject = {
 
 export type EventQueueProps = Pick<AnalyticsConfig, 'analyticsContext' | 'clientKey'> & { analyticsPath: string };
 
-export type SendAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'component' | 'subtype'>;
+export type SendAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'component'>;
 
 export type FieldErrorAnalyticsObject = {
     fieldType: string;

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -81,10 +81,7 @@ export type CreateAnalyticsEventObject = {
 
 export type EventQueueProps = Pick<AnalyticsConfig, 'analyticsContext' | 'clientKey'> & { analyticsPath: string };
 
-export type SendAnalyticsObject = Pick<
-    AnalyticsObject,
-    'type' | 'target' | 'validationErrorCode' | 'validationErrorMessage' | 'isStoredPaymentMethod' | 'brand'
->;
+export type SendAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'component' | 'subtype'>;
 
 export type FieldErrorAnalyticsObject = {
     fieldType: string;

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -11,32 +11,34 @@ export const getUTCTimestamp = () => Date.now();
  *  "code", "errorType" & "message"
  *
  * Log objects have, in addition to the base props:
- *  "message" &
- *  "type" & "target" (e.g. when onSubmit is called after a pay button click), or,
- *  "type" & "subtype" (e.g. when an action is handled), or,
- *  "type" (e.g. logging during the 3DS2 process)
+ *  "message" & "type" &
+ *    "target" (e.g. when onSubmit is called after a pay button click), or,
+ *    "subtype" (e.g. when an action is handled)
  *
  * Info objects have, in addition to the base props:
  *   "type" & "target" &
- *   "isStoredPaymentMethod" & "brand" (when a storedCard is "selected")
- *   // TODO - NEW info events can also have validationErrorCode & validationErrorMessage props
+ *     "isStoredPaymentMethod" & "brand" (when a storedCard is "selected"), or,
+ *     "validationErrorCode" & "validationErrorMessage" (when the event is describing a validation error)
  *
  *  All objects can also have a "metadata" object of key-value pairs
  */
 export const createAnalyticsObject = (aObj: CreateAnalyticsObject): AnalyticsObject => ({
     timestamp: String(getUTCTimestamp()),
     component: aObj.component,
-    ...(aObj.event === 'error' && { code: aObj.code, errorType: aObj.errorType }), // only added if we have an error object
-    ...((aObj.event === 'error' || aObj.event === 'log') && { message: aObj.message }), // only added if we have an error, or log object
-    ...(aObj.event === 'log' && { type: aObj.type }), // only added if we have a log object
-    ...(aObj.event === 'log' && aObj.type === ANALYTICS_ACTION_STR && { subType: aObj.subtype }), // only added if we have a log object of Action type
-    ...(aObj.event === 'log' && aObj.type === ANALYTICS_SUBMIT_STR && { target: aObj.target }), // only added if we have a log object of Submit type
-    ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // only added if we have an info object
-    ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info object about a storedPM
+    /** ERROR */
+    ...(aObj.event === 'error' && { code: aObj.code, errorType: aObj.errorType, message: aObj.message }), // error event
+    /** LOG */
+    ...(aObj.event === 'log' && { type: aObj.type, message: aObj.message }), // log event
+    ...(aObj.event === 'log' && aObj.type === ANALYTICS_ACTION_STR && { subType: aObj.subtype }), // only added if we have a log event of Action type
+    ...(aObj.event === 'log' && aObj.type === ANALYTICS_SUBMIT_STR && { target: aObj.target }), // only added if we have a log event of Submit type
+    /** INFO */
+    ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // info event
+    ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info event about a storedPM
     ...(aObj.event === 'info' &&
         aObj.type === ANALYTICS_VALIDATION_ERROR_STR && {
             validationErrorCode: aObj.validationErrorCode,
             validationErrorMessage: aObj.validationErrorMessage
-        }),
+        }), // only added if we have an info event describing a validation error
+    /** All */
     ...(aObj.metadata && { metadata: aObj.metadata })
 });

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -1,5 +1,5 @@
 import { AnalyticsObject, CreateAnalyticsObject } from './types';
-import { ANALYTICS_ACTION_STR, ANALYTICS_SUBMIT_STR, ANALYTICS_VALIDATION_ERROR_STR } from './constants';
+import { ANALYTICS_ACTION_STR, ANALYTICS_VALIDATION_ERROR_STR } from './constants';
 
 export const getUTCTimestamp = () => Date.now();
 
@@ -12,7 +12,6 @@ export const getUTCTimestamp = () => Date.now();
  *
  * Log objects have, in addition to the base props:
  *  "message" & "type" &
- *    "target" (e.g. when onSubmit is called after a pay button click), or,
  *    "subtype" (e.g. when an action is handled)
  *
  * Info objects have, in addition to the base props:
@@ -30,7 +29,6 @@ export const createAnalyticsObject = (aObj: CreateAnalyticsObject): AnalyticsObj
     /** LOG */
     ...(aObj.event === 'log' && { type: aObj.type, message: aObj.message }), // log event
     ...(aObj.event === 'log' && aObj.type === ANALYTICS_ACTION_STR && { subType: aObj.subtype }), // only added if we have a log event of Action type
-    ...(aObj.event === 'log' && aObj.type === ANALYTICS_SUBMIT_STR && { target: aObj.target }), // only added if we have a log event of Submit type
     /** INFO */
     ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // info event
     ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info event about a storedPM

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -67,7 +67,7 @@ const actionTypes = {
             _parentInstance: props._parentInstance,
             paymentMethodType: props.paymentMethodType,
             challengeWindowSize: props.challengeWindowSize, // always pass challengeWindowSize in case it's been set directly in the handleAction config object
-            analytics: props.modules?.analytics,
+            modules: { analytics: props.modules?.analytics },
 
             // Props unique to a particular flow
             ...get3DS2FlowProps(action.subtype, props)

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -15,7 +15,7 @@ import { hasOwnProperty } from '../utils/hasOwnProperty';
 import { Resources } from './Context/Resources';
 import { SRPanel } from './Errors/SRPanel';
 import { ANALYTICS_ACTION_STR } from './Analytics/constants';
-import { capitalizeFirstLetter } from '../utils/Formatters/formatters';
+import { THREEDS2_FULL } from '../components/ThreeDS2/config';
 
 class Core {
     public session: Session;
@@ -148,15 +148,13 @@ class Core {
         }
 
         if (action.type) {
-            // AnalyticsAction: action: 'log' type:'action'
-            this.modules.analytics.createAnalyticsEvent({
-                event: 'log',
-                data: {
-                    component: `${action.type}${action.subtype ?? ''}`,
-                    type: ANALYTICS_ACTION_STR,
-                    subtype: capitalizeFirstLetter(action.type),
-                    message: `${action.type}${action.subtype ?? ''} action was handled by the SDK`
-                }
+            // 'threeDS2' OR 'qrCode', 'voucher', 'redirect', 'await', 'bankTransfer`
+            const component = action.type === THREEDS2_FULL ? `${action.type}${action.subtype}` : action.paymentMethodType;
+
+            this.modules.analytics.sendAnalytics(component, {
+                type: ANALYTICS_ACTION_STR,
+                subtype: action.type,
+                message: `${component} action was handled by the SDK`
             });
 
             // Create a component based on the action

--- a/packages/playground/src/pages/SecuredFields/securedFields.config.js
+++ b/packages/playground/src/pages/SecuredFields/securedFields.config.js
@@ -280,7 +280,7 @@ export function onChange(state, component) {
     }
 }
 
-const setErrorClasses = function(pNode, pSetErrors) {
+const setErrorClasses = function (pNode, pSetErrors) {
     if (pSetErrors) {
         if (pNode.className.indexOf('pm-input-field--error') === -1) {
             pNode.className += ' pm-input-field--error';
@@ -295,7 +295,7 @@ const setErrorClasses = function(pNode, pSetErrors) {
     }
 };
 
-const setFocusClasses = function(pNode, pSetFocus) {
+const setFocusClasses = function (pNode, pSetFocus) {
     if (pSetFocus) {
         if (pNode.className.indexOf('pm-input-field--focus') === -1) {
             pNode.className += ' pm-input-field--focus';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Adding analytics events for the 3DS2 process (data sent, iframe loaded, fingerprint/challenge complete)
- Moved app specific analytics logic to a separate processing function (`analyticsPreProcessor`) in order to separate concerns and make testing easier
- Added `"configured"` type to info event - generate when a component's securedFields are all configured and ready for use
- Added "focus" & "unfocus" info events for the Custom Card component

## Tested scenarios
All existing unit tests run
Added unit tests for all the analytics events that we currently generate

<hr>

**NOTE:** extends changes made in #2521 

