### PR TITLE
fix: show the instant payments when they are the only supported PMs

### DIFF
--- a/.changeset/smart-tables-cry.md
+++ b/.changeset/smart-tables-cry.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fix the bug that the drop-in is not rendered when there are only instant payments. 

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -114,6 +114,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
     render(props, { elements, instantPaymentElements, status, activePaymentMethod, cachedPaymentMethods }) {
         const isLoading = status.type === 'loading';
         const isRedirecting = status.type === 'redirect';
+        const hasPayments = elements?.length > 0 || instantPaymentElements?.length > 0;
 
         switch (status.type) {
             case 'success':
@@ -130,7 +131,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                     <div className={`adyen-checkout__dropin adyen-checkout__dropin--${status.type}`}>
                         {isRedirecting && status.props.component && status.props.component.render()}
                         {isLoading && status.props && status.props.component && status.props.component.render()}
-                        {elements && !!elements.length && (
+                        {hasPayments && (
                             <PaymentMethodList
                                 isLoading={isLoading || isRedirecting}
                                 isDisablingPaymentMethod={this.state.isDisabling}

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/InstantPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/InstantPaymentMethods.tsx
@@ -5,9 +5,10 @@ import UIElement from '../../../UIElement';
 
 interface InstantPaymentMethodsProps {
     paymentMethods: UIElement[];
+    showContentSeparator: boolean;
 }
 
-function InstantPaymentMethods({ paymentMethods }: InstantPaymentMethodsProps) {
+function InstantPaymentMethods({ paymentMethods, showContentSeparator }: InstantPaymentMethodsProps) {
     const { i18n } = useCoreContext();
 
     return (
@@ -17,7 +18,7 @@ function InstantPaymentMethods({ paymentMethods }: InstantPaymentMethodsProps) {
                     <li key={pm.type}>{pm.render()}</li>
                 ))}
             </ul>
-            <ContentSeparator label={i18n.get('orPayWith')} />
+            {showContentSeparator && <ContentSeparator label={i18n.get('orPayWith')} />}
         </Fragment>
     );
 }

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -68,6 +68,7 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
         });
 
         const brandLogoConfiguration = useBrandLogoConfiguration(paymentMethods);
+        const showContentSeparator = paymentMethods?.length > 0;
 
         return (
             <Fragment>
@@ -80,7 +81,9 @@ class PaymentMethodList extends Component<PaymentMethodListProps> {
                     />
                 )}
 
-                {!!instantPaymentMethods.length && <InstantPaymentMethods paymentMethods={instantPaymentMethods} />}
+                {!!instantPaymentMethods.length && (
+                    <InstantPaymentMethods showContentSeparator={showContentSeparator} paymentMethods={instantPaymentMethods} />
+                )}
 
                 <ul className={paymentMethodListClassnames} role="radiogroup" aria-label={i18n.get('paymentMethodsList.aria.label')} required>
                     {paymentMethods.map((paymentMethod, index, paymentMethodsCollection) => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix the bug that the drop-in is not rendered when there are only instant payments.

## Tested scenarios
To reproduce:
- For the manual flow, pass the following to the checkout config
```javascript
paymentMethodsResponse: {
            paymentMethods: [
                {
                    configuration: {
                        merchantId: '12345678',
                        gatewayMerchantId: 'testMerchant'
                    },
                    name: 'Google Pay',
                    type: 'paywithgoogle'
                }
            ]
        },
```
- Specify the `instantPaymentTypes: ['paywithgoogle']` in the drop-in config
- The drop-in is not rendered
