### PR TITLE
Chore/v5 refactor how wallet p ms call submit analytics

### DIFF
--- a/.changeset/pretty-planets-occur.md
+++ b/.changeset/pretty-planets-occur.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Refactor how wallet PMs call submitAnalytics when they are used as express PMs

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -8,23 +8,14 @@ import defaultProps from './defaultProps';
 import { getCheckoutDetails } from './services';
 import './AmazonPay.scss';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
-import { ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
 
 export class AmazonPayElement extends UIElement<AmazonPayElementProps> {
     public static type = 'amazonpay';
     protected static defaultProps = defaultProps;
 
     protected submitAnalytics(analyticsObj: SendAnalyticsObject) {
-        let extraAnalyticsObject = {};
-        if (analyticsObj.type === ANALYTICS_RENDERED_STR) {
-            const isExpress = this.props.isExpress;
-            const expressPage = this.props.expressPage ?? null;
-            extraAnalyticsObject = {
-                isExpress,
-                ...(isExpress && expressPage && { expressPage }) // We only care about the expressPage value if isExpress is true
-            };
-        }
-        super.submitAnalytics({ ...analyticsObj, ...extraAnalyticsObject });
+        // Analytics will need to know about this.props.isExpress & this.props.expressPage
+        super.submitAnalytics({ ...analyticsObj }, this.props);
     }
     formatProps(props) {
         return {

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -10,7 +10,7 @@ import { preparePaymentRequest } from './payment-request';
 import { resolveSupportedVersion, mapBrands } from './utils';
 import { ApplePayElementProps, ApplePayElementData, ApplePaySessionRequest, OnAuthorizedCallback } from './types';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
-import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_RENDERED_STR, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
+import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
 import { DecodeObject } from '../types';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 
@@ -28,16 +28,8 @@ class ApplePayElement extends UIElement<ApplePayElementProps> {
     }
 
     protected submitAnalytics(analyticsObj: SendAnalyticsObject) {
-        let extraAnalyticsObject = {};
-        if (analyticsObj.type === ANALYTICS_RENDERED_STR) {
-            const isExpress = this.props.isExpress;
-            const expressPage = this.props.expressPage ?? null;
-            extraAnalyticsObject = {
-                isExpress,
-                ...(isExpress && expressPage && { expressPage }) // We only care about the expressPage value if isExpress is true
-            };
-        }
-        super.submitAnalytics({ ...analyticsObj, ...extraAnalyticsObject });
+        // Analytics will need to know about this.props.isExpress & this.props.expressPage
+        super.submitAnalytics({ ...analyticsObj }, this.props);
     }
 
     /**

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -7,7 +7,7 @@ import { GooglePayProps } from './types';
 import { mapBrands, getGooglePayLocale } from './utils';
 import collectBrowserInfo from '../../utils/browserInfo';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
-import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_RENDERED_STR, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
+import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 
 class GooglePay extends UIElement<GooglePayProps> {
@@ -16,16 +16,8 @@ class GooglePay extends UIElement<GooglePayProps> {
     protected googlePay = new GooglePayService(this.props);
 
     protected submitAnalytics(analyticsObj: SendAnalyticsObject) {
-        let extraAnalyticsObject = {};
-        if (analyticsObj.type === ANALYTICS_RENDERED_STR) {
-            const isExpress = this.props.isExpress;
-            const expressPage = this.props.expressPage ?? null;
-            extraAnalyticsObject = {
-                isExpress,
-                ...(isExpress && expressPage && { expressPage }) // We only care about the expressPage value if isExpress is true
-            };
-        }
-        super.submitAnalytics({ ...analyticsObj, ...extraAnalyticsObject });
+        // Analytics will need to know about this.props.isExpress & this.props.expressPage
+        super.submitAnalytics({ ...analyticsObj }, this.props);
     }
 
     /**

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -10,7 +10,6 @@ import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { ERRORS } from './constants';
 import { createShopperDetails } from './utils/create-shopper-details';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
-import { ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
 
 class PaypalElement extends UIElement<PayPalElementProps> {
     public static type = 'paypal';
@@ -31,16 +30,8 @@ class PaypalElement extends UIElement<PayPalElementProps> {
     }
 
     protected submitAnalytics(analyticsObj: SendAnalyticsObject) {
-        let extraAnalyticsObject = {};
-        if (analyticsObj.type === ANALYTICS_RENDERED_STR) {
-            const isExpress = this.props.isExpress;
-            const expressPage = this.props.expressPage ?? null;
-            extraAnalyticsObject = {
-                isExpress,
-                ...(isExpress && expressPage && { expressPage }) // We only care about the expressPage value if isExpress is true
-            };
-        }
-        super.submitAnalytics({ ...analyticsObj, ...extraAnalyticsObject });
+        // Analytics will need to know about this.props.isExpress & this.props.expressPage
+        super.submitAnalytics({ ...analyticsObj }, this.props);
     }
 
     formatProps(props: PayPalElementProps): PayPalElementProps {

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -67,7 +67,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
      *  In some other cases e.g. 3DS2 components, this function is overridden to allow more specific analytics actions to be created
      */
     /* eslint-disable-next-line */
-    protected submitAnalytics(analyticsObj: SendAnalyticsObject) {
+    protected submitAnalytics(analyticsObj: SendAnalyticsObject, uiElementProps?) {
         /** Work out what the component's "type" is:
          * - first check for a dedicated "analyticsType" (currently only applies to custom-cards)
          * - otherwise, distinguish cards from non-cards: cards will use their static type property, everything else will use props.type
@@ -77,7 +77,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
             component = this.constructor['type'] === 'scheme' || this.constructor['type'] === 'bcmc' ? this.constructor['type'] : this.props.type;
         }
 
-        this.props.modules?.analytics.sendAnalytics(component, analyticsObj);
+        this.props.modules?.analytics.sendAnalytics(component, analyticsObj, uiElementProps);
     }
 
     private onSubmit(): void {

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -84,7 +84,7 @@ export interface AnalyticsModule {
     getEventsQueue: () => EventsQueueModule;
     createAnalyticsEvent: (a: CreateAnalyticsEventObject) => AnalyticsObject;
     getEnabled: () => boolean;
-    sendAnalytics: (component: string, analyticsObj: SendAnalyticsObject) => void;
+    sendAnalytics: (component: string, analyticsObj: SendAnalyticsObject, uiElementProps?: any) => void;
 }
 
 export interface BaseElementProps {

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.test.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.test.ts
@@ -1,0 +1,95 @@
+import Analytics from './Analytics';
+import { PaymentAmount } from '../../types';
+import { analyticsPreProcessor } from './analyticsPreProcessor';
+import { ANALYTICS_EVENT_INFO, ANALYTICS_RENDERED_STR } from './constants';
+
+let analytics;
+let sendAnalytics;
+
+const amount: PaymentAmount = { value: 50000, currency: 'USD' };
+
+describe('Testing AnalyticsPreProcessor: process and output', () => {
+    beforeEach(() => {
+        analytics = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', amount });
+        analytics.createAnalyticsEvent = jest.fn(() => {});
+        sendAnalytics = analyticsPreProcessor(analytics);
+    });
+
+    describe('Testing the data object created for wallets used as expressPMs', () => {
+        test('GooglePay with this.props.isExpress = true & this.props.expressPage = "cart" should see these values reflected in the object passed to analytics.createAnalyticsEvent', () => {
+            sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: true, expressPage: 'cart' });
+
+            expect(analytics.createAnalyticsEvent).toBeCalledWith({
+                event: ANALYTICS_EVENT_INFO,
+                data: {
+                    component: 'paywithgoogle',
+                    type: 'rendered',
+                    isExpress: true,
+                    expressPage: 'cart'
+                }
+            });
+        });
+
+        test('GooglePay with this.props.isExpress = null & this.props.expressPage = "cart" should see both these values excluded from the object passed to analytics.createAnalyticsEvent', () => {
+            sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: null, expressPage: 'cart' });
+
+            expect(analytics.createAnalyticsEvent).toBeCalledWith({
+                event: ANALYTICS_EVENT_INFO,
+                data: {
+                    component: 'paywithgoogle',
+                    type: 'rendered'
+                }
+            });
+        });
+
+        test('GooglePay with this.props.isExpress = undefined & this.props.expressPage = "cart" should see both these values excluded from the object passed to analytics.createAnalyticsEvent', () => {
+            sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: undefined, expressPage: 'cart' });
+
+            expect(analytics.createAnalyticsEvent).toBeCalledWith({
+                event: ANALYTICS_EVENT_INFO,
+                data: {
+                    component: 'paywithgoogle',
+                    type: 'rendered'
+                }
+            });
+        });
+
+        test('GooglePay with this.props.isExpress = "true" (i.e. a string) & this.props.expressPage = "cart" should see both these values excluded from the object passed to analytics.createAnalyticsEvent', () => {
+            sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: 'true', expressPage: 'cart' });
+
+            expect(analytics.createAnalyticsEvent).toBeCalledWith({
+                event: ANALYTICS_EVENT_INFO,
+                data: {
+                    component: 'paywithgoogle',
+                    type: 'rendered'
+                }
+            });
+        });
+
+        test('GooglePay with this.props.isExpress = false & this.props.expressPage = "cart" should just see the isExpress reflected in the object passed to analytics.createAnalyticsEvent', () => {
+            sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: false, expressPage: 'cart' });
+
+            expect(analytics.createAnalyticsEvent).toBeCalledWith({
+                event: ANALYTICS_EVENT_INFO,
+                data: {
+                    component: 'paywithgoogle',
+                    type: 'rendered',
+                    isExpress: false
+                }
+            });
+        });
+
+        test('GooglePay with this.props.isExpress = true & this.props.expressPage = "foobar" (i.e. not a valid value) should just see the isExpress reflected in the object passed to analytics.createAnalyticsEvent', () => {
+            sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: true, expressPage: 'foobar' });
+
+            expect(analytics.createAnalyticsEvent).toBeCalledWith({
+                event: ANALYTICS_EVENT_INFO,
+                data: {
+                    component: 'paywithgoogle',
+                    type: 'rendered',
+                    isExpress: true
+                }
+            });
+        });
+    });
+});

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -93,3 +93,5 @@ export const errorCodeMapping = {
     ['error.va.sf-ach-loc.01']: '947',
     ['error.va.sf-ach-loc.02']: '948'
 };
+
+export const ANALYTICS_EXPRESS_PAGES_ARRAY = ['cart', 'minicart', 'pdp', 'checkout'];


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Refactor how wallet PMS call `submitAnalytics` when they are used as express.PMS. 
We move the logic to `analyticsPreProcessor` so the wallet PMs can keep their `submitAnalytics` override as simple as possible

## Tested scenarios
All unit tests pass
Added new unit tests to test `analyticsPreProcessor` and how it handles the `"rendered"` event - which is the one that need to set the `isExpress` and `expressPage` properties for express PMs

