### PR TITLE
Using securedFields v4.8.3 to handle 19 digit Diners

### DIFF
--- a/.changeset/quiet-teachers-unite.md
+++ b/.changeset/quiet-teachers-unite.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": minor
+---
+
+Using securedFields v4.8.3 to handle 19 digit Diners

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -17,7 +17,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '4.8.2';
+export const SF_VERSION = '4.8.3';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Using securedFields v4.8.3 to handle 19 digit Diners

## Tested scenarios
You can enter a 19 digit Diners PAN

**Fixed issue**:  <!-- #-prefixed issue number -->
