### PR TITLE
v6 - Tracking different bundle types on analytics

### DIFF
--- a/packages/lib/auto/auto.js
+++ b/packages/lib/auto/auto.js
@@ -8,6 +8,6 @@ const { Dropin, ...Components } = components;
 const Classes = Object.keys(Components).map(key => Components[key]);
 
 AdyenCheckout.register(...Classes);
-AdyenCheckout.setBundleType(BUNDLE_TYPES.AUTO);
+AdyenCheckout.setBundleType(BUNDLE_TYPES.auto);
 
 export * from '../dist/es-legacy/index.js';

--- a/packages/lib/auto/auto.js
+++ b/packages/lib/auto/auto.js
@@ -2,10 +2,12 @@
  * 'auto' uses the legacy bundle in order to be backwards compatible with Webpack 4
  */
 import { AdyenCheckout, components } from '../dist/es-legacy/index.js';
+import { BUNDLE_TYPES } from '../config/utils/bundle-types.js';
 
 const { Dropin, ...Components } = components;
 const Classes = Object.keys(Components).map(key => Components[key]);
 
 AdyenCheckout.register(...Classes);
+AdyenCheckout.setBundleType(BUNDLE_TYPES.AUTO);
 
 export * from '../dist/es-legacy/index.js';

--- a/packages/lib/config/rollup.dev.js
+++ b/packages/lib/config/rollup.dev.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import * as dotenv from 'dotenv';
 import { compileCSS, compileJavascript, convertJsonToESM, lint, loadCommonjsPackage, replaceValues, resolveExtensions } from './rollup.plugins.js';
+import { BUNDLE_TYPES } from './utils/bundle-types.js';
 
 dotenv.config({ path: path.resolve('../../', '.env') });
 
@@ -13,7 +14,7 @@ export default () => {
                 resolveExtensions(),
                 loadCommonjsPackage(),
                 lint(),
-                replaceValues({ moduleType: 'es' }),
+                replaceValues({ bundleType: BUNDLE_TYPES.ESM }),
                 convertJsonToESM(),
                 compileCSS({}),
                 compileJavascript({ target: 'es2022' })

--- a/packages/lib/config/rollup.dev.js
+++ b/packages/lib/config/rollup.dev.js
@@ -14,7 +14,7 @@ export default () => {
                 resolveExtensions(),
                 loadCommonjsPackage(),
                 lint(),
-                replaceValues({ bundleType: BUNDLE_TYPES.ESM }),
+                replaceValues({ bundleType: BUNDLE_TYPES.esm }),
                 convertJsonToESM(),
                 compileCSS({}),
                 compileJavascript({ target: 'es2022' })

--- a/packages/lib/config/rollup.plugins.js
+++ b/packages/lib/config/rollup.plugins.js
@@ -19,13 +19,13 @@ export const lint = () =>
         exclude: ['./src/**/*.json', './src/**/*.scss']
     });
 
-export const replaceValues = ({ moduleType = undefined } = {}) => {
-    if (!moduleType) {
-        throw Error('Rollup plugins: replaceValues: moduleType is missing');
+export const replaceValues = ({ bundleType = undefined } = {}) => {
+    if (!bundleType) {
+        throw Error('Rollup plugins: replaceValues: "bundleType" is missing');
     }
     return replace({
         values: {
-            'process.env.MODULE_TYPE': JSON.stringify(moduleType),
+            'process.env.BUNDLE_TYPE': JSON.stringify(bundleType),
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
             'process.env.VERSION': JSON.stringify(currentVersion.ADYEN_WEB_VERSION),
             'process.env.COMMIT_HASH': JSON.stringify(currentVersion.COMMIT_HASH),

--- a/packages/lib/config/rollup.prod.js
+++ b/packages/lib/config/rollup.prod.js
@@ -10,6 +10,7 @@ import {
     generateTypes,
     minify
 } from './rollup.plugins.js';
+import { BUNDLE_TYPES } from './utils/bundle-types.js';
 
 dotenv.config({ path: path.resolve('../../', '.env') });
 
@@ -30,7 +31,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ moduleType: 'es' }),
+                replaceValues({ bundleType: BUNDLE_TYPES.ESM }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ target: 'es2022', sourceMaps: true }),
@@ -62,7 +63,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ moduleType: 'es-legacy' }),
+                replaceValues({ bundleType: BUNDLE_TYPES['ES-LEGACY'] }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ target: 'es2017', sourceMaps: true }),
@@ -95,7 +96,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ moduleType: 'umd' }),
+                replaceValues({ bundleType: BUNDLE_TYPES.UMD }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ sourceMaps: true }),
@@ -116,7 +117,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ moduleType: 'commonjs' }),
+                replaceValues({ bundleType: BUNDLE_TYPES.COMMONJS }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ target: 'es2017', sourceMaps: true }),

