### PR TITLE
v6 - Logging warnings when AdyenCheckout has wrong properties

### DIFF
--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -7,7 +7,7 @@ import { resolveEnvironment, resolveCDNEnvironment, resolveAnalyticsEnvironment 
 import Analytics from './Analytics';
 import { AdditionalDetailsStateData, PaymentAction, PaymentResponseData } from '../types/global-types';
 import { CoreConfiguration, ICore } from './types';
-import { processGlobalOptions } from './utils';
+import { assertConfigurationPropertiesAreValid, processGlobalOptions } from './utils';
 import Session from './CheckoutSession';
 import { hasOwnProperty } from '../utils/hasOwnProperty';
 import { Resources } from './Context/Resources';
@@ -61,6 +61,8 @@ class Core implements ICore {
     }
 
     constructor(props: CoreConfiguration) {
+        assertConfigurationPropertiesAreValid(props);
+
         this.createFromAction = this.createFromAction.bind(this);
 
         this.setOptions({ exposeLibraryMetadata: true, ...props });

--- a/packages/lib/src/core/utils.ts
+++ b/packages/lib/src/core/utils.ts
@@ -1,4 +1,5 @@
 import { GENERIC_OPTIONS } from './config';
+import type { CoreConfiguration } from './types';
 
 /**
  * Filter properties in a global configuration object from an allow list (GENERIC_OPTIONS)
@@ -10,4 +11,70 @@ export function processGlobalOptions(globalOptions) {
         if (GENERIC_OPTIONS.includes(e)) r[e] = globalOptions[e];
         return r;
     }, {});
+}
+
+/**
+ * Validates that there is no unknown property as part of the CoreConfiguration.
+ * The validator makes sure to throw a lint error in case a property is added to CoreConfiguration, but it is not added here
+ *
+ * @param props - AdyenCheckout props
+ */
+export function assertConfigurationPropertiesAreValid(propsSetByMerchant: CoreConfiguration): void {
+    /** Helper that creates a function that validates the array contain ALL CoreConfiguration properties in it */
+    function createConfigurationKeysValidator<T>() {
+        const arrayOfAll =
+            <T>() =>
+            <U extends T[]>(array: U & ([T] extends [U[number]] ? unknown : 'Invalid')) =>
+                array;
+        const arrayWithAllKeys = arrayOfAll<T>();
+        return arrayWithAllKeys;
+    }
+
+    const validator = createConfigurationKeysValidator<keyof CoreConfiguration>();
+    const possibleFields = validator([
+        'session',
+        'environment',
+        'environmentUrls',
+        'showPayButton',
+        'clientKey',
+        'locale',
+        'translationFile',
+        'translations',
+        'paymentMethodsResponse',
+        'amount',
+        'secondaryAmount',
+        'countryCode',
+        'allowPaymentMethods',
+        'removePaymentMethods',
+        'srConfig',
+        'cdnContext',
+        'resourceEnvironment',
+        'analytics',
+        'risk',
+        'order',
+        'exposeLibraryMetadata',
+        'beforeRedirect',
+        'beforeSubmit',
+        'onPaymentCompleted',
+        'onPaymentFailed',
+        'onSubmit',
+        'onAdditionalDetails',
+        'onActionHandled',
+        'onChange',
+        'onError',
+        'onBalanceCheck',
+        'onOrderRequest',
+        'onPaymentMethodsRequest',
+        'onOrderCancel',
+        'onOrderUpdated',
+        'loadingContext'
+    ]);
+
+    Object.keys(propsSetByMerchant).forEach((prop: keyof CoreConfiguration) => {
+        if (!possibleFields.includes(prop)) {
+            console.warn(
+                `AdyenCheckout - Configuration property "${prop}" is not a valid AdyenCheckout property. If it is a payment method configuration, make sure to pass it directly to the Component. If you are using Drop-in, make sure to pass it to "paymentMethodsConfiguration" object`
+            );
+        }
+    });
 }

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -15,8 +15,6 @@ export async function initManual() {
         clientKey: process.env.__CLIENT_KEY__,
         paymentMethodsResponse,
 
-        onShippingOptionsChange: true,
-
         locale: 'pt-BR',
         translationFile: getTranslationFile(shopperLocale),
 

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -15,6 +15,8 @@ export async function initManual() {
         clientKey: process.env.__CLIENT_KEY__,
         paymentMethodsResponse,
 
+        onShippingOptionsChange: true,
+
         locale: 'pt-BR',
         translationFile: getTranslationFile(shopperLocale),
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Adding helper function that validates that there are no unknown properties being passed to Core. It does not validate the object itself, but it validates the keys
- The `createConfigurationKeysValidator` is just a helper to make sure that we are in sync between the `CoreConfiguration` options and the `possibleFields` array. If we add a property to `CoreConfiguration` and we forget to add to the `possibleFields`, TS will complain.  (I got this TS check idea from [here](https://stackoverflow.com/questions/60131681/make-sure-array-has-all-types-from-a-union). I am also fine to ditch it and just use a simple array to validate)



