### PR TITLE
Small fixes for e2e tests

### DIFF
--- a/packages/e2e/app/src/services/index.js
+++ b/packages/e2e/app/src/services/index.js
@@ -21,6 +21,12 @@ export const getPaymentMethods = configuration =>
 
 export const makePayment = (data, config = {}) => {
     // NOTE: Merging data object. DO NOT do this in production.
+
+    // Needed for storedPMs in v70 if a standalone comp, or, in Dropin, advanced flow. (Sessions, v70, works with or without this prop)
+    if (data.paymentMethod.storedPaymentMethodId) {
+        config = { recurringProcessingModel: 'CardOnFile', ...config };
+    }
+
     const paymentRequest = { ...paymentsConfig, ...config, ...data };
     return httpPost('payments', paymentRequest)
         .then(response => {

--- a/packages/e2e/tests/cards/binLookup/ui/panLength/panLength.focus.kcp.test.js
+++ b/packages/e2e/tests/cards/binLookup/ui/panLength/panLength.focus.kcp.test.js
@@ -46,3 +46,17 @@ test('#1 Fill out PAN (binLookup w. panLength) see that focus moves to tax numbe
     // Expect focus to be place on tax number field
     await t.expect(cardPage.kcpTaxNumberLabelWithFocus.exists).ok();
 });
+
+test('#2 Paste non KCP PAN and see focus move to date field', async t => {
+    await t.addRequestHooks(getMock('visaMock'));
+
+    // Wait for field to appear in DOM
+    await cardPage.numHolder();
+
+    await t.wait(1000);
+
+    await cardPage.cardUtils.fillCardNumber(t, REGULAR_TEST_CARD, 'paste');
+
+    // Expect focus to be place on date field
+    await t.expect(cardPage.dateLabelWithFocus.exists).ok();
+});

--- a/packages/e2e/tests/vouchers/boleto/boleto.test.js
+++ b/packages/e2e/tests/vouchers/boleto/boleto.test.js
@@ -20,7 +20,9 @@ const mockData = {
         houseNumberOrName: '123',
         city: 'Sao Paulo',
         postalCode: '11111555',
-        stateOrProvince: 'SP'
+        stateOrProvince: 'SP',
+        firstName: 'N/A',
+        lastName: 'N/A'
     },
     shopperEmail: 'shopper@adyen.nl'
 };

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -203,7 +203,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
             props.autoFocus &&
             hasPanLengthRef.current > 0 &&
             ((!valid.encryptedCardNumber && sfState.valid?.encryptedCardNumber) ||
-                (valid.encryptedCardNumber && sfState.valid.encryptedCardNumber && eventDetails.event === 'handleOnBrand'))
+                (valid.encryptedCardNumber && sfState.valid.encryptedCardNumber && eventDetails?.event === 'handleOnBrand'))
         ) {
             doPanAutoJump();
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Some issues existed with the current testcafe e2e tests:
- Mock data in Boleto test needed to be updated after the Riverty change
- StoredCard payment tests were failing when the API version was `70`
- An edge case existed with pasting a non KCP card into a card component set up as KCP (i.e. with KCP fields present from start). This has been fixed and a new e2e test written to catch it in the future

## Tested scenarios
All e2e tests pass


