### PR TITLE
Fix/v5 sr panel issues for open invoices

### DIFF
--- a/.changeset/brave-masks-refuse.md
+++ b/.changeset/brave-masks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fixing SRPanel issues in OpenInvoice comp now that (delivery) addresses can have first & last Names

--- a/packages/e2e-playwright/app/src/pages/OpenInvoices/OpenInvoices.html
+++ b/packages/e2e-playwright/app/src/pages/OpenInvoices/OpenInvoices.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
+        <title>Adyen Web | Open Invoices</title>
+        <meta name="description" content="" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    </head>
+
+    <body>
+        <main>
+            <div class="merchant-checkout__form">
+                <div id="openInvoicesContainer">
+                    <div id="rivertyContainer"></div>
+                </div>
+            </div>
+        </main>
+
+        <script type="text/javascript">
+            window.htmlPages = <%= JSON.stringify(htmlWebpackPlugin.htmlPages) || '' %>;
+        </script>
+    </body>
+</html>

--- a/packages/e2e-playwright/app/src/pages/OpenInvoices/OpenInvoices.js
+++ b/packages/e2e-playwright/app/src/pages/OpenInvoices/OpenInvoices.js
@@ -1,0 +1,28 @@
+import AdyenCheckout from '@adyen/adyen-web';
+import '@adyen/adyen-web/dist/es/adyen.css';
+import { getPaymentMethods } from '../../services';
+import { amount, shopperLocale, countryCode } from '../../services/commonConfig';
+import { handleSubmit, handleAdditionalDetails, handleError } from '../../handlers';
+import '../../style.scss';
+
+const initCheckout = async () => {
+    const paymentMethodsResponse = await getPaymentMethods({ amount, shopperLocale });
+
+    window.checkout = await AdyenCheckout({
+        amount,
+        countryCode,
+        clientKey: process.env.__CLIENT_KEY__,
+        paymentMethodsResponse,
+        locale: shopperLocale,
+        environment: 'test',
+        onSubmit: handleSubmit,
+        onAdditionalDetails: handleAdditionalDetails,
+        onError: handleError,
+        showPayButton: true,
+        ...window.mainConfiguration
+    });
+
+    window.riverty = checkout.create('riverty', window.rivertyConfig).mount('#rivertyContainer');
+};
+
+initCheckout();

--- a/packages/e2e-playwright/models/openInvoices.ts
+++ b/packages/e2e-playwright/models/openInvoices.ts
@@ -1,0 +1,30 @@
+import { Locator, Page } from '@playwright/test';
+
+class OpenInvoices {
+    readonly page: Page;
+
+    readonly rootElement: Locator;
+    readonly rootElementSelector: string;
+
+    readonly riverty: Locator;
+    readonly rivertyDeliveryAddressCheckbox: Locator;
+
+    constructor(page: Page, rootElementSelector = '#openInvoicesContainer') {
+        this.page = page;
+
+        this.rootElement = page.locator(rootElementSelector);
+        this.rootElementSelector = rootElementSelector;
+
+        this.riverty = this.rootElement.locator('#rivertyContainer');
+
+        this.rivertyDeliveryAddressCheckbox = this.riverty
+            .locator('.adyen-checkout__checkbox')
+            .filter({ hasText: 'Specify a separate delivery address' });
+    }
+
+    async isComponentVisible() {
+        await this.rootElement.waitFor({ state: 'visible' });
+    }
+}
+
+export { OpenInvoices };

