### PR TITLE
v6 - Calling onAdditionalDetails without setting status

### DIFF
--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -222,7 +222,6 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     }
 
     private async submitUsingSessionsFlow(data: PaymentData): Promise<CheckoutSessionPaymentResponse> {
-        // Call analytics endpoint
         this.submitAnalytics({ type: ANALYTICS_SUBMIT_STR });
 
         try {
@@ -268,8 +267,6 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     }
 
     private makeAdditionalDetailsCall(state: AdditionalDetailsStateData): Promise<CheckoutSessionDetailsResponse | CheckoutAdvancedFlowResponse> {
-        this.setElementStatus('loading');
-
         if (this.props.onAdditionalDetails) {
             return new Promise<CheckoutAdvancedFlowResponse>((resolve, reject) => {
                 this.props.onAdditionalDetails(state, this.elementRef, { resolve, reject });

--- a/packages/playground/src/pages/Dropin/manual.js
+++ b/packages/playground/src/pages/Dropin/manual.js
@@ -1,4 +1,4 @@
-import { AdyenCheckout, Dropin, Card, GooglePay, PayPal, Ach, Affirm, WeChat, Giftcard, AmazonPay, Ideal } from '@adyen/adyen-web';
+import { AdyenCheckout, Dropin, Card, GooglePay, PayPal, Ach, Affirm, WeChat, Giftcard, AmazonPay, Ideal, Pix } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
 import { getPaymentMethods, makePayment, checkBalance, createOrder, cancelOrder, makeDetailsCall } from '../../services';
 import { amount, shopperLocale, countryCode } from '../../config/commonConfig';
@@ -119,7 +119,7 @@ export async function initManual() {
     }
 
     const dropin = new Dropin(checkout, {
-        paymentMethodComponents: [Card, GooglePay, PayPal, Ach, Affirm, WeChat, Giftcard, AmazonPay, Ideal],
+        paymentMethodComponents: [Card, GooglePay, PayPal, Ach, Affirm, WeChat, Giftcard, AmazonPay, Ideal, Pix],
         instantPaymentTypes: ['googlepay'],
         disableFinalAnimation: true,
         paymentMethodsConfiguration: {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

On [v6 - Synchronous submit with order tracking](https://github.com/Adyen/adyen-web/pull/2425) PR, we started setting the `status` to `loading` during the `onAdditionalDetails` step. (We don't do this on v5) 

Taking in consideration the Drop-in scenario, doing the above sets the Drop-in status to `loading` and therefore re-renders it, however when doing the `onAdditionalDetails`  we must not render Drop-in again and we should render the `sucessfull` or `error` state based on the API response.

This problem could be seen after handling the 3DS challenge iframe or when processing the completion of a voucher/qr code payment, where the `onAdditionalDetails` is triggered.

