### PR TITLE
v6 - Enabling typescript strict mode 

### DIFF
--- a/packages/lib/src/components/CashAppPay/components/CashAppComponent.tsx
+++ b/packages/lib/src/components/CashAppPay/components/CashAppComponent.tsx
@@ -66,7 +66,8 @@ export function CashAppComponent({
 
             setStatus('ready');
         } catch (error) {
-            onError(error);
+            if (error instanceof AdyenCheckoutError) onError(error);
+            else onError(new AdyenCheckoutError('ERROR', 'Error when initializing CashAppPay', { cause: error }));
         }
     }, [cashAppService, onError, onAuthorize]);
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.tsx
@@ -16,6 +16,7 @@ import isMobile from '../../../../../utils/isMobile';
 import Language from '../../../../../language';
 import { PaymentAmount } from '../../../../../types/global-types';
 import './CtPCards.scss';
+import AdyenCheckoutError from '../../../../../core/Errors/AdyenCheckoutError';
 
 type CtPCardsProps = {
     onDisplayCardComponent?(): void;
@@ -62,13 +63,15 @@ const CtPCards = ({ onDisplayCardComponent }: CtPCardsProps) => {
             onSetStatus('loading');
             const payload = await checkout(checkoutCard);
             onSubmit(payload);
-        } catch (error) {
+        } catch (error: unknown) {
             if (error instanceof SrciError) {
                 setErrorCode(error?.reason);
                 console.warn(`CtP - Checkout: Reason: ${error?.reason} / Source: ${error?.source} / Scheme: ${error?.scheme}`);
             }
             setIsShopperCheckingOutWithCtp(false);
-            onError(error);
+
+            if (error instanceof AdyenCheckoutError) onError(error);
+            else onError(new AdyenCheckoutError('ERROR', 'Error during ClickToPay checkout', { cause: error }));
         }
     }, [checkout, checkoutCard]);
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
@@ -9,6 +9,7 @@ import SrciError from '../../services/sdks/SrciError';
 import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import './CtPLogin.scss';
 import TimeoutError from '../../errors/TimeoutError';
+import { isSrciError } from '../../services/utils';
 
 const CtPLogin = (): h.JSX.Element => {
     const { i18n } = useCoreContext();
@@ -51,10 +52,12 @@ const CtPLogin = (): h.JSX.Element => {
                 setErrorCode('NOT_FOUND');
                 setIsLoggingIn(false);
             }
-        } catch (error) {
+        } catch (error: unknown) {
             if (error instanceof SrciError) console.warn(`CtP - Login error: ${error.toString()}`);
             if (error instanceof TimeoutError) console.warn(error.toString());
-            setErrorCode(error?.reason);
+            if (isSrciError(error)) setErrorCode(error?.reason);
+            else console.error(error);
+
             setIsLoggingIn(false);
         }
     }, [verifyIfShopperIsEnrolled, startIdentityValidation, shopperLogin, isValid, loginInputHandlers]);

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.tsx
@@ -9,6 +9,7 @@ import CtPSection from '../CtPSection';
 import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import './CtPOneTimePassword.scss';
 import CtPSaveCookiesCheckbox from './CtPSaveCookiesCheckbox';
+import { isSrciError } from '../../services/utils';
 
 type CtPOneTimePasswordProps = {
     onDisplayCardComponent?(): void;
@@ -48,7 +49,12 @@ const CtPOneTimePassword = ({ onDisplayCardComponent }: CtPOneTimePasswordProps)
 
         try {
             await finishIdentityValidation(otp);
-        } catch (error) {
+        } catch (error: unknown) {
+            if (!isSrciError(error)) {
+                setIsValidatingOtp(false);
+                return;
+            }
+
             setErrorCode(error?.reason);
             setIsValidatingOtp(false);
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
@@ -4,6 +4,7 @@ import useClickToPayContext from '../../../context/useClickToPayContext';
 import classnames from 'classnames';
 import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import Icon from '../../../../Icon';
+import { isSrciError } from '../../../services/utils';
 
 const CONFIRMATION_SHOWING_TIME = 2000;
 
@@ -47,10 +48,16 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: CtPResendOtpLinkP
                 onResendCode();
                 setShowConfirmation(true);
                 await startIdentityValidation();
-            } catch (error) {
-                onError(error.reason);
+            } catch (error: unknown) {
                 setCounter(0);
                 setShowConfirmation(false);
+
+                if (!isSrciError(error)) {
+                    console.error(error);
+                    return;
+                }
+
+                onError(error.reason);
             }
         },
         [startIdentityValidation, onError, onResendCode]

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/AbstractSrcInitiator.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/AbstractSrcInitiator.ts
@@ -10,7 +10,7 @@ import {
     SrcInitParams,
     SrcProfile
 } from './types';
