### PR TITLE
Checkout analytics can be passed a checkoutAttemptId

### DIFF
--- a/.changeset/long-maps-turn.md
+++ b/.changeset/long-maps-turn.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": minor
+---
+
+Checkout analytics can be passed a checkoutAttemptId

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -88,11 +88,14 @@ describe('Analytics initialisation and event queue', () => {
             }
         };
 
+        const checkoutAttemptId = 'my.attempt.id';
+
         analytics = Analytics({
             analytics: {
                 analyticsData: {
                     applicationInfo,
-                    // @ts-ignore - this is one of the things we're testing
+                    checkoutAttemptId,
+                    // @ts-ignore - this is one of the things we're testing (that this object gets stripped out)
                     foo: {
                         bar: 'val'
                     }
@@ -109,7 +112,7 @@ describe('Analytics initialisation and event queue', () => {
         expect(collectIdPromiseMock).toHaveBeenCalled();
         await Promise.resolve(); // wait for the next tick
 
-        const enhancedSetupEvent = { ...setUpEvent, applicationInfo };
+        const enhancedSetupEvent = { ...setUpEvent, applicationInfo, checkoutAttemptId };
 
         expect(collectIdPromiseMock).toHaveBeenCalledWith({ ...enhancedSetupEvent });
 

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -22,14 +22,6 @@ const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analy
 
     const props = { ...defaultProps, ...analytics };
 
-    const { telemetry, enabled } = props;
-    if (telemetry === true && enabled === true) {
-        if (props.checkoutAttemptId) {
-            // handle prefilled checkoutAttemptId // TODO is this still something that ever happens?
-            capturedCheckoutAttemptId = props.checkoutAttemptId;
-        }
-    }
-
     const logEvent = LogEvent({ loadingContext, locale });
     const collectId = CollectId({ analyticsContext, clientKey, locale, amount, analyticsPath: ANALYTICS_PATH });
     const eventsQueue: EventsQueueModule = EventsQueue({ analyticsContext, clientKey, analyticsPath: ANALYTICS_PATH });
@@ -69,15 +61,19 @@ const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analy
     };
 
     const anlModule: AnalyticsModule = {
+        /**
+         * Make "setup" call, to pass containerWidth, buildType, channel etc, and receive a checkoutAttemptId in return
+         * @param initialEvent -
+         */
         setUp: async (initialEvent: AnalyticsInitialEvent) => {
             const { enabled, payload, telemetry } = props; // TODO what is payload, is it ever used?
 
             const analyticsData = processAnalyticsData(props.analyticsData);
+            console.log('### Analytics::setUp:: analyticsData', analyticsData);
 
             if (enabled === true) {
                 if (telemetry === true && !capturedCheckoutAttemptId) {
                     try {
-                        // fetch a new checkoutAttemptId if none is already available
                         const checkoutAttemptId = await collectId({
                             ...initialEvent,
                             ...(payload && { ...payload }),

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -69,7 +69,6 @@ const Analytics = ({ loadingContext, locale, clientKey, analytics, amount, analy
             const { enabled, payload, telemetry } = props; // TODO what is payload, is it ever used?
 
             const analyticsData = processAnalyticsData(props.analyticsData);
-            console.log('### Analytics::setUp:: analyticsData', analyticsData);
 
             if (enabled === true) {
                 if (telemetry === true && !capturedCheckoutAttemptId) {

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -95,3 +95,5 @@ export const errorCodeMapping = {
 };
 
 export const ANALYTICS_EXPRESS_PAGES_ARRAY = ['cart', 'minicart', 'pdp', 'checkout'];
+
+export const ALLOWED_ANALYTICS_DATA = ['applicationInfo', 'checkoutAttemptId'];

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -28,9 +28,12 @@ export interface AnalyticsData {
             osVersion: string;
         };
     };
-}
 
-export const ALLOWED_ANALYTICS_DATA = ['applicationInfo'];
+    /**
+     * Use a checkoutAttemptId from a previous page
+     */
+    checkoutAttemptId?: string;
+}
 
 export interface AnalyticsOptions {
     /**
@@ -42,11 +45,6 @@ export interface AnalyticsOptions {
      * Enable/Disable telemetry data
      */
     telemetry?: boolean;
-
-    /**
-     * Reuse a previous checkoutAttemptId from a previous page
-     */
-    checkoutAttemptId?: string;
 
     /**
      * Data to be sent along with the event data

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -1,5 +1,5 @@
-import { ALLOWED_ANALYTICS_DATA, AnalyticsData, AnalyticsObject, CreateAnalyticsObject } from './types';
-import { ANALYTICS_ACTION_STR, ANALYTICS_VALIDATION_ERROR_STR, errorCodeMapping } from './constants';
+import { AnalyticsData, AnalyticsObject, CreateAnalyticsObject } from './types';
+import { ANALYTICS_ACTION_STR, ANALYTICS_VALIDATION_ERROR_STR, ALLOWED_ANALYTICS_DATA, errorCodeMapping } from './constants';
 import uuid from '../../utils/uuid';
 import { ERROR_CODES, ERROR_MSG_INCOMPLETE_FIELD } from '../Errors/constants';
 
@@ -55,9 +55,9 @@ const mapErrorCodesForAnalytics = (errorCode: string, target: string) => {
     return errorCodeMapping[errorCode] ?? errorCode;
 };
 
-export const processAnalyticsData = (analyticsData: AnalyticsData) => {
-    return Object.keys(analyticsData).reduce((r, e) => {
-        if (ALLOWED_ANALYTICS_DATA.includes(e)) r[e] = analyticsData[e];
-        return r;
+export const processAnalyticsData = (analyticsData: AnalyticsData): AnalyticsData => {
+    return Object.keys(analyticsData).reduce((acc, prop) => {
+        if (ALLOWED_ANALYTICS_DATA.includes(prop)) acc[prop] = analyticsData[prop];
+        return acc;
     }, {});
 };

--- a/packages/lib/src/core/Services/analytics/collect-id.test.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.test.ts
@@ -1,6 +1,7 @@
 import { httpPost } from '../http';
 import collectId, { FAILURE_MSG } from './collect-id';
 import { ANALYTICS_PATH } from '../../Analytics/constants';
+import { CollectIdEvent } from './types';
 
 jest.mock('../http');
 
@@ -30,7 +31,7 @@ beforeEach(() => {
 
 test('Should lead to a rejected promise since no clientKey is provided', () => {
     const log = collectId(BASE_CONFIGURATION);
-    log({})
+    log({} as CollectIdEvent)
         .then()
         .catch(e => {
             expect(e).toEqual('no-client-key');
@@ -49,7 +50,7 @@ test('Should fail since path is incorrect', () => {
     };
 
     const log = collectId(configuration);
-    log({})
+    log({} as CollectIdEvent)
         .then(val => {
             expect(val).toEqual(FAILURE_MSG);
         })

--- a/packages/lib/src/core/Services/analytics/collect-id.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.ts
@@ -1,6 +1,6 @@
 import { httpPost } from '../http';
 import Storage from '../../../utils/Storage';
-import { CheckoutAttemptIdSession, CollectIdProps, TelemetryEvent } from './types';
+import { CheckoutAttemptIdSession, CollectIdEvent, CollectIdProps, TelemetryEvent } from './types';
 
 export const FAILURE_MSG =
     'WARNING: Failed to retrieve "checkoutAttemptId". Consequently, analytics will not be available for this payment. The payment process, however, will not be affected.';
@@ -32,7 +32,7 @@ const collectId = ({ analyticsContext, clientKey, locale, analyticsPath }: Colle
         path: `${analyticsPath}?clientKey=${clientKey}`
     };
 
-    return (event): Promise<string> => {
+    return (event: CollectIdEvent): Promise<string> => {
         const telemetryEvent: TelemetryEvent = {
             // amount,  // TODO will be supported in the future
             version: process.env.VERSION,

--- a/packages/lib/src/core/Services/analytics/types.ts
+++ b/packages/lib/src/core/Services/analytics/types.ts
@@ -1,4 +1,4 @@
-import { AnalyticsConfig } from '../../Analytics/types';
+import { AnalyticsConfig, AnalyticsData, AnalyticsInitialEvent } from '../../Analytics/types';
 import { PaymentAmount } from '../../../types';
 
 export type CheckoutAttemptIdSession = {
@@ -13,11 +13,16 @@ export type LogEventProps = Pick<AnalyticsConfig, 'loadingContext' | 'locale'>;
 export type TelemetryEvent = {
     version: string;
     channel: 'Web';
+    platform: 'Web';
     locale: string;
     referrer: string;
     screenWidth: number;
     containerWidth: number;
     component: string;
     flavor: string;
+    buildType: string;
     amount?: PaymentAmount;
-};
+} & AnalyticsInitialEvent &
+    AnalyticsData;
+
+export type CollectIdEvent = AnalyticsInitialEvent & AnalyticsData;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13531,15 +13531,10 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.11:
+regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.9, regenerator-runtime@^0.14.0:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
-
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.15.1:
   version "0.15.1"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
PBL already has a `checkoutAttemptId` which it can use internally for it's own analytics calls.

In order to link events within the Dropin that PBL renders e.g. "payment method selected", or, "Pay button pressed" - it is necessary for PBL to pass the `checkoutAttemptId` to Checkout so it can be used as a shared identifier.

At the same time Checkout still wants to make the analytics "set up" call (the one that normally results in a `checkoutAttemptId` being sent as a response), so that it can pass in other, initial, data (like `platform, channel` etc).

The API endpoint now accepts that a `checkoutAttemptId` can now be passed to it in this "set up" call - and mirrors it back, if it is valid.

This way the Checkout flow can proceed as normal - passing in initial data and always getting a `checkoutAttemptId` in return


## Tested scenarios
Added condition to existing unit test
All existing unit tests pass

**Fixed issue**:  COWEB-1376
