### PR TITLE
v5 GooglePay adds origin to state.data

### DIFF
--- a/.changeset/grumpy-worms-carry.md
+++ b/.changeset/grumpy-worms-carry.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+GooglePay adds origin to state.data

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -47,7 +47,8 @@ class GooglePay extends UIElement<GooglePayProps> {
                 type: this.props.type ?? GooglePay.type,
                 ...this.state
             },
-            browserInfo: this.browserInfo
+            browserInfo: this.browserInfo,
+            origin: !!window && window.location.origin
         };
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adding `origin` to `state.data` allows Card payments in GooglePay to follow the native 3DS2 checkout flow.
Without this property the ` /payments` request triggers the 3DSInMDFlow (redirect).

NOTE: this issue has already been addressed in v6 

## Tested Scenarios
Manually tested: Card payment in GooglePay, leads to native 3DS2 challenge

**Fixed issue**:  COWEB-1222, #2681 