-import SrciError from './SrciError';
+import SrciError, { MastercardError, VisaError } from './SrciError';
 import { ClickToPayScheme } from '../../types';
 import Script from '../../../../../utils/Script';
 
@@ -86,7 +86,7 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
             const checkoutResponse = await this.schemeSdk.checkout(params);
             return checkoutResponse;
         } catch (error) {
-            const srciError = new SrciError(error, 'checkout', this.schemeName);
+            const srciError = new SrciError(error as VisaError | MastercardError, 'checkout', this.schemeName);
             throw srciError;
         }
     }
@@ -98,7 +98,7 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
         try {
             await this.schemeSdk.unbindAppInstance();
         } catch (error) {
-            const srciError = new SrciError(error, 'unbindAppInstance', this.schemeName);
+            const srciError = new SrciError(error as VisaError | MastercardError, 'unbindAppInstance', this.schemeName);
             throw srciError;
         }
     }
@@ -112,7 +112,7 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
             const isRecognizedResponse = await this.schemeSdk.isRecognized();
             return isRecognizedResponse;
         } catch (error) {
-            const srciError = new SrciError(error, 'isRecognized', this.schemeName);
+            const srciError = new SrciError(error as VisaError | MastercardError, 'isRecognized', this.schemeName);
             throw srciError;
         }
     }
@@ -126,7 +126,7 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
             const identityValidationResponse = await this.schemeSdk.initiateIdentityValidation();
             return identityValidationResponse;
         } catch (error) {
-            const srciError = new SrciError(error, 'initiateIdentityValidation', this.schemeName);
+            const srciError = new SrciError(error as VisaError | MastercardError, 'initiateIdentityValidation', this.schemeName);
             throw srciError;
         }
     }
@@ -139,7 +139,7 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
             const getSrcProfileResponse = await this.schemeSdk.getSrcProfile({ idTokens });
             return getSrcProfileResponse;
         } catch (error) {
-            const srciError = new SrciError(error, 'getSrcProfile', this.schemeName);
+            const srciError = new SrciError(error as VisaError | MastercardError, 'getSrcProfile', this.schemeName);
             throw srciError;
         }
     }

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/MastercardSdk.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/MastercardSdk.ts
@@ -1,6 +1,6 @@
 import { getMastercardSettings, MC_SDK_PROD, MC_SDK_TEST } from './config';
 import AbstractSrcInitiator from './AbstractSrcInitiator';
-import SrciError from './SrciError';
+import SrciError, { MastercardError, VisaError } from './SrciError';
 import {
     CustomSdkConfiguration,
     SrciCompleteIdentityValidationResponse,
@@ -41,7 +41,7 @@ class MastercardSdk extends AbstractSrcInitiator {
             };
             await this.schemeSdk.init(sdkProps);
         } catch (err) {
-            const srciError = new SrciError(err, 'init', this.schemeName);
+            const srciError = new SrciError(err as VisaError | MastercardError, 'init', this.schemeName);
             throw srciError;
         }
     }
@@ -56,7 +56,7 @@ class MastercardSdk extends AbstractSrcInitiator {
             const response = await this.schemeSdk.identityLookup({ consumerIdentity });
             return response;
         } catch (err) {
-            const srciError = new SrciError(err, 'identityLookup', this.schemeName);
+            const srciError = new SrciError(err as VisaError | MastercardError, 'identityLookup', this.schemeName);
             throw srciError;
         }
     }
@@ -66,7 +66,7 @@ class MastercardSdk extends AbstractSrcInitiator {
             const response = await this.schemeSdk.completeIdentityValidation({ validationData: otp });
             return response;
         } catch (err) {
-            const srciError = new SrciError(err, 'completeIdentityValidation', this.schemeName);
+            const srciError = new SrciError(err as VisaError | MastercardError, 'completeIdentityValidation', this.schemeName);
             throw srciError;
         }
     }

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.ts
@@ -1,7 +1,7 @@
 import { getVisaSetttings, VISA_SDK_PROD, VISA_SDK_TEST } from './config';
 import AbstractSrcInitiator from './AbstractSrcInitiator';
