### PR TITLE
Fix/v6 mandatory country code with redirects

### DIFF
--- a/packages/lib/src/components/Dropin/elements/createElements.ts
+++ b/packages/lib/src/components/Dropin/elements/createElements.ts
@@ -31,7 +31,7 @@ const createElements = (
 
             if (!PaymentMethodElement) {
                 console.warn(
-                    `Dropin: You support the payment method '${
+                    `\nDropin: You support the payment method '${
                         paymentMethod.type
                     }' but this component has not been configured. Make sure to import the Class  '${getComponentNameOfPaymentType(
                         paymentMethod.type

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -104,7 +104,6 @@ class Core implements ICore {
                     return this;
                 })
                 .catch(error => {
-                    console.log('### core:::: error');
                     if (this.options.onError) this.options.onError(error);
                     return Promise.reject(error);
                 });
@@ -210,17 +209,12 @@ class Core implements ICore {
     public update = (options: Partial<CoreConfiguration> = {}): Promise<this> => {
         this.setOptions(options);
 
-        return this.initialize()
-            .then(() => {
-                // Update each component under this instance
-                // here we should update only the new options that have been received from core
-                this.components.forEach(c => c.update(options));
-                return this;
-            })
-            .catch(e => {
-                console.log('### core:::: CATCH e', e);
-                return this;
-            });
+        return this.initialize().then(() => {
+            // Update each component under this instance
+            // here we should update only the new options that have been received from core
+            this.components.forEach(c => c.update(options));
+            return this;
+        });
     };
 
     /**

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -10,7 +10,7 @@ export async function initManual() {
 
     window.checkout = await AdyenCheckout({
         amount,
-        countryCode,
+        // countryCode,
         clientKey: process.env.__CLIENT_KEY__,
         paymentMethodsResponse,
 
@@ -128,7 +128,7 @@ export async function initManual() {
     }
 
     const dropin = new Dropin(checkout, {
-        paymentMethodComponents: [Card, GooglePay, PayPal, Ach, Affirm, WeChat, Giftcard, AmazonPay],
+        paymentMethodComponents: [Card, GooglePay, PayPal, Ach, Affirm, WeChat, Giftcard, AmazonPay, Ideal],
         instantPaymentTypes: ['googlepay'],
         paymentMethodsConfiguration: {
             card: {

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -10,7 +10,7 @@ export async function initManual() {
 
     window.checkout = await AdyenCheckout({
         amount,
-        // countryCode,
+        countryCode,
         clientKey: process.env.__CLIENT_KEY__,
         paymentMethodsResponse,
 

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -12,8 +12,8 @@ export async function initSession() {
         shopperLocale,
         shopperReference,
         telephoneNumber: '+611223344',
-        shopperEmail: 'shopper.ctp1@adyen.com',
-        countryCode
+        shopperEmail: 'shopper.ctp1@adyen.com'
+        // countryCode
     });
 
     const checkout = await AdyenCheckout({
@@ -34,7 +34,7 @@ export async function initSession() {
             console.log('onPaymentFailed', result, element);
         },
         onError: (error, component) => {
-            console.info(JSON.stringify(error), component);
+            console.error('error', JSON.stringify(error.name), JSON.stringify(error.message), component);
         },
         onChange: (state, component) => {
             console.log('onChange', state);

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -12,8 +12,8 @@ export async function initSession() {
         shopperLocale,
         shopperReference,
         telephoneNumber: '+611223344',
-        shopperEmail: 'shopper.ctp1@adyen.com'
-        // countryCode
+        shopperEmail: 'shopper.ctp1@adyen.com',
+        countryCode
     });
 
     const checkout = await AdyenCheckout({


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed issue with mandatory `countryCode`,  `/sessions` and redirects. For sessions you only ever have to specify `countryCode` the first time you initialise Checkout
The only issue is with the manual, non-sessions flow - if you handle the redirect by making a new instance of Checkout, instead of just making a `/details` call, then you have to specify the `countryCode`.  This is how our playground example currently works.

## Tested scenarios
Redirect in /sessions does not generate a "missing countryCode" error


**Relates to issue**: #2540
