### PR TITLE
v6 - Enhancing the Core.initialize to perform variable checks

### DIFF
--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -295,37 +295,27 @@ describe('Core', () => {
 
     describe('Initialising without a countryCode', () => {
         test('AdvancedFlow, without a countryCode, should throw an error', () => {
-            expect(() => {
-                new AdyenCheckout({
-                    environment: 'test',
-                    environmentUrls: {
-                        api: 'https://localhost:8080/checkoutshopper/'
-                    },
-                    clientKey: 'devl_FX923810'
-                });
-            }).toThrow('You must specify a countryCode when initializing checkout');
+            const core = new AdyenCheckout({
+                environment: 'test',
+                environmentUrls: {
+                    api: 'https://localhost:8080/checkoutshopper/'
+                },
+                clientKey: 'devl_FX923810'
+            });
+
+            expect(async () => await core.initialize()).rejects.toThrow('You must specify a countryCode');
         });
 
-        const onError = jest.fn(() => {});
-
-        test('SessionsFlow, without a countryCode, should throw an error', async () => {
+        test('SessionsFlow, without a countryCode, should throw an error', () => {
             delete sessionSetupResponseMock.countryCode;
 
             const checkout = new AdyenCheckout({
-                countryCode: 'US',
                 environment: 'test',
                 clientKey: 'test_123456',
-                session: { id: 'session-id', sessionData: 'session-data' },
-                onError
+                session: { id: 'session-id', sessionData: 'session-data' }
             });
 
-            let err;
-
-            await checkout.initialize().catch(e => {
-                err = e;
-            });
-
-            expect(onError).toBeCalledWith(err);
+            expect(async () => await checkout.initialize()).rejects.toThrow('You must specify a countryCode');
         });
     });
 });

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -111,9 +111,15 @@ class Core implements ICore {
     }
 
     private validateCoreConfiguration(): void {
+        // @ts-ignore This property does not exist, although merchants might be using when migrating from v5 to v6
+        if (this.options.paymentMethodsConfiguration) {
+            console.warn('WARNING:  "paymentMethodsConfiguration" is supported only by Drop-in.');
+        }
+
         if (!this.options.locale) {
             this.setOptions({ locale: DEFAULT_LOCALE });
         }
+
         if (!this.options.countryCode) {
             throw new AdyenCheckoutError(IMPLEMENTATION_ERROR, 'You must specify a countryCode when initializing checkout');
         }
@@ -239,10 +245,6 @@ class Core implements ICore {
      * Create or update the config object passed when AdyenCheckout is initialised (environment, clientKey, etc...)
      */
     private setOptions = (options: CoreConfiguration): void => {
-        if (hasOwnProperty(options, 'paymentMethodsConfiguration')) {
-            console.warn('WARNING:  "paymentMethodsConfiguration" is supported only by Drop-in.');
-        }
-
         this.options = {
             ...this.options,
             ...options,

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -13,11 +13,11 @@ import { hasOwnProperty } from '../utils/hasOwnProperty';
 import { Resources } from './Context/Resources';
 import { SRPanel } from './Errors/SRPanel';
 import registry, { NewableComponent } from './core.registry';
-import { DEFAULT_LOCALE } from '../language/config';
 import { cleanupFinalResult, sanitizeResponse, verifyPaymentDidNotFail } from '../components/internal/UIElement/utils';
 import AdyenCheckoutError, { IMPLEMENTATION_ERROR } from './Errors/AdyenCheckoutError';
 import { ANALYTICS_ACTION_STR } from './Analytics/constants';
 import { THREEDS2_FULL } from '../components/ThreeDS2/config';
+import { DEFAULT_LOCALE } from '../language/config';
 
 class Core implements ICore {
     public session?: Session;
@@ -59,11 +59,6 @@ class Core implements ICore {
     constructor(props: CoreConfiguration) {
         this.createFromAction = this.createFromAction.bind(this);
 
-        // If it's not a session - check if we have the required countryCode
-        if (!props.session && !hasOwnProperty(props, 'countryCode')) {
-            throw new AdyenCheckoutError(IMPLEMENTATION_ERROR, 'You must specify a countryCode when initializing checkout');
-        }
-
         this.setOptions(props);
 
         this.loadingContext = resolveEnvironment(this.options.environment, this.options.environmentUrls?.api);
@@ -80,16 +75,19 @@ class Core implements ICore {
         window['adyenWebVersion'] = Core.version.version;
     }
 
-    public initialize(): Promise<this> {
+    public async initialize(): Promise<this> {
+        await this.initializeCore();
+        this.validateCoreConfiguration();
+        this.createCoreModules();
+        return this;
+    }
+
+    private async initializeCore(): Promise<this> {
         if (this.session) {
             return this.session
                 .setupSession(this.options)
                 .then(sessionResponse => {
                     const { amount, shopperLocale, countryCode, paymentMethods, ...rest } = sessionResponse;
-
-                    if (!hasOwnProperty(sessionResponse, 'countryCode')) {
-                        throw new AdyenCheckoutError(IMPLEMENTATION_ERROR, 'You must specify a countryCode when creating a session');
-                    }
 
                     this.setOptions({
                         ...rest,
@@ -99,7 +97,6 @@ class Core implements ICore {
                     });
 
                     this.createPaymentMethodsList(paymentMethods);
-                    this.createCoreModules();
 
                     return this;
                 })
@@ -110,9 +107,16 @@ class Core implements ICore {
         }
 
         this.createPaymentMethodsList();
-        this.createCoreModules();
-
         return Promise.resolve(this);
+    }
+
+    private validateCoreConfiguration(): void {
+        if (!this.options.locale) {
+            this.setOptions({ locale: DEFAULT_LOCALE });
+        }
+        if (!this.options.countryCode) {
+            throw new AdyenCheckoutError(IMPLEMENTATION_ERROR, 'You must specify a countryCode when initializing checkout');
+        }
     }
 
     /**
@@ -242,7 +246,7 @@ class Core implements ICore {
         this.options = {
             ...this.options,
             ...options,
-            locale: options?.locale || this.options?.locale || DEFAULT_LOCALE
+            locale: options?.locale || this.options?.locale
         };
     };
 

--- a/packages/lib/src/language/Language.ts
+++ b/packages/lib/src/language/Language.ts
@@ -11,7 +11,7 @@ export class Language {
     public translations: Record<string, string>;
     public readonly customTranslations;
 
-    constructor(locale: string, customTranslations: CustomTranslations = {}, translationFile?: Translation) {
+    constructor(locale = DEFAULT_LOCALE, customTranslations: CustomTranslations = {}, translationFile?: Translation) {
         this.customTranslations = formatCustomTranslations(customTranslations, SUPPORTED_LOCALES);
         const localesFromCustomTranslations = Object.keys(this.customTranslations);
         this.supportedLocales = [...SUPPORTED_LOCALES, ...localesFromCustomTranslations].filter((v, i, a) => a.indexOf(v) === i); // our locales + validated custom locales


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Current issue: `shopperLocale`  is being ignored if it comes from the session creation. Currently it always fallback to en-US

Solution:
- Introduce an mechanism after the initialization happens, to provide the default value
- The same mechanism can be used to validate if all properties are valid (Ex: validate `countryCode`)

## Tested scenarios
- Fixed tests