--- a/packages/e2e-playwright/pages/openInvoices/openInvoices.fixture.ts
+++ b/packages/e2e-playwright/pages/openInvoices/openInvoices.fixture.ts
@@ -1,0 +1,40 @@
+import { test as base, expect, Page } from '@playwright/test';
+import { OpenInvoicesPage } from './openInvoices.page';
+type Fixture = {
+    openInvoicesPage: OpenInvoicesPage;
+    openInvoicesPage_riverty: OpenInvoicesPage;
+};
+
+const test = base.extend<Fixture>({
+    openInvoicesPage: async ({ page }, use) => {
+        await useOpenInvoicesPage(page, use);
+    },
+
+    openInvoicesPage_riverty: async ({ page }, use) => {
+        const mainConfig = JSON.stringify({
+            srConfig: {
+                showPanel: true
+            }
+        });
+        await page.addInitScript({
+            content: `window.mainConfiguration = ${mainConfig}`
+        });
+
+        const rivertyConfig = JSON.stringify({
+            countryCode: 'DE'
+        });
+        await page.addInitScript({
+            content: `window.rivertyConfig = ${rivertyConfig}`
+        });
+
+        await useOpenInvoicesPage(page, use);
+    }
+});
+
+const useOpenInvoicesPage = async (page: Page, use: any, PageType = OpenInvoicesPage) => {
+    const openInvoicesPage = new PageType(page);
+    await openInvoicesPage.goto();
+    await use(openInvoicesPage);
+};
+
+export { test, expect };

--- a/packages/e2e-playwright/pages/openInvoices/openInvoices.page.ts
+++ b/packages/e2e-playwright/pages/openInvoices/openInvoices.page.ts
@@ -1,0 +1,25 @@
+import { Locator, Page } from '@playwright/test';
+import { OpenInvoices } from '../../models/openInvoices';
+
+class OpenInvoicesPage {
+    readonly page: Page;
+
+    readonly openInvoices: OpenInvoices;
+    readonly payButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.openInvoices = new OpenInvoices(page);
+        this.payButton = page.getByRole('button', { name: /Confirm/i });
+    }
+
+    async goto(url?: string) {
+        await this.page.goto('http://localhost:3024/openinvoices');
+    }
+
+    async pay() {
+        await this.payButton.click();
+    }
+}
+
+export { OpenInvoicesPage };

--- a/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
+++ b/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../../pages/openInvoices/openInvoices.fixture';
 
 import LANG from '../../../lib/src/language/locales/en-US.json';
 
-const SR_PREFIX = ''; // needs to be '-sr' if running locally;
+const SR_PREFIX = process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' ? '' : '-sr';
 
 const INVALID_FORMAT_EXPECTS = LANG['invalidFormatExpects'].replace('%{format}', `99999${SR_PREFIX}`);
 

--- a/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
+++ b/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
@@ -2,30 +2,28 @@ import { test, expect } from '../../pages/openInvoices/openInvoices.fixture';
 
 import LANG from '../../../lib/src/language/locales/en-US.json';
 
-const SR_PREFIX = process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' ? '' : '-sr';
-
-const INVALID_FORMAT_EXPECTS = LANG['invalidFormatExpects'].replace('%{format}', `99999${SR_PREFIX}`);
+const INVALID_FORMAT_EXPECTS = LANG['invalidFormatExpects'].replace('%{format}', `99999`);
 
 const BILLING_ADDRESS = LANG['billingAddress'];
 const DELIVERY_ADDRESS = LANG['deliveryAddress'];
 
 const expectedSRPanelTexts = [
-    `${LANG['firstName.invalid']}${SR_PREFIX}`,
-    `${LANG['lastName.invalid']}${SR_PREFIX}`,
-    `${LANG['dateOfBirth.invalid']}${SR_PREFIX}`,
-    `${LANG['shopperEmail.invalid']}${SR_PREFIX}`,
-    `${LANG['telephoneNumber.invalid']}${SR_PREFIX}`,
-    `${BILLING_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${BILLING_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${LANG['firstName.invalid']}`,
+    `${LANG['lastName.invalid']}`,
+    `${LANG['dateOfBirth.invalid']}`,
+    `${LANG['shopperEmail.invalid']}`,
+    `${LANG['telephoneNumber.invalid']}`,
+    `${BILLING_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}`,
+    `${BILLING_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}`,
     `${BILLING_ADDRESS} ${LANG['postalCode']}: ${INVALID_FORMAT_EXPECTS}`,
-    `${BILLING_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.firstName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.lastName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${DELIVERY_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${DELIVERY_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${BILLING_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}`,
+    `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.firstName']}: ${LANG['error.va.gen.01']}`,
+    `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.lastName']}: ${LANG['error.va.gen.01']}`,
+    `${DELIVERY_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}`,
+    `${DELIVERY_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}`,
     `${DELIVERY_ADDRESS} ${LANG['postalCode']}: ${INVALID_FORMAT_EXPECTS}`,
-    `${DELIVERY_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${LANG['consent.checkbox.invalid']}${SR_PREFIX}`
+    `${DELIVERY_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}`,
+    `${LANG['consent.checkbox.invalid']}`
 ];
 
 test.describe('Test Riverty Component', () => {
@@ -51,7 +49,7 @@ test.describe('Test Riverty Component', () => {
                     // console.log('\n### riverty.spec:::: retrievedText', retrievedText);
                     // console.log('### riverty.spec:::: expectedTexts', expectedSRPanelTexts[index]);
 
-                    expect(retrievedText).toEqual(expectedSRPanelTexts[index]);
+                    expect(retrievedText).toContain(expectedSRPanelTexts[index]);
                 });
             });
 

