### PR TITLE
style: set background to white for 'Save card details' checkbox

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.scss
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.scss
@@ -84,6 +84,7 @@
 .adyen-checkout__store-details {
     display: flex;
     align-items: center;
+    background: var(--adyen-checkout-color-background-primary);
     gap: var(--adyen-checkout-spacer-060);
     padding: var(--adyen-checkout-spacer-060) var(--adyen-checkout-spacer-070);
     margin-top: var(--adyen-checkout-spacer-070);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Set background to white for 'Save card details' checkbox. 
Because when rendered in the dropin, if selected, the background of the checkbox needs to be white instead of grey (inherited from the selected payment item background)