### PR TITLE
fix: display date and time in some vouchers

### DIFF
--- a/.changeset/brown-wolves-stare.md
+++ b/.changeset/brown-wolves-stare.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+fix: vouchers (econtext and dragonpay) can now show expiration date with time

--- a/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.tsx
@@ -25,7 +25,7 @@ export default function DragonpayVoucherResult(props: DragonpayVoucherResultProp
             surcharge={surcharge && i18n.amount(surcharge.value, surcharge.currency)}
             voucherDetails={
                 [
-                    { label: i18n.get('voucher.expirationDate'), value: i18n.date(expiresAt) },
+                    { label: i18n.get('voucher.expirationDate'), value: i18n.dateTime(expiresAt) },
                     { label: i18n.get('voucher.alternativeReference'), value: alternativeReference }
                 ] as VoucherDetail[]
             }

--- a/packages/lib/src/components/Econtext/components/EcontextVoucherResult/EcontextVoucherResult.tsx
+++ b/packages/lib/src/components/Econtext/components/EcontextVoucherResult/EcontextVoucherResult.tsx
@@ -20,7 +20,7 @@ const EcontextVoucherResult = (props: EcontextVoucherResultProps) => {
             amount={totalAmount && i18n.amount(totalAmount.value, totalAmount.currency)}
             voucherDetails={[
                 { label: i18n.get('voucher.collectionInstitutionNumber'), value: collectionInstitutionNumber },
-                { label: i18n.get('voucher.expirationDate'), value: i18n.date(expiresAt) },
+                { label: i18n.get('voucher.expirationDate'), value: i18n.dateTime(expiresAt) },
                 { label: i18n.get('voucher.telephoneNumber'), value: maskedTelephoneNumber }
             ]}
             copyBtn

--- a/packages/lib/src/language/Language.ts
+++ b/packages/lib/src/language/Language.ts
@@ -2,7 +2,6 @@ import { formatCustomTranslations, formatLocale, getTranslation, loadTranslation
 import { FALLBACK_LOCALE, defaultTranslation } from './config';
 import locales from './locales';
 import { getLocalisedAmount } from '../utils/amount-util';
-import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
 
 export class Language {
     private readonly supportedLocales: string[];
@@ -13,6 +12,18 @@ export class Language {
     public readonly customTranslations;
     public loaded: Promise<any>;
 
+    public readonly timeFormatOptions: Intl.DateTimeFormatOptions = {
+        hour: 'numeric',
+        minute: 'numeric'
+    };
+    public readonly timeAndDateFormatOptions: Intl.DateTimeFormatOptions = {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        ...this.timeFormatOptions
+    };
+    public readonly timeAndDateFormatter: Intl.DateTimeFormat;
+
     constructor(locale: string = FALLBACK_LOCALE, customTranslations: object = {}) {
         const defaultLocales = Object.keys(locales);
         this.customTranslations = formatCustomTranslations(customTranslations, defaultLocales);
@@ -22,6 +33,8 @@ export class Language {
         this.locale = formatLocale(locale) || parseLocale(locale, this.supportedLocales) || FALLBACK_LOCALE;
         const [languageCode] = this.locale.split('-');
         this.languageCode = languageCode;
+
+        this.timeAndDateFormatter = Intl.DateTimeFormat(undefined, this.timeAndDateFormatOptions);
 
         this.loaded = loadTranslations(this.locale, this.customTranslations).then(translations => {
             this.translations = translations;
@@ -61,6 +74,14 @@ export class Language {
     date(date: string, options: object = {}) {
         const dateOptions: DateTimeFormatOptions = { year: 'numeric', month: '2-digit', day: '2-digit', ...options };
         return new Date(date).toLocaleDateString(this.locale, dateOptions);
+    }
+
+    /**
+     * Returns a localized string for a date and time
+     * @param date - Date to be localized
+     */
+    dateTime(date: string) {
+        return this.timeAndDateFormatter.format(new Date(date));
     }
 }
 

--- a/packages/lib/src/language/Language.ts
+++ b/packages/lib/src/language/Language.ts
@@ -35,7 +35,7 @@ export class Language {
         const [languageCode] = this.locale.split('-');
         this.languageCode = languageCode;
 
-        this.timeAndDateFormatter = Intl.DateTimeFormat(locale, this.timeAndDateFormatOptions);
+        this.timeAndDateFormatter = DateTimeFormat(this.locale, this.timeAndDateFormatOptions);
 
         this.loaded = loadTranslations(this.locale, this.customTranslations).then(translations => {
             this.translations = translations;

--- a/packages/lib/src/language/Language.ts
+++ b/packages/lib/src/language/Language.ts
@@ -2,7 +2,8 @@ import { formatCustomTranslations, formatLocale, getTranslation, loadTranslation
 import { FALLBACK_LOCALE, defaultTranslation } from './config';
 import locales from './locales';
 import { getLocalisedAmount } from '../utils/amount-util';
-
+import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+import DateTimeFormat = Intl.DateTimeFormat;
 export class Language {
     private readonly supportedLocales: string[];
 
@@ -12,17 +13,17 @@ export class Language {
     public readonly customTranslations;
     public loaded: Promise<any>;
 
-    public readonly timeFormatOptions: Intl.DateTimeFormatOptions = {
+    public readonly timeFormatOptions: DateTimeFormatOptions = {
         hour: 'numeric',
         minute: 'numeric'
     };
-    public readonly timeAndDateFormatOptions: Intl.DateTimeFormatOptions = {
+    public readonly timeAndDateFormatOptions: DateTimeFormatOptions = {
         year: 'numeric',
         month: '2-digit',
         day: '2-digit',
         ...this.timeFormatOptions
     };
-    public readonly timeAndDateFormatter: Intl.DateTimeFormat;
+    public readonly timeAndDateFormatter: DateTimeFormat;
 
     constructor(locale: string = FALLBACK_LOCALE, customTranslations: object = {}) {
         const defaultLocales = Object.keys(locales);
@@ -34,7 +35,7 @@ export class Language {
         const [languageCode] = this.locale.split('-');
         this.languageCode = languageCode;
 
-        this.timeAndDateFormatter = Intl.DateTimeFormat(undefined, this.timeAndDateFormatOptions);
+        this.timeAndDateFormatter = Intl.DateTimeFormat(locale, this.timeAndDateFormatOptions);
 
         this.loaded = loadTranslations(this.locale, this.customTranslations).then(translations => {
             this.translations = translations;

--- a/packages/lib/src/language/Language.ts
+++ b/packages/lib/src/language/Language.ts
@@ -73,6 +73,7 @@ export class Language {
      * @param options - Options for {@link Date.toLocaleDateString}
      */
     date(date: string, options: object = {}) {
+        if (date === undefined) return '';
         const dateOptions: DateTimeFormatOptions = { year: 'numeric', month: '2-digit', day: '2-digit', ...options };
         return new Date(date).toLocaleDateString(this.locale, dateOptions);
     }
@@ -82,6 +83,7 @@ export class Language {
      * @param date - Date to be localized
      */
     dateTime(date: string) {
+        if (date === undefined) return '';
         return this.timeAndDateFormatter.format(new Date(date));
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

For some voucher like Econtext and Dragon pay we shuold display expiration time together with the date.
Created a new i18n function to format dateTime. Also make a tittle change to make sure we are not creating a new formatter every time as it's a slow operation (according MDN).

## Tested scenarios
<!-- Description of tested scenarios -->

- Tested with the mock data in the playground
- Still needs a test with the 2 payment methods test data


**Fixed issue**:  <!-- #-prefixed issue number -->
COWEB-1297, COWEB-1359