### PR TITLE
v6 - Fix for calling onSubmit -> action.reject with empty parameters for GooglePay/ApplePay

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -11,10 +11,10 @@ import { resolveSupportedVersion, mapBrands, formatApplePayContactToAdyenAddress
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { TxVariants } from '../tx-variants';
 import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement/utils';
+import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
 import type { ApplePayConfiguration, ApplePayElementData, ApplePayPaymentOrderDetails, ApplePaySessionRequest } from './types';
 import type { ICore } from '../../core/types';
 import type { PaymentResponseData, RawPaymentResponse } from '../../types/global-types';
-import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
 
 const latestSupportedVersion = 14;
 
@@ -122,7 +122,7 @@ class ApplePayElement extends UIElement<ApplePayConfiguration> {
                     .then(paymentResponse => {
                         this.handleResponse(paymentResponse);
                     })
-                    .catch((paymentResponse: RawPaymentResponse) => {
+                    .catch((paymentResponse?: RawPaymentResponse) => {
                         const errors = paymentResponse?.error?.applePayError;
 
                         reject({
@@ -130,7 +130,14 @@ class ApplePayElement extends UIElement<ApplePayConfiguration> {
                             errors: errors ? (Array.isArray(errors) ? errors : [errors]) : undefined
                         });
 
-                        this.handleFailedResult(paymentResponse);
+                        const responseWithError: RawPaymentResponse = {
+                            ...paymentResponse,
+                            error: {
+                                applePayError: errors
+                            }
+                        };
+
+                        this.handleFailedResult(responseWithError);
                     });
             }
         });

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -8,10 +8,10 @@ import collectBrowserInfo from '../../utils/browserInfo';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { TxVariants } from '../tx-variants';
 import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement/utils';
+import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
 import type { AddressData, PaymentResponseData, RawPaymentResponse } from '../../types/global-types';
 import type { GooglePayConfiguration } from './types';
-import { ICore } from '../../core/types';
-import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
+import type { ICore } from '../../core/types';
 
 class GooglePay extends UIElement<GooglePayConfiguration> {
     public static type = TxVariants.googlepay;
@@ -113,10 +113,10 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
                 .then(paymentResponse => {
                     this.handleResponse(paymentResponse);
                 })
-                .catch((paymentResponse: RawPaymentResponse) => {
+                .catch((paymentResponse?: RawPaymentResponse) => {
                     this.setElementStatus('ready');
 
-                    const googlePayError = paymentResponse.error?.googlePayError;
+                    const googlePayError = paymentResponse?.error?.googlePayError;
                     const fallbackMessage = this.props.i18n.get('error.subtitle.payment');
 
                     const error: google.payments.api.PaymentDataError =
@@ -137,7 +137,14 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
                         error
                     });
 
-                    this.handleFailedResult(paymentResponse);
+                    const responseWithError = {
+                        ...paymentResponse,
+                        error: {
+                            googlePayError: error
+                        }
+                    };
+
+                    this.handleFailedResult(responseWithError);
                 });
         });
     };

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -189,7 +189,7 @@ export interface CoreConfiguration {
         element: UIElement,
         actions: {
             resolve: (response: CheckoutAdvancedFlowResponse) => void;
-            reject: () => void;
+            reject: (error?: Pick<CheckoutAdvancedFlowResponse, 'error'>) => void;
         }
     ): void;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Calling `action.reject` without parameters on `onSubmit` was leading to unhandled exception error.

In this PR, we add possibility to pass GooglePay/ApplePay error to `action.reject` , in the same way as the error is passed to the `action.resolve`.

Example:

```js
onSubmit: async (state, element, actions) => {
  try {
    const { action, order, resultCode, donationToken } = await makePayment(state.data);
                
    if (!resultCode) {
      // Now we can pass custom error during the reject
      actions.reject({
        error: {
          googlePayError: 'No result code error'
        }
      });
      return;
    }

    actions.resolve({
      resultCode,
      action,
      order,
      donationToken,
      // Error can be passed here if payment was Refused for ex.
      error: {
          googlePayError: 'Payment failed'
      }
    });
  } catch (error) {
     // Or just keep it empty and then we display the default error message
     actions.reject();
    }
},
```

## Tested scenarios
- Added unit tests testing action.reject without parameter