### PR TITLE
v6 - Making sure 'useCoreContext' returns valid context values

### DIFF
--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import ANCVInput from './components/ANCVInput';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import config from './components/ANCVAwait/config';
 import Await from '../../components/internal/Await';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';

--- a/packages/lib/src/components/ANCV/components/ANCVInput.tsx
+++ b/packages/lib/src/components/ANCV/components/ANCVInput.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import LoadingWrapper from '../../internal/LoadingWrapper';
 import InputText from '../../internal/FormFields/InputText';
 import Field from '../../internal/FormFields/Field';

--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import AchInput from './components/AchInput';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import RedirectButton from '../internal/RedirectButton';
 import { AchConfiguration } from './types';
 import { TxVariants } from '../tx-variants';

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.test.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { render, screen } from '@testing-library/preact';
 import AchInput from './AchInput';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 jest.mock('../../../internal/SecuredFields/lib/CSF');
 

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
@@ -8,7 +8,7 @@ import Field from '../../../internal/FormFields/Field';
 import LoadingWrapper from '../../../internal/LoadingWrapper/LoadingWrapper';
 import defaultProps from './defaultProps';
 import defaultStyles from './defaultStyles';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import './AchInput.scss';
 import { ACHInputDataState, ACHInputProps, ACHInputStateError, ACHInputStateValid } from './types';
 import StoreDetails from '../../../internal/StoreDetails';

