### PR TITLE
Fix: ANCV ignoring existing orders & not working as intended via custom payButton

### DIFF
--- a/.changeset/dry-tomatoes-allow.md
+++ b/.changeset/dry-tomatoes-allow.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+fix: ANCV ignoring exesting order & payButton not working as intended

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -61,28 +61,35 @@ export class ANCVElement extends UIElement<ANCVProps> {
     };
 
     public createOrder = () => {
-        if (!this.isValid) {
-            this.showValidation();
-            return false;
-        }
-
         this.setStatus('loading');
 
         // allow for multiple ANCV payments, follow giftcard logic and just use order if it exists
         if (this.props.order) {
-            this.submit();
+            this.onSubmit();
+            return;
         }
 
-        return this.onOrderRequest(this.data)
+        this.onOrderRequest(this.data)
             .then((order: { orderData: string; pspReference: string }) => {
                 this.setState({ order: { orderData: order.orderData, pspReference: order.pspReference } });
-                this.submit();
+                // we should probably return here, breaks the promise chain for no reason
+                return this.onSubmit();
             })
             .catch(error => {
                 this.setStatus(error?.message || 'error');
                 if (this.props.onError) this.handleError(new AdyenCheckoutError('ERROR', error));
             });
+        return;
     };
+
+    public submit() {
+        if (!this.isValid) {
+            this.showValidation();
+            return false;
+        }
+
+        this.createOrder();
+    }
 
     // Reimplement payButton similar to GiftCard to allow to set onClick
     public payButton = props => {
@@ -131,7 +138,7 @@ export class ANCVElement extends UIElement<ANCVProps> {
                         this.componentRef = ref;
                     }}
                     {...this.props}
-                    onSubmit={this.createOrder}
+                    onSubmit={this.submit}
                     onChange={this.setState}
                     payButton={this.payButton}
                     showPayButton={this.props.showPayButton}

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -68,6 +68,11 @@ export class ANCVElement extends UIElement<ANCVProps> {
 
         this.setStatus('loading');
 
+        // allow for multiple ANCV payments, follow giftcard logic and just use order if it exists
+        if (this.props.order) {
+            this.submit();
+        }
+
         return this.onOrderRequest(this.data)
             .then((order: { orderData: string; pspReference: string }) => {
                 this.setState({ order: { orderData: order.orderData, pspReference: order.pspReference } });

--- a/packages/lib/src/components/UIElement.tsx
+++ b/packages/lib/src/components/UIElement.tsx
@@ -80,7 +80,7 @@ export class UIElement<P extends UIElementProps = any> extends BaseElement<P> im
         this.props.modules?.analytics.sendAnalytics(component, analyticsObj, uiElementProps);
     }
 
-    private onSubmit(): void {
+    protected onSubmit(): void {
         //TODO: refactor this, instant payment methods are part of Dropin logic not UIElement
         if (this.props.isInstantPayment) {
             const dropinElementRef = this.elementRef as DropinElement;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This PR was original intended to fix a bug in ANCV where it always made new `order` calls. This was an issue if ANCV was not the first partial payment method, ie: Giftcard -> ANCV, or ANCV -> ANCV.

To fix this issue a check was introduce to use an existing order. The problem is that in the process it was notice that passing a different Class instance function to `payButton` was causing it to dereference `this.props` and use the one from `payButton` instead of `UIElement`/`ANCVElement`.

The solution was to use `submit` in the `payButton`. The problem is that `submit` only really gets reimplemented in express payment methods. This also lead to realise that contrary to what we do in gift card, this is probably the most correct way. It was because of this also necessary to change `onSubmit` access modifier, from private, to protected. This makes so we can use `onSubmit` implementation on the component. I believe this change is more in line what we are doing in V6.

Possible further discussion can be held on this point about `.submit()` being more consistent for partial payment methods.

## Tested scenarios
<!-- Description of tested scenarios -->

- ANCV was tested with the help of Jakub making multiple payments

**Fixed issue**:  <!-- #-prefixed issue number -->
