### PR TITLE
Passing config to allow SF to expose expiryDate

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -22,6 +22,7 @@ export default {
     autoFocus: true,
     isPayButtonPrimaryVariant: true,
     disableIOSArrowKeys: true,
+    exposeExpiryDate: false,
 
     // Events
     onLoad: (): any => {},

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -128,6 +128,7 @@ export interface CardInputProps {
     trimTrailingSeparator?: boolean;
     type?: string;
     maskSecurityCode?: boolean;
+    exposeExpiryDate?: boolean;
     disclaimerMessage?: DisclaimerMsgObject;
     onErrorAnalytics?: (obj: FieldErrorAnalyticsObject) => {};
 }

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -161,6 +161,7 @@ export const extractPropsForSFP = (props: CardInputProps) => {
         showWarnings: props.showWarnings,
         trimTrailingSeparator: props.trimTrailingSeparator,
         maskSecurityCode: props.maskSecurityCode,
+        exposeExpiryDate: props.exposeExpiryDate,
         resources: props.resources
     } as SFPProps; // Can't set as return type on fn or it will complain about missing, mandatory, props
 };

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -145,6 +145,11 @@ export interface CardElementProps extends UIElementProps {
     onBinLookup?: (event: CbObjOnBinLookup) => void;
 
     [key: string]: any; // TODO get rid of this and explicitly declare props
+
+    /**
+     * Allows SF to return an unencrypted expiryDate
+     */
+    exposeExpiryDate?: boolean;
 }
 
 export type SocialSecurityMode = 'show' | 'hide' | 'auto';

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -184,6 +184,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
             implementationType: this.props.implementationType || 'components', // to distinguish between 'regular' and 'custom' card component
             forceCompat: this.props.forceCompat,
             maskSecurityCode: this.props.maskSecurityCode,
+            exposeExpiryDate: this.props.exposeExpiryDate,
             shouldDisableIOSArrowKeys: !!this.props.disableIOSArrowKeys // convert whether function has been defined into a boolean
         };
 

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -44,6 +44,7 @@ export interface SFPProps {
     render: () => {};
     resources: Resources;
     maskSecurityCode: boolean;
+    exposeExpiryDate: boolean;
     disableIOSArrowKeys: (obj: TouchStartEventObj) => void | null;
 }
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -213,6 +213,7 @@ export function setupSecuredField(pItem: HTMLElement, cvcPolicy?: CVCPolicyType,
             minimumExpiryDate: this.config.minimumExpiryDate,
             implementationType: this.config.implementationType,
             maskSecurityCode: this.config.maskSecurityCode,
+            exposeExpiryDate: this.props.exposeExpiryDate,
             disableIOSArrowKeys: this.config.shouldDisableIOSArrowKeys
         };
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleEncryption.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/handleEncryption.ts
@@ -1,6 +1,12 @@
 import { makeCallbackObjectsEncryption } from '../utils/callbackUtils';
 import { addEncryptedElements } from '../utils/encryptedElements';
-import { ENCRYPTED_EXPIRY_MONTH, ENCRYPTED_EXPIRY_YEAR, ENCRYPTED_SECURITY_CODE, ENCRYPTED_CARD_NUMBER } from '../../configuration/constants';
+import {
+    ENCRYPTED_EXPIRY_MONTH,
+    ENCRYPTED_EXPIRY_YEAR,
+    ENCRYPTED_SECURITY_CODE,
+    ENCRYPTED_CARD_NUMBER,
+    ENCRYPTED_EXPIRY_DATE
+} from '../../configuration/constants';
 import { processErrors } from '../utils/processErrors';
 import { truthy } from '../../utilities/commonUtils';
 import { SFFeedbackObj, CbObjOnFieldValid, EncryptionObj } from '../../types';
@@ -78,6 +84,11 @@ export function handleEncryption(pFeedbackObj: SFFeedbackObj): void {
     // For number field - add the 8 digit issuerBin to the encryption object
     if (fieldType === ENCRYPTED_CARD_NUMBER && truthy(pFeedbackObj.issuerBin)) {
         callbackObjectsArr[0].issuerBin = +pFeedbackObj.issuerBin;
+    }
+
+    // Add expiryDate to "encryptedExpiryYear" field. It will only be present if the correct config has been sent to SF
+    if (fieldType === ENCRYPTED_EXPIRY_DATE && truthy(pFeedbackObj.expiryDate)) {
+        callbackObjectsArr[1].expiryDate = pFeedbackObj.expiryDate;
     }
 
     // BROADCAST VALID STATE OF INDIVIDUAL INPUTS - passing the encryption objects

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
@@ -54,6 +54,7 @@ export interface CSFSetupObject extends CSFCommonProps {
     isKCP?: boolean;
     i18n?: Language;
     forceCompat: boolean;
+    exposeExpiryDate: boolean;
 }
 
 /**

--- a/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/configuration/constants.ts
@@ -17,7 +17,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '4.8.3';
+export const SF_VERSION = '4.9.0';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
@@ -40,6 +40,7 @@ export interface SFInternalConfig {
     minimumExpiryDate: string;
     implementationType: string;
     maskSecurityCode: boolean;
+    exposeExpiryDate: boolean;
     disableIOSArrowKeys: boolean;
 }
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
@@ -149,6 +149,7 @@ class SecuredField extends AbstractSecuredField {
             minimumExpiryDate: this.sfConfig.minimumExpiryDate,
             implementationType: this.sfConfig.implementationType,
             maskSecurityCode: this.sfConfig.maskSecurityCode,
+            exposeExpiryDate: this.sfConfig.exposeExpiryDate,
             disableIOSArrowKeys: this.sfConfig.disableIOSArrowKeys
         };
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -116,6 +116,7 @@ export interface CbObjOnFieldValid {
     rootNode: HTMLElement;
     blob?: string;
     endDigits?: string;
+    expiryDate?: string;
     issuerBin?: number;
 }
 
@@ -196,6 +197,7 @@ export interface SFFeedbackObj {
     error?: string;
     endDigits?: string;
     issuerBin?: string;
+    expiryDate?: string;
     type?: string;
     binValue?: string;
     focus?: boolean;


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
After confirmation from Legal and the PCI team, it has been determined that in some cases we can pass the `expiryDate` from the `Card` component to it's `onFieldValid` callback.

Basically this should be an opt-in process, with a new Card config property, `exposeExpiryDate`, making this possible.

This config will allow SF to pass back the expiryDate; and Checkout will then propagate this to `onFieldValid` callback

## Tested scenarios
Only in the case where `exposeExpiryDate` is set to a boolean, `true` will securedFields pass back the expiryDate in an unencrypted form


**Relates to issue**:  COM-16473