### PR TITLE
Feature/using checkoutanalytics mapping validation errors

### DIFF
--- a/packages/lib/src/components/Card/Card.Analytics.test.tsx
+++ b/packages/lib/src/components/Card/Card.Analytics.test.tsx
@@ -26,9 +26,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
             }
         });
 
-        analyticsModule.createAnalyticsEvent = jest.fn(obj => {
-            console.log('### analyticsPreProcessor.test:::: obj=', obj);
-        });
+        analyticsModule.createAnalyticsEvent = jest.fn(() => null);
     });
 
     test('Analytics should produce an "info" event, of type "rendered", for a card PM', () => {
@@ -122,8 +120,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
     test('Analytics should produce an "info" event, of type "validationError", with the expected properties', () => {
         card.onErrorAnalytics({
             fieldType: 'encryptedCardNumber',
-            errorCode: 'error.va.sf-cc-num.04',
-            errorMessage: 'Enter the complete card number-sr'
+            errorCode: 'error.va.sf-cc-num.04'
         });
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
@@ -133,7 +130,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
                 type: ANALYTICS_VALIDATION_ERROR_STR,
                 target: 'card_number',
                 validationErrorCode: 'error.va.sf-cc-num.04',
-                validationErrorMessage: 'Enter the complete card number-sr'
+                validationErrorMessage: 'card-number-not-filled-correctly'
             }
         });
     });
