### PR TITLE
Fix OpenInvoice consent checkbox issue

### DIFF
--- a/.changeset/serious-radios-flash.md
+++ b/.changeset/serious-radios-flash.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fix for the OpenInvoice uncaught error when checking and unchecking terms and conditions. This change also fixed the issue that payment goes through without accepting terms and conditions. 

--- a/packages/lib/.storybook/main.css
+++ b/packages/lib/.storybook/main.css
@@ -1,8 +1,15 @@
 html,
 body {
-    font: 16px/1.21 -apple-system, BlinkMacSystemFont, sans-serif;
+    font:
+        16px/1.21 -apple-system,
+        BlinkMacSystemFont,
+        sans-serif;
     font-weight: 400;
     background-color: #fbfbfb;
+}
+
+button {
+    font-family: inherit;
 }
 
 .component-wrapper {

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -108,7 +108,7 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         const { checked } = e.target;
         setData(prevData => ({ ...prevData, consentCheckbox: checked }));
         setValid(prevValid => ({ ...prevValid, consentCheckbox: checked }));
-        setErrors(prevErrors => ({ ...prevErrors, consentCheckbox: !checked }));
+        setErrors(prevErrors => ({ ...prevErrors, ...{ consentCheckbox: !checked ? consentCBErrorObj : null } }));
     };
     return (
         <div className="adyen-checkout__open-invoice">

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -1,12 +1,12 @@
 import { h } from 'preact';
-import { useEffect, useRef, useState, useMemo } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import CompanyDetails from '../CompanyDetails';
 import PersonalDetails from '../PersonalDetails';
 import Address from '../Address';
 import Checkbox from '../FormFields/Checkbox';
 import ConsentCheckbox from '../FormFields/ConsentCheckbox';
-import { getActiveFieldsData, getInitialActiveFieldsets, fieldsetsSchema, mapFieldKey } from './utils';
+import { getActiveFieldsData, getInitialActiveFieldsets, fieldsetsSchema } from './utils';
 import {
     OpenInvoiceActiveFieldsets,
     OpenInvoiceFieldsetsRefs,
@@ -18,19 +18,10 @@ import {
 import './OpenInvoice.scss';
 import IbanInput from '../IbanInput';
 import { ComponentMethodsRef } from '../../types';
-import { enhanceErrorObjectKeys } from '../../../core/Errors/utils';
-import { GenericError, SetSRMessagesReturnObject, SortedErrorObject } from '../../../core/Errors/types';
-import useSRPanelContext from '../../../core/Errors/useSRPanelContext';
-import { SetSRMessagesReturnFn } from '../../../core/Errors/SRPanelProvider';
-import Specifications from '../Address/Specifications';
-import { PERSONAL_DETAILS_SCHEMA } from '../PersonalDetails/PersonalDetails';
-import { COMPANY_DETAILS_SCHEMA } from '../CompanyDetails/CompanyDetails';
-import { setFocusOnField } from '../../../utils/setFocus';
-import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../core/Errors/constants';
-import { usePrevious } from '../../../utils/hookUtils';
-import { getArrayDifferences } from '../../../utils/arrayUtils';
+import { GenericError } from '../../../core/Errors/types';
 import Field from '../FormFields/Field';
 import FormInstruction from '../FormInstruction';
+import useSRPanelForOpenInvoiceErrors from './useSRPanelForOpenInvoiceErrors';
 
 const consentCBErrorObj: GenericError = {
     isValid: false,
@@ -50,18 +41,6 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
     }
 
     const isValidating = useRef(false);
-
-    /** SR stuff */
-    const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
-
-    // Generate a setSRMessages function - implemented as a partial, since the initial set of arguments don't change.
-    const setSRMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({
-        fieldTypeMappingFn: mapFieldKey
-    });
-
-    const billingAddressSpecifications = useMemo(() => new Specifications(), []);
-    const deliveryAddressSpecifications = useMemo(() => new Specifications(props.deliveryAddressSpecification), []);
-    /** end SR stuff */
 
     const initialActiveFieldsets: OpenInvoiceActiveFieldsets = getInitialActiveFieldsets(visibility, props.data);
     const [activeFieldsets, setActiveFieldsets] = useState<OpenInvoiceActiveFieldsets>(initialActiveFieldsets);
@@ -88,9 +67,6 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
     const [valid, setValid] = useState<OpenInvoiceStateValid>({});
     const [status, setStatus] = useState('ready');
 
-    // Relates to onBlur errors
-    const [sortedErrorList, setSortedErrorList] = useState<SortedErrorObject[]>(null);
-
     // Expose methods expected by parent
     openInvoiceRef.current.showValidation = () => {
         isValidating.current = true;
@@ -105,123 +81,13 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
 
     openInvoiceRef.current.setStatus = setStatus;
 
-    // Get the previous value (Relates to onBlur errors)
-    const previousSortedErrors = usePrevious(sortedErrorList);
+    useSRPanelForOpenInvoiceErrors({ errors, data, props, isValidating });
 
     useEffect(() => {
         const fieldsetsAreValid: boolean = checkFieldsets();
         const consentCheckboxValid: boolean = !hasConsentCheckbox || !!valid.consentCheckbox;
         const isValid: boolean = fieldsetsAreValid && consentCheckboxValid;
         const newData: OpenInvoiceStateData = getActiveFieldsData(activeFieldsets, data);
-
-        const DELIVERY_ADDRESS_PREFIX = 'deliveryAddress:';
-        const BILLING_ADDRESS_PREFIX = 'billingAddress:';
-
-        /** Create messages for SRPanel */
-        // Extract nested errors from the various child components...
-        const {
-            companyDetails: extractedCompanyDetailsErrors,
-            personalDetails: extractedPersonalDetailsErrors,
-            bankAccount: extractedBankAccountErrors,
-            billingAddress: extractedBillingAddressErrors,
-            deliveryAddress: extractedDeliveryAddressErrors,
-            ...remainingErrors
-        } = errors;
-
-        // Differentiate between billingAddress and deliveryAddress errors by adding a prefix.
-        // This also allows overlapping errors e.g. now that addresses can contain first & last name fields
-        const enhancedBillingAddressErrors = enhanceErrorObjectKeys(extractedBillingAddressErrors, BILLING_ADDRESS_PREFIX);
-        const enhancedDeliveryAddressErrors = enhanceErrorObjectKeys(extractedDeliveryAddressErrors, DELIVERY_ADDRESS_PREFIX);
-
-        // ...and then collate the errors into a new object so that they all sit at top level
-        const errorsForPanel = {
-            ...(typeof extractedCompanyDetailsErrors === 'object' && extractedCompanyDetailsErrors),
-            ...(typeof extractedPersonalDetailsErrors === 'object' && extractedPersonalDetailsErrors),
-            ...(typeof extractedBankAccountErrors === 'object' && extractedBankAccountErrors),
-            ...(typeof enhancedBillingAddressErrors === 'object' && enhancedBillingAddressErrors),
-            ...(typeof enhancedDeliveryAddressErrors === 'object' && enhancedDeliveryAddressErrors),
-            ...remainingErrors
-        };
-
-        // Create layout
-        const companyDetailsLayout: string[] = COMPANY_DETAILS_SCHEMA;
-
-        const personalDetailsReqFields: string[] = props.personalDetailsRequiredFields ?? PERSONAL_DETAILS_SCHEMA;
-        const personalDetailLayout: string[] = PERSONAL_DETAILS_SCHEMA.filter(x => personalDetailsReqFields?.includes(x));
-
-        const bankAccountLayout = ['holder', 'iban'];
-
-        const billingAddressLayout = billingAddressSpecifications.getAddressSchemaForCountryFlat(data.billingAddress?.country);
-        // In order to sort the address errors the layout entries need to have the same (prefixed) identifier as the errors themselves
-        const billingAddressLayoutEnhanced = billingAddressLayout.map(item => `${BILLING_ADDRESS_PREFIX}${item}`);
-
-        const deliveryAddressLayout = deliveryAddressSpecifications.getAddressSchemaForCountryFlat(data.deliveryAddress?.country);
-        const deliveryAddressLayoutEnhanced = deliveryAddressLayout.map(item => `${DELIVERY_ADDRESS_PREFIX}${item}`);
-
-        const fullLayout = companyDetailsLayout.concat(
-            personalDetailLayout,
-            bankAccountLayout,
-            billingAddressLayoutEnhanced,
-            deliveryAddressLayoutEnhanced,
-            ['consentCheckbox']
-        );
-
-        // Country specific address labels
-        const countrySpecificLabels_billing = billingAddressSpecifications.getAddressLabelsForCountry(data.billingAddress?.country);
-        const countrySpecificLabels_delivery = deliveryAddressSpecifications.getAddressLabelsForCountry(data.deliveryAddress?.country);
-
-        // Set messages: Pass dynamic props (errors, layout etc) to SRPanel via partial
-        const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
-            errors: errorsForPanel,
-            isValidating: isValidating.current,
-            layout: fullLayout,
-            countrySpecificLabels: { ...countrySpecificLabels_billing, ...countrySpecificLabels_delivery }
-        });
-
-        // Relates to onBlur errors
-        const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
-
-        // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
-        setSortedErrorList(currentErrorsSortedByLayout); // Relates to onBlur errors
-
-        /**
-         * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
-         */
-        switch (srPanelResp?.action) {
-            // A call to focus the first field in error will always follow the call to validate the whole form
-            case ERROR_ACTION_FOCUS_FIELD:
-                // Focus first field in error, if required
-                if (shouldMoveFocusSR) setFocusOnField('.adyen-checkout__open-invoice', srPanelResp.fieldToFocus);
-                // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
-                setTimeout(() => {
-                    isValidating.current = false;
-                }, 300);
-                break;
-
-            /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
-            case ERROR_ACTION_BLUR_SCENARIO: {
-                const difference = getArrayDifferences(currentErrorsSortedByLayout, previousSortedErrors, 'field');
-
-                const latestErrorMsg = difference?.[0];
-
-                if (latestErrorMsg) {
-                    // Is error actually a blur based one - depends on the specific fields in a component as to whether they validate on blur
-                    const isBlurBasedError = latestErrorMsg.errorCode === 'shopperEmail.invalid';
-
-                    // Only add blur based errors to the error panel - doing this step prevents the non-blur based errors from being read out twice
-                    const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
-                    setSRMessagesFromStrings(latestSRError);
-                } else {
-                    // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
-                    clearSRPanel();
-                }
-
-                break;
-            }
-            default:
-                break;
-        }
-
         props.onChange({ data: newData, errors, valid, isValid });
     }, [data, activeFieldsets]);
 

--- a/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
@@ -143,10 +143,10 @@ const useSRPanelForOpenInvoiceErrors = ({ errors, data, props, isValidating }: U
                 default:
                     break;
             }
-        } catch (e) {
-            console.warn('Error in useSafeSRPanelForErrors', e);
+        } catch (_) {
+            // We don't handle the error related to the sr panel, let it fail silently.
         }
-    }, [errors, data.billingAddress, data.deliveryAddress]);
+    }, [errors, data]);
 };
 
 export default useSRPanelForOpenInvoiceErrors;

