### PR TITLE
Don't log threeDSCompInd or transStatus from 3DS2 process

### DIFF
--- a/.changeset/good-fishes-admire.md
+++ b/.changeset/good-fishes-admire.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Don't log threeDSCompInd or transStatus from 3DS2 process

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -40,8 +40,8 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             if (!acsURL || !acsTransID || !messageVersion || !threeDSServerTransID) {
                 this.setStatusError({
                     errorInfo:
-                        'Challenge Data missing one or more of the following properties (acsURL | acsTransID | messageVersion | threeDSServerTransID)',
-                    errorObj: challengeData
+                        'Challenge Data missing one or more of the following properties (acsURL | acsTransID | messageVersion | threeDSServerTransID)'
+                    // errorObj: challengeData // TODO Decide if we want to expose this data
                 });
                 return;
             }
@@ -85,8 +85,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             // Create log object - the process is completed, one way or another
             const analyticsObject: SendAnalyticsObject = {
                 type: THREEDS2_FULL,
-                message: `${THREEDS2_NUM} challenge has completed`,
-                metadata: { ...resultObj }
+                message: `${THREEDS2_NUM} challenge has completed`
             };
 
             // Send log to analytics endpoint

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -80,8 +80,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
             /** The fingerprint process is completed, one way or another */
             const analyticsObject: SendAnalyticsObject = {
                 type: THREEDS2_FULL,
-                message: `${THREEDS2_NUM} fingerprinting has completed`,
-                metadata: { ...resultObj }
+                message: `${THREEDS2_NUM} fingerprinting has completed`
             };
 
             // Send log to analytics endpoint


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Stopped logging `threeDSCompInd` and `transStatus` i.e. fingerprint and challenge result codes

## Tested scenarios
All unit tests pass


**Partly relates to issue**:  AUTHN-1922
