### PR TITLE
For zero auth payments, only store the payment method if the configuration says we should

### DIFF
--- a/.changeset/moody-boxes-exist.md
+++ b/.changeset/moody-boxes-exist.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+For regular card, zero auth payments, we store the payment method only if the configuration says we should

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.test.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.test.tsx
@@ -33,7 +33,7 @@ describe('AchInput', () => {
     });
 
     test('should render StoreDetails when enabled', async () => {
-        withCoreProvider(<AchInput enableStoreDetails resources={new Resources()} />);
+        withCoreProvider(<AchInput enableStoreDetails={true} resources={new Resources()} />);
         expect(await screen.findByText(/save for my next payment/i)).toBeTruthy();
     });
 

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
@@ -54,7 +54,7 @@ export const CardFieldsWrapper = ({
     billingAddressAllowedCountries,
     billingAddressValidationRules = null,
     brandsConfiguration,
-    enableStoreDetails,
+    showStoreDetailsCheckbox,
     hasCVC,
     hasHolderName,
     holderNameRequired,
@@ -137,7 +137,7 @@ export const CardFieldsWrapper = ({
                 </div>
             )}
 
-            {enableStoreDetails && <StoreDetails onChange={handleOnStoreDetails} />}
+            {showStoreDetailsCheckbox && <StoreDetails onChange={handleOnStoreDetails} />}
 
             {hasInstallments && (
                 <Installments

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -120,6 +120,7 @@ export interface CardInputProps {
     showFormInstruction?: boolean;
     showInstallmentAmounts?: boolean;
     showPayButton?: boolean;
+    showStoreDetailsCheckbox?: boolean;
     showWarnings?: boolean;
     specifications?: Specifications;
     storedPaymentMethodId?: string;

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -116,7 +116,7 @@ export const extractPropsForCardFields = (props: CardInputProps) => {
         billingAddressRequiredFields: props.billingAddressRequiredFields,
         billingAddressAllowedCountries: props.billingAddressAllowedCountries,
         brandsConfiguration: props.brandsConfiguration,
-        enableStoreDetails: props.enableStoreDetails,
+        showStoreDetailsCheckbox: props.showStoreDetailsCheckbox,
         hasCVC: props.hasCVC,
         hasHolderName: props.hasHolderName,
         holderNameRequired: props.holderNameRequired,

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -70,7 +70,13 @@ export interface CardElementProps extends UIElementProps {
      */
     showFormInstruction?: boolean;
 
-    /** Show/hide the "store details" checkbox */
+    /** Config option related to whether we set storePaymentMethod in the card data, and showing/hiding the "store details" checkbox */
+    enableStoreDetails?: boolean;
+
+    /**
+     * Show/hide the "store details" checkbox
+     * @internal
+     */
     showStoreDetailsCheckbox?: boolean;
 
     /** Show/hide the CVC field - merchant set config option */

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -71,7 +71,7 @@ export interface CardElementProps extends UIElementProps {
     showFormInstruction?: boolean;
 
     /** Show/hide the "store details" checkbox */
-    enableStoreDetails?: boolean;
+    showStoreDetailsCheckbox?: boolean;
 
     /** Show/hide the CVC field - merchant set config option */
     hideCVC?: boolean;

--- a/packages/playground/src/services.js
+++ b/packages/playground/src/services.js
@@ -11,8 +11,10 @@ export const getPaymentMethods = configuration =>
         .catch(console.error);
 
 export const makePayment = (data, config = {}) => {
-    // Needed for storedPMs in v70 if a standalone comp, or, in Dropin, advanced flow. (Sessions, v70, works with or without this prop)
-    if (data.paymentMethod.storedPaymentMethodId) {
+    // Needed for v70 if a standalone comp, or, in Dropin, advanced flow. (Sessions, v70, works with or without this prop).
+    //  - Needed for storedPMs
+    //  - Also needed for regular card, if the "save for my next payment" checkbox is clicked
+    if (data.paymentMethod.storedPaymentMethodId || data.storePaymentMethod) {
         config = { recurringProcessingModel: 'CardOnFile', ...config };
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The fix in #2571  did not cover all use cases

For regular card, zero auth payments, we should store the payment method _only if the configuration says we should_:
- For sessions, this means if the session has been created with `storePaymentMethodMode: 'askForConsent'` (which will lead to a `configuration: {enableStoreDetails: true}` object in the `/sessions/setup` response)
- For the advanced flow, this means if the merchant has still set `enableStoreDetails: true`

What we are doing is.. if for a normal payment we would show the "Save for my next payment" checkbox, for a zero-auth payment we effectively click the checkbox on behalf of the shopper, _if_ we are allowed to.

To this end, in the `Card` component I have created a new, separate property `showStoreDetailsCheckbox` which is solely concerned with the UI and whether we should show the "Save for my next payment" checkbox. 
The original `enableStoreDetails` property is retained to store the original value from the configuration passed to the component 

## Tested scenarios
New unit tests
All unit tests pass

**Fixed issue**:  COWEB-1352
