### PR TITLE
Sessions - Replacing "Invalid ClientKey" error message with more meaningful error

### DIFF
--- a/.changeset/purple-kids-ring.md
+++ b/.changeset/purple-kids-ring.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+For sessions /setup call, we are passing the full error object instead of hardcoded 'ERROR: Invalid ClientKey' message

--- a/packages/lib/src/core/Services/sessions/setup-session.ts
+++ b/packages/lib/src/core/Services/sessions/setup-session.ts
@@ -3,8 +3,6 @@ import Session from '../../CheckoutSession';
 import { CheckoutSessionSetupResponse } from '../../../types';
 import { API_VERSION } from './constants';
 
-/**
- */
 function setupSession(session: Session, options): Promise<CheckoutSessionSetupResponse> {
     const path = `${API_VERSION}/sessions/${session.id}/setup?clientKey=${session.clientKey}`;
     const data = {
@@ -20,8 +18,7 @@ function setupSession(session: Session, options): Promise<CheckoutSessionSetupRe
         {
             loadingContext: session.loadingContext,
             path,
-            errorLevel: 'fatal',
-            errorMessage: 'ERROR: Invalid ClientKey'
+            errorLevel: 'fatal'
         },
         data
     );

--- a/packages/playground/src/pages/Dropin/session.js
+++ b/packages/playground/src/pages/Dropin/session.js
@@ -28,7 +28,7 @@ export async function initSession() {
             console.info(result, component);
         },
         onError: (error, component) => {
-            console.info(JSON.stringify(error), component);
+            console.log(error.name, error.message, error.cause);
         },
         // onChange: (state, component) => {
         //     console.log('onChange', state);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- The error message "Invalid ClientKey" is misleading. Now we are returning more meaningful error message containing the actual error in it;
- The full error object is assigned to the  `AdyenCheckoutError` property `cause` and it can be inspected properly;