### PR TITLE
Ci run e2e against multiple api versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,8 +41,8 @@ jobs:
         CLIENT_ENV: test
         TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{matrix.api-version}}
         API_VERSION: ${{matrix.api-version}}
-    - name: Archive test result artifacts on failure
-      if: failure()
+    - name: Archive test result artifacts
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: playwright-report-${{ github.sha }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,12 +7,13 @@ on:
 jobs:
   build-then-e2e:
     if: ${{ github.actor != 'renovate[bot]' && github.actor != 'lgtm-com[bot]' }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node-version: [18.15]
+        api-version: ["v68", "v69", "v70", "v71"]
         # node-version: [16.x, 18.x, 19.x]
         # Currently 18 and 19 are not supported, still keeping it
         # as a reminder for compatibility check
@@ -38,11 +39,12 @@ jobs:
         MERCHANT_ACCOUNT: ${{secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT}}
         CLIENT_KEY: ${{secrets.ADYEN_CHECKOUT_CLIENT_KEY}}
         CLIENT_ENV: test
-        TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/v71
-        API_VERSION: v71
-    - name: Archive test result artifacts
-      if: always()
+        TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{matrix.api-version}}
+        API_VERSION: ${{matrix.api-version}}
+    - name: Archive test result artifacts on failure
+      if: failure()
       uses: actions/upload-artifact@v3
       with:
-        name: html-report
+        name: playwright-report-${{ github.sha }}
         path: packages/e2e-playwright/playwright-report
+        retention-days: 5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-then-e2e:
     if: ${{ github.actor != 'renovate[bot]' && github.actor != 'lgtm-com[bot]' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/packages/e2e-playwright/models/dropin.ts
+++ b/packages/e2e-playwright/models/dropin.ts
@@ -1,7 +1,9 @@
 import { Locator, Page } from '@playwright/test';
+import { DropinPage } from '../pages/dropin/dropin.page';
 
 class Dropin {
     readonly page: Page;
+    readonly dropinPage: DropinPage;
 
     readonly rootElement: Locator;
     readonly rootElementSelector: string;
@@ -10,9 +12,9 @@ class Dropin {
     readonly creditCard: Locator;
     readonly brandsHolder: Locator;
 
-    constructor(page: Page, rootElementSelector = '.adyen-checkout__dropin') {
+    constructor(page: Page, dropinPage: DropinPage, rootElementSelector = '.adyen-checkout__dropin') {
         this.page = page;
-
+        this.dropinPage = dropinPage;
         this.rootElement = page.locator(rootElementSelector);
         this.rootElementSelector = rootElementSelector;
 
@@ -23,8 +25,10 @@ class Dropin {
         await this.pmList.waitFor({ state: 'visible' });
     }
 
-    getPaymentMethodItem(pmName: string) {
-        return this.pmList.locator(`.adyen-checkout__payment-method:has-text("${pmName}")`);
+    getPaymentMethodItem(pmType: string) {
+        // @ts-ignore
+        const pmLabel = this.dropinPage.paymentMethods.find((pm: { type: string }) => pm.type === pmType).name;
+        return this.pmList.locator(`.adyen-checkout__payment-method:has-text("${pmLabel}")`);
     }
 }
 

--- a/packages/e2e-playwright/models/dropin.ts
+++ b/packages/e2e-playwright/models/dropin.ts
@@ -25,7 +25,7 @@ class Dropin {
         await this.pmList.waitFor({ state: 'visible' });
     }
 
-    getPaymentMethodItem(pmType: string) {
+    getPaymentMethodItemByType(pmType: string) {
         // @ts-ignore
         const pmLabel = this.dropinPage.paymentMethods.find((pm: { type: string }) => pm.type === pmType).name;
         return this.pmList.locator(`.adyen-checkout__payment-method:has-text("${pmLabel}")`);

--- a/packages/e2e-playwright/models/dropinModelUtils/getDropinCardComp.ts
+++ b/packages/e2e-playwright/models/dropinModelUtils/getDropinCardComp.ts
@@ -2,7 +2,7 @@ import { Dropin } from '../dropin';
 import { getImageCount } from '../../tests/utils/image';
 
 export const getCreditCardPM = (dropin: Dropin) => {
-    const creditCard = dropin.getPaymentMethodItem('Cards');
+    const creditCard = dropin.getPaymentMethodItem('scheme');
 
     const brandsHolder = creditCard.locator('.adyen-checkout__payment-method__brands');
 

--- a/packages/e2e-playwright/models/dropinModelUtils/getDropinCardComp.ts
+++ b/packages/e2e-playwright/models/dropinModelUtils/getDropinCardComp.ts
@@ -2,7 +2,7 @@ import { Dropin } from '../dropin';
 import { getImageCount } from '../../tests/utils/image';
 
 export const getCreditCardPM = (dropin: Dropin) => {
-    const creditCard = dropin.getPaymentMethodItem('scheme');
+    const creditCard = dropin.getPaymentMethodItemByType('scheme');
 
     const brandsHolder = creditCard.locator('.adyen-checkout__payment-method__brands');
 

--- a/packages/e2e-playwright/pages/dropin/dropin.page.ts
+++ b/packages/e2e-playwright/pages/dropin/dropin.page.ts
@@ -1,25 +1,26 @@
-import { Locator, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Dropin } from '../../models/dropin';
 
 class DropinPage {
     readonly page: Page;
 
     readonly dropin: Dropin;
-    // readonly payButton: Locator;
+    private _paymentMethods: Array<{ name: string; type: string }>;
 
     constructor(page: Page) {
         this.page = page;
-        this.dropin = new Dropin(page);
-        // this.payButton = page.getByRole('button', { name: /Pay/i });
+        this.dropin = new Dropin(page, this);
     }
 
     async goto(url?: string) {
         await this.page.goto('http://localhost:3024');
+        const response = await this.page.waitForResponse(response => response.url().includes('paymentMethods') && response.status() === 200);
+        this._paymentMethods = (await response.json()).paymentMethods.map(({ name, type }: { name: string; type: string }) => ({ name, type }));
     }
 
-    // async pay() {
-    //     await this.payButton.click();
-    // }
+    get paymentMethods() {
+        return this._paymentMethods;
+    }
 }
 
 export { DropinPage };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- increase the timeout of the e2e github action
- add all api versions to test against
- modify the e2e tests to collect api response from the BE and use it to query the card element in the dropin (because BE returns different labels among versions)
- check [here](https://github.com/Adyen/adyen-web/actions/runs/8528345633) for the expected result