--- a/packages/lib/config/rollup.prod.js
+++ b/packages/lib/config/rollup.prod.js
@@ -31,7 +31,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ bundleType: BUNDLE_TYPES.ESM }),
+                replaceValues({ bundleType: BUNDLE_TYPES.esm }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ target: 'es2022', sourceMaps: true }),
@@ -63,7 +63,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ bundleType: BUNDLE_TYPES['ES-LEGACY'] }),
+                replaceValues({ bundleType: BUNDLE_TYPES.eslegacy }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ target: 'es2017', sourceMaps: true }),
@@ -96,7 +96,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ bundleType: BUNDLE_TYPES.UMD }),
+                replaceValues({ bundleType: BUNDLE_TYPES.umd }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ sourceMaps: true }),
@@ -117,7 +117,7 @@ export default () => {
             plugins: [
                 resolveExtensions(),
                 loadCommonjsPackage(),
-                replaceValues({ bundleType: BUNDLE_TYPES.COMMONJS }),
+                replaceValues({ bundleType: BUNDLE_TYPES.commonjs }),
                 convertJsonToESM(),
                 compileCSS(),
                 compileJavascript({ target: 'es2017', sourceMaps: true }),

--- a/packages/lib/config/utils/bundle-types.js
+++ b/packages/lib/config/utils/bundle-types.js
@@ -2,11 +2,11 @@
  * These values are injected in the bundle and eventually propagated to our analytics
  */
 const BUNDLE_TYPES = {
-    ESM: 'ESM',
-    'ES-LEGACY': 'ES-LEGACY',
-    UMD: 'UMD',
-    AUTO: 'AUTO',
-    COMMONJS: 'COMMONJS'
+    esm: 'esm',
+    eslegacy: 'eslegacy',
+    umd: 'umd',
+    auto: 'auto',
+    commonjs: 'commonjs'
 };
 
 export { BUNDLE_TYPES };

--- a/packages/lib/config/utils/bundle-types.js
+++ b/packages/lib/config/utils/bundle-types.js
@@ -1,0 +1,12 @@
+/**
+ * These values are injected in the bundle and eventually propagated to our analytics
+ */
+const BUNDLE_TYPES = {
+    ESM: 'ESM',
+    'ES-LEGACY': 'ES-LEGACY',
+    UMD: 'UMD',
+    AUTO: 'AUTO',
+    COMMONJS: 'COMMONJS'
+};
+
+export { BUNDLE_TYPES };

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -120,7 +120,7 @@
         "postcss": "8.4.35",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "rollup": "4.11.0",
+        "rollup": "4.12.0",
         "rollup-plugin-dts": "6.1.0",
         "rollup-plugin-postcss": "4.0.2",
         "rollup-plugin-stylelint": "1.0.0",

--- a/packages/lib/src/components/Card/Card.Analytics.test.tsx
+++ b/packages/lib/src/components/Card/Card.Analytics.test.tsx
@@ -1,7 +1,7 @@
 import { CardElement } from './Card';
 import Analytics from '../../core/Analytics';
 
-const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
+const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
 
 let card;
 

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -4,7 +4,7 @@ import GooglePayService from './GooglePayService';
 import Analytics from '../../core/Analytics';
 import { ANALYTICS_EVENT_INFO, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
 
-const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
+const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
 
 jest.mock('./GooglePayService');
 

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../core/Analytics/constants';
 import { THREEDS2_CHALLENGE_ERROR, THREEDS2_ERROR } from './config';
 
-const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
+const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
 
 describe('ThreeDS2Challenge: calls that generate analytics should produce objects with the expected shapes ', () => {
     let challenge;

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../core/Analytics/constants';
 import { THREEDS2_ERROR, THREEDS2_FINGERPRINT_ERROR } from './config';
 
-const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '' });
+const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
 
 describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produce objects with the expected shapes ', () => {
     let fingerprint;

--- a/packages/lib/src/core/AdyenCheckout.ts
+++ b/packages/lib/src/core/AdyenCheckout.ts
@@ -1,14 +1,22 @@
-import Checkout from './index';
+import Core from './core';
 import type { CoreConfiguration, ICore } from './types';
 import type { IUIElement } from '../components/internal/UIElement/types';
 
-async function AdyenCheckout(props: CoreConfiguration): Promise<Checkout> {
-    const checkout = new Checkout(props);
+async function AdyenCheckout(props: CoreConfiguration): Promise<Core> {
+    const checkout = new Core(props);
     return await checkout.initialize();
 }
 
 AdyenCheckout.register = (...items: (new (checkout: ICore, props) => IUIElement)[]) => {
-    Checkout.register(...items);
+    Core.register(...items);
+};
+
+/**
+ * Function used by the 'auto' package to insert its bundle type information in the Core.
+ * We can't inject its bundle type when bundling with Rollup (as done with the other bundle types), since 'auto' uses ES-LEGACY bundle type under the hood.
+ */
+AdyenCheckout.setBundleType = (type: string) => {
+    Core.setBundleType(type);
 };
 
 export { AdyenCheckout };

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -45,7 +45,7 @@ describe('Analytics initialisation and event queue', () => {
     });
 
     test('Creates an Analytics module with defaultProps', () => {
-        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
         expect(analytics.setUp).not.toBe(null);
         expect(analytics.getCheckoutAttemptId).not.toBe(null);
         expect(analytics.getEnabled).not.toBe(null);
@@ -56,7 +56,7 @@ describe('Analytics initialisation and event queue', () => {
     });
 
     test('Should not fire any calls if analytics is disabled', () => {
-        const analytics = Analytics({ analytics: { enabled: false }, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: { enabled: false }, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
 
         analytics.setUp(event);
         expect(collectIdPromiseMock).not.toHaveBeenCalled();
@@ -64,7 +64,7 @@ describe('Analytics initialisation and event queue', () => {
     });
 
     test('Will not call the collectId endpoint if telemetry is disabled, but will call the logEvent (analytics pixel)', () => {
-        const analytics = Analytics({ analytics: { telemetry: false }, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: { telemetry: false }, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
         expect(collectIdPromiseMock).not.toHaveBeenCalled();
         analytics.setUp(event);
         expect(collectIdPromiseMock).not.toHaveBeenCalled();
@@ -73,7 +73,7 @@ describe('Analytics initialisation and event queue', () => {
     });
 
     test('Calls the collectId endpoint by default, adding expected fields', async () => {
-        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
         analytics.setUp(event);
 
         expect(collectIdPromiseMock).toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe('Analytics initialisation and event queue', () => {
         const payload = {
             payloadData: 'test'
         };
-        const analytics = Analytics({ analytics: { payload }, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: { payload }, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
 
         analytics.setUp(event);
 
@@ -95,7 +95,7 @@ describe('Analytics initialisation and event queue', () => {
     });
 
     test('Analytics events queue sends event object', async () => {
-        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
 
         const aObj = createAnalyticsObject(analyticsEventObj);
 
@@ -113,7 +113,7 @@ describe('Analytics initialisation and event queue', () => {
     });
 
     test('Analytics events queue sends error object', async () => {
-        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
 
         const evObj = createAnalyticsObject(analyticsEventObj);
         analytics.createAnalyticsEvent({ event: 'info', data: evObj });
@@ -142,7 +142,7 @@ describe('Analytics initialisation and event queue', () => {
     });
 
     test('Analytics events queue sends log object', async () => {
-        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount });
+        const analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount, bundleType: 'umd' });
 
         const aObj = createAnalyticsObject({
             event: 'log',

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -12,7 +12,7 @@ let capturedCheckoutAttemptId = null;
 let hasLoggedPixel = false;
 let sendEventsTimerId = null;
 
-const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analyticsContext }: AnalyticsProps): AnalyticsModule => {
+const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analyticsContext, bundleType }: AnalyticsProps): AnalyticsModule => {
     const defaultProps = {
         enabled: true,
         telemetry: true,
@@ -30,7 +30,7 @@ const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analy
     }
 
     const logEvent = LogEvent({ loadingContext, locale });
-    const collectId = CollectId({ analyticsContext, clientKey, locale, amount, analyticsPath: ANALYTICS_PATH });
+    const collectId = CollectId({ analyticsContext, clientKey, locale, amount, analyticsPath: ANALYTICS_PATH, bundleType });
     const eventsQueue: EventsQueueModule = EventsQueue({ analyticsContext, clientKey, analyticsPath: ANALYTICS_PATH });
 
     const sendAnalyticsEvents = () => {

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -35,6 +35,7 @@ export interface AnalyticsOptions {
 }
 
 export type AnalyticsProps = Pick<CoreConfiguration, 'loadingContext' | 'locale' | 'clientKey' | 'analytics' | 'amount'> & {
+    bundleType: string;
     analyticsContext?: string;
 };
 

--- a/packages/lib/src/core/Services/analytics/collect-id.test.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.test.ts
@@ -13,6 +13,7 @@ const httpPromiseFailMock = jest.fn(() => Promise.reject(' url incorrect'));
 const BASE_CONFIGURATION = {
     analyticsContext: 'https://checkoutanalytics-test.adyen.com/checkoutanalytics/',
     locale: 'en-US',
+    bundleType: 'umd',
     amount: {
         value: 10000,
         currency: 'USD'
@@ -45,7 +46,8 @@ test('Should fail since path is incorrect', () => {
     const configuration = {
         ...BASE_CONFIGURATION,
         clientKey: 'xxxx-yyyy',
-        analyticsPath: 'v99/analytics'
+        analyticsPath: 'v99/analytics',
+        bundleType: 'umd'
     };
 
     const log = collectId(configuration);

--- a/packages/lib/src/core/Services/analytics/collect-id.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.ts
@@ -23,7 +23,7 @@ function confirmSessionDurationIsMaxFifteenMinutes(checkoutAttemptIdSession: Che
  * @returns a function returning a promise containing the response of the call (an object containing a checkoutAttemptId property)
  */
 // const collectId = ({ analyticsContext, clientKey, locale, amount }: CollectIdProps) => { // TODO - amount will be supported in the future
-const collectId = ({ analyticsContext, clientKey, locale, analyticsPath }: CollectIdProps) => {
+const collectId = ({ analyticsContext, clientKey, locale, analyticsPath, bundleType }: CollectIdProps) => {
     let promise;
 
     const options = {
@@ -39,7 +39,7 @@ const collectId = ({ analyticsContext, clientKey, locale, analyticsPath }: Colle
             // The data team want both platform & channel properties:
             channel: 'Web',
             platform: 'Web',
-            buildType: window['AdyenWeb'] ? 'umd' : 'compiled',
+            buildType: bundleType,
             locale,
             referrer: window.location.href,
             screenWidth: window.screen.width,

--- a/packages/lib/src/core/Services/analytics/types.ts
+++ b/packages/lib/src/core/Services/analytics/types.ts
@@ -6,7 +6,10 @@ export type CheckoutAttemptIdSession = {
     timestamp: number;
 };
 
-export type CollectIdProps = Pick<AnalyticsConfig, 'clientKey' | 'analyticsContext' | 'locale' | 'amount'> & { analyticsPath: string };
+export type CollectIdProps = Pick<AnalyticsConfig, 'clientKey' | 'analyticsContext' | 'locale' | 'amount'> & {
+    analyticsPath: string;
+    bundleType: string;
+};
 
 export type LogEventProps = Pick<AnalyticsConfig, 'loadingContext' | 'locale'>;
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -322,7 +322,8 @@ class Core implements ICore {
                 clientKey: this.options.clientKey,
                 locale: this.options.locale,
                 analytics: this.options.analytics,
-                amount: this.options.amount
+                amount: this.options.amount,
+                bundleType: Core.metadata.bundleType
             }),
             resources: new Resources(this.cdnContext),
             i18n: new Language(this.options.locale, this.options.translations, this.options.translationFile),

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -30,15 +30,19 @@ class Core implements ICore {
 
     private components: UIElement[] = [];
 
-    public static readonly version = {
+    public static readonly metadata = {
         version: process.env.VERSION,
         revision: process.env.COMMIT_HASH,
         branch: process.env.COMMIT_BRANCH,
         buildId: process.env.ADYEN_BUILD_ID,
-        moduleType: process.env.MODULE_TYPE
+        bundleType: process.env.BUNDLE_TYPE
     };
 
     public static registry = registry;
+
+    public static setBundleType(type: string): void {
+        Core.metadata.bundleType = type;
+    }
 
     public static register(...items: NewableComponent[]) {
         registry.add(...items);
@@ -59,7 +63,7 @@ class Core implements ICore {
     constructor(props: CoreConfiguration) {
         this.createFromAction = this.createFromAction.bind(this);
 
-        this.setOptions(props);
+        this.setOptions({ exposeLibraryMetadata: true, ...props });
 
         this.loadingContext = resolveEnvironment(this.options.environment, this.options.environmentUrls?.api);
         this.cdnContext = resolveCDNEnvironment(this.options.resourceEnvironment || this.options.environment, this.options.environmentUrls?.api);
@@ -68,11 +72,15 @@ class Core implements ICore {
 
         const clientKeyType = this.options.clientKey?.substr(0, 4);
         if ((clientKeyType === 'test' || clientKeyType === 'live') && !this.loadingContext.includes(clientKeyType)) {
-            throw new Error(`Error: you are using a '${clientKeyType}' clientKey against the '${this.options.environment}' environment`);
+            throw new AdyenCheckoutError(
+                'IMPLEMENTATION_ERROR',
+                `Error: you are using a ${clientKeyType} clientKey against the ${this.options.environment} environment`
+            );
         }
 
-        // Expose version number for npm builds
-        window['adyenWebVersion'] = Core.version.version;
+        if (this.options.exposeLibraryMetadata) {
+            window['AdyenWebMetadata'] = Core.metadata;
+        }
     }
 
     public async initialize(): Promise<this> {

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -144,6 +144,14 @@ export interface CoreConfiguration {
 
     setStatusAutomatically?: boolean;
 
+    /**
+     * Add @adyen/web metadata to the window object.
+     * It helps to identify version number and bundle type in the merchant environment
+     *
+     * @default true
+     */
+    exposeLibraryMetadata?: boolean;
+
     beforeRedirect?(
         resolve: () => void,
         reject: () => void,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,130 +2519,65 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rollup/rollup-android-arm-eabi@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.11.0.tgz#78693f843483a511bce6ce1d8a153a49f4cbab87"
-  integrity sha512-BV+u2QSfK3i1o6FucqJh5IK9cjAU6icjFFhvknzFgu472jzl0bBojfDAkJLBEsHFMo+YZg6rthBvBBt8z12IBQ==
-
 "@rollup/rollup-android-arm-eabi@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz#38c3abd1955a3c21d492af6b1a1dca4bb1d894d6"
   integrity sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==
-
-"@rollup/rollup-android-arm64@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.11.0.tgz#772cb1856f720863d982c17f25d3fbb930c946d3"
-  integrity sha512-0ij3iw7sT5jbcdXofWO2NqDNjSVVsf6itcAkV2I6Xsq4+6wjW1A8rViVB67TfBEan7PV2kbLzT8rhOVWLI2YXw==
 
 "@rollup/rollup-android-arm64@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz#3822e929f415627609e53b11cec9a4be806de0e2"
   integrity sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==
 
-"@rollup/rollup-darwin-arm64@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.11.0.tgz#cac4aac05432ac684a6c6c5788e8db738e047a22"
-  integrity sha512-yPLs6RbbBMupArf6qv1UDk6dzZvlH66z6NLYEwqTU0VHtss1wkI4UYeeMS7TVj5QRVvaNAWYKP0TD/MOeZ76Zg==
-
 "@rollup/rollup-darwin-arm64@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz#6c082de71f481f57df6cfa3701ab2a7afde96f69"
   integrity sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==
-
-"@rollup/rollup-darwin-x64@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.11.0.tgz#e36d66c6b2d4d716c94926a375d6865b0c0c9c02"
-  integrity sha512-OvqIgwaGAwnASzXaZEeoJY3RltOFg+WUbdkdfoluh2iqatd090UeOG3A/h0wNZmE93dDew9tAtXgm3/+U/B6bw==
 
 "@rollup/rollup-darwin-x64@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz#c34ca0d31f3c46a22c9afa0e944403eea0edcfd8"
   integrity sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.11.0.tgz#f7cc62debb348fb109724c882b99adc5c3f73e31"
-  integrity sha512-X17s4hZK3QbRmdAuLd2EE+qwwxL8JxyVupEqAkxKPa/IgX49ZO+vf0ka69gIKsaYeo6c1CuwY3k8trfDtZ9dFg==
-
 "@rollup/rollup-linux-arm-gnueabihf@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz#48e899c1e438629c072889b824a98787a7c2362d"
   integrity sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==
-
-"@rollup/rollup-linux-arm64-gnu@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.11.0.tgz#ed398c7434734101e77a1fd0b05682b2c2027ecd"
-  integrity sha512-673Lu9EJwxVB9NfYeA4AdNu0FOHz7g9t6N1DmT7bZPn1u6bTF+oZjj+fuxUcrfxWXE0r2jxl5QYMa9cUOj9NFg==
 
 "@rollup/rollup-linux-arm64-gnu@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz#788c2698a119dc229062d40da6ada8a090a73a68"
   integrity sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==
 
-"@rollup/rollup-linux-arm64-musl@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.11.0.tgz#4860560d18d9f18568859a800b1e79fe3b85df9e"
-  integrity sha512-yFW2msTAQNpPJaMmh2NpRalr1KXI7ZUjlN6dY/FhWlOclMrZezm5GIhy3cP4Ts2rIAC+IPLAjNibjp1BsxCVGg==
-
 "@rollup/rollup-linux-arm64-musl@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz#3882a4e3a564af9e55804beeb67076857b035ab7"
   integrity sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==
-
-"@rollup/rollup-linux-riscv64-gnu@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.11.0.tgz#25bc0e9dbd5feab0b6fa68b2b87ce5f28a8a7c19"
-  integrity sha512-kKT9XIuhbvYgiA3cPAGntvrBgzhWkGpBMzuk1V12Xuoqg7CI41chye4HU0vLJnGf9MiZzfNh4I7StPeOzOWJfA==
 
 "@rollup/rollup-linux-riscv64-gnu@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz#0c6ad792e1195c12bfae634425a3d2aa0fe93ab7"
   integrity sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==
 
-"@rollup/rollup-linux-x64-gnu@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.11.0.tgz#8c318d9c33a89cf9f917a1be90b0d8c75e0ab3ba"
-  integrity sha512-6q4ESWlyTO+erp1PSCmASac+ixaDv11dBk1fqyIuvIUc/CmRAX2Zk+2qK1FGo5q7kyDcjHCFVwgGFCGIZGVwCA==
-
 "@rollup/rollup-linux-x64-gnu@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz#9d62485ea0f18d8674033b57aa14fb758f6ec6e3"
   integrity sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==
-
-"@rollup/rollup-linux-x64-musl@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.11.0.tgz#132cf0787c966b3b22cf4475706fc4cb08ec880c"
-  integrity sha512-vIAQUmXeMLmaDN78HSE4Kh6xqof2e3TJUKr+LPqXWU4NYNON0MDN9h2+t4KHrPAQNmU3w1GxBQ/n01PaWFwa5w==
 
 "@rollup/rollup-linux-x64-musl@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz#50e8167e28b33c977c1f813def2b2074d1435e05"
   integrity sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==
 
-"@rollup/rollup-win32-arm64-msvc@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.11.0.tgz#18e49376786def75843e605bdc8059a301c11dad"
-  integrity sha512-LVXo9dDTGPr0nezMdqa1hK4JeoMZ02nstUxGYY/sMIDtTYlli1ZxTXBYAz3vzuuvKO4X6NBETciIh7N9+abT1g==
-
 "@rollup/rollup-win32-arm64-msvc@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz#68d233272a2004429124494121a42c4aebdc5b8e"
   integrity sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==
 
-"@rollup/rollup-win32-ia32-msvc@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.11.0.tgz#ff9281d8b189436b7c234a52e7e0b635631c8667"
-  integrity sha512-xZVt6K70Gr3I7nUhug2dN6VRR1ibot3rXqXS3wo+8JP64t7djc3lBFyqO4GiVrhNaAIhUCJtwQ/20dr0h0thmQ==
-
 "@rollup/rollup-win32-ia32-msvc@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz#366ca62221d1689e3b55a03f4ae12ae9ba595d40"
   integrity sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==
-
-"@rollup/rollup-win32-x64-msvc@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.11.0.tgz#a59158f78d07cd3ac15092ffca2f0319f3bb69f6"
-  integrity sha512-f3I7h9oTg79UitEco9/2bzwdciYkWr8pITs3meSDSlr1TdvQ7IxkQaaYN2YqZXX5uZhiYL+VuYDmHwNzhx+HOg==
 
 "@rollup/rollup-win32-x64-msvc@4.12.0":
   version "4.12.0"
@@ -12279,36 +12214,7 @@ rollup-preserve-directives@^1.0.0:
   dependencies:
     magic-string "^0.30.5"
 
-rollup@4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.11.0.tgz#28f28d8f8660facfed001b512d3cfda8c0dc09b6"
-  integrity sha512-2xIbaXDXjf3u2tajvA5xROpib7eegJ9Y/uPlSFhXLNpK9ampCczXAhLEb5yLzJyG3LAdI1NWtNjDXiLyniNdjQ==
-  dependencies:
-    "@types/estree" "1.0.5"
-  optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.11.0"
-    "@rollup/rollup-android-arm64" "4.11.0"
-    "@rollup/rollup-darwin-arm64" "4.11.0"
-    "@rollup/rollup-darwin-x64" "4.11.0"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.11.0"
-    "@rollup/rollup-linux-arm64-gnu" "4.11.0"
-    "@rollup/rollup-linux-arm64-musl" "4.11.0"
-    "@rollup/rollup-linux-riscv64-gnu" "4.11.0"
-    "@rollup/rollup-linux-x64-gnu" "4.11.0"
-    "@rollup/rollup-linux-x64-musl" "4.11.0"
-    "@rollup/rollup-win32-arm64-msvc" "4.11.0"
-    "@rollup/rollup-win32-ia32-msvc" "4.11.0"
-    "@rollup/rollup-win32-x64-msvc" "4.11.0"
-    fsevents "~2.3.2"
-
-"rollup@^2.25.0 || ^3.3.0":
-  version "3.29.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
-  integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-rollup@^4.2.0:
+rollup@4.12.0, rollup@^4.2.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.12.0.tgz#0b6d1e5f3d46bbcf244deec41a7421dc54cc45b5"
   integrity sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==
@@ -12328,6 +12234,13 @@ rollup@^4.2.0:
     "@rollup/rollup-win32-arm64-msvc" "4.12.0"
     "@rollup/rollup-win32-ia32-msvc" "4.12.0"
     "@rollup/rollup-win32-x64-msvc" "4.12.0"
+    fsevents "~2.3.2"
+
+"rollup@^2.25.0 || ^3.3.0":
+  version "3.29.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
+  integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
+  optionalDependencies:
     fsevents "~2.3.2"
 
 rst-selector-parser@^2.2.3:


### PR DESCRIPTION
## Summary
- Passing to the analytics endpoint the bundle type - esm , eslegacy, umd, auto or cjs
- Added property to core `exposeLibraryMetadata` which defaults to `true` . When enabled, it populates the `window.AdyenWebMetadata` with Core metadata. Merchants can disable this in case they care about polluting global scope