--- a/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
+++ b/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
@@ -2,26 +2,9 @@ import { test, expect } from '../../pages/openInvoices/openInvoices.fixture';
 
 import LANG from '../../../lib/src/language/locales/en-US.json';
 
-// const expectedSRPanelTexts = [
-//     'Enter your first name-sr',
-//     'Enter your last name-sr',
-//     'Date of birth: Enter a valid date of birth that indicates you are at least 18 years old-sr',
-//     'Invalid email address-sr',
-//     'Invalid telephone number-sr',
-//     'Billing address Street: Incomplete field-sr',
-//     'Billing address House number: Incomplete field-sr',
-//     'Billing address Postal code: Invalid format. Expected format: 99999-sr',
-//     'Billing address City: Incomplete field-sr',
-//     'Delivery Address Recipient first name: Incomplete field-sr',
-//     'Delivery Address Recipient last name: Incomplete field-sr',
-//     'Delivery Address Street: Incomplete field-sr',
-//     'Delivery Address House number: Incomplete field-sr',
-//     'Delivery Address Postal code: Invalid format. Expected format: 99999-sr',
-//     'Delivery Address City: Incomplete field-sr',
-//     'You must agree with the terms & conditions-sr'
-// ];
-
 const SR_PREFIX = '-sr';
+
+const INVALID_FORMAT_EXPECTS = LANG['invalidFormatExpects'].replace('%{format}', `99999${SR_PREFIX}`);
 
 const BILLING_ADDRESS = LANG['billingAddress'];
 const DELIVERY_ADDRESS = LANG['deliveryAddress'];
