### PR TITLE
fix(a11y): Select/Combobox aria-activedescendant is now empty when list item id is null

### DIFF
--- a/.changeset/giant-hotels-act.md
+++ b/.changeset/giant-hotels-act.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fix(a11y): select/combobox aria-activedescendant is now empty when active item is null

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -38,6 +38,9 @@ function SelectButton(props: SelectButtonProps) {
 
     const onFocusHandler = readonly ? null : props.onFocus;
 
+    // check COWEB-1301 [Investigate] Drop-in Accessibility - ADA Compliance questions
+    const currentSelectedItemId = active.id ? `listItem-${active.id}` : '';
+
     return (
         <SelectButtonElement
             className={cx({
@@ -78,7 +81,7 @@ function SelectButton(props: SelectButtonProps) {
                         placeholder={i18n.get('select.filter.placeholder')}
                         ref={props.filterInputRef}
                         role="combobox"
-                        aria-activedescendant={`listItem-${active.id}`}
+                        aria-activedescendant={currentSelectedItemId}
                         type="text"
                         readOnly={props.readonly}
                         id={props.id}

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -11,7 +11,7 @@ function SelectButtonElement({ filterable, toggleButtonRef, ...props }) {
     return <button id={props.id} aria-describedby={props.ariaDescribedBy} type={'button'} {...props} ref={toggleButtonRef} />;
 }
 
-function SelectButton(props: SelectButtonProps) {
+function SelectButton(props: Readonly<SelectButtonProps>) {
     const { i18n } = useCoreContext();
     const { active, selected, inputText, readonly, showList } = props;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

When the Combobox elements are rendered, for example the country selector. Their initial selected item is null, therefore we don't have a value to point in `aria-activedescendant` in these cases we were displaying an id of an element that didn't exist (`listItem-undefined`), now we display empty value `aria-activedescendant=""`. 

Is not clear from the spec what should be done in these scenarios but for now this seems to be the best option: https://stackoverflow.com/questions/76611272/what-should-aria-activedescendant-be-if-there-is-no-appropriate-element

## Tested scenarios
<!-- Description of tested scenarios -->

- Inspected the DOM to check if indeed aria-activedescendant has empty value
- Checked Combobox still works as normal 
 
**Fixed issue**:  <!-- #-prefixed issue number -->
COWEB-1301