### PR TITLE
Fix: ACH not respecting showPayButton

### DIFF
--- a/.changeset/eleven-students-hunt.md
+++ b/.changeset/eleven-students-hunt.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fix: ACH not respecting showPayButton

--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -77,6 +77,7 @@ export class AchElement extends UIElement<AchElementProps> {
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                 {this.props.storedPaymentMethodId ? (
                     <RedirectButton
+                        showPayButton={this.props.showPayButton}
                         name={this.displayName}
                         amount={this.props.amount}
                         payButton={this.payButton}

--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -53,9 +53,13 @@ export class BankTransferElement extends UIElement<BankTransferProps> {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                 {this.props.showEmailAddress && <BankTransferInput ref={this.handleRef} {...this.props} onChange={this.setState} />}
-                {this.props.showPayButton && (
-                    <RedirectButton {...this.props} name={this.displayName} onSubmit={this.submit} payButton={this.payButton} />
-                )}
+                <RedirectButton
+                    {...this.props}
+                    showPayButton={this.props.showPayButton}
+                    name={this.displayName}
+                    onSubmit={this.submit}
+                    payButton={this.payButton}
+                />
             </CoreProvider>
         );
     }

--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -89,6 +89,7 @@ class BlikElement extends UIElement {
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                 {this.props.storedPaymentMethodId ? (
                     <RedirectButton
+                        showPayButton={this.props.showPayButton}
                         name={this.displayName}
                         amount={this.props.amount}
                         payButton={this.payButton}

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -142,6 +142,7 @@ export class CashAppPay extends UIElement<CashAppPayElementProps> {
             <CoreProvider i18n={this.props.i18n} resources={this.resources} loadingContext={this.props.loadingContext}>
                 {this.props.storedPaymentMethodId ? (
                     <RedirectButton
+                        showPayButton={this.props.showPayButton}
                         label={payAmountLabel(this.props.i18n, this.props.amount)}
                         icon={this.resources?.getImage({ imageFolder: 'components/' })('lock')}
                         name={this.displayName}

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem.scss
@@ -120,8 +120,9 @@
     position: relative;
 }
 
-.adyen-checkout__payment-method__details__content {
-    margin: 0 0 16px;
+
+.adyen-checkout__payment-method__details__content > *:last-child {
+    margin-bottom: 16px;
 }
 
 .adyen-checkout__payment-method__image__wrapper {

--- a/packages/lib/src/components/Multibanco/Multibanco.tsx
+++ b/packages/lib/src/components/Multibanco/Multibanco.tsx
@@ -47,6 +47,7 @@ export class MultibancoElement extends UIElement {
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                     <RedirectButton
+                        showPayButton={this.props.showPayButton}
                         name={this.displayName}
                         amount={this.props.amount}
                         payButton={this.payButton}

--- a/packages/lib/src/components/helpers/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer.tsx
@@ -123,17 +123,16 @@ class IssuerListContainer extends UIElement<IssuerListContainerProps> {
                         />
                     </SRPanelProvider>
                 ) : (
-                    this.props.showPayButton && (
-                        <RedirectButton
-                            name={this.props.name}
-                            {...this.props}
-                            onSubmit={this.submit}
-                            payButton={this.payButton}
-                            ref={ref => {
-                                this.componentRef = ref;
-                            }}
-                        />
-                    )
+                    <RedirectButton
+                        showPayButton={this.props.showPayButton}
+                        name={this.props.name}
+                        {...this.props}
+                        onSubmit={this.submit}
+                        payButton={this.payButton}
+                        ref={ref => {
+                            this.componentRef = ref;
+                        }}
+                    />
                 )}
             </CoreProvider>
         );

--- a/packages/lib/src/components/helpers/QRLoaderContainer.tsx
+++ b/packages/lib/src/components/helpers/QRLoaderContainer.tsx
@@ -87,6 +87,7 @@ class QRLoaderContainer<T extends QRLoaderContainerProps = QRLoaderContainerProp
             return (
                 <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                     <RedirectButton
+                        showPayButton={this.props.showPayButton}
                         name={this.displayName}
                         onSubmit={this.submit}
                         payButton={this.payButton}

--- a/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
+++ b/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
@@ -1,8 +1,22 @@
 import { h, Fragment } from 'preact';
 import useCoreContext from '../../../core/Context/useCoreContext';
 import { useState } from 'preact/hooks';
+import { PaymentAmount } from '../../../types';
 
-function RedirectButton({ label = null, icon = null, payButton, onSubmit, amount = null, name, ...props }) {
+// TODO this should ideally be remove but we need let prop propagate down
+//  probably not worth changing this behaviour now
+export interface RedirectButtonProps {
+    label?: string;
+    icon?: string;
+    payButton: Function;
+    onSubmit: Function;
+    amount?: PaymentAmount;
+    name: string;
+    showPayButton: boolean;
+    ref?: any;
+}
+
+function RedirectButton({ label = null, icon = null, payButton, onSubmit, amount = null, name, showPayButton, ...props }: RedirectButtonProps) {
     const { i18n } = useCoreContext();
     const [status, setStatus] = useState('ready');
 
@@ -16,7 +30,7 @@ function RedirectButton({ label = null, icon = null, payButton, onSubmit, amount
         return `${i18n.get('continueTo')} ${name}`;
     };
 
-    if (!props.showPayButton) {
+    if (!showPayButton) {
         return;
     }
 

--- a/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
+++ b/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
@@ -16,6 +16,10 @@ function RedirectButton({ label = null, icon = null, payButton, onSubmit, amount
         return `${i18n.get('continueTo')} ${name}`;
     };
 
+    if (!props.showPayButton) {
+        return;
+    }
+
     return (
         <Fragment>
             {payButton({

--- a/packages/lib/src/core/core.misc.test.ts
+++ b/packages/lib/src/core/core.misc.test.ts
@@ -1,0 +1,92 @@
+import AdyenCheckout from './core';
+import { render, screen, within } from '@testing-library/preact';
+
+// TODO copy
+const paymentMethodsResponse = {
+    paymentMethods: [
+        {
+            name: 'ACH Direct Debit',
+            type: 'ach'
+        },
+        {
+            brands: ['visa', 'mc', 'amex', 'maestro', 'bcmc', 'cartebancaire'],
+            name: 'Credit Card',
+            type: 'scheme'
+        }
+    ],
+    storedPaymentMethods: [
+        {
+            bankAccountNumber: '55555553123',
+            bankLocationId: '121000358',
+            id: 'RZTQFFMNG6KXWD82',
+            //storedPaymentMethodId: 'RZTQFFMNG6KXWD82',
+            name: 'ACH Direct Debit',
+            ownerName: 'Jay jay',
+            supportedRecurringProcessingModels: ['Subscription', 'UnscheduledCardOnFile', 'CardOnFile'],
+            supportedShopperInteractions: ['ContAuth', 'Ecommerce'],
+            type: 'ach'
+        },
+        {
+            brand: 'visa',
+            expiryMonth: '03',
+            expiryYear: '2030',
+            holderName: 'Checkout Shopper PlaceHolder',
+            id: '8415',
+            lastFour: '1111',
+            name: 'VISA',
+            networkTxReference: '0591',
+            supportedShopperInteractions: ['Ecommerce', 'ContAuth'],
+            type: 'scheme',
+            storedPaymentMethodId: '8415'
+        }
+    ]
+};
+
+const checkoutConfig = {
+    amount: {
+        currency: 'USD',
+        value: 19000
+    },
+    shopperLocale: 'en-US',
+    environment: 'test',
+    clientKey: 'test_F7_FEKJHF',
+    paymentMethodsResponse
+    //storedPaymentMethods: [paymentMethodsResponse.storedPaymentMethods]
+};
+
+const createDropinComponent = async mergeConfig => {
+    const checkout = new AdyenCheckout({ ...checkoutConfig, ...mergeConfig });
+    await checkout.initialize();
+    const component = checkout.create('dropin', {});
+    return component;
+};
+
+test('should render payButton', async () => {
+    const dropinElement = await createDropinComponent({ showPayButton: true });
+    render(dropinElement.render());
+
+    // get all possible payment method selector buttons
+    const paymentMethodListItemArray = await screen.findAllByRole('listitem');
+
+    // go trough and select each element in the dropin, check if it has payButton
+    for (const paymentMethodListItem of paymentMethodListItemArray) {
+        paymentMethodListItem.click();
+        expect(await within(paymentMethodListItem).findAllByRole('button')).toHaveLength(1);
+    }
+});
+
+test('should NOT render payButton', async () => {
+    const dropinElement = await createDropinComponent({ showPayButton: false });
+    render(dropinElement.render());
+
+    // get all possible payment method selector buttons
+    const paymentMethodListItemArray = await screen.findAllByRole('listitem');
+
+    // go trough and select each element in the dropin, check if it has payButton
+    for (const paymentMethodListItem of paymentMethodListItemArray) {
+        paymentMethodListItem.click();
+        const element = within(paymentMethodListItem).queryByRole('button');
+        // @ts-ignore toBeInDocument
+        expect(element).not.toBeInTheDocument();
+    }
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

ACH and some other stored payment methods do not respect `showPayButton` config.
This hopefully fixes that by moving the responsibility to the RedirectButton component.  Together with that there's a small CSS fix to ensure we don't display extra bottom margins if there's no content.

## Tested scenarios
<!-- Description of tested scenarios -->
* Set Dropin to `showPayButton` false

**Fixed issue**:  <!-- #-prefixed issue number -->
#2554 