--- a/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
@@ -1,0 +1,152 @@
+import { useEffect, useState, useMemo, MutableRef } from 'preact/hooks';
+import { enhanceErrorObjectKeys } from '../../../core/Errors/utils';
+import { COMPANY_DETAILS_SCHEMA } from '../CompanyDetails/CompanyDetails';
+import { PERSONAL_DETAILS_SCHEMA } from '../PersonalDetails/PersonalDetails';
+import { SetSRMessagesReturnObject } from '../../../core/Errors/types';
+import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../core/Errors/constants';
+import useSRPanelContext from '../../../core/Errors/useSRPanelContext';
+import { SetSRMessagesReturnFn } from '../../../core/Errors/SRPanelProvider';
+import Specifications from '../Address/Specifications';
+import { setFocusOnField } from '../../../utils/setFocus';
+import { usePrevious } from '../../../utils/hookUtils';
+import { getArrayDifferences } from '../../../utils/arrayUtils';
+import { mapFieldKey } from './utils';
+import { OpenInvoiceProps, OpenInvoiceStateData, OpenInvoiceStateError } from './types';
+
+interface UseSRPanelForErrorsProps {
+    errors: OpenInvoiceStateError;
+    data: OpenInvoiceStateData;
+    props: OpenInvoiceProps;
+    isValidating: MutableRef<boolean>;
+}
+
+const useSRPanelForOpenInvoiceErrors = ({ errors, data, props, isValidating }: UseSRPanelForErrorsProps) => {
+    // Relates to onBlur errors
+    const [sortedErrorList, setSortedErrorList] = useState(null);
+    // Get the previous value (Relates to onBlur errors)
+    const previousSortedErrors = usePrevious(sortedErrorList);
+    const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
+    // Generate a setSRMessages function - implemented as a partial, since the initial set of arguments don't change.
+    const setSRMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({
+        fieldTypeMappingFn: mapFieldKey
+    });
+
+    const billingAddressSpecifications = useMemo(() => new Specifications(), []);
+    const deliveryAddressSpecifications = useMemo(() => new Specifications(props.deliveryAddressSpecification), []);
+
+    useEffect(() => {
+        try {
+            const DELIVERY_ADDRESS_PREFIX = 'deliveryAddress:';
+            const BILLING_ADDRESS_PREFIX = 'billingAddress:';
+
+            /** Create messages for SRPanel */
+            // Extract nested errors from the various child components...
+            const {
+                companyDetails: extractedCompanyDetailsErrors,
+                personalDetails: extractedPersonalDetailsErrors,
+                bankAccount: extractedBankAccountErrors,
+                billingAddress: extractedBillingAddressErrors,
+                deliveryAddress: extractedDeliveryAddressErrors,
+                ...remainingErrors
+            } = errors;
+
+            // Differentiate between billingAddress and deliveryAddress errors by adding a prefix.
+            // This also allows overlapping errors e.g. now that addresses can contain first & last name fields
+            const enhancedBillingAddressErrors = enhanceErrorObjectKeys(extractedBillingAddressErrors, BILLING_ADDRESS_PREFIX);
+            const enhancedDeliveryAddressErrors = enhanceErrorObjectKeys(extractedDeliveryAddressErrors, DELIVERY_ADDRESS_PREFIX);
+
+            // ...and then collate the errors into a new object so that they all sit at top level
+            const errorsForPanel = {
+                ...(typeof extractedCompanyDetailsErrors === 'object' && extractedCompanyDetailsErrors),
+                ...(typeof extractedPersonalDetailsErrors === 'object' && extractedPersonalDetailsErrors),
+                ...(typeof extractedBankAccountErrors === 'object' && extractedBankAccountErrors),
+                ...(typeof enhancedBillingAddressErrors === 'object' && enhancedBillingAddressErrors),
+                ...(typeof enhancedDeliveryAddressErrors === 'object' && enhancedDeliveryAddressErrors),
+                ...remainingErrors
+            };
+
+            // Create layout
+            const companyDetailsLayout: string[] = COMPANY_DETAILS_SCHEMA;
+
+            const personalDetailsReqFields: string[] = props.personalDetailsRequiredFields ?? PERSONAL_DETAILS_SCHEMA;
+            const personalDetailLayout: string[] = PERSONAL_DETAILS_SCHEMA.filter(x => personalDetailsReqFields?.includes(x));
+
+            const bankAccountLayout = ['holder', 'iban'];
+
+            const billingAddressLayout = billingAddressSpecifications.getAddressSchemaForCountryFlat(data.billingAddress?.country);
+            // In order to sort the address errors the layout entries need to have the same (prefixed) identifier as the errors themselves
+            const billingAddressLayoutEnhanced = billingAddressLayout.map(item => `${BILLING_ADDRESS_PREFIX}${item}`);
+
+            const deliveryAddressLayout = deliveryAddressSpecifications.getAddressSchemaForCountryFlat(data.deliveryAddress?.country);
+            const deliveryAddressLayoutEnhanced = deliveryAddressLayout.map(item => `${DELIVERY_ADDRESS_PREFIX}${item}`);
+
+            const fullLayout = companyDetailsLayout.concat(
+                personalDetailLayout,
+                bankAccountLayout,
+                billingAddressLayoutEnhanced,
+                deliveryAddressLayoutEnhanced,
+                ['consentCheckbox']
+            );
+
+            // Country specific address labels
+            const countrySpecificLabels_billing = billingAddressSpecifications.getAddressLabelsForCountry(data.billingAddress?.country);
+            const countrySpecificLabels_delivery = deliveryAddressSpecifications.getAddressLabelsForCountry(data.deliveryAddress?.country);
+
+            // Set messages: Pass dynamic props (errors, layout etc) to SRPanel via partial
+            const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
+                errors: errorsForPanel,
+                isValidating: isValidating.current,
+                layout: fullLayout,
+                countrySpecificLabels: { ...countrySpecificLabels_billing, ...countrySpecificLabels_delivery }
+            });
+
+            // Relates to onBlur errors
+            const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
+
+            // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
+            setSortedErrorList(currentErrorsSortedByLayout); // Relates to onBlur errors
+
+            /**
+             * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
+             */
+            switch (srPanelResp?.action) {
+                // A call to focus the first field in error will always follow the call to validate the whole form
+                case ERROR_ACTION_FOCUS_FIELD:
+                    // Focus first field in error, if required
+                    if (shouldMoveFocusSR) setFocusOnField('.adyen-checkout__open-invoice', srPanelResp.fieldToFocus);
+                    // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
+                    setTimeout(() => {
+                        isValidating.current = false;
+                    }, 300);
+                    break;
+
+                /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
+                case ERROR_ACTION_BLUR_SCENARIO: {
+                    const difference = getArrayDifferences(currentErrorsSortedByLayout, previousSortedErrors, 'field');
+
+                    const latestErrorMsg = difference?.[0];
+
+                    if (latestErrorMsg) {
+                        // Is error actually a blur based one - depends on the specific fields in a component as to whether they validate on blur
+                        const isBlurBasedError = latestErrorMsg.errorCode === 'shopperEmail.invalid';
+
+                        // Only add blur based errors to the error panel - doing this step prevents the non-blur based errors from being read out twice
+                        const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
+                        setSRMessagesFromStrings(latestSRError);
+                    } else {
+                        // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
+                        clearSRPanel();
+                    }
+
+                    break;
+                }
+                default:
+                    break;
+            }
+        } catch (e) {
+            console.warn('Error in useSafeSRPanelForErrors', e);
+        }
+    }, [errors, data.billingAddress, data.deliveryAddress]);
+};
+
+export default useSRPanelForOpenInvoiceErrors;

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -77,7 +77,9 @@ export const sortErrorsByLayout = ({ errors, i18n, layout, countrySpecificLabels
         if (value) {
             const errObj: ValidationRuleResult | SFError | GenericError = errors[key];
             // console.log('### utils::sortErrorsByLayout:: key', key, 'errObj', errObj);
-
+            if (errObj == null) {
+                return acc;
+            }
             /**
              * Get error codes - these are used if we need to distinguish between showValidation & onBlur errors
              * - For a ValidationRuleResult or GenericError the error "code" is contained in the errorMessage prop.
@@ -101,7 +103,7 @@ export const sortErrorsByLayout = ({ errors, i18n, layout, countrySpecificLabels
              * For other fields we still need to translate it, so we use the errorMessage prop as a translation key
              */
             let errorMsg: string;
-            if (!(errObj instanceof ValidationRuleResult) && 'errorI18n' in errObj) {
+            if (!(errObj instanceof ValidationRuleResult) && typeof errObj === 'object' && 'errorI18n' in errObj) {
                 errorMsg = errObj.errorI18n + SR_INDICATOR_PREFIX; // is SFError
             } else {
                 /** Special handling for Address~postalCode (see above) */

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -77,9 +77,6 @@ export const sortErrorsByLayout = ({ errors, i18n, layout, countrySpecificLabels
         if (value) {
             const errObj: ValidationRuleResult | SFError | GenericError = errors[key];
             // console.log('### utils::sortErrorsByLayout:: key', key, 'errObj', errObj);
-            if (errObj == null) {
-                return acc;
-            }
             /**
              * Get error codes - these are used if we need to distinguish between showValidation & onBlur errors
              * - For a ValidationRuleResult or GenericError the error "code" is contained in the errorMessage prop.
@@ -103,7 +100,7 @@ export const sortErrorsByLayout = ({ errors, i18n, layout, countrySpecificLabels
              * For other fields we still need to translate it, so we use the errorMessage prop as a translation key
              */
             let errorMsg: string;
-            if (!(errObj instanceof ValidationRuleResult) && typeof errObj === 'object' && 'errorI18n' in errObj) {
+            if (!(errObj instanceof ValidationRuleResult) && 'errorI18n' in errObj) {
                 errorMsg = errObj.errorI18n + SR_INDICATOR_PREFIX; // is SFError
             } else {
                 /** Special handling for Address~postalCode (see above) */

--- a/packages/playground/src/style.scss
+++ b/packages/playground/src/style.scss
@@ -5,13 +5,21 @@
 *:before {
     box-sizing: border-box;
 }
+
 html,
 body {
-    font: 16px/1.21 -apple-system, BlinkMacSystemFont, sans-serif;
+    font:
+        16px/1.21 -apple-system,
+        BlinkMacSystemFont,
+        sans-serif;
     font-weight: 400;
     margin: 0;
     min-height: 100vh;
     overflow-x: hidden;
+}
+
+button {
+    font-family: inherit;
 }
 
 body {
@@ -105,7 +113,9 @@ h2 {
     background: none;
     border: 0;
     cursor: pointer;
-    transition: background-color 0.3s ease-out, opacity 0.3s ease-out;
+    transition:
+        background-color 0.3s ease-out,
+        opacity 0.3s ease-out;
 
     @media screen and (min-width: 1240px) {
         display: none;
@@ -252,7 +262,9 @@ h2 {
             color: $color-primary;
             border-radius: 3px;
             padding: 4px 8px;
-            transition: background-color 0.25s linear, color 0.25s linear;
+            transition:
+                background-color 0.25s linear,
+                color 0.25s linear;
             cursor: pointer;
 
             &:hover,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The PR includes:
- Fixed the `Uncaught TypeError: Cannot use 'in' operator to search for 'errorI18n' in true` when checking and unchecking the consent checkbox by setting the correct error in `OpenInvoice`
- Abstracted the logic related to the sr panel into a custom hook, added a `try ... catch` block so that errors related to the sr panel are 'handled', but we let them fail silently. By doing so, we make sure that any exceptions related to the sr panel are not blocking the logic for the `OpenInvoice` component

## Tested scenarios
Added tests and all tests passed

**Fixed issue**:  COWEB-1380 & COWEB-1379
