### PR TITLE
Fix missing bindings for 'this' that had started causing errors in iOS

### DIFF
--- a/.changeset/five-bobcats-admire.md
+++ b/.changeset/five-bobcats-admire.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fix missing bindings for 'this' that had started causing errors in iOS

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
@@ -96,11 +96,11 @@ class CSF extends AbstractCSF {
 
         this.postMessageToAllIframes = partial(postMessageToAllIframes, thisObj);
 
-        this.handleIOSTouchEvents = handleIOSTouchEvents.handleTouchend;
+        this.handleIOSTouchEvents = handleIOSTouchEvents.handleTouchend.bind(this);
         this.touchendListener = handleIOSTouchEvents.touchendListener.bind(this);
-        this.destroyTouchendListener = handleIOSTouchEvents.destroyTouchendListener;
+        this.destroyTouchendListener = handleIOSTouchEvents.destroyTouchendListener.bind(this);
         this.touchstartListener = handleIOSTouchEvents.touchstartListener.bind(this);
-        this.destroyTouchstartListener = handleIOSTouchEvents.destroyTouchstartListener;
+        this.destroyTouchstartListener = handleIOSTouchEvents.destroyTouchstartListener.bind(this);
 
         this.setFocusOnFrame = partial(setFocusOnFrame, thisObj);
         this.handleFocus = partial(handleFocus, thisObj, this.handleIOSTouchEvents);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed missing bindings for `this` in `CSF.ts` caused by the introduction of a new `partial` function  in `v5.56.0`

## Tested scenarios
Manually testing confirms error no longer occurs


**Fixed issue**:  some versions of iOS had started throwing errors over the missing `this` binding