@@ -147,10 +144,6 @@ describe('Card: calls that generate "log" analytics should produce objects with 
             modules: {
                 analytics: analyticsModule
             }
-        });
-
-        analyticsModule.createAnalyticsEvent = jest.fn(obj => {
-            console.log('### analyticsPreProcessor.test:::: obj=', obj);
         });
     });
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -24,6 +24,8 @@ import {
 import { ALL_SECURED_FIELDS } from '../internal/SecuredFields/lib/configuration/constants';
 import { FieldErrorAnalyticsObject, SendAnalyticsObject } from '../../core/Analytics/types';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
+import { ERROR_CODES } from '../../core/Errors/constants';
+import { getErrorMessageFromCode } from '../../core/Errors/utils';
 
 export class CardElement extends UIElement<CardElementProps> {
     public static type = 'scheme';
@@ -228,7 +230,7 @@ export class CardElement extends UIElement<CardElementProps> {
             type: ANALYTICS_VALIDATION_ERROR_STR,
             target: fieldTypeToSnakeCase(obj.fieldType),
             validationErrorCode: obj.errorCode,
-            validationErrorMessage: obj.errorMessage
+            validationErrorMessage: getErrorMessageFromCode(obj.errorCode, ERROR_CODES)
         });
     };
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -429,8 +429,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
             newErrors?.forEach(errorItem => {
                 const aObj: FieldErrorAnalyticsObject = {
                     fieldType: errorItem.field,
-                    errorCode: errorItem.errorCode,
-                    errorMessage: errorItem.errorMessage
+                    errorCode: errorItem.errorCode
                 };
 
                 props.onErrorAnalytics(aObj);

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -308,7 +308,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             if (this.state.errors[key]) {
                 acc[key] = {
                     isValid: false,
-                    errorMessage: getError(this.state.errors[key]),
+                    errorMessage: getError(this.state.errors[key]), // this is the human-readable, untranslated, explanation of the error that will exist on the error object in card.state.errors
                     // For v5 the object found in state.errors should also contain the additional properties that used to be sent to the onError callback
                     // namely: translation, errorCode, a ref to rootNode &, in the case of failed binLookup, an array of the detectedBrands
                     errorI18n: this.props.i18n.get(this.state.errors[key]),

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -175,7 +175,7 @@ describe('Analytics initialisation and event queue', () => {
         expect(aObj.timestamp).not.toBe(undefined);
         expect(aObj.target).toEqual('card_number');
         expect(aObj.type).toEqual(ANALYTICS_VALIDATION_ERROR_STR);
-        expect(aObj.validationErrorCode).toEqual('error.va.sf-cc-num.04');
+        expect(aObj.validationErrorCode).toEqual('901');
         expect(aObj.validationErrorMessage).toEqual('error-msg-incorrectly-filled-pan');
 
         // info event should not be sent immediately

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -104,7 +104,8 @@ const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analy
                 event,
                 ...data
             });
-            // console.log('### Analytics::createAnalyticsEvent:: event=', event, ' aObj=', aObj);
+
+            // if (aObj.type === 'validationError') console.log('### Analytics::createAnalyticsEvent:: event=', event, ' aObj=', aObj);
 
             addAnalyticsEvent(event, aObj);
 

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -50,3 +50,43 @@ export const ANALYTICS_ERROR_CODE_3DS2_TIMEOUT = 'web_705'; // 3DS2 process has 
 
 export const ANALYTICS_ERROR_CODE_TOKEN_IS_MISSING_ACSURL = 'web_800'; // Decoded token is missing a valid acsURL property
 export const ANALYTICS_ERROR_CODE_NO_TRANSSTATUS = 'web_801'; // Challenge has resulted in an error (no transStatus could be retrieved by the backend)
+
+export const errorCodeMapping = {
+    ['error.va.sf-cc-num.02']: '900',
+    ['error.va.sf-cc-num.04']: '901',
+    ['error.va.sf-cc-num.01']: '902',
+    ['error.va.sf-cc-num.03']: '903',
+    //
+    ['error.va.sf-cc-dat.04']: '910',
+    ['error.va.sf-cc-dat.05']: '911',
+    ['error.va.sf-cc-dat.01']: '912',
+    ['error.va.sf-cc-dat.02']: '913',
+    ['error.va.sf-cc-dat.03']: '914',
+    ['error.va.sf-cc-mth.01']: '915',
+    ['error.va.sf-cc-yr.01']: '917',
+    ['error.va.sf-cc-yr.02']: '918',
+    //
+    ['error.va.sf-cc-cvc.01']: '920',
+    ['error.va.sf-cc-cvc.02']: '921',
+    //
+    ['creditCard.holderName.invalid']: '925',
+    //
+    ['boleto.socialSecurityNumber.invalid']: '926',
+    //
+    ['error.va.gen.01.country']: '930',
+    ['error.va.gen.01.street']: '931',
+    ['error.va.gen.01.house_number_or_name']: '932',
+    ['error.va.gen.01.postal_code']: '933',
+    ['invalidFormatExpects.postal_code']: '934',
+    ['error.va.gen.01.city']: '935',
+    ['error.va.gen.01.state_or_province']: '936',
+    //
+    ['error.va.sf-kcp-pwd.01']: '940',
+    ['error.va.sf-kcp-pwd.02']: '941',
+    ['creditCard.taxNumber.invalid']: '942',
+    //
+    ['error.va.sf-ach-num.01']: '945',
+    ['error.va.sf-ach-num.02']: '946',
+    ['error.va.sf-ach-loc.01']: '947',
+    ['error.va.sf-ach-loc.02']: '948'
+};

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -88,5 +88,4 @@ export type SendAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'component
 export type FieldErrorAnalyticsObject = {
     fieldType: string;
     errorCode: string;
-    errorMessage: string;
 };

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -1,6 +1,7 @@
 import { AnalyticsObject, CreateAnalyticsObject } from './types';
-import { ANALYTICS_ACTION_STR, ANALYTICS_VALIDATION_ERROR_STR } from './constants';
+import { ANALYTICS_ACTION_STR, ANALYTICS_VALIDATION_ERROR_STR, errorCodeMapping } from './constants';
 import uuid from '../../utils/uuid';
+import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD } from '../Errors/constants';
 
 export const getUTCTimestamp = () => Date.now();
 
@@ -32,13 +33,23 @@ export const createAnalyticsObject = (aObj: CreateAnalyticsObject): AnalyticsObj
     ...(aObj.event === 'log' && { type: aObj.type, message: aObj.message }), // log event
     ...(aObj.event === 'log' && aObj.type === ANALYTICS_ACTION_STR && { subType: aObj.subtype }), // only added if we have a log event of Action type
     /** INFO */
-    ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target, issuer: aObj.issuer }), // info event
+    ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // info event
+    ...(aObj.event === 'info' && aObj.issuer && { issuer: aObj.issuer }), // relates to issuerLists
     ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info event about a storedPM
     ...(aObj.event === 'info' &&
         aObj.type === ANALYTICS_VALIDATION_ERROR_STR && {
-            validationErrorCode: aObj.validationErrorCode,
+            validationErrorCode: mapErrorCodesForAnalytics(aObj.validationErrorCode, aObj.target),
             validationErrorMessage: aObj.validationErrorMessage
         }), // only added if we have an info event describing a validation error
     /** All */
     ...(aObj.metadata && { metadata: aObj.metadata })
 });
+
+const mapErrorCodesForAnalytics = (errorCode: string, target: string) => {
+    // Some of the more generic error codes required combination with target to retrieve a specific code
+    if (errorCode === ERROR_CODES[ERROR_MSG_INCOMPLETE_FIELD] || errorCode === 'invalidFormatExpects') {
+        return errorCodeMapping[`${errorCode}.${target}`] ?? errorCode;
+    }
+
+    return errorCodeMapping[errorCode] ?? errorCode;
+};

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -49,6 +49,17 @@ export const addErrorTranslationsToObject = (originalObj, i18n) => {
     return nuObj;
 };
 
+export const getErrorMessageFromCode = (errorCode: string, codeMap: Record<string, string>): string => {
+    let errMsg = errorCode;
+    for (const [key, value] of Object.entries(codeMap)) {
+        if (value === errorCode) {
+            errMsg = key;
+            break;
+        }
+    }
+    return errMsg?.toLowerCase().replace(/[_.\s]/g, '-');
+};
+
 /**
  * sortErrorsByLayout - takes a list of errors and a layout, and returns a sorted array of error objects with translated error messages
  *


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Aligning `errorCodes` generated for validation errors so that a common set of values can be shared between all the SDKs.

This is the v5 equivalent of #2581 but without the breaking changes. This means that a more extensive mapping is required.

## Tested scenarios
All unit tests pass