--- a/packages/lib/src/components/Ach/components/AchInput/components/AchSecuredFields.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/components/AchSecuredFields.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import AchSFInput from './AchSFInput';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 
 const AchSecuredFields = ({ focusedElement, onFocusField, errors, valid }) => {
     const { i18n } = useCoreContext();

--- a/packages/lib/src/components/Address/Address.tsx
+++ b/packages/lib/src/components/Address/Address.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import Address from '../internal/Address';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { TxVariants } from '../tx-variants';
 
 export class AddressElement extends UIElement {

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import collectBrowserInfo from '../../utils/browserInfo';
 import AmazonPayComponent from './components/AmazonPayComponent';
 import { AmazonPayElementData, AmazonPayConfiguration, CheckoutDetailsRequest } from './types';

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { getAmazonSignature } from '../services';
 import { getAmazonPaySettings, getPayloadJSON } from '../utils';
 import { AmazonPayButtonProps, CheckoutSessionConfig, PayloadJSON } from '../types';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 
 export default function AmazonPayButton(props: AmazonPayButtonProps) {
     const { loadingContext } = useCoreContext();

--- a/packages/lib/src/components/AmazonPay/components/ChangePaymentDetailsButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/ChangePaymentDetailsButton.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useEffect } from 'preact/hooks';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { ChangeActionOptions, ChangePaymentDetailsButtonProps } from '../types';
 
 export default function ChangePaymentDetailsButton(props: ChangePaymentDetailsButtonProps) {

--- a/packages/lib/src/components/AmazonPay/components/OrderButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/OrderButton.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Button from '../../internal/Button';
 import { updateAmazonCheckoutSession } from '../services';
 import { OrderButtonProps, UpdateAmazonCheckoutSessionRequest } from '../types';

--- a/packages/lib/src/components/AmazonPay/components/SignOutButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/SignOutButton.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { SignOutButtonProps } from '../types';
 
 export default function SignOutButton(props: SignOutButtonProps) {

--- a/packages/lib/src/components/BacsDD/BacsDD.tsx
+++ b/packages/lib/src/components/BacsDD/BacsDD.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import BacsInput from './components/BacsInput';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import BacsResult from './components/BacsResult';
 import PayButton from '../internal/PayButton';
 import { TxVariants } from '../tx-variants';

--- a/packages/lib/src/components/BacsDD/components/BacsInput.test.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.test.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import BacsInput from './BacsInput';
 import { BacsInputProps } from './types';
 import { mock } from 'jest-mock-extended';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const defaultProps = {
     onChange: () => {},

--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import classNames from 'classnames';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Field from '../../internal/FormFields/Field';
 import ConsentCheckbox from '../../internal/FormFields/ConsentCheckbox';
 import { bacsValidationRules, bacsFormatters } from './validate';

--- a/packages/lib/src/components/BacsDD/components/BacsResult.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsResult.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Voucher from '../../internal/Voucher';
 import '../../internal/Voucher/Voucher.scss';
 import './BacsResult.scss';

--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import RedirectButton from '../internal/RedirectButton';
 import { BankTransferConfiguration, BankTransferState } from './types';
 import BankTransferResult from './components/BankTransferResult';

--- a/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
+++ b/packages/lib/src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import './BankTransferInput.scss';
 import SendCopyToEmail from '../../../internal/SendCopyToEmail/SendCopyToEmail';
 import { useEffect, useState } from 'preact/hooks';

--- a/packages/lib/src/components/BankTransfer/components/BankTransferResult/BankTransferResult.tsx
+++ b/packages/lib/src/components/BankTransfer/components/BankTransferResult/BankTransferResult.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Voucher from '../../../internal/Voucher';
 
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useImage from '../../../../core/Context/useImage';
 
 export default function BankTransferResult(props) {

--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import BlikInput from '../../components/Blik/components/BlikInput';
 import Await from '../internal/Await';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import config from './config';
 import RedirectButton from '../../components/internal/RedirectButton';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';

--- a/packages/lib/src/components/Blik/components/BlikInput.tsx
+++ b/packages/lib/src/components/Blik/components/BlikInput.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Field from '../../internal/FormFields/Field';
 import './BlikInput.scss';
 import useForm from '../../../utils/useForm';

--- a/packages/lib/src/components/Boleto/Boleto.tsx
+++ b/packages/lib/src/components/Boleto/Boleto.tsx
@@ -3,7 +3,7 @@ import UIElement from '../internal/UIElement/UIElement';
 import BoletoInput from './components/BoletoInput';
 import { cleanCPFCNPJ } from '../internal/SocialSecurityNumberBrazil/utils';
 import BoletoVoucherResult from './components/BoletoVoucherResult';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { TxVariants } from '../tx-variants';
 import { VoucherConfiguration } from '../internal/Voucher/types';
 

--- a/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.test.tsx
+++ b/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { render, screen } from '@testing-library/preact';
 import BoletoInput from './BoletoInput';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 describe('BoletoInput', () => {
     const customRender = ui => {

--- a/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.tsx
+++ b/packages/lib/src/components/Boleto/components/BoletoInput/BoletoInput.tsx
@@ -4,7 +4,7 @@ import Address from '../../../internal/Address';
 import { boletoValidationRules } from './validate';
 import { boletoFormatters } from './utils';
 import SendCopyToEmail from '../../../internal/SendCopyToEmail/SendCopyToEmail';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { BoletoInputDataState } from '../../types';
 import useForm from '../../../../utils/useForm';
 import { BrazilPersonalDetail } from '../../../internal/SocialSecurityNumberBrazil/BrazilPersonalDetail';

--- a/packages/lib/src/components/Boleto/components/BoletoVoucherResult/BoletoVoucherResult.tsx
+++ b/packages/lib/src/components/Boleto/components/BoletoVoucherResult/BoletoVoucherResult.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Voucher from '../../../internal/Voucher';
 
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import './BoletoVoucherResult.scss';
 import { VoucherDetail } from '../../../internal/Voucher/types';
 import useImage from '../../../../core/Context/useImage';

--- a/packages/lib/src/components/Card/Card.test.tsx
+++ b/packages/lib/src/components/Card/Card.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { CardElement } from './Card';
 import { render, screen } from '@testing-library/preact';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import Language from '../../language';
 import { Resources } from '../../core/Context/Resources';
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import CardInput from './components/CardInput';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import collectBrowserInfo from '../../utils/browserInfo';
 import { BinLookupResponse, CardElementData, CardConfiguration } from './types';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -5,7 +5,7 @@ import Language from '../../../../language/Language';
 import { CardInputDataState, CardInputValidState } from './types';
 import { render, screen, fireEvent } from '@testing-library/preact';
 import { CardFieldsWrapper } from './components/CardFieldsWrapper';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 jest.mock('../../../internal/SecuredFields/lib/CSF');
 

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import classNames from 'classnames';
 import CVCHint from './CVCHint';
 import Field from '../../../../internal/FormFields/Field';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { CVCProps } from './types';
 import {
     CVC_POLICY_HIDDEN,

--- a/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFields.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import CardNumber from './CardNumber';
 import CVC from './CVC';
 import ExpirationDate from './ExpirationDate';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { CardFieldsProps } from './types';
 import classNames from 'classnames';
 import {

--- a/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardHolderName.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import Field from '../../../../internal/FormFields/Field';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { CardHolderNameProps } from './types';
 import InputText from '../../../../internal/FormFields/InputText';
 import { CREDITCARD_HOLDER_NAME_INVALID } from '../../../../../core/Errors/constants';

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import { h } from 'preact';
 import CardNumber from './CardNumber';
-import CoreProvider from '../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../core/Context/CoreProvider';
 
 // https://github.com/enzymejs/enzyme/issues/1925#issuecomment-490637648
 const Proxy = props => (

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import BrandIcon from './BrandIcon';
 import DualBrandingIcon from './DualBrandingIcon/DualBrandingIcon';
 import Field from '../../../../internal/FormFields/Field';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { CardNumberProps } from './types';
 import DataSfSpan from './DataSfSpan';
 import { ENCRYPTED_CARD_NUMBER } from '../../../../internal/SecuredFields/lib/configuration/constants';

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import classNames from 'classnames';
 import Field from '../../../../internal/FormFields/Field';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { ExpirationDateProps } from './types';
 import DataSfSpan from './DataSfSpan';
 

--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import Installments from './Installments';
 import { InstallmentOptions } from '../types';
 import { render, screen } from '@testing-library/preact';
-import CoreProvider from '../../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../../core/Context/CoreProvider';
 
 describe('Installments', () => {
     let installmentOptions;

--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import Field from '../../../../../internal/FormFields/Field';
-import useCoreContext from '../../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import { InstallmentsItem, InstallmentsProps } from '../types';
 import Fieldset from '../../../../../internal/FormFields/Fieldset/Fieldset';
 import RadioGroup from '../../../../../internal/FormFields/RadioGroup';

--- a/packages/lib/src/components/Card/components/CardInput/components/KCPAuthentication.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/KCPAuthentication.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { useMemo } from 'preact/hooks';
 import classNames from 'classnames';
 import Field from '../../../../internal/FormFields/Field';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { KCPProps } from './types';
 import DataSfSpan from './DataSfSpan';
 import InputTelephone from '../../../../internal/FormFields/InputTelephone';

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/preact';
 
 import { CVC_POLICY_REQUIRED } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import StoredCardFields from './StoredCardFields';
-import CoreProvider from '../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../core/Context/CoreProvider';
 
 const storedCardProps = {
     brand: 'visa',

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import CVC from './CVC';
 import Field from '../../../../internal/FormFields/Field';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { StoredCardFieldsProps } from './types';
 import { ENCRYPTED_SECURITY_CODE } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import InputText from '../../../../internal/FormFields/InputText';

--- a/packages/lib/src/components/Card/components/ClickToPayHolder.tsx
+++ b/packages/lib/src/components/Card/components/ClickToPayHolder.tsx
@@ -5,7 +5,7 @@ import { CtpState } from '../../internal/ClickToPay/services/ClickToPayService';
 import ClickToPayComponent from '../../internal/ClickToPay';
 import ContentSeparator from '../../internal/ContentSeparator';
 import Button from '../../internal/Button';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 
 type ClickToPayWrapperProps = {
     children(isCardPrimaryInput?: boolean): h.JSX.Element;

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { CashAppComponent } from './components/CashAppComponent';
 import CashAppService from './services/CashAppService';
 import { CashAppSdkLoader } from './services/CashAppSdkLoader';

--- a/packages/lib/src/components/ClickToPay/ClickToPay.tsx
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { ClickToPayConfiguration, ClickToPayPaymentData } from './types';
 import collectBrowserInfo from '../../utils/browserInfo';
 import { ClickToPayCheckoutPayload, IClickToPayService } from '../internal/ClickToPay/services/types';

--- a/packages/lib/src/components/CustomCard/CustomCard.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCard.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement';
 import CustomCardInput from './CustomCardInput';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import collectBrowserInfo from '../../utils/browserInfo';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';
 import { CbObjOnBinLookup, CbObjOnFocus } from '../internal/SecuredFields/lib/types';

--- a/packages/lib/src/components/Doku/Doku.tsx
+++ b/packages/lib/src/components/Doku/Doku.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import DokuInput from './components/DokuInput';
 import DokuVoucherResult from './components/DokuVoucherResult';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { TxVariants } from '../tx-variants';
 import { VoucherConfiguration } from '../internal/Voucher/types';
 

--- a/packages/lib/src/components/Doku/components/DokuInput/DokuInput.test.tsx
+++ b/packages/lib/src/components/Doku/components/DokuInput/DokuInput.test.tsx
@@ -2,7 +2,7 @@
 import { h } from 'preact';
 import { render, screen } from '@testing-library/preact';
 import DokuInput from './DokuInput';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 import { Resources } from '../../../../core/Context/Resources';
 
 describe('DokuInput', () => {

--- a/packages/lib/src/components/Doku/components/DokuInput/DokuInput.tsx
+++ b/packages/lib/src/components/Doku/components/DokuInput/DokuInput.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useRef, useState } from 'preact/hooks';
 import PersonalDetails from '../../../internal/PersonalDetails/PersonalDetails';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import FormInstruction from '../../../internal/FormInstruction';
 import { ComponentMethodsRef } from '../../../internal/UIElement/types';
 

--- a/packages/lib/src/components/Doku/components/DokuVoucherResult/DokuVoucherResult.tsx
+++ b/packages/lib/src/components/Doku/components/DokuVoucherResult/DokuVoucherResult.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Voucher from '../../../internal/Voucher';
 
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { DokuVoucherResultProps } from '../../types';
 import useImage from '../../../../core/Context/useImage';
 

--- a/packages/lib/src/components/Donation/Donation.tsx
+++ b/packages/lib/src/components/Donation/Donation.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import DonationComponent from './components/DonationComponent';
 import { TxVariants } from '../tx-variants';
 import type { ICore } from '../../core/types';

--- a/packages/lib/src/components/Donation/components/DonationComponent.test.tsx
+++ b/packages/lib/src/components/Donation/components/DonationComponent.test.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { mount } from 'enzyme';
 import DonationComponent from './DonationComponent';
 import { render, screen } from '@testing-library/preact';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const onDonate = () => {};
 const amounts = {

--- a/packages/lib/src/components/Donation/components/DonationComponent.tsx
+++ b/packages/lib/src/components/Donation/components/DonationComponent.tsx
@@ -4,7 +4,7 @@ import CampaignContainer from './CampaignContainer';
 import ButtonGroup from '../../internal/ButtonGroup';
 import Button from '../../internal/Button';
 import Img from '../../internal/Img';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import '../Donation.scss';
 import DisclaimerMessage from '../../internal/DisclaimerMessage';
 import { DonationComponentProps } from './types';

--- a/packages/lib/src/components/Dragonpay/Dragonpay.tsx
+++ b/packages/lib/src/components/Dragonpay/Dragonpay.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import DragonpayInput from './components/DragonpayInput';
 import DragonpayVoucherResult from './components/DragonpayVoucherResult';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { DragonpayConfiguraton } from './types';
 import { TxVariants } from '../tx-variants';
 

--- a/packages/lib/src/components/Dragonpay/components/DragonpayInput/DragonpayInput.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayInput/DragonpayInput.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'preact/hooks';
 import useForm from '../../../../utils/useForm';
 import Field from '../../../internal/FormFields/Field';
 import getIssuerImageUrl from '../../../../utils/get-issuer-image';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { DragonpayInputData, DragonpayInputIssuerItem, DragonpayInputProps } from '../../types';
 import InputEmail from '../../../internal/FormFields/InputEmail';
 import Select from '../../../internal/FormFields/Select';

--- a/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.test.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import DragonpayVoucherResult from './DragonpayVoucherResult';
 import { mount } from 'enzyme';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 describe('DragonpayVoucherResult', () => {
     test('should not render issuer image for dragonpay_otc_philippines', () => {

--- a/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.tsx
+++ b/packages/lib/src/components/Dragonpay/components/DragonpayVoucherResult/DragonpayVoucherResult.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Voucher from '../../../internal/Voucher';
 import getIssuerImageUrl from '../../../../utils/get-issuer-image';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { DragonpayVoucherResultProps } from '../../types';
 import { VoucherDetail } from '../../../internal/Voucher/types';
 import useImage from '../../../../core/Context/useImage';

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import defaultProps from './defaultProps';
 import DropinComponent from '../../components/Dropin/components/DropinComponent';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { getCommonProps } from './components/utils';
 import { createElements, createStoredElements } from './elements';
 import createInstantPaymentElements from './elements/createInstantPaymentElements';

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/DisableOneClickConfirmation.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/DisableOneClickConfirmation.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import classNames from 'classnames';
 import './DisableOneClickConfirmation.scss';
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -1,8 +1,8 @@
 import { h } from 'preact';
 import PaymentMethodIcon from './PaymentMethodIcon';
-import useCoreContext from '../../../../core/Context/useCoreContext';
-import './OrderPaymentMethods.scss';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useImage from '../../../../core/Context/useImage';
+import './OrderPaymentMethods.scss';
 
 export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLogoConfiguration }) => {
     const { i18n } = useCoreContext();

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -4,18 +4,18 @@ import PaymentMethodDetails from '../PaymentMethodDetails';
 import PaymentMethodIcon from '../PaymentMethodIcon';
 import DisableOneClickConfirmation from '../DisableOneClickConfirmation';
 import './PaymentMethodItem.scss';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
 import UIElement from '../../../../internal/UIElement/UIElement';
 import PaymentMethodBrands from '../PaymentMethodBrands/PaymentMethodBrands';
 import { BRAND_ICON_UI_EXCLUSION_LIST } from '../../../../internal/SecuredFields/lib/configuration/constants';
 import PaymentMethodName from '../PaymentMethodName';
 import { ExpandButton } from './ExpandButton';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 
-interface PaymentMethodItemProps {
+export interface PaymentMethodItemProps {
     paymentMethod: UIElement;
-    isSelected: boolean;
-    isLoaded: boolean;
-    isLoading: boolean;
+    isSelected?: boolean;
+    isLoaded?: boolean;
+    isLoading?: boolean;
     isDisablingPaymentMethod: boolean;
     showRemovePaymentMethodButton: boolean;
     onDisableStoredPaymentMethod: (paymentMethod) => void;

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
@@ -6,7 +6,7 @@ import UIElement from '../../../internal/UIElement/UIElement';
 import userEvent from '@testing-library/user-event';
 import Giftcard from '../../../Giftcard';
 import { Order, OrderStatus } from '../../../../types';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 function createInstantPaymentMethods() {
     return [

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -4,7 +4,7 @@ import UIElement from '../../../internal/UIElement/UIElement';
 import { Order, OrderStatus } from '../../../../types/global-types';
 import OrderPaymentMethods from './OrderPaymentMethods';
 import InstantPaymentMethods from './InstantPaymentMethods';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { useBrandLogoConfiguration } from './useBrandLogoConfiguration';
 import PaymentMethodsContainer, { PaymentMethodsContainerProps } from './PaymentMethodsContainer';
 import { useEffect } from 'preact/hooks';

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import PaymentMethodItem from './PaymentMethodItem/PaymentMethodItem';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { useMemo } from 'preact/hooks';
 import uuid from '../../../../utils/uuid';
 import classNames from 'classnames';

--- a/packages/lib/src/components/Dropin/components/status/Error.tsx
+++ b/packages/lib/src/components/Dropin/components/status/Error.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 
 import Img from '../../../internal/Img';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useImage from '../../../../core/Context/useImage';
 import { useA11yReporter } from '../../../../core/Errors/useA11yReporter';
 

--- a/packages/lib/src/components/Dropin/components/status/Status.test.tsx
+++ b/packages/lib/src/components/Dropin/components/status/Status.test.tsx
@@ -4,7 +4,7 @@ import { SRPanel } from '../../../../core/Errors/SRPanel';
 import SRPanelProvider from '../../../../core/Errors/SRPanelProvider';
 import Error from './Error';
 import Success from './Success';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 describe('Status', () => {
     const srPanel = new SRPanel(global.core);

--- a/packages/lib/src/components/Dropin/components/status/Success.tsx
+++ b/packages/lib/src/components/Dropin/components/status/Success.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 
 import Img from '../../../internal/Img';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useImage from '../../../../core/Context/useImage';
 import { useA11yReporter } from '../../../../core/Errors/useA11yReporter';
 

--- a/packages/lib/src/components/Econtext/Econtext.tsx
+++ b/packages/lib/src/components/Econtext/Econtext.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import EcontextInput from './components/EcontextInput';
 import EcontextVoucherResult from './components/EcontextVoucherResult';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { TxVariants } from '../tx-variants';
 import { EcontextConfiguration } from './types';
 

--- a/packages/lib/src/components/Econtext/components/EcontextInput/EcontextInput.test.tsx
+++ b/packages/lib/src/components/Econtext/components/EcontextInput/EcontextInput.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import EcontextInput from './EcontextInput';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 const requiredPropsFromUiElement = {
     showPayButton: false
@@ -38,55 +38,63 @@ describe('Econtext: EcontextInput', () => {
     });
 
     test('hide PayButton if showPayButton is set to false', () => {
-        const wrapper = shallow(
-            <EcontextInput
-                {...requiredPropsFromUiElement}
-                personalDetailsRequired={false}
-                onChange={jest.fn()}
-                onSubmit={jest.fn()}
-                showPayButton={false}
-                payButton={() => <button className="pay-button" />}
-            />
+        const wrapper = mount(
+            <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+                <EcontextInput
+                    {...requiredPropsFromUiElement}
+                    personalDetailsRequired={false}
+                    onChange={jest.fn()}
+                    onSubmit={jest.fn()}
+                    showPayButton={false}
+                    payButton={() => <button className="pay-button" />}
+                />
+            </CoreProvider>
         );
         expect(wrapper.contains(<button className="pay-button" />)).toBeFalsy();
     });
 
     test('hide form instruction if personalDetailsRequired sets to false', () => {
-        const wrapper = shallow(
-            <EcontextInput
-                {...requiredPropsFromUiElement}
-                personalDetailsRequired={false}
-                onChange={jest.fn()}
-                onSubmit={jest.fn()}
-                payButton={() => <button className="pay-button" />}
-            />
+        const wrapper = mount(
+            <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+                <EcontextInput
+                    {...requiredPropsFromUiElement}
+                    personalDetailsRequired={false}
+                    onChange={jest.fn()}
+                    onSubmit={jest.fn()}
+                    payButton={() => <button className="pay-button" />}
+                />
+            </CoreProvider>
         );
         expect(wrapper.find('FormInstruction')).toHaveLength(0);
     });
 
     test('hide form instruction if showFormInstruction sets to false', () => {
-        const wrapper = shallow(
-            <EcontextInput
-                {...requiredPropsFromUiElement}
-                showFormInstruction={false}
-                onChange={jest.fn()}
-                onSubmit={jest.fn()}
-                payButton={() => <button className="pay-button" />}
-            />
+        const wrapper = mount(
+            <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+                <EcontextInput
+                    {...requiredPropsFromUiElement}
+                    showFormInstruction={false}
+                    onChange={jest.fn()}
+                    onSubmit={jest.fn()}
+                    payButton={() => <button className="pay-button" />}
+                />
+            </CoreProvider>
         );
         expect(wrapper.find('FormInstruction')).toHaveLength(0);
     });
 
     test('show form instruction if personalDetailsRequired and showFormInstruction set to true', () => {
-        const wrapper = shallow(
-            <EcontextInput
-                {...requiredPropsFromUiElement}
-                personalDetailsRequired
-                showFormInstruction
-                onChange={jest.fn()}
-                onSubmit={jest.fn()}
-                payButton={() => <button className="pay-button" />}
-            />
+        const wrapper = mount(
+            <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+                <EcontextInput
+                    {...requiredPropsFromUiElement}
+                    personalDetailsRequired
+                    showFormInstruction
+                    onChange={jest.fn()}
+                    onSubmit={jest.fn()}
+                    payButton={() => <button className="pay-button" />}
+                />
+            </CoreProvider>
         );
         expect(wrapper.find('FormInstruction')).toHaveLength(1);
     });

--- a/packages/lib/src/components/Econtext/components/EcontextInput/EcontextInput.tsx
+++ b/packages/lib/src/components/Econtext/components/EcontextInput/EcontextInput.tsx
@@ -1,7 +1,7 @@
 import { h, VNode } from 'preact';
 import { useRef, useState } from 'preact/hooks';
 import PersonalDetails from '../../../internal/PersonalDetails/PersonalDetails';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { econtextValidationRules } from '../../validate';
 import { PersonalDetailsSchema } from '../../../../types/global-types';
 import './EcontextInput.scss';

--- a/packages/lib/src/components/Econtext/components/EcontextVoucherResult/EcontextVoucherResult.tsx
+++ b/packages/lib/src/components/Econtext/components/EcontextVoucherResult/EcontextVoucherResult.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Voucher from '../../../internal/Voucher';
 
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { EcontextVoucherResultProps } from '../../types';
 import useImage from '../../../../core/Context/useImage';
 

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import GiftcardComponent from './components/GiftcardComponent';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import PayButton from '../internal/PayButton';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { PaymentAmount } from '../../types//global-types';

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -2,7 +2,7 @@ import { Component, FunctionComponent, h } from 'preact';
 import SecuredFieldsProvider from '../../internal/SecuredFields/SFP/SecuredFieldsProvider';
 import Alert from '../../internal/Alert';
 import GiftcardResult from './GiftcardResult';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { PaymentAmount } from '../../../types/global-types';
 import { GIFT_CARD } from '../../internal/SecuredFields/lib/configuration/constants';
 import { GiftCardFields } from './GiftcardFields';

--- a/packages/lib/src/components/Giftcard/components/GiftcardResult.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardResult.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import './GiftcardResult.scss';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 
 function GiftcardResult({ brand, amount, balance, transactionLimit, ...props }) {
     const { i18n } = useCoreContext();

--- a/packages/lib/src/components/Giropay/Giropay.tsx
+++ b/packages/lib/src/components/Giropay/Giropay.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import RedirectElement from '../Redirect';
 import RedirectButton from '../internal/RedirectButton';
 import { TxVariants } from '../tx-variants';

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { KlarnConfiguration } from './types';
 import PayButton from '../internal/PayButton';
 import { KlarnaContainer } from './components/KlarnaContainer/KlarnaContainer';

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import MBWayInput from './components/MBWayInput';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import config from './components/MBWayAwait/config';
 import Await from '../../components/internal/Await';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useState, useRef } from 'preact/hooks';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { MBWayInputProps } from './types';
 import './MBWayInput.scss';
 import PhoneInput from '../../../internal/PhoneInput';

--- a/packages/lib/src/components/Multibanco/Multibanco.tsx
+++ b/packages/lib/src/components/Multibanco/Multibanco.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import MultibancoVoucherResult from './components/MultibancoVoucherResult';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import RedirectButton from '../internal/RedirectButton';
 import { TxVariants } from '../tx-variants';
 import { VoucherConfiguration } from '../internal/Voucher/types';

--- a/packages/lib/src/components/Multibanco/components/MultibancoVoucherResult/MultibancoVoucherResult.tsx
+++ b/packages/lib/src/components/Multibanco/components/MultibancoVoucherResult/MultibancoVoucherResult.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import Voucher from '../../../internal/Voucher';
 
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { MultibancoVoucherResultProps } from '../../types';
 import { VoucherDetail } from '../../../internal/Voucher/types';
 import useImage from '../../../../core/Context/useImage';

--- a/packages/lib/src/components/Oxxo/Oxxo.tsx
+++ b/packages/lib/src/components/Oxxo/Oxxo.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import OxxoVoucherResult from './components/OxxoVoucherResult';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { OxxoElementData } from './types';
 import { TxVariants } from '../tx-variants';
 import { VoucherConfiguration } from '../internal/Voucher/types';

--- a/packages/lib/src/components/Oxxo/components/OxxoVoucherResult/OxxoVoucherResult.tsx
+++ b/packages/lib/src/components/Oxxo/components/OxxoVoucherResult/OxxoVoucherResult.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import Voucher from '../../../../components/internal/Voucher';
 import { VoucherDetail } from '../../../internal/Voucher/types';
 
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { OxxoVoucherResultProps } from '../../types';
 import './OxxoVoucherResult.scss';
 import useImage from '../../../../core/Context/useImage';

--- a/packages/lib/src/components/PayMe/Instructions.test.tsx
+++ b/packages/lib/src/components/PayMe/Instructions.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/preact';
 import { h } from 'preact';
 import { Resources } from '../../core/Context/Resources';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import Instructions from './Instructions';
 
 describe('Instructions', () => {

--- a/packages/lib/src/components/PayMe/Instructions.tsx
+++ b/packages/lib/src/components/PayMe/Instructions.tsx
@@ -1,4 +1,4 @@
-import useCoreContext from '../../core/Context/useCoreContext';
+import { useCoreContext } from '../../core/Context/CoreProvider';
 import { h } from 'preact';
 import './Instructions.scss';
 

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import PaypalComponent from './components/PaypalComponent';
 import defaultProps from './defaultProps';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { ERRORS } from './constants';
 import { TxVariants } from '../tx-variants';

--- a/packages/lib/src/components/PayPal/components/PaypalButtons.test.tsx
+++ b/packages/lib/src/components/PayPal/components/PaypalButtons.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import PaypalButtons from './PaypalButtons';
 import { render } from '@testing-library/preact';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import { mock } from 'jest-mock-extended';
 import { PayPalButtonsProps } from './types';
 

--- a/packages/lib/src/components/PayPal/components/PaypalButtons.tsx
+++ b/packages/lib/src/components/PayPal/components/PaypalButtons.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'preact/hooks';
 import classnames from 'classnames';
 import { getStyle } from '../utils/get-paypal-styles';
 import Spinner from '../../internal/Spinner';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 
 import type { PayPalButtonsProps } from './types';
 import type { FundingSource } from '../types';

--- a/packages/lib/src/components/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/PersonalDetails/PersonalDetails.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import PersonalDetails from '../internal/PersonalDetails';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { TxVariants } from '../tx-variants';
 import FormInstruction from '../internal/FormInstruction';
 import { UIElementProps } from '../internal/UIElement/types';

--- a/packages/lib/src/components/Pix/Pix.tsx
+++ b/packages/lib/src/components/Pix/Pix.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import QRLoaderContainer from '../helpers/QRLoaderContainer/QRLoaderContainer';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import PixInput from './PixInput';
 import { cleanCPFCNPJ } from '../internal/SocialSecurityNumberBrazil/utils';
 import { PixElementData, PixConfiguration } from './types';

--- a/packages/lib/src/components/Pix/PixInput/PixInput.tsx
+++ b/packages/lib/src/components/Pix/PixInput/PixInput.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { pixValidationRules } from './validate';
 import { pixFormatters } from './utils';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import useForm from '../../../utils/useForm';
 import { BrazilPersonalDetail } from '../../internal/SocialSecurityNumberBrazil/BrazilPersonalDetail';
 import { PixInputDataState, PixInputProps } from './types';

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import RedirectShopper from './components/RedirectShopper';
 import RedirectButton from '../internal/RedirectButton';
 import { TxVariants } from '../tx-variants';

--- a/packages/lib/src/components/Sepa/Sepa.tsx
+++ b/packages/lib/src/components/Sepa/Sepa.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import IbanInput from '../internal/IbanInput';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import { SepaElementData, SepaConfiguration } from './types';
 import { TxVariants } from '../tx-variants';
 import FormInstruction from '../internal/FormInstruction';

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -9,6 +9,7 @@ import { ThreeDS2ChallengeConfiguration } from './types';
 import AdyenCheckoutError, { API_ERROR } from '../../core/Errors/AdyenCheckoutError';
 import { ANALYTICS_API_ERROR, ANALYTICS_ERROR_CODE_ACTION_IS_MISSING_PAYMENT_DATA, ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeConfiguration> {
     public static type = TxVariants.threeDS2Challenge;
@@ -51,7 +52,11 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeConfiguration> {
             return null;
         }
 
-        return <PrepareChallenge {...this.props} onComplete={this.onComplete} onSubmitAnalytics={this.submitAnalytics} />;
+        return (
+            <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
+                <PrepareChallenge {...this.props} onComplete={this.onComplete} onSubmitAnalytics={this.submitAnalytics} />
+            </CoreProvider>
+        );
     }
 }
 

--- a/packages/lib/src/components/Trustly/Trustly.tsx
+++ b/packages/lib/src/components/Trustly/Trustly.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import RedirectElement from '../Redirect';
 import RedirectButton from '../internal/RedirectButton';
 import { TxVariants } from '../tx-variants';

--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -1,7 +1,7 @@
 import { h, RefObject } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import UPIComponent from './components/UPIComponent';
-import CoreProvider from '../../core/Context/CoreProvider';
+import { CoreProvider } from '../../core/Context/CoreProvider';
 import Await from '../internal/Await';
 import QRLoader from '../internal/QRLoader';
 import { UPIConfiguration, UpiMode, UpiPaymentData } from './types';

--- a/packages/lib/src/components/UPI/components/UPIComponent/UPIComponent.tsx
+++ b/packages/lib/src/components/UPI/components/UPIComponent/UPIComponent.tsx
@@ -1,6 +1,6 @@
 import { Fragment, h, RefObject } from 'preact';
 import { useCallback, useState } from 'preact/hooks';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { VpaInputDataState, VpaInputHandlers } from '../VpaInput/VpaInput';
 import VpaInput from '../VpaInput';
 import SegmentedControl from '../../../internal/SegmentedControl';

--- a/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
@@ -3,7 +3,7 @@ import UIElement from '../../internal/UIElement/UIElement';
 import IssuerList from '../../internal/IssuerList';
 import getIssuerImageUrl from '../../../utils/get-issuer-image';
 import { FALLBACK_CONTEXT } from '../../../core/config';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import RedirectButton from '../../internal/RedirectButton';
 import SRPanelProvider from '../../../core/Errors/SRPanelProvider';
 import { IssuerListConfiguration, IssuerListData } from './types';

--- a/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
+++ b/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../../internal/UIElement/UIElement';
 import OpenInvoice from '../../internal/OpenInvoice';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import SRPanelProvider from '../../../core/Errors/SRPanelProvider';
 import { OpenInvoiceConfiguration } from './types';
 

--- a/packages/lib/src/components/helpers/QRLoaderContainer/QRLoaderContainer.tsx
+++ b/packages/lib/src/components/helpers/QRLoaderContainer/QRLoaderContainer.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import UIElement from '../../internal/UIElement/UIElement';
 import QRLoader from '../../internal/QRLoader';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import RedirectButton from '../../internal/RedirectButton';
 import SRPanelProvider from '../../../core/Errors/SRPanelProvider';
 import { QRLoaderConfiguration } from './types';

--- a/packages/lib/src/components/internal/Address/Address.test.tsx
+++ b/packages/lib/src/components/internal/Address/Address.test.tsx
@@ -1,13 +1,15 @@
-import { shallow } from 'enzyme';
 import { h } from 'preact';
 import Address from './Address';
 import getDataset from '../../../core/Services/get-dataset';
-import { AddressSchema, AddressSpecifications } from './types';
+import { AddressSpecifications } from './types';
 import { AddressData } from '../../../types';
 import { FALLBACK_VALUE } from './constants';
+import { render, screen } from '@testing-library/preact';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
+import { Resources } from '../../../core/Context/Resources';
 
 jest.mock('../../../core/Services/get-dataset');
-(getDataset as jest.Mock).mockImplementation(jest.fn(() => Promise.resolve({})));
+(getDataset as jest.Mock).mockImplementation(jest.fn(() => Promise.resolve([{ id: 'NL', name: 'Netherlands' }])));
 
 describe('Address', () => {
     const addressSpecificationsMock: AddressSpecifications = {
@@ -19,22 +21,44 @@ describe('Address', () => {
             schema: ['country', 'street', 'houseNumberOrName', 'postalCode', 'city', 'stateOrProvince']
         }
     };
-    const getWrapper = props => shallow(<Address specifications={addressSpecificationsMock} {...props} />);
 
-    test('has the required fields', () => {
-        const requiredFields: AddressSchema = ['street', 'houseNumberOrName', 'postalCode', 'country'];
-        const wrapper = getWrapper({ requiredFields });
-        expect(wrapper.find('FieldContainer')).toHaveLength(requiredFields.length);
+    const customRender = ui => {
+        return render(
+            <CoreProvider i18n={global.i18n} loadingContext="test" resources={new Resources()}>
+                {ui}
+            </CoreProvider>
+        );
+    };
+
+    // const getWrapper = props => shallow(<Address specifications={addressSpecificationsMock} {...props} />);
+
+    test('should have the required fields', async () => {
+        const requiredFields = ['street', 'houseNumberOrName', 'postalCode', 'country'];
+
+        customRender(<Address specifications={addressSpecificationsMock} requiredFields={requiredFields} />);
+
+        expect(screen.getByLabelText('Street')).toBeInTheDocument();
+        expect(screen.getByLabelText('House number')).toBeInTheDocument();
+        expect(screen.getByLabelText('Postal code')).toBeInTheDocument();
+        expect(await screen.findByLabelText('Country')).toBeInTheDocument();
     });
 
-    test('shows the address as readOnly', () => {
-        const requiredFields: AddressSchema = ['street', 'houseNumberOrName', 'postalCode', 'country'];
-        const visibility = 'readOnly';
-        const wrapper = getWrapper({ requiredFields, visibility });
-        expect(wrapper.find('ReadOnlyAddress')).toHaveLength(1);
+    test('should show the address as readOnly', () => {
+        const requiredFields = ['street', 'houseNumberOrName', 'postalCode', 'country'];
+
+        customRender(
+            <Address
+                data={{ street: 'Simon Carmiggeltstraat 6-50' }}
+                specifications={addressSpecificationsMock}
+                requiredFields={requiredFields}
+                visibility="readOnly"
+            />
+        );
+
+        expect(screen.getByText('Simon Carmiggeltstraat 6-50')).toBeInTheDocument();
     });
 
-    test('prefills the address fields from the passed data object', () => {
+    test('should prefill the address fields from the passed data object', () => {
         const data: AddressData = {
             street: 'Infinite Loop',
             postalCode: '95014',
@@ -43,16 +67,14 @@ describe('Address', () => {
             country: 'US',
             stateOrProvince: 'CA'
         };
-
         const onChangeMock = jest.fn();
-        const wrapper = getWrapper({ data, onChange: onChangeMock });
-        wrapper.update(null);
+        customRender(<Address data={data} specifications={addressSpecificationsMock} onChange={onChangeMock} />);
 
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         expect(lastOnChangeCall[0].data).toMatchObject(data);
     });
 
-    test('validates prefilled data', () => {
+    test('should validate prefilled data', () => {
         const data: AddressData = {
             street: 'Infinite Loop',
             postalCode: '95014',
@@ -63,12 +85,13 @@ describe('Address', () => {
         };
 
         const onChangeMock = jest.fn();
-        getWrapper({ data, onChange: onChangeMock });
+        customRender(<Address data={data} specifications={addressSpecificationsMock} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         expect(lastOnChangeCall[0].isValid).toBe(true);
     });
 
-    test('validates prefilled data correctly when a field is optional', () => {
+    test('should validate prefilled data correctly when a field is optional', () => {
         const data: AddressData = {
             street: '1 Infinite Loop',
             postalCode: '95014',
@@ -81,12 +104,13 @@ describe('Address', () => {
         };
 
         const onChangeMock = jest.fn();
-        getWrapper({ data, specifications, onChange: onChangeMock });
+        customRender(<Address data={data} specifications={specifications} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         expect(lastOnChangeCall[0].isValid).toBe(true);
     });
 
-    test('validates prefilled data correctly when a country with no state or province field is used', () => {
+    test('should validate prefilled data correctly when a country with no state or province field is used', () => {
         const data: AddressData = {
             street: 'Simon Carmiggeltstraat',
             postalCode: '1011DJ',
@@ -96,19 +120,22 @@ describe('Address', () => {
         };
 
         const onChangeMock = jest.fn();
-        getWrapper({ data, onChange: onChangeMock });
+        customRender(<Address data={data} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         expect(lastOnChangeCall[0].isValid).toBe(true);
     });
 
-    test('sets not required fields as "N/A" except for the ones that are passed in the data object', () => {
-        const requiredFields: AddressSchema = ['street'];
+    test('should set not required fields as "N/A" except for the ones that are passed in the data object', () => {
+        const requiredFields = ['street'];
         const data = { country: 'NL' };
         const onChangeMock = jest.fn();
 
-        getWrapper({ data, requiredFields, onChange: onChangeMock });
+        customRender(<Address data={data} requiredFields={requiredFields} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         const receivedData = lastOnChangeCall[0].data;
+
         expect(receivedData.street).toBe(undefined);
         expect(receivedData.postalCode).toBe(FALLBACK_VALUE);
         expect(receivedData.city).toBe(FALLBACK_VALUE);
@@ -116,7 +143,7 @@ describe('Address', () => {
         expect(receivedData.country).toBe(data.country);
     });
 
-    test('sets optional fields as "N/A" if no data is set', () => {
+    test('should set optional fields as "N/A" if no data is set', () => {
         const data: AddressData = {
             street: '1 Infinite Loop',
             postalCode: '95014',
@@ -127,7 +154,9 @@ describe('Address', () => {
             US: { optionalFields: ['houseNumberOrName', 'postalCode'] }
         };
         const onChangeMock = jest.fn();
-        getWrapper({ data, specifications, onChange: onChangeMock });
+
+        customRender(<Address data={data} specifications={specifications} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         const receivedData = lastOnChangeCall[0].data;
         expect(receivedData.street).toBe(data.street);
@@ -137,11 +166,12 @@ describe('Address', () => {
         expect(receivedData.country).toBe(data.country);
     });
 
-    test('does not include fields without a value in the data object', () => {
+    test('should  not include fields without a value in the data object', () => {
         const data: AddressData = { country: 'NL' };
         const onChangeMock = jest.fn();
 
-        getWrapper({ data, onChange: onChangeMock });
+        customRender(<Address data={data} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         const receivedData = lastOnChangeCall[0].data;
 
@@ -152,23 +182,26 @@ describe('Address', () => {
         expect(receivedData.country).toBe(data.country);
     });
 
-    test('sets the stateOrProvince field to "N/A" for countries with no state dataset', () => {
+    test('should set the stateOrProvince field to "N/A" for countries with no state dataset', () => {
         const data: AddressData = { country: 'NL' };
         const onChangeMock = jest.fn();
-        const wrapper = getWrapper({ data, onChange: onChangeMock });
+
+        customRender(<Address data={data} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         const receivedData = lastOnChangeCall[0].data;
-        wrapper.update(null);
+
         expect(receivedData.stateOrProvince).toBe(FALLBACK_VALUE);
     });
 
-    test('removes the stateOrProvince field for countries with a state dataset', () => {
+    test('should remove the stateOrProvince field for countries with a state dataset', () => {
         const data: AddressData = { country: 'US' };
         const onChangeMock = jest.fn();
-        const wrapper = getWrapper({ data, onChange: onChangeMock });
+
+        customRender(<Address data={data} onChange={onChangeMock} />);
+
         const lastOnChangeCall = onChangeMock.mock.calls.pop();
         const receivedData = lastOnChangeCall[0].data;
-        wrapper.update(null);
         expect(receivedData.stateOrProvince).toBe(undefined);
     });
 });

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -11,7 +11,7 @@ import useForm from '../../../utils/useForm';
 import Specifications from './Specifications';
 import { ADDRESS_SCHEMA, FALLBACK_VALUE } from './constants';
 import { getMaxLengthByFieldAndCountry } from '../../../utils/validator-utils';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import AddressSearch from './components/AddressSearch';
 import { ComponentMethodsRef } from '../UIElement/types';
 

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/preact';
 import AddressSearch from './AddressSearch';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 import { Resources } from '../../../../core/Context/Resources';
 
 const ADDRESS_LOOKUP_RESULT = [

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 import { AddressLookupItem } from '../types';
 import { useCallback, useEffect, useState, useMemo } from 'preact/hooks';
 import './AddressSearch.scss';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { debounce } from '../../../../utils/debounce';
 import Select from '../../FormFields/Select';
 import { AddressData } from '../../../../types';

--- a/packages/lib/src/components/internal/Address/components/CountryField.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.test.tsx
@@ -4,7 +4,7 @@ import CountryField from './CountryField';
 import getDataset from '../../../../core/Services/get-dataset';
 import { mock } from 'jest-mock-extended';
 import { CountryFieldProps } from '../types';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 jest.mock('../../../../core/Services/get-dataset');
 const countriesMock = [

--- a/packages/lib/src/components/internal/Address/components/CountryField.tsx
+++ b/packages/lib/src/components/internal/Address/components/CountryField.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useLayoutEffect, useState } from 'preact/hooks';
 import Field from '../../FormFields/Field';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import getDataset from '../../../../core/Services/get-dataset';
 import { CountryFieldProps, CountryFieldItem } from '../types';
 import Select from '../../FormFields/Select';

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.test.tsx
@@ -4,7 +4,7 @@ import FieldContainer from './FieldContainer';
 import Specifications from '../Specifications';
 import { mock } from 'jest-mock-extended';
 import { FieldContainerProps } from '../types';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 const propsMock = {
     errors: {},

--- a/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
+++ b/packages/lib/src/components/internal/Address/components/FieldContainer.tsx
@@ -3,7 +3,7 @@ import Field from '../../FormFields/Field';
 import StateField from './StateField';
 import CountryField from './CountryField';
 import { AddressStateError, FieldContainerProps } from '../types';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import Language from '../../../../language/Language';
 import InputText from '../../FormFields/InputText';
 

--- a/packages/lib/src/components/internal/Address/components/StateField.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.test.tsx
@@ -5,7 +5,7 @@ import getDataset from '../../../../core/Services/get-dataset';
 import Specifications from '../Specifications';
 import { mock } from 'jest-mock-extended';
 import { StateFieldProps } from '../types';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 jest.mock('../../../../core/Services/get-dataset');
 const statesMock = [

--- a/packages/lib/src/components/internal/Address/components/StateField.tsx
+++ b/packages/lib/src/components/internal/Address/components/StateField.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useState, useLayoutEffect } from 'preact/hooks';
 import Field from '../../FormFields/Field';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import getDataset from '../../../../core/Services/get-dataset';
 import { StateFieldItem, StateFieldProps } from '../types';
 import Select from '../../FormFields/Select';

--- a/packages/lib/src/components/internal/Await/Await.test.tsx
+++ b/packages/lib/src/components/internal/Await/Await.test.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import checkPaymentStatus from '../../../core/Services/payment-status';
 import Await from './Await';
 import { fireEvent, render, screen, waitFor } from '@testing-library/preact';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import { Resources } from '../../../core/Context/Resources';
 import { AwaitComponentProps } from './types';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -7,7 +7,7 @@ import processResponse from '../../../core/ProcessResponse';
 import Spinner from '../../internal/Spinner';
 import Countdown from '../Countdown';
 import Button from '../Button';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { AwaitComponentProps, StatusObject } from './types';
 import './Await.scss';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';

--- a/packages/lib/src/components/internal/Button/Button.test.tsx
+++ b/packages/lib/src/components/internal/Button/Button.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { mount } from 'enzyme';
 import Button from './Button';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const getWrapper = props => {
     return mount(

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from 'preact';
 import classNames from 'classnames';
 import Spinner from '../Spinner';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import './Button.scss';
 import { ButtonProps, ButtonState } from './types';
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import CtPCards from './CtPCards';
 import ShopperCard from '../../models/ShopperCard';
 import { IClickToPayService, MastercardCheckout, VisaCheckout } from '../../services/types';
-import CoreProvider from '../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../core/Context/CoreProvider';
 import ClickToPayProvider, { ClickToPayProviderProps } from '../../context/ClickToPayProvider';
 
 const customRender = (children: ComponentChildren, providerProps?: ClickToPayProviderProps) => {

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.tsx
@@ -11,7 +11,7 @@ import CtPSection from '../CtPSection';
 import { CTP_IFRAME_NAME } from '../../services/utils';
 import Iframe from '../../../../internal/IFrame';
 import useImage from '../../../../../core/Context/useImage';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import isMobile from '../../../../../utils/isMobile';
 import Language from '../../../../../language';
 import { PaymentAmount } from '../../../../../types/global-types';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCardsList/CtPCardsList.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCardsList/CtPCardsList.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { useEffect, useMemo } from 'preact/hooks';
 import ShopperCard from '../../../models/ShopperCard';
 import useClickToPayContext from '../../../context/useClickToPayContext';
-import useCoreContext from '../../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import useImage from '../../../../../../core/Context/useImage';
 import useForm from '../../../../../../utils/useForm';
 import isMobile from '../../../../../../utils/isMobile';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPSingleCard/CtPSingleCard.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPSingleCard/CtPSingleCard.test.tsx
@@ -2,7 +2,7 @@ import { ComponentChildren, h } from 'preact';
 import { render, screen } from '@testing-library/preact';
 import CtPSingleCard from './CtPSingleCard';
 import ShopperCard from '../../../models/ShopperCard';
-import CoreProvider from '../../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../../core/Context/CoreProvider';
 
 function createShopperCard({ panExpirationYear = '2030', panExpirationMonth = '09' }): ShopperCard {
     return new ShopperCard(

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPSingleCard/CtPSingleCard.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPSingleCard/CtPSingleCard.tsx
@@ -2,7 +2,7 @@ import { Fragment, h } from 'preact';
 import classnames from 'classnames';
 import Img from '../../../../Img';
 import ShopperCard from '../../../models/ShopperCard';
-import useCoreContext from '../../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import useImage from '../../../../../../core/Context/useImage';
 import './CtPSingleCard.scss';
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPInfo/CtPInfo.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPInfo/CtPInfo.tsx
@@ -2,7 +2,7 @@ import { Fragment, h } from 'preact';
 import { useCallback, useRef, useState } from 'preact/hooks';
 import { CtPInfoModal } from './CtPInfoModal';
 import useImage from '../../../../../core/Context/useImage';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import Img from '../../../Img';
 import './CtPInfo.scss';
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPInfo/CtPInfoModal/CtPInfoModal.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPInfo/CtPInfoModal/CtPInfoModal.tsx
@@ -1,7 +1,7 @@
 import { Fragment, h } from 'preact';
 import { useRef } from 'preact/hooks';
 import { CtPBrand } from '../../CtPBrand';
-import useCoreContext from '../../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import useImage from '../../../../../../core/Context/useImage';
 import { Modal } from '../../../../Modal';
 import Img from '../../../../Img';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLoader/CtPLoader.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLoader/CtPLoader.tsx
@@ -1,5 +1,5 @@
 import { Fragment, h } from 'preact';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import './CtPLoader.scss';
 
 const CtPLoader = (): h.JSX.Element => {

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
@@ -6,7 +6,7 @@ import CtPLoginInput, { CtPLoginInputHandlers } from './CtPLoginInput';
 import { CtPInfo } from '../CtPInfo';
 import CtPSection from '../CtPSection';
 import SrciError from '../../services/sdks/SrciError';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import './CtPLogin.scss';
 import TimeoutError from '../../errors/TimeoutError';
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import { loginValidationRules } from './validate';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import useForm from '../../../../../utils/useForm';
 import Field from '../../../FormFields/Field';
 import InputEmail from '../../../FormFields/InputEmail';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtpLogin.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtpLogin.test.tsx
@@ -1,7 +1,7 @@
 import { ComponentChildren, h } from 'preact';
 import { ClickToPayContext, IClickToPayContext } from '../../context/ClickToPayContext';
 import { render, screen } from '@testing-library/preact';
-import CoreProvider from '../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../core/Context/CoreProvider';
 import { mock } from 'jest-mock-extended';
 import CtPLogin from './CtPLogin';
 import userEvent from '@testing-library/user-event';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.test.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { render, screen } from '@testing-library/preact';
-import CoreProvider from '../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../core/Context/CoreProvider';
 import ClickToPayProvider from '../../context/ClickToPayProvider';
 import { IClickToPayService } from '../../services/types';
 import { mock } from 'jest-mock-extended';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.tsx
@@ -6,7 +6,7 @@ import CtPOneTimePasswordInput from './CtPOneTimePasswordInput';
 import { CtPOneTimePasswordInputHandlers } from './CtPOneTimePasswordInput/CtPOneTimePasswordInput';
 import { CtPInfo } from '../CtPInfo';
 import CtPSection from '../CtPSection';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import './CtPOneTimePassword.scss';
 import CtPSaveCookiesCheckbox from './CtPSaveCookiesCheckbox';
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.test.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { render, screen, waitFor } from '@testing-library/preact';
-import CoreProvider from '../../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../../core/Context/CoreProvider';
 import ClickToPayProvider from '../../../context/ClickToPayProvider';
 import { IClickToPayService } from '../../../services/types';
 import { mock } from 'jest-mock-extended';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import { otpValidationRules } from './validate';
 import CtPResendOtpLink from './CtPResendOtpLink';
 import useClickToPayContext from '../../../context/useClickToPayContext';
-import useCoreContext from '../../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import useForm from '../../../../../../utils/useForm';
 import Field from '../../../../FormFields/Field';
 import './CtPOneTimePasswordInput.scss';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 import useClickToPayContext from '../../../context/useClickToPayContext';
 import classnames from 'classnames';
-import useCoreContext from '../../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import Icon from '../../../../Icon';
 
 const CONFIRMATION_SHOWING_TIME = 2000;

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPSaveCookiesCheckbox/CtPSaveCookiesCheckbox.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPSaveCookiesCheckbox/CtPSaveCookiesCheckbox.tsx
@@ -2,7 +2,7 @@ import { h, Fragment } from 'preact';
 import classnames from 'classnames';
 import Field from '../../../../FormFields/Field';
 import Checkbox from '../../../../FormFields/Checkbox';
-import useCoreContext from '../../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import { useState, useCallback } from 'preact/hooks';
 import useClickToPayContext from '../../../context/useClickToPayContext';
 import isScreenSmall from '../../../../../../utils/isScreenSmall';

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.test.tsx
@@ -6,7 +6,7 @@ import { ClickToPayContext, IClickToPayContext } from '../../context/ClickToPayC
 import CtPLogoutLink from './CtPLogoutLink';
 import { CtpState } from '../../services/ClickToPayService';
 import ShopperCard from '../../models/ShopperCard';
-import CoreProvider from '../../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../../core/Context/CoreProvider';
 
 const customRender = (children: ComponentChildren, providerProps: IClickToPayContext) => {
     return render(

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.tsx
@@ -3,7 +3,7 @@ import useClickToPayContext from '../../context/useClickToPayContext';
 import { CtpState } from '../../services/ClickToPayService';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import './CtPLogoutLink.scss';
 
 const CtPLogoutLink = () => {

--- a/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
+++ b/packages/lib/src/components/internal/CompanyDetails/CompanyDetails.tsx
@@ -4,7 +4,7 @@ import Fieldset from '../FormFields/Fieldset';
 import Field from '../FormFields/Field';
 import ReadOnlyCompanyDetails from './ReadOnlyCompanyDetails';
 import { companyDetailsValidationRules } from './validate';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { getFormattedData } from './utils';
 import { CompanyDetailsSchema, CompanyDetailsProps } from './types';
 import useForm from '../../../utils/useForm';

--- a/packages/lib/src/components/internal/ConsentCheckboxLabel/ConsentCheckboxLabel.tsx
+++ b/packages/lib/src/components/internal/ConsentCheckboxLabel/ConsentCheckboxLabel.tsx
@@ -1,5 +1,5 @@
 import { Fragment, h } from 'preact';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 
 interface ConsentCheckboxLabelProps {
     url: string;

--- a/packages/lib/src/components/internal/ContentSeparator/ContentSeparator.tsx
+++ b/packages/lib/src/components/internal/ContentSeparator/ContentSeparator.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import classnames from 'classnames';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import './ContentSeparator.scss';
 
 interface ContentSeparatorProps {

--- a/packages/lib/src/components/internal/Countdown/Countdown.test.tsx
+++ b/packages/lib/src/components/internal/Countdown/Countdown.test.tsx
@@ -3,7 +3,7 @@ import Countdown from './index';
 import { render, screen } from '@testing-library/preact';
 import { SRPanel } from '../../../core/Errors/SRPanel';
 import SRPanelProvider from '../../../core/Errors/SRPanelProvider';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 describe('Countdown', () => {
     const srPanel = new SRPanel(global.core);

--- a/packages/lib/src/components/internal/Countdown/useCountdownA11yReporter.ts
+++ b/packages/lib/src/components/internal/Countdown/useCountdownA11yReporter.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'preact/hooks';
 import { CountdownA11yReporter } from './CountdownA11yReporter';
 import useSRPanelContext from '../../../core/Errors/useSRPanelContext';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { CountdownTime } from './types';
 
 export const useCountdownA11yReporter = (time: CountdownTime): void => {

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { mount } from 'enzyme';
 import Fieldset from './Fieldset';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 describe('Fieldset', () => {
     const i18n = { get: key => key };

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
@@ -1,6 +1,6 @@
 import { h, ComponentChildren } from 'preact';
 import cx from 'classnames';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import './Fieldset.scss';
 
 interface FieldsetProps {

--- a/packages/lib/src/components/internal/FormFields/RadioGroup/RadioGroup.tsx
+++ b/packages/lib/src/components/internal/FormFields/RadioGroup/RadioGroup.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import './RadioGroup.scss';
 import { RadioGroupProps } from './types';
 import { getUniqueId } from '../../../../utils/idGenerator';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 
 export default function RadioGroup(props: RadioGroupProps) {
     const { items, name, onChange, value, isInvalid, uniqueId } = props;

--- a/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { render, screen } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import Select from './Select';
-import CoreProvider from '../../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../../core/Context/CoreProvider';
 
 describe('Select', () => {
     const user = userEvent.setup();

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import cx from 'classnames';
 import SelectListItem from './SelectListItem';
-import useCoreContext from '../../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import { SelectListProps } from '../types';
 
 function SelectList({ selected, active, filteredItems, showList, ...props }: SelectListProps) {

--- a/packages/lib/src/components/internal/FormInstruction/FormInstruction.tsx
+++ b/packages/lib/src/components/internal/FormInstruction/FormInstruction.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import './FormInstruction.scss';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 
 const FormInstruction = () => {
     const { i18n } = useCoreContext();

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.test.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.test.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { h } from 'preact';
 import IbanInput from './IbanInput';
 import { GenericError } from '../../../core/Errors/types';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const createWrapper = (props = {}) =>
     mount(

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from 'preact';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Field from '../FormFields/Field';
 import { checkIbanStatus, isValidHolder } from './validate';
 import { electronicFormat, formatIban, getCountryCode, getNextCursorPosition } from './utils';

--- a/packages/lib/src/components/internal/IssuerList/IssuerButtonGroup/IssuerButtonGroup.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerButtonGroup/IssuerButtonGroup.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useCallback } from 'preact/hooks';
 import IssuerButton from './IssuerButton';
-import useCoreContext from '../../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import './IssuerButtonGroup.scss';
 import { IssuerItem } from '../types';
 

--- a/packages/lib/src/components/internal/IssuerList/IssuerList.test.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerList.test.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { h } from 'preact';
 import IssuerList from './IssuerList';
 import PayButton from '../PayButton';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import { ANALYTICS_FEATURED_ISSUER, ANALYTICS_LIST, ANALYTICS_SELECTED_STR } from '../../../core/Analytics/constants';
 
 describe('IssuerList', () => {

--- a/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
+++ b/packages/lib/src/components/internal/IssuerList/IssuerList.tsx
@@ -4,7 +4,7 @@ import useForm from '../../../utils/useForm';
 import Field from '../FormFields/Field';
 import IssuerButtonGroup from './IssuerButtonGroup';
 import ContentSeparator from '../ContentSeparator';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { ValidatorRules } from '../../../utils/Validator/types';
 import { IssuerListProps } from './types';
 import './IssuerList.scss';

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
@@ -4,7 +4,7 @@ import OpenInvoice from './OpenInvoice';
 import { mock } from 'jest-mock-extended';
 import { OpenInvoiceProps } from './types';
 import { FieldsetVisibility } from '../../../types';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 let componentRef;
 const setComponentRef = ref => {

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useEffect, useRef, useState, useMemo } from 'preact/hooks';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import CompanyDetails from '../CompanyDetails';
 import PersonalDetails from '../PersonalDetails';
 import Address from '../Address';

--- a/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.test.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 import PayButton, { PayButtonProps } from './PayButton';
 import { PAY_BTN_DIVIDER } from './utils';
 import { mock } from 'jest-mock-extended';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const getWrapper = (props = {}) => {
     const mockedProps = mock<PayButtonProps>();

--- a/packages/lib/src/components/internal/PayButton/PayButton.tsx
+++ b/packages/lib/src/components/internal/PayButton/PayButton.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import Button from '../Button';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { ButtonProps } from '../Button/types';
 import { payAmountLabel, secondaryAmountLabel } from './utils';
 import { PaymentAmountExtended } from '../../../types/global-types';

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.test.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.test.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { mount } from 'enzyme';
 import PersonalDetails from './PersonalDetails';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const getWrapper = (props = {}) => {
     return mount(

--- a/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
+++ b/packages/lib/src/components/internal/PersonalDetails/PersonalDetails.tsx
@@ -4,7 +4,7 @@ import Fieldset from '../FormFields/Fieldset';
 import Field from '../FormFields/Field';
 import ReadOnlyPersonalDetails from './ReadOnlyPersonalDetails';
 import { personalDetailsValidationRules } from './validate';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { PersonalDetailsProps } from './types';
 import { checkDateInputSupport } from '../FormFields/InputDate/utils';
 import { PersonalDetailsSchema } from '../../../types';

--- a/packages/lib/src/components/internal/PhoneInput/PhoneInput.test.tsx
+++ b/packages/lib/src/components/internal/PhoneInput/PhoneInput.test.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { fireEvent, render, screen } from '@testing-library/preact';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import { Resources } from '../../../core/Context/Resources';
 import userEvent from '@testing-library/user-event';
 import PhoneInput from './PhoneInput';

--- a/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
+++ b/packages/lib/src/components/internal/PhoneInput/PhoneInput.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { useCallback, useEffect } from 'preact/hooks';
 import Field from '../FormFields/Field';
 import useForm from '../../../utils/useForm';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import './PhoneInput.scss';
 import Select from '../FormFields/Select';
 import { phoneFormatters, phoneValidationRules } from './validate';

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.test.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.test.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { h } from 'preact';
 import QRLoader from './QRLoader';
 import checkPaymentStatus from '../../../core/Services/payment-status';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 import { SRPanel } from '../../../core/Errors/SRPanel';
 import SRPanelProvider from '../../../core/Errors/SRPanelProvider';
 

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.tsx
@@ -9,7 +9,7 @@ import './QRLoader.scss';
 import { QRLoaderProps, QRLoaderState } from './types';
 import copyToClipboard from '../../../utils/clipboard';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import ContentSeparator from '../ContentSeparator';
 import { StatusObject } from '../Await/types';
 import useImage from '../../../core/Context/useImage';

--- a/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
+++ b/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
@@ -1,5 +1,5 @@
 import { h, Fragment } from 'preact';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { useState } from 'preact/hooks';
 
 function RedirectButton({ label = null, icon = null, payButton, onSubmit, amount = null, name, ...props }) {

--- a/packages/lib/src/components/internal/SendCopyToEmail/SendCopyToEmail.tsx
+++ b/packages/lib/src/components/internal/SendCopyToEmail/SendCopyToEmail.tsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import cx from 'classnames';
 import { useState } from 'preact/hooks';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Field from '../FormFields/Field';
 import Checkbox from '../FormFields/Checkbox';
 import InputEmail from '../FormFields/InputEmail';

--- a/packages/lib/src/components/internal/SocialSecurityNumberBrazil/SocialSecurityNumberBrazil.tsx
+++ b/packages/lib/src/components/internal/SocialSecurityNumberBrazil/SocialSecurityNumberBrazil.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import Field from '../../internal/FormFields/Field';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import InputText from '../FormFields/InputText';
 
 export default function ({

--- a/packages/lib/src/components/internal/StoreDetails/StoreDetails.test.tsx
+++ b/packages/lib/src/components/internal/StoreDetails/StoreDetails.test.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { render, screen } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import StoreDetails from './StoreDetails';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const renderWithCoreProvider = ui => {
     return render(

--- a/packages/lib/src/components/internal/StoreDetails/StoreDetails.tsx
+++ b/packages/lib/src/components/internal/StoreDetails/StoreDetails.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'preact/hooks';
 import { h } from 'preact';
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Checkbox from '../FormFields/Checkbox';
 
 /**

--- a/packages/lib/src/components/internal/Voucher/Voucher.test.tsx
+++ b/packages/lib/src/components/internal/Voucher/Voucher.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import { h } from 'preact';
 import Voucher from './Voucher';
-import CoreProvider from '../../../core/Context/CoreProvider';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
 
 const outputDetails = {
     paymentMethodType: 'type',

--- a/packages/lib/src/components/internal/Voucher/Voucher.tsx
+++ b/packages/lib/src/components/internal/Voucher/Voucher.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import Button from '../Button';
 import { copyToClipboard } from '../../../utils/clipboard';
 
-import useCoreContext from '../../../core/Context/useCoreContext';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
 import './Voucher.scss';
 import { VoucherProps } from './types';
 import useImage from '../../../core/Context/useImage';

--- a/packages/lib/src/core/Context/CoreContext.ts
+++ b/packages/lib/src/core/Context/CoreContext.ts
@@ -1,9 +1,0 @@
-import { createContext } from 'preact';
-import { CommonPropsTypes } from './CoreProvider';
-
-export const CoreContext = createContext({
-    i18n: null,
-    loadingContext: '',
-    commonProps: {} as CommonPropsTypes,
-    resources: null
-});

--- a/packages/lib/src/core/Context/CoreProvider.tsx
+++ b/packages/lib/src/core/Context/CoreProvider.tsx
@@ -1,21 +1,25 @@
-import { h, toChildArray } from 'preact';
-import { CoreContext } from './CoreContext';
+import { h, toChildArray, createContext } from 'preact';
+import { useContext, useEffect } from 'preact/hooks';
 import { Resources } from './Resources';
-import { useEffect } from 'preact/hooks';
+import Language from '../../language';
+import type { ComponentChildren } from 'preact';
 
 interface CoreProviderProps {
     loadingContext: string;
-    i18n: any;
+    i18n: Language;
     resources: Resources;
-    children?: any;
-    commonProps?: CommonPropsTypes;
+    children: ComponentChildren;
 }
 
-export interface CommonPropsTypes {
-    [key: string]: any;
-}
+type ContextValue = {
+    i18n: Language;
+    loadingContext: string;
+    resources: Resources;
+};
 
-const CoreProvider = ({ i18n, loadingContext, commonProps, resources, children }: CoreProviderProps) => {
+const CoreContext = createContext<ContextValue | undefined>(undefined);
+
+const CoreProvider = ({ i18n, loadingContext, resources, children }: CoreProviderProps) => {
     useEffect(() => {
         if (!i18n || !loadingContext || !resources) {
             console.error('CoreProvider - WARNING core provider is missing one of the following: i18n, loadingContext or resources');
@@ -27,7 +31,6 @@ const CoreProvider = ({ i18n, loadingContext, commonProps, resources, children }
             value={{
                 i18n,
                 loadingContext,
-                commonProps: commonProps || {},
                 resources
             }}
         >
@@ -36,4 +39,14 @@ const CoreProvider = ({ i18n, loadingContext, commonProps, resources, children }
     );
 };
 
-export default CoreProvider;
+const useCoreContext = (): ContextValue => {
+    const context = useContext(CoreContext);
+
+    if (context === undefined) {
+        throw new Error('"useCoreContext" must be used within a CoreProvider');
+    }
+
+    return context;
+};
+
+export { CoreProvider, useCoreContext };

--- a/packages/lib/src/core/Context/useCoreContext.ts
+++ b/packages/lib/src/core/Context/useCoreContext.ts
@@ -1,8 +1,0 @@
-import { useContext } from 'preact/hooks';
-import { CoreContext } from './CoreContext';
-
-function useCoreContext() {
-    return useContext(CoreContext);
-}
-
-export default useCoreContext;

--- a/packages/lib/src/core/Context/useImage.ts
+++ b/packages/lib/src/core/Context/useImage.ts
@@ -1,4 +1,4 @@
-import useCoreContext from './useCoreContext';
+import { useCoreContext } from './CoreProvider';
 import { useCallback } from 'preact/hooks';
 import { GetImageFnType, ImageOptions } from './Resources';
 

--- a/packages/lib/src/core/Errors/SRPanelProvider.tsx
+++ b/packages/lib/src/core/Errors/SRPanelProvider.tsx
@@ -1,6 +1,6 @@
 import { h, ComponentChildren } from 'preact';
 import { SRPanelContext } from './SRPanelContext';
-import useCoreContext from '../Context/useCoreContext';
+import { useCoreContext } from '../Context/CoreProvider';
 import { partial } from '../../components/internal/SecuredFields/lib/utilities/commonUtils';
 import { setSRMessagesFromErrors } from './utils';
 import { SRPanel } from './SRPanel';

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -59,7 +59,10 @@ const actionTypes = {
             paymentMethodType: props.paymentMethodType,
             challengeWindowSize: props.challengeWindowSize, // always pass challengeWindowSize in case it's been set directly in the handleAction config object
             isMDFlow: props.isMDFlow,
-            modules: { analytics: props.modules?.analytics },
+            modules: {
+                analytics: props.modules?.analytics,
+                resources: props.modules?.resources
+            },
 
             // Props unique to a particular flow
             ...get3DS2FlowProps(action.subtype, props)

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,5 @@
+import 'preact/debug';
+
 import * as components from './components';
 
 export { components };

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,5 +1,3 @@
-import 'preact/debug';
-
 import * as components from './components';
 
 export { components };

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -10,7 +10,7 @@ import { MockReactApp } from './MockReactApp';
 import getTranslationFile from '../../config/getTranslation';
 import { searchFunctionExample } from '../../utils';
 
-const onlyShowCard = false;
+const onlyShowCard = true;
 
 const showComps = {
     clickToPay: true,

--- a/packages/playground/src/pages/Cards/Cards.js
+++ b/packages/playground/src/pages/Cards/Cards.js
@@ -10,7 +10,7 @@ import { MockReactApp } from './MockReactApp';
 import getTranslationFile from '../../config/getTranslation';
 import { searchFunctionExample } from '../../utils';
 
-const onlyShowCard = true;
+const onlyShowCard = false;
 
 const showComps = {
     clickToPay: true,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This PR aim to fix the issue that `useCoreContext` could return defined properties even without initializing the CoreProvider.

What was done:
- Moved the `useCoreContext` hook location to be within the `CoreProvider` file. By doing that, we don't have to expose the `CoreContext` to another modules. We expose only one way to consume the context value and one way to provide it
- Added validation on `useCoreContext` to trigger error if the CoreProvider is not defined
- Set the initial CoreProvider context value to be 'undefined' instead of the defined provider props 
- Fixed tests that were broken due to using not a valid `CoreProvider`
- Wrapped `ThreeDS2Challenge` with the `CoreProvider`

Many files changed, but most of them are just fixing the import.