### PR TITLE
v6 - Removing setStatusAutomatically property

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -24,6 +24,33 @@ describe('Dropin', () => {
         });
     });
 
+    describe('Configuration "disableFinalAnimation"', () => {
+        test('should not set the Dropin status if disableFinalAnimation is set to true', () => {
+            const dropin = new Dropin(checkout, { disableFinalAnimation: true });
+            const setStatusMock = jest.fn();
+            dropin.dropinRef = {
+                setStatus: setStatusMock
+            };
+            dropin.displayFinalAnimation('success');
+
+            expect(dropin.props.disableFinalAnimation).toBeTruthy();
+            expect(setStatusMock).toHaveBeenCalledTimes(0);
+        });
+
+        test('should set the Dropin final status if configuration is not provided', () => {
+            const dropin = new Dropin(checkout);
+            const setStatusMock = jest.fn();
+            dropin.dropinRef = {
+                setStatus: setStatusMock
+            };
+            dropin.displayFinalAnimation('success');
+
+            expect(dropin.props.disableFinalAnimation).toBeFalsy();
+            expect(setStatusMock).toHaveBeenCalledWith('success');
+            expect(setStatusMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('isValid', () => {
         test('should fail if no activePaymentMethod', () => {
             const dropin = new Dropin(checkout);

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -3,14 +3,15 @@ import UIElement from '../internal/UIElement/UIElement';
 import defaultProps from './defaultProps';
 import DropinComponent from '../../components/Dropin/components/DropinComponent';
 import CoreProvider from '../../core/Context/CoreProvider';
-import { PaymentAction, PaymentResponseData } from '../../types/global-types';
-import { DropinConfiguration, InstantPaymentTypes, PaymentMethodsConfiguration } from './types';
 import { getCommonProps } from './components/utils';
 import { createElements, createStoredElements } from './elements';
 import createInstantPaymentElements from './elements/createInstantPaymentElements';
 import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import splitPaymentMethods from './elements/splitPaymentMethods';
+
+import type { DropinConfiguration, InstantPaymentTypes, PaymentMethodsConfiguration } from './types';
+import type { PaymentAction, PaymentResponseData } from '../../types/global-types';
 import type { ICore } from '../../core/types';
 import type { IDropin } from './types';
 
@@ -81,6 +82,12 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
         }
 
         return this.dropinRef.state.activePaymentMethod.data;
+    }
+
+    public displayFinalAnimation(type: 'success' | 'error') {
+        if (this.props.disableFinalAnimation) return;
+
+        this.dropinRef.setStatus(type);
     }
 
     /**

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -68,7 +68,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
 
         // onSelect event
         if ((activePaymentMethod && activePaymentMethod._id !== paymentMethod._id) || !activePaymentMethod) {
-            this.props.onSelect(paymentMethod);
+            this.props.onSelect?.(paymentMethod);
 
             paymentMethod.submitAnalytics({ type: ANALYTICS_RENDERED_STR });
         }

--- a/packages/lib/src/components/Dropin/defaultProps.ts
+++ b/packages/lib/src/components/Dropin/defaultProps.ts
@@ -1,20 +1,15 @@
-export default {
+import type { DropinConfiguration } from './types';
+
+const props: DropinConfiguration = {
+    isDropin: true,
     instantPaymentTypes: [],
     paymentMethodComponents: [],
-
-    isDropin: true,
-    onReady: () => {}, // triggered when the Dropin is fully loaded
-    onComplete: () => {}, // triggered when the shopper completes a payment
-    onError: () => {}, // triggered when an error occurs (for example, could not submit a payment)
-    onSelect: () => {}, // triggered when a paymentMethod is selected
-    onDisableStoredPaymentMethod: null, // triggered when a shopper removes a storedPaymentMethod
-    onChange: () => {},
-
-    amount: {},
-    paymentMethodsConfiguration: {}, // per paymentMethod configuration
-    openFirstPaymentMethod: true, // focus the first payment method automatically on load
-    openFirstStoredPaymentMethod: true, // focus the first one click payment method automatically on load
-    showStoredPaymentMethods: true, // shows/hides oneclick paymentMethods
-    showPaymentMethods: true, // shows/hides regular paymentMethods
-    showRemoveStoredPaymentMethodButton: false
+    paymentMethodsConfiguration: {},
+    openFirstPaymentMethod: true,
+    openFirstStoredPaymentMethod: true,
+    showStoredPaymentMethods: true,
+    showPaymentMethods: true,
+    disableFinalAnimation: false
 };
+
+export default props;

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -53,6 +53,12 @@ export interface DropinConfiguration extends UIElementProps {
     showStoredPaymentMethods?: boolean;
 
     /**
+     * Disable the final animation when the payment is successful or if it fails.
+     * @defaultValue false
+     */
+    disableFinalAnimation?: boolean;
+
+    /**
      * Show/Hide regular (non-stored) payment methods
      * @defaultValue true
      */
@@ -126,6 +132,13 @@ export interface DropinComponentState {
 }
 
 export interface IDropin {
+    /**
+     * Used to make the Dropin display the final animation
+     *
+     * @internal
+     * @param type - animation type
+     */
+    displayFinalAnimation(type: 'success' | 'error'): void;
     activePaymentMethod: () => null;
     closeActivePaymentMethod: () => void;
 }

--- a/packages/lib/src/components/internal/UIElement/types.ts
+++ b/packages/lib/src/components/internal/UIElement/types.ts
@@ -70,12 +70,6 @@ export type UIElementProps = BaseElementProps &
          */
         showPayButton?: boolean;
 
-        /**
-         *  Set to false to not set the Component status to 'loading' when onSubmit is triggered.
-         *  @defaultValue true
-         */
-        setStatusAutomatically?: boolean;
-
         /** @internal */
         payButton?: (options: PayButtonFunctionProps) => h.JSX.Element;
 

--- a/packages/lib/src/components/internal/UIElement/utils.ts
+++ b/packages/lib/src/components/internal/UIElement/utils.ts
@@ -59,10 +59,10 @@ export function verifyPaymentDidNotFail(response: PaymentResponseData): Promise<
     return Promise.resolve(response);
 }
 
-export function assertIsDropin(dropin: IDropin) {
-    if (!dropin) return false;
+export function assertIsDropin(element: any): element is IDropin {
+    if (!element) return false;
 
-    const isDropin = typeof dropin.activePaymentMethod === 'object' && typeof dropin.closeActivePaymentMethod === 'function';
+    const isDropin = typeof element.activePaymentMethod === 'object' && typeof element.closeActivePaymentMethod === 'function';
     return isDropin;
 }
 

--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -30,7 +30,6 @@ export const GENERIC_OPTIONS = [
     'onBalanceCheck',
     'onOrderRequest',
     'onOrderUpdated',
-    'setStatusAutomatically',
     'onPaymentMethodsRequest'
 ];
 

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -142,8 +142,6 @@ export interface CoreConfiguration {
 
     order?: Order;
 
-    setStatusAutomatically?: boolean;
-
     /**
      * Add @adyen/web metadata to the window object.
      * It helps to identify version number and bundle type in the merchant environment

--- a/packages/playground/src/handlers.js
+++ b/packages/playground/src/handlers.js
@@ -9,6 +9,16 @@ export function handleChange(state, component) {
     console.groupEnd();
 }
 
+export function handleOnPaymentCompleted(result, element) {
+    alert(`onPaymentCompleted - ${result.resultCode}`);
+    console.log('onPaymentCompleted', result, element);
+}
+
+export function handleOnPaymentFailed(result, element) {
+    alert(`onPaymentFailed - ${result.resultCode}`);
+    console.log('onPaymentFailed', result, element);
+}
+
 export function handleError(obj) {
     // SecuredField related errors should not go straight to console.error
     if (obj.type === 'card') {
@@ -19,8 +29,6 @@ export function handleError(obj) {
 }
 
 export async function handleSubmit(state, component, actions) {
-    component.setStatus('loading');
-
     try {
         const { action, order, resultCode, donationToken } = await makePayment(state.data);
 

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -2,7 +2,7 @@ import { AdyenCheckout, Card, Bancontact, nl_NL } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
 
 import { getPaymentMethods } from '../../services';
-import { handleSubmit, handleAdditionalDetails, handleError } from '../../handlers';
+import { handleSubmit, handleAdditionalDetails, handleError, handleOnPaymentFailed, handleOnPaymentCompleted } from '../../handlers';
 import { amount, shopperLocale, countryCode } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
@@ -49,12 +49,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         risk: {
             enabled: false
         },
-        onPaymentCompleted(result, element) {
-            console.log('onPaymentCompleted', result, element);
-        },
-        onPaymentFailed(result, element) {
-            console.log('onPaymentFailed', result, element);
-        }
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed
     });
 
     // Stored Card

--- a/packages/playground/src/pages/Components/Components.js
+++ b/packages/playground/src/pages/Components/Components.js
@@ -19,7 +19,7 @@ import '@adyen/adyen-web/styles/adyen.css';
 import '../../../config/polyfills';
 import '../../style.scss';
 import { getPaymentMethods } from '../../services';
-import { handleSubmit, handleAdditionalDetails, handleChange } from '../../handlers';
+import { handleSubmit, handleAdditionalDetails, handleChange, handleOnPaymentFailed, handleOnPaymentCompleted } from '../../handlers';
 import { amount, shopperLocale, countryCode } from '../../config/commonConfig';
 import getTranslationFile from '../../config/getTranslation';
 
@@ -35,12 +35,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         onChange: handleChange,
         onSubmit: handleSubmit,
         onAdditionalDetails: handleAdditionalDetails,
-        onPaymentCompleted(result, element) {
-            console.log('onPaymentCompleted', result, element);
-        },
-        onPaymentFailed(result, element) {
-            console.log('onPaymentFailed', result, element);
-        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed,
         onError: (error, component) => {
             console.info(error, component);
         },

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -4,6 +4,7 @@ import { getPaymentMethods, makePayment, checkBalance, createOrder, cancelOrder,
 import { amount, shopperLocale, countryCode } from '../../config/commonConfig';
 import { getSearchParameters } from '../../utils';
 import getTranslationFile from '../../config/getTranslation';
+import { handleOnPaymentCompleted, handleOnPaymentFailed } from '../../handlers';
 
 export async function initManual() {
     const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
@@ -53,12 +54,6 @@ export async function initManual() {
                 actions.reject();
             }
         },
-        onPaymentCompleted(result, element) {
-            console.log('onPaymentCompleted', result, element);
-        },
-        onPaymentFailed(result, element) {
-            console.log('onPaymentFailed', result, element);
-        },
         onBalanceCheck: async (resolve, reject, data) => {
             console.log('onBalanceCheck', data);
             resolve(await checkBalance(data));
@@ -87,7 +82,9 @@ export async function initManual() {
         onPaymentMethodsRequest: async (data, { resolve, reject }) => {
             console.log('onPaymentMethodsRequest', data);
             resolve(await getPaymentMethods({ amount, shopperLocale: data.locale, order: data.order }));
-        }
+        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed
     });
 
     function handleFinalState(resultCode, dropin) {
@@ -130,6 +127,7 @@ export async function initManual() {
     const dropin = new Dropin(checkout, {
         paymentMethodComponents: [Card, GooglePay, PayPal, Ach, Affirm, WeChat, Giftcard, AmazonPay, Ideal],
         instantPaymentTypes: ['googlepay'],
+        disableFinalAnimation: true,
         paymentMethodsConfiguration: {
             card: {
                 challengeWindowSize: '03',

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -3,6 +3,7 @@ import '@adyen/adyen-web/styles/adyen.css';
 import { createSession } from '../../services';
 import { amount, shopperLocale, shopperReference, countryCode, returnUrl } from '../../config/commonConfig';
 import getTranslationFile from '../../config/getTranslation';
+import { handleOnPaymentCompleted, handleOnPaymentFailed } from '../../handlers';
 
 export async function initSession() {
     const session = await createSession({
@@ -27,18 +28,14 @@ export async function initSession() {
         beforeSubmit: (data, component, actions) => {
             actions.resolve(data);
         },
-        onPaymentCompleted: (result, component) => {
-            console.info('onPaymentCompleted', result, component);
-        },
-        onPaymentFailed(result, element) {
-            console.log('onPaymentFailed', result, element);
-        },
         onError: (error, component) => {
             console.error('error', JSON.stringify(error.name), JSON.stringify(error.message), component);
         },
         onChange: (state, component) => {
             console.log('onChange', state);
-        }
+        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed
     });
 
     const dropin = new Dropin(checkout, {

--- a/packages/playground/src/pages/DropinAuto/manual.js
+++ b/packages/playground/src/pages/DropinAuto/manual.js
@@ -4,6 +4,7 @@ import { getPaymentMethods, makePayment, checkBalance, createOrder, cancelOrder,
 import { amount, shopperLocale, countryCode, returnUrl } from '../../config/commonConfig';
 import { getSearchParameters } from '../../utils';
 import getTranslationFile from '../../config/getTranslation';
+import { handleOnPaymentCompleted, handleOnPaymentFailed } from '../../handlers';
 
 export async function initManual() {
     const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
@@ -57,12 +58,6 @@ export async function initManual() {
                 actions.reject();
             }
         },
-        onPaymentCompleted(data, component) {
-            component.setStatus('success');
-        },
-        onPaymentFailed(data, component) {
-            component.setStatus('error');
-        },
         onBalanceCheck: async (resolve, reject, data) => {
             resolve(await checkBalance(data));
         },
@@ -78,7 +73,9 @@ export async function initManual() {
         },
         onActionHandled: rtnObj => {
             console.log('onActionHandled', rtnObj);
-        }
+        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed
     });
 
     function handleFinalState(resultCode, dropin) {

--- a/packages/playground/src/pages/DropinAuto/session.js
+++ b/packages/playground/src/pages/DropinAuto/session.js
@@ -3,6 +3,7 @@ import '@adyen/adyen-web/styles/adyen.css';
 import { createSession } from '../../services';
 import { amount, shopperLocale, shopperReference, countryCode, returnUrl } from '../../config/commonConfig';
 import getTranslationFile from '../../config/getTranslation';
+import { handleOnPaymentCompleted, handleOnPaymentFailed } from '../../handlers';
 
 export async function initSession() {
     const session = await createSession({
@@ -28,20 +29,14 @@ export async function initSession() {
         beforeSubmit: (data, component, actions) => {
             actions.resolve(data);
         },
-        onPaymentCompleted(data, component) {
-            console.info('onPaymentCompleted', data, component);
-            component.setStatus('success');
-        },
-        onPaymentFailed(data, component) {
-            console.info('onPaymentFailed', data, component);
-            component.setStatus('error');
-        },
         onError: (error, component) => {
             console.info(JSON.stringify(error), component);
         },
         onChange: (state, component) => {
             console.log('onChange', state);
-        }
+        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed
     });
 
     const dropin = new Dropin(checkout, {

--- a/packages/playground/src/pages/DropinUMD/manual.js
+++ b/packages/playground/src/pages/DropinUMD/manual.js
@@ -3,6 +3,7 @@ import { getPaymentMethods, makePayment, checkBalance, createOrder, cancelOrder,
 import { amount, shopperLocale, countryCode, returnUrl } from '../../config/commonConfig';
 import { getSearchParameters } from '../../utils';
 import getTranslationFile from '../../config/getTranslation';
+import { handleOnPaymentCompleted, handleOnPaymentFailed } from '../../handlers';
 
 export async function initManual() {
     const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
@@ -51,12 +52,9 @@ export async function initManual() {
                 actions.reject();
             }
         },
-        onPaymentCompleted(data, component) {
-            component.setStatus('success');
-        },
-        onPaymentFailed(data, component) {
-            component.setStatus('error');
-        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed,
+
         onBalanceCheck: async (resolve, reject, data) => {
             resolve(await checkBalance(data));
         },

--- a/packages/playground/src/pages/DropinUMD/session.js
+++ b/packages/playground/src/pages/DropinUMD/session.js
@@ -2,6 +2,7 @@ import '@adyen/adyen-web/styles/adyen.css';
 import { createSession } from '../../services';
 import { amount, shopperLocale, shopperReference, countryCode, returnUrl } from '../../config/commonConfig';
 import getTranslationFile from '../../config/getTranslation';
+import { handleOnPaymentCompleted, handleOnPaymentFailed } from '../../handlers';
 
 export async function initSession() {
     const session = await createSession({
@@ -24,14 +25,11 @@ export async function initSession() {
         locale: shopperLocale,
         translationFile: getTranslationFile(shopperLocale),
 
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed,
+
         beforeSubmit: (data, component, actions) => {
             actions.resolve(data);
-        },
-        onPaymentCompleted: (result, component) => {
-            console.info('onPaymentCompleted', result, component);
-        },
-        onPaymentFailed: (result, component) => {
-            console.info('onPaymentFailed', result, component);
         },
         onError: (error, component) => {
             console.info(JSON.stringify(error), component);

--- a/packages/playground/src/pages/GiftCards/GiftCards.js
+++ b/packages/playground/src/pages/GiftCards/GiftCards.js
@@ -1,6 +1,6 @@
 import { AdyenCheckout, Giftcard, MealVoucherFR, Card, fr_FR } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
-import { handleChange, handleSubmit } from '../../handlers';
+import { handleChange, handleOnPaymentCompleted, handleOnPaymentFailed, handleSubmit } from '../../handlers';
 import { amount, shopperLocale, countryCode, returnUrl, shopperReference } from '../../config/commonConfig';
 import { checkBalance, createOrder, createSession } from '../../services';
 import '../../../config/polyfills';
@@ -17,12 +17,8 @@ import getTranslationFile from '../../config/getTranslation';
         environment: process.env.__CLIENT_ENV__,
         onChange: handleChange,
         onSubmit: handleSubmit,
-        onPaymentCompleted(result, element) {
-            console.log('onPaymentCompleted', result, element);
-        },
-        onPaymentFailed(result, element) {
-            console.log('onPaymentFailed', result, element);
-        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed,
         showPayButton: true,
         amount
     });

--- a/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
+++ b/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
@@ -1,7 +1,7 @@
-import { AdyenCheckout, RatePay, RatePayDirectDebit, AfterPay, AfterPayB2B, FacilPay3x, Affirm, Atome, en_US } from '@adyen/adyen-web';
+import { AdyenCheckout, RatePay, Riverty, RatePayDirectDebit, AfterPay, AfterPayB2B, FacilPay3x, Affirm, Atome, en_US } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
 import { getPaymentMethods } from '../../services';
-import { handleChange, handleSubmit } from '../../handlers';
+import { handleChange, handleOnPaymentCompleted, handleOnPaymentFailed, handleSubmit } from '../../handlers';
 import { amount, shopperLocale, countryCode } from '../../config/commonConfig';
 import '../../../config/polyfills';
 import '../../style.scss';
@@ -30,12 +30,8 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsData => {
         environment: process.env.__CLIENT_ENV__,
         onChange: handleChange,
         onSubmit: handleSubmit,
-        onPaymentCompleted(result, element) {
-            console.log('onPaymentCompleted', result, element);
-        },
-        onPaymentFailed(result, element) {
-            console.log('onPaymentFailed', result, element);
-        },
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed,
         onError: console.error,
         showPayButton: true,
         amount // Optional. Used to display the amount in the Pay Button.
@@ -43,16 +39,14 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsData => {
 
     // RIVERTY
     if (showComps.riverty) {
-        window.riverty = checkout
-            .create('riverty', {
-                countryCode: 'DE', // 'DE' / 'AT' / 'CH'
-                visibility: {
-                    personalDetails: 'editable', // editable [default] / readOnly / hidden
-                    billingAddress: 'editable',
-                    deliveryAddress: 'editable'
-                }
-            })
-            .mount('.riverty-field');
+        window.riverty = new Riverty(window.core, {
+            countryCode: 'DE', // 'DE' / 'AT' / 'CH'
+            visibility: {
+                personalDetails: 'editable', // editable [default] / readOnly / hidden
+                billingAddress: 'editable',
+                deliveryAddress: 'editable'
+            }
+        }).mount('.riverty-field');
     }
 
     // RATEPAY

--- a/packages/playground/src/pages/QRCodes/QRCodes.js
+++ b/packages/playground/src/pages/QRCodes/QRCodes.js
@@ -8,6 +8,7 @@ import '../../style.scss';
 import './QRCodes.scss';
 import getCurrency from '../../config/getCurrency';
 import getTranslationFile from '../../config/getTranslation';
+import { handleOnPaymentCompleted, handleOnPaymentFailed } from '../../handlers';
 
 const handleQRCodePayment = async (state, component, actions, countryCode) => {
     const currency = getCurrency(countryCode);
@@ -40,12 +41,8 @@ const handleQRCodePayment = async (state, component, actions, countryCode) => {
         translationFile: getTranslationFile(shopperLocale),
         environment: process.env.__CLIENT_ENV__,
         risk: { node: 'body', onError: console.error },
-        onPaymentCompleted(result, element) {
-            console.log('onPaymentCompleted', result, element);
-        },
-        onPaymentFailed(result, element) {
-            console.log('onPaymentFailed', result, element);
-        }
+        onPaymentCompleted: handleOnPaymentCompleted,
+        onPaymentFailed: handleOnPaymentFailed
     });
 
     // WechatPay QR

--- a/packages/playground/src/pages/Wallets/Wallets.js
+++ b/packages/playground/src/pages/Wallets/Wallets.js
@@ -20,16 +20,16 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         environment: process.env.__CLIENT_ENV__,
         onSubmit: handleSubmit,
         onAdditionalDetails: handleAdditionalDetails,
-        onError(error) {
-            console.log(error);
-        },
-        onPaymentCompleted(result, element) {
+        onPaymentCompleted: (result, element) => {
             console.log('onPaymentCompleted', result, element);
         },
-        onPaymentFailed(result, element) {
+        onPaymentFailed: (result, element) => {
+            alert(`onPaymentFailed - ${result.resultCode}`);
             console.log('onPaymentFailed', result, element);
         },
-        showPayButton: true
+        onError(error) {
+            console.log(error);
+        }
     });
 
     // Cash App Pay
@@ -145,9 +145,6 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsResponse =
         onAuthorized(data, actions) {
             console.log('onAuthorized', data, actions);
             actions.resolve();
-        },
-        onError: (error, component) => {
-            console.log('paypal onError', error);
         }
     }).mount('.paypal-field');
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Removed `setStatusAutomatically` . That means that the UIElement will always be set to `loading` when the submit/additionalDetails is triggered.
- When the payment is finalized, the UI will be kept in the 'loading' state. The merchant needs to react upon it on the callbacks `onPaymentCompleted` or `onPaymentFailed` to display the desired UI or redirect the shopper to the next page
- The Drop-in has now the property `disableFinalAnimation` which handles if the final GIF animation will be displayed or not. If deactivated, the UI will be kept in 'loading' state , and the merchant needs to react upon that.

## Tested scenarios
- Added unit tests


