### PR TITLE
Fixing unit tests that were giving false positives

### DIFF
--- a/packages/lib/src/components/Redirect/Redirect.test.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.test.tsx
@@ -19,7 +19,7 @@ describe('Redirect', () => {
     });
 
     describe('Redirect Status', () => {
-        test('Accepts a POST redirect status', () => {
+        test('Accepts a POST redirect status', done => {
             window.HTMLFormElement.prototype.submit = jest.fn();
 
             // @ts-ignore ignore
@@ -28,10 +28,14 @@ describe('Redirect', () => {
             expect(wrapper.find('form')).toHaveLength(1);
             expect(wrapper.find('form').prop('action')).toBe('http://www.adyen.com');
             expect(wrapper.find('form').prop('target')).toBe(undefined);
-            setTimeout(() => expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled(), 0);
+
+            setTimeout(() => {
+                expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled();
+                done();
+            }, 0);
         });
 
-        test('Accepts a POST redirect status, setting target to _top, when the config prop tells it to', () => {
+        test('Accepts a POST redirect status, setting target to _top, when the config prop tells it to', done => {
             window.HTMLFormElement.prototype.submit = jest.fn();
 
             // @ts-ignore ignore
@@ -39,7 +43,10 @@ describe('Redirect', () => {
 
             expect(wrapper.find('form')).toHaveLength(1);
             expect(wrapper.find('form').prop('target')).toBe('_top');
-            setTimeout(() => expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled(), 0);
+            setTimeout(() => {
+                expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled();
+                done();
+            }, 0);
         });
     });
 

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.test.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
 import IbanInput from './IbanInput';
 import { GenericError } from '../../../core/Errors/types';
 import { CoreProvider } from '../../../core/Context/CoreProvider';
@@ -83,33 +84,40 @@ describe('IbanInput', () => {
     });
 
     describe('Send values from outside', () => {
-        test('Set ibanNumber', () => {
-            const wrapper = createWrapper({ data: { ibanNumber: 'NL13TEST0123456789' } });
-            setTimeout(() => {
-                expect(wrapper.find('input[name="ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
-            });
+        const createElement = (props = {}) => {
+            return (
+                <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+                    {/* @ts-ignore Iban is valid TSX */}
+                    <IbanInput data={{}} {...props} />
+                </CoreProvider>
+            );
+        };
+
+        test('Set ibanNumber', async () => {
+            const el = createElement({ data: { ibanNumber: 'NL13TEST0123456789' } });
+            render(el);
+
+            const inputEl = await screen.findByLabelText('Account Number (IBAN)');
+
+            expect(inputEl).toHaveValue('NL13 TEST 0123 4567 89');
         });
 
-        test('Set ibanNumber formatted', () => {
-            const wrapper = createWrapper({ data: { ibanNumber: 'NL13 TEST 0123 4567 89' } });
-            setTimeout(() => {
-                expect(wrapper.find('input[name="ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
-            });
+        test('Set ibanNumber formatted', async () => {
+            const el = createElement({ data: { ibanNumber: 'NL13 TEST 0123 4567 89' } });
+            render(el);
+
+            const inputEl = await screen.findByLabelText('Account Number (IBAN)');
+
+            expect(inputEl).toHaveValue('NL13 TEST 0123 4567 89');
         });
 
-        test('Set ownerName', () => {
-            const wrapper = createWrapper({ data: { ownerName: 'Hello World' } });
-            setTimeout(() => {
-                expect(wrapper.find('input[name="ownerName"]').text()).toBe('Hello World');
-            });
-        });
+        test('Set ownerName', async () => {
+            const el = createElement({ data: { ownerName: 'Hello World' } });
+            render(el);
 
-        test('Set ibanNumber and ownerName', () => {
-            const wrapper = createWrapper({ data: { ibanNumber: 'NL13TEST0123456789', ownerName: 'Hello World' } });
-            setTimeout(() => {
-                expect(wrapper.find('input[name="ibanNumber"]').text()).toBe('NL13 TEST 0123 4567 89');
-                expect(wrapper.find('input[name="ownerName"]').text()).toBe('Hello World');
-            });
+            const inputEl = await screen.findByLabelText('Holder Name');
+
+            expect(inputEl).toHaveValue('Hello World');
         });
     });
 });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Some unit tests were giving false positives i.e. passing _without_ running all their assertions, because of incorrect usage of `setTimeout`
They were using `setTimeout` without also setting and calling Jest's `done` function. In effect this meant that the code within the `setTimeout` block was not being run

## Tested scenarios
Affected unit tests now run _all_ their assertions