-import SrciError from './SrciError';
-import {
+import SrciError, { MastercardError, VisaError } from './SrciError';
+import type {
     CustomSdkConfiguration,
     SrciCompleteIdentityValidationResponse,
     SrcIdentityLookupParams,
@@ -42,7 +42,7 @@ class VisaSdk extends AbstractSrcInitiator {
 
             await this.schemeSdk.init(sdkProps);
         } catch (err) {
-            const srciError = new SrciError(err, 'init', this.schemeName);
+            const srciError = new SrciError(err as VisaError | MastercardError, 'init', this.schemeName);
             throw srciError;
         }
     }
@@ -57,7 +57,7 @@ class VisaSdk extends AbstractSrcInitiator {
             const response = await this.schemeSdk.identityLookup(consumerIdentity);
             return response;
         } catch (err) {
-            const srciError = new SrciError(err, 'identityLookup', this.schemeName);
+            const srciError = new SrciError(err as VisaError | MastercardError, 'identityLookup', this.schemeName);
             throw srciError;
         }
     }
@@ -66,8 +66,8 @@ class VisaSdk extends AbstractSrcInitiator {
         try {
             const response = await this.schemeSdk.completeIdentityValidation(otp);
             return response;
-        } catch (err) {
-            const srciError = new SrciError(err, 'completeIdentityValidation', this.schemeName);
+        } catch (err: unknown) {
+            const srciError = new SrciError(err as VisaError | MastercardError, 'completeIdentityValidation', this.schemeName);
             throw srciError;
         }
     }

--- a/packages/lib/src/components/internal/ClickToPay/services/utils.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/utils.ts
@@ -1,6 +1,7 @@
 import { CardTypes, ClickToPayCheckoutPayload, SrcProfileWithScheme } from './types';
 import { SrciCheckoutResponse } from './sdks/types';
 import ShopperCard from '../models/ShopperCard';
+import SrciError from './sdks/SrciError';
 
 export const CTP_IFRAME_NAME = 'ctpIframe';
 
@@ -64,4 +65,9 @@ function createShopperCardsList(srcProfiles: SrcProfileWithScheme[]): ShopperCar
     return [...availableCards.sort(sortCardByLastTimeUsed), ...expiredCards.sort(sortCardByLastTimeUsed)];
 }
 
-export { createShopperCardsList, createCheckoutPayloadBasedOnScheme };
+function isSrciError(error: unknown): error is SrciError {
+    if ((error as SrciError).reason) return true;
+    return false;
+}
+
+export { createShopperCardsList, createCheckoutPayloadBasedOnScheme, isSrciError };

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -226,8 +226,10 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
 
         try {
             return await this.core.session.submitPayment(data);
-        } catch (error) {
-            this.handleError(error);
+        } catch (error: unknown) {
+            if (error instanceof AdyenCheckoutError) this.handleError(error);
+            else this.handleError(new AdyenCheckoutError('ERROR', 'Error when making /payments call', { cause: error }));
+
             return Promise.reject(error);
         }
 
@@ -288,8 +290,10 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     private async submitAdditionalDetailsUsingSessionsFlow(data: any): Promise<CheckoutSessionDetailsResponse> {
         try {
             return await this.core.session.submitDetails(data);
-        } catch (error) {
-            this.handleError(error);
+        } catch (error: unknown) {
+            if (error instanceof AdyenCheckoutError) this.handleError(error);
+            else this.handleError(new AdyenCheckoutError('ERROR', 'Error when making /details call', { cause: error }));
+
             return Promise.reject(error);
         }
     }

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -135,8 +135,9 @@ class Core implements ICore {
         try {
             const translation = await getTranslations(this.cdnTranslationsUrl, Core.metadata.version, this.options.locale, this.options.translations);
             return translation;
-        } catch (error) {
-            this.options.onError?.(error);
+        } catch (error: unknown) {
+            if (error instanceof AdyenCheckoutError) this.options.onError?.(error);
+            else this.options.onError?.(new AdyenCheckoutError('ERROR', 'Failed to fetch translation', { cause: error }));
         }
     }
 

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -17,14 +17,14 @@
         "moduleDetection": "force",
 
         /* Strictness */
-        "strict": false,
-        "noUncheckedIndexedAccess": true,
+        "strict": true,
         "noImplicitAny": false,
         "noImplicitThis": false,
-        "noImplicitReturns": false,
-        "noImplicitOverride": false,
-        "strictPropertyInitialization": false,
+        "alwaysStrict": false,
+        "strictBindCallApply": false,
         "strictNullChecks": false,
+        "strictFunctionTypes": false,
+        "strictPropertyInitialization": false,
         "useDefineForClassFields": false,
 
         /** Preact */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Adjusted `tsconfig.json` to use `strict: true` and fixed some lint issues on try-catch blocks

We can start enforcing the strict rules by tackling the deactivated rules from tsconfig file one by one (Example: we can remove a rule, then fix the lint issues and create a PR for that specific fix)
