### PR TITLE
[v6]style: adding box-shadow to the brands, transition on margin for error messages

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
@@ -3,12 +3,24 @@
     flex-basis: auto;
     flex-shrink: 1;
     flex-wrap: wrap;
-    gap: var(--adyen-checkout-spacer-020);
-    height: var(--adyen-checkout-spacer-070);
+    height: var(--adyen-checkout-spacer-090);
     overflow: hidden;
-    margin-top: -8px;
-    margin-bottom: var(--adyen-checkout-spacer-070);
+    margin-top: -12px;
+    margin-bottom: var(--adyen-checkout-spacer-060);
     transition: all 0.3s ease-out;
+
+    &__brand-wrapper {
+        box-shadow:
+            0 1px 1px 0 rgb(0 17 44 / 2%),
+            0 1px var(--adyen-checkout-spacer-010) 0 rgb(0 17 44 / 4%);
+        overflow: hidden;
+        display: inline-block;
+        height: var(--adyen-checkout-spacer-070);
+        width: var(--adyen-checkout-spacer-090);
+        position: relative;
+        border-radius: var(--adyen-checkout-border-radius-s);
+        margin: var(--adyen-checkout-spacer-020) var(--adyen-checkout-spacer-010);
+    }
 }
 
 .adyen-checkout__card__brands--hidden {
@@ -24,13 +36,3 @@
     width: 100%;
     height: auto;
 }
-
-.adyen-checkout__card__brands__brand-wrapper {
-    overflow: hidden;
-    display: inline-block;
-    height: var(--adyen-checkout-spacer-070);
-    width: var(--adyen-checkout-spacer-090);
-    position: relative;
-    border-radius: var(--adyen-checkout-border-radius-s);
-}
-

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodName.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodName.scss
@@ -2,6 +2,8 @@
 
 .adyen-checkout__payment-method {
     &__name {
+        display: inline-block;
+        width: 100%;
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
@@ -17,6 +19,7 @@
     }
 
     &__name_wrapper {
+        min-width: var(--adyen-checkout-spacer-120);
         display: flex;
         align-items: flex-start;
         flex-direction: column;

--- a/packages/lib/src/components/internal/FormFields/Field/Field.scss
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.scss
@@ -120,6 +120,10 @@
     line-height: var(--adyen-checkout-line-height-100);
     align-items: center;
     color: var(--adyen-checkout-input-field-context-color);
+    opacity: 1;
+    transition:
+        margin 200ms ease-out,
+        opacity 200ms ease-out;
 }
 
 .adyen-checkout-contextual-text {
@@ -130,4 +134,10 @@
 
         color: var(--adyen-checkout-color-label-critical);
     }
+}
+
+.adyen-checkout-contextual-text--hidden {
+    height: 0;
+    margin: 0;
+    opacity: 0;
 }

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -47,9 +47,10 @@ const Field: FunctionalComponent<FieldProps> = props => {
     // Controls whether any error element has an aria-hidden="true" attr (which means it is the error for a securedField)
     // or whether it has an id attr that can be pointed to by an aria-describedby attr on an input element
     const contextVisibleToSR = contextVisibleToScreenReader ?? true;
+    const showError = showErrorElement && typeof errorMessage === 'string' && errorMessage.length > 0;
+    const showContext = showContextualElement && !showError && contextualText?.length > 0;
 
     const uniqueId = useRef(getUniqueId(`adyen-checkout-${name}`));
-
     const [focused, setFocused] = useState(false);
     const [filled, setFilled] = useState(false);
 
@@ -103,21 +104,18 @@ const Field: FunctionalComponent<FieldProps> = props => {
     }, [label, errorMessage, labelEndAdornment, helper]);
 
     const renderInputRelatedElements = useCallback(() => {
-        const showError = showErrorElement && typeof errorMessage === 'string' && errorMessage.length > 0;
-        const errorElem = showError && (
+        const errorElem = (
             <span
-                className={'adyen-checkout-contextual-text--error'}
+                className={classNames({ 'adyen-checkout-contextual-text--error': true, 'adyen-checkout-contextual-text--hidden': !showError })}
                 {...(contextVisibleToSR && { id: `${uniqueId.current}${ARIA_ERROR_SUFFIX}` })}
                 aria-hidden={contextVisibleToSR ? null : 'true'}
             >
                 {errorMessage}
             </span>
         );
-
-        const showContext = showContextualElement && !showError && contextualText?.length > 0;
-        const contextualElem = showContext && (
+        const contextualElem = (
             <span
-                className={'adyen-checkout-contextual-text'}
+                className={classNames({ 'adyen-checkout-contextual-text': true, 'adyen-checkout-contextual-text--hidden': !showContext })}
                 {...(contextVisibleToSR && { id: `${uniqueId.current}${ARIA_CONTEXT_SUFFIX}` })}
                 aria-hidden={contextVisibleToSR ? null : 'true'}
             >


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added box-shadow to the card brands, readjusted the margin of brands so that the box-shadow fits
- Transition on the margin for error message
- Set the `min-width` for pm label so that the `text-overflow: ellipsis;` would work