@@ -34,19 +17,19 @@ const expectedSRPanelTexts = [
     `${LANG['telephoneNumber.invalid']}${SR_PREFIX}`,
     `${BILLING_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
     `${BILLING_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${BILLING_ADDRESS} ${LANG['postalCode']}: Invalid format. Expected format: 99999-sr`,
+    `${BILLING_ADDRESS} ${LANG['postalCode']}: ${INVALID_FORMAT_EXPECTS}`,
     `${BILLING_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
     `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.firstName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
     `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.lastName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
     `${DELIVERY_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
     `${DELIVERY_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
-    `${DELIVERY_ADDRESS} ${LANG['postalCode']}: Invalid format. Expected format: 99999-sr`,
+    `${DELIVERY_ADDRESS} ${LANG['postalCode']}: ${INVALID_FORMAT_EXPECTS}`,
     `${DELIVERY_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
     `${LANG['consent.checkbox.invalid']}${SR_PREFIX}`
 ];
 
 test.describe('Test Riverty Component', () => {
-    test('#1 test how Riverty component handles SRPanel messages', async ({ openInvoicesPage_riverty }) => {
+    test('#1 Test how Riverty component handles SRPanel messages', async ({ openInvoicesPage_riverty }) => {
         const { openInvoices, page } = openInvoicesPage_riverty;
 
         await openInvoices.isComponentVisible();
@@ -64,6 +47,7 @@ test.describe('Test Riverty Component', () => {
             .allInnerTexts()
             .then(retrievedSRPanelTexts => {
                 retrievedSRPanelTexts.forEach((retrievedText, index) => {
+                    // KEEP - handy for debugging test
                     // console.log('\n### riverty.spec:::: retrievedText', retrievedText);
                     // console.log('### riverty.spec:::: expectedTexts', expectedSRPanelTexts[index]);
 
@@ -71,7 +55,7 @@ test.describe('Test Riverty Component', () => {
                 });
             });
 
-        // Inspect SRPanel errors
+        // KEEP - handy for debugging test
         // await expect(page.getByText('Enter your first name-sr', { exact: true })).toBeVisible();
 
         await page.waitForTimeout(1000);

--- a/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
+++ b/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '../../pages/openInvoices/openInvoices.fixture';
+
+import LANG from '../../../lib/src/language/locales/en-US.json';
+
+// const expectedSRPanelTexts = [
+//     'Enter your first name-sr',
+//     'Enter your last name-sr',
+//     'Date of birth: Enter a valid date of birth that indicates you are at least 18 years old-sr',
+//     'Invalid email address-sr',
+//     'Invalid telephone number-sr',
+//     'Billing address Street: Incomplete field-sr',
+//     'Billing address House number: Incomplete field-sr',
+//     'Billing address Postal code: Invalid format. Expected format: 99999-sr',
+//     'Billing address City: Incomplete field-sr',
+//     'Delivery Address Recipient first name: Incomplete field-sr',
+//     'Delivery Address Recipient last name: Incomplete field-sr',
+//     'Delivery Address Street: Incomplete field-sr',
+//     'Delivery Address House number: Incomplete field-sr',
+//     'Delivery Address Postal code: Invalid format. Expected format: 99999-sr',
+//     'Delivery Address City: Incomplete field-sr',
+//     'You must agree with the terms & conditions-sr'
+// ];
+
+const SR_PREFIX = '-sr';
+
+const BILLING_ADDRESS = LANG['billingAddress'];
+const DELIVERY_ADDRESS = LANG['deliveryAddress'];
+
+const expectedSRPanelTexts = [
+    `${LANG['firstName.invalid']}${SR_PREFIX}`,
+    `${LANG['lastName.invalid']}${SR_PREFIX}`,
+    `${LANG['dateOfBirth.invalid']}${SR_PREFIX}`,
+    `${LANG['shopperEmail.invalid']}${SR_PREFIX}`,
+    `${LANG['telephoneNumber.invalid']}${SR_PREFIX}`,
+    `${BILLING_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${BILLING_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${BILLING_ADDRESS} ${LANG['postalCode']}: Invalid format. Expected format: 99999-sr`,
+    `${BILLING_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.firstName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${DELIVERY_ADDRESS} ${LANG['deliveryAddress.lastName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${DELIVERY_ADDRESS} ${LANG['street']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${DELIVERY_ADDRESS} ${LANG['houseNumberOrName']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${DELIVERY_ADDRESS} ${LANG['postalCode']}: Invalid format. Expected format: 99999-sr`,
+    `${DELIVERY_ADDRESS} ${LANG['city']}: ${LANG['error.va.gen.01']}${SR_PREFIX}`,
+    `${LANG['consent.checkbox.invalid']}${SR_PREFIX}`
+];
+
+test.describe('Test Riverty Component', () => {
+    test('#1 test how Riverty component handles SRPanel messages', async ({ openInvoicesPage_riverty }) => {
+        const { openInvoices, page } = openInvoicesPage_riverty;
+
+        await openInvoices.isComponentVisible();
+
+        await openInvoices.rivertyDeliveryAddressCheckbox.click();
+
+        await openInvoicesPage_riverty.pay();
+
+        // Need to wait so that the expected elements can be found by locator.allInnerTexts
+        await page.waitForTimeout(100);
+
+        // Inspect SRPanel errors: all expected errors, in the expected order
+        await page
+            .locator('.adyen-checkout-sr-panel__msg')
+            .allInnerTexts()
+            .then(retrievedSRPanelTexts => {
+                retrievedSRPanelTexts.forEach((retrievedText, index) => {
+                    // console.log('\n### riverty.spec:::: retrievedText', retrievedText);
+                    // console.log('### riverty.spec:::: expectedTexts', expectedSRPanelTexts[index]);
+
+                    expect(retrievedText).toEqual(expectedSRPanelTexts[index]);
+                });
+            });
+
+        // Inspect SRPanel errors
+        // await expect(page.getByText('Enter your first name-sr', { exact: true })).toBeVisible();
+
+        await page.waitForTimeout(1000);
+    });
+});

--- a/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
+++ b/packages/e2e-playwright/tests/openInvoices/riverty.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../../pages/openInvoices/openInvoices.fixture';
 
 import LANG from '../../../lib/src/language/locales/en-US.json';
 
-const SR_PREFIX = '-sr';
+const SR_PREFIX = ''; // needs to be '-sr' if running locally;
 
 const INVALID_FORMAT_EXPECTS = LANG['invalidFormatExpects'].replace('%{format}', `99999${SR_PREFIX}`);
 

--- a/packages/lib/src/components/internal/Address/Specifications.ts
+++ b/packages/lib/src/components/internal/Address/Specifications.ts
@@ -79,7 +79,6 @@ class Specifications {
      * Returns an array with the address schema of the selected country or the default address schema
      * Flat version of getAddressSchemaForCountry
      * @param country - The selected country
-     * @param mode - Address schema mode, can be 'full', 'partial' or 'none'
      * @returns Array
      */
     getAddressSchemaForCountryFlat(country: string): AddressField[] {

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -59,7 +59,7 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         fieldTypeMappingFn: mapFieldKey
     });
 
-    const specifications = useMemo(() => new Specifications(), []);
+    const specifications = useMemo(() => new Specifications(props.deliveryAddressSpecification), []);
     /** end SR stuff */
 
     const initialActiveFieldsets: OpenInvoiceActiveFieldsets = getInitialActiveFieldsets(visibility, props.data);
@@ -114,6 +114,7 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         const newData: OpenInvoiceStateData = getActiveFieldsData(activeFieldsets, data);
 
         const DELIVERY_ADDRESS_PREFIX = 'deliveryAddress:';
+        const BILLING_ADDRESS_PREFIX = 'billingAddress:';
 
         /** Create messages for SRPanel */
         // Extract nested errors from the various child components...
@@ -126,7 +127,9 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
             ...remainingErrors
         } = errors;
 
-        // (Differentiate between billingAddress and deliveryAddress errors by adding a prefix to the latter)
+        // Differentiate between billingAddress and deliveryAddress errors by adding a prefix.
+        // This also allows overlapping errors e.g. now that addresses can contain first & last name fields
+        const enhancedBillingAddressErrors = enhanceErrorObjectKeys(extractedBillingAddressErrors, BILLING_ADDRESS_PREFIX);
         const enhancedDeliveryAddressErrors = enhanceErrorObjectKeys(extractedDeliveryAddressErrors, DELIVERY_ADDRESS_PREFIX);
 
         // ...and then collate the errors into a new object so that they all sit at top level
@@ -134,7 +137,7 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
             ...(typeof extractedCompanyDetailsErrors === 'object' && extractedCompanyDetailsErrors),
             ...(typeof extractedPersonalDetailsErrors === 'object' && extractedPersonalDetailsErrors),
             ...(typeof extractedBankAccountErrors === 'object' && extractedBankAccountErrors),
-            ...(typeof extractedBillingAddressErrors === 'object' && extractedBillingAddressErrors),
+            ...(typeof enhancedBillingAddressErrors === 'object' && enhancedBillingAddressErrors),
             ...(typeof enhancedDeliveryAddressErrors === 'object' && enhancedDeliveryAddressErrors),
             ...remainingErrors
         };
@@ -148,14 +151,19 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         const bankAccountLayout = ['holder', 'iban'];
 
         const billingAddressLayout = specifications.getAddressSchemaForCountryFlat(data.billingAddress?.country);
+        // In order to sort the address errors the layout entries need to have the same (prefixed) identifier as the errors themselves
+        const billingAddressLayoutEnhanced = billingAddressLayout.map(item => `${BILLING_ADDRESS_PREFIX}${item}`);
 
         const deliveryAddressLayout = specifications.getAddressSchemaForCountryFlat(data.deliveryAddress?.country);
-        // In order to sort the deliveryAddress errors the layout entries need to have the same (prefixed) identifier as the errors themselves
         const deliveryAddressLayoutEnhanced = deliveryAddressLayout.map(item => `${DELIVERY_ADDRESS_PREFIX}${item}`);
 
-        const fullLayout = companyDetailsLayout.concat(personalDetailLayout, bankAccountLayout, billingAddressLayout, deliveryAddressLayoutEnhanced, [
-            'consentCheckbox'
-        ]);
+        const fullLayout = companyDetailsLayout.concat(
+            personalDetailLayout,
+            bankAccountLayout,
+            billingAddressLayoutEnhanced,
+            deliveryAddressLayoutEnhanced,
+            ['consentCheckbox']
+        );
 
         // Country specific address labels
         const countrySpecificLabels = specifications.getAddressLabelsForCountry(data.billingAddress?.country ?? data.deliveryAddress?.country);

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -59,7 +59,8 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         fieldTypeMappingFn: mapFieldKey
     });
 
-    const specifications = useMemo(() => new Specifications(props.deliveryAddressSpecification), []);
+    const billingAddressSpecifications = useMemo(() => new Specifications(), []);
+    const deliveryAddressSpecifications = useMemo(() => new Specifications(props.deliveryAddressSpecification), []);
     /** end SR stuff */
 
     const initialActiveFieldsets: OpenInvoiceActiveFieldsets = getInitialActiveFieldsets(visibility, props.data);
@@ -150,11 +151,11 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
 
         const bankAccountLayout = ['holder', 'iban'];
 
-        const billingAddressLayout = specifications.getAddressSchemaForCountryFlat(data.billingAddress?.country);
+        const billingAddressLayout = billingAddressSpecifications.getAddressSchemaForCountryFlat(data.billingAddress?.country);
         // In order to sort the address errors the layout entries need to have the same (prefixed) identifier as the errors themselves
         const billingAddressLayoutEnhanced = billingAddressLayout.map(item => `${BILLING_ADDRESS_PREFIX}${item}`);
 
-        const deliveryAddressLayout = specifications.getAddressSchemaForCountryFlat(data.deliveryAddress?.country);
+        const deliveryAddressLayout = deliveryAddressSpecifications.getAddressSchemaForCountryFlat(data.deliveryAddress?.country);
         const deliveryAddressLayoutEnhanced = deliveryAddressLayout.map(item => `${DELIVERY_ADDRESS_PREFIX}${item}`);
 
         const fullLayout = companyDetailsLayout.concat(
@@ -166,14 +167,15 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         );
 
         // Country specific address labels
-        const countrySpecificLabels = specifications.getAddressLabelsForCountry(data.billingAddress?.country ?? data.deliveryAddress?.country);
+        const countrySpecificLabels_billing = billingAddressSpecifications.getAddressLabelsForCountry(data.billingAddress?.country);
+        const countrySpecificLabels_delivery = deliveryAddressSpecifications.getAddressLabelsForCountry(data.deliveryAddress?.country);
 
         // Set messages: Pass dynamic props (errors, layout etc) to SRPanel via partial
         const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
             errors: errorsForPanel,
             isValidating: isValidating.current,
             layout: fullLayout,
-            countrySpecificLabels
+            countrySpecificLabels: { ...countrySpecificLabels_billing, ...countrySpecificLabels_delivery }
         });
 
         // Relates to onBlur errors

--- a/packages/lib/src/components/internal/OpenInvoice/utils.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/utils.ts
@@ -52,7 +52,8 @@ export const mapFieldKey = (key: string, i18n: Language, countrySpecificLabels: 
     }
 
     const addressKey = mapFieldKeyAddress(refKey, i18n, countrySpecificLabels);
-    if (addressKey) return hasSplitKey ? `${i18n.get(label)} ${addressKey}` : addressKey;
+    // Also use the presence of a label to know that we are dealing with address related fields. (This matters now that addresses can contain first & last name fields.)
+    if (addressKey && label) return hasSplitKey ? `${i18n.get(label)} ${addressKey}` : addressKey;
 
     // Personal details related
     switch (refKey) {

--- a/packages/lib/src/components/internal/OpenInvoice/utils.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/utils.ts
@@ -1,6 +1,5 @@
 import { OpenInvoiceActiveFieldsets, OpenInvoiceStateData, OpenInvoiceVisibility } from './types';
 import Language from '../../../language';
-import { mapFieldKey as mapFieldKeyPD } from '../PersonalDetails/utils';
 import { mapFieldKey as mapFieldKeyAddress } from '../Address/utils';
 import { StringObject } from '../Address/types';
 
@@ -54,15 +53,6 @@ export const mapFieldKey = (key: string, i18n: Language, countrySpecificLabels: 
     const addressKey = mapFieldKeyAddress(refKey, i18n, countrySpecificLabels);
     // Also use the presence of a label to know that we are dealing with address related fields. (This matters now that addresses can contain first & last name fields.)
     if (addressKey && label) return hasSplitKey ? `${i18n.get(label)} ${addressKey}` : addressKey;
-
-    // Personal details related
-    switch (refKey) {
-        case 'gender':
-        case 'dateOfBirth':
-            return mapFieldKeyPD(refKey, i18n);
-        default:
-            break;
-    }
 
     // We know that the translated error messages do contain a reference to the field they refer to, so we won't need to map them
     return null;

--- a/packages/lib/src/components/internal/PersonalDetails/utils.ts
+++ b/packages/lib/src/components/internal/PersonalDetails/utils.ts
@@ -26,7 +26,6 @@ export const getFormattedData = data => {
 export const mapFieldKey = (key: string, i18n: Language): string => {
     switch (key) {
         case 'gender':
-        case 'dateOfBirth':
             return i18n.get(key);
         // We know that the translated error messages do contain a reference to the field they refer to, so we won't need to map them
         default:

--- a/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
+++ b/packages/playground/src/pages/OpenInvoices/OpenInvoices.js
@@ -25,7 +25,7 @@ getPaymentMethods({ amount, shopperLocale }).then(async paymentMethodsData => {
         locale: shopperLocale,
         paymentMethodsResponse: paymentMethodsData,
         environment: process.env.__CLIENT_ENV__,
-        onChange: handleChange,
+        // onChange: handleChange,
         onSubmit: handleSubmit,
         onError: console.error,
         showPayButton: true,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixing `SRPanel` issues in `OpenInvoice` comp now that (delivery) addresses can have first & last names
Ensuring no first & last name errors get overwritten and that the `SRPanel` has the correct translations for every field

## Tested scenarios
All unit tests pass
Added Playwright e2e test for `Riverty` component and check every field in the `SRPanel`

