### PR TITLE
[v6] Fixes instalments not opening on click

### DIFF
--- a/packages/lib/src/components/internal/FormFields/Select/Select.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.scss
@@ -27,7 +27,7 @@
     text-decoration: none;
     outline: 0;
     padding: 0 var(--adyen-checkout-spacer-060);
-    flex: 1;
+    width: 100%;
     font-size: var(--adyen-checkout-font-size-medium);
     height: var(--adyen-checkout-spacer-110);
     line-height: var(--adyen-checkout-spacer-080);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This PR aims to fix a bug where clicking in right part of the instalments selector/button would not toggle the options.
This was due to the fact the button was not spanning the entire length of it's containing `div.adyen-checkout__dropdown` (where the border is rendered).

This results from a change done in this PR: https://github.com/Adyen/adyen-web/commit/97273d4790387c9d3145036abb1b709a81842000#diff-b48047fd7fe33a72a9307d54ea04c0f71b99614a7416e4f52f1ac015c493b43aL27

The question is to @longyulongyu does this need to be `flex: 1`? 
* Because if it doesn't then the change in this PR is smallest change we can make and it fixes the issue
* In case it make sense to have `flex: 1`, for consistency reasons for example. Then I will change it's wrapping `div` to be `display: flex` which currently isn't. Additionally will change the way the dropdown aligns, since it right now needs it starts at the end of the `block` element which is the wrapping `div.adyen-checkout__dropdown`.


## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
