### PR TITLE
[v6] card input has custom hook for sr panel

### DIFF
--- a/packages/e2e/app/src/pages/IssuerLists/IssuerLists.js
+++ b/packages/e2e/app/src/pages/IssuerLists/IssuerLists.js
@@ -1,4 +1,4 @@
-import { AdyenCheckout, Ideal } from '@adyen/adyen-web';
+import { AdyenCheckout, Redirect } from '@adyen/adyen-web';
 import '@adyen/adyen-web/styles/adyen.css';
 import { handleSubmit, handleAdditionalDetails, handleError, handlePaymentCompleted } from '../../handlers';
 import { amount, shopperLocale, countryCode } from '../../services/commonConfig';
@@ -34,7 +34,7 @@ const initCheckout = async () => {
         // ...window.mainConfiguration
     });
 
-    window.ideal = new Ideal(checkout, { highlightedIssuers: ['1121', '1154', '1153'] }).mount('.ideal-field');
+    window.ideal = new Redirect(checkout, { type: 'ideal' }).mount('.ideal-field');
 };
 
 initCheckout();

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -34,15 +34,6 @@ const CardInput = (props: CardInputProps) => {
     const isValidating = useRef(false);
     const getImage = useImage();
 
-    /** SR stuff */
-    // const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
-    //
-    // // Generate a setSRMessages function - implemented as a partial, since the initial set of arguments don't change.
-    // const setSRMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({
-    //     fieldTypeMappingFn: mapFieldKey
-    // });
-    /** end SR stuff */
-
     const billingAddressRef = useRef(null);
     const setAddressRef = ref => {
         billingAddressRef.current = ref;
@@ -337,16 +328,13 @@ const CardInput = (props: CardInputProps) => {
         });
     }, [formData, formValid, formErrors]);
 
-    // Get the previous value
-    // const previousSortedErrors = usePrevious(sortedErrorList);
-
+    // Use the custom hook to set (or clear) errors in the SRPanel
     const {
         sortedErrorList: currentErrorsSortedByLayout,
         previousSortedErrors,
         clearSRPanel
     } = useSRPanelForCardInputErrors({
         errors,
-        // data,
         props,
         isValidating,
         retrieveLayout,
@@ -372,65 +360,6 @@ const CardInput = (props: CardInputProps) => {
 
         const sfStateErrorsObj = sfp.current.mapErrorsToValidationRuleResult();
         const mergedErrors = { ...errors, ...sfStateErrorsObj }; // maps sfErrors AND solves race condition problems for sfp from showValidation
-
-        // Extract and then flatten billingAddress errors into a new object with *all* the field errors at top level
-        // const { billingAddress: extractedAddressErrors, ...errorsWithoutAddress } = mergedErrors;
-        //
-        // const errorsForPanel = { ...errorsWithoutAddress, ...extractedAddressErrors };
-        //
-        // // Pass dynamic props (errors, layout etc) to SRPanel via partial
-        // const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
-        //     errors: errorsForPanel,
-        //     isValidating: isValidating.current,
-        //     layout: retrieveLayout(),
-        //     // If we don't have country specific address labels, we might have a label related to a partialAddressSchema (i.e. zipCode)
-        //     countrySpecificLabels: specifications.getAddressLabelsForCountry(billingAddress?.country) ?? partialAddressSchema?.default?.labels
-        // });
-        //
-        // /**
-        //  * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
-        //  */
-        // const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
-        //
-        // // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
-        // setSortedErrorList(currentErrorsSortedByLayout);
-        //
-        // switch (srPanelResp?.action) {
-        //     // A call to focus the first field in error will always follow the call to validate the whole form
-        //     case ERROR_ACTION_FOCUS_FIELD:
-        //         if (shouldMoveFocusSR) setFocusOnFirstField(isValidating.current, sfp, srPanelResp?.fieldToFocus);
-        //         // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
-        //         setTimeout(() => {
-        //             isValidating.current = false;
-        //         }, 300);
-        //         break;
-        //     /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
-        //     case ERROR_ACTION_BLUR_SCENARIO: {
-        //         const difference = getArrayDifferences<SortedErrorObject, string>(currentErrorsSortedByLayout, previousSortedErrors, 'field');
-        //
-        //         const latestErrorMsg = difference?.[0];
-        //
-        //         if (latestErrorMsg) {
-        //             // Use the error code to look up whether error is actually a blur based one (most are but some SF ones aren't)
-        //             const isBlurBasedError = lookupBlurBasedErrors(latestErrorMsg.errorCode);
-        //
-        //             /**
-        //              *  ONLY ADD BLUR BASED ERRORS TO THE ERROR PANEL - doing this step prevents the non-blur based errors from being read out twice
-        //              *  (once from the aria-live, error panel & once from the aria-describedby element)
-        //              */
-        //             const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
-        //             // console.log('### CardInput2::componentDidUpdate:: #2 (not validating) single error:: latestSRError', latestSRError);
-        //             setSRMessagesFromStrings(latestSRError);
-        //         } else {
-        //             // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
-        //             // console.log('### CardInput2::componentDidUpdate:: #3(not validating) clearing errors:: NO latestErrorMsg');
-        //             clearSRPanel();
-        //         }
-        //         break;
-        //     }
-        //     default:
-        //         break;
-        // }
 
         // Analytics
         if (currentErrorsSortedByLayout) {

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -10,20 +10,16 @@ import { BinLookupResponse } from '../../types';
 import { cardInputFormatters, cardInputValidationRules, getRuleByNameAndMode } from './validate';
 import CIExtensions from '../../../internal/SecuredFields/binLookup/extensions';
 import useForm from '../../../../utils/useForm';
-import { SetSRMessagesReturnObject, SortedErrorObject } from '../../../../core/Errors/types';
-import { handlePartialAddressMode, extractPropsForCardFields, extractPropsForSFP, getLayout, lookupBlurBasedErrors, mapFieldKey } from './utils';
-import { usePrevious } from '../../../../utils/hookUtils';
+import { SortedErrorObject } from '../../../../core/Errors/types';
+import { handlePartialAddressMode, extractPropsForCardFields, extractPropsForSFP, getLayout } from './utils';
 import Specifications from '../../../internal/Address/Specifications';
 import { StoredCardFieldsWrapper } from './components/StoredCardFieldsWrapper';
 import { CardFieldsWrapper } from './components/CardFieldsWrapper';
-import { getAddressHandler, getAutoJumpHandler, getFocusHandler, setFocusOnFirstField } from './handlers';
+import { getAddressHandler, getAutoJumpHandler, getFocusHandler } from './handlers';
 import { InstallmentsObj } from './components/Installments/Installments';
 import { TouchStartEventObj } from './components/types';
 import classNames from 'classnames';
 import { getPartialAddressValidationRules } from '../../../internal/Address/validate';
-import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../../core/Errors/constants';
-import useSRPanelContext from '../../../../core/Errors/useSRPanelContext';
-import { SetSRMessagesReturnFn } from '../../../../core/Errors/SRPanelProvider';
 import useImage from '../../../../core/Context/useImage';
 import { getArrayDifferences } from '../../../../utils/arrayUtils';
 import FormInstruction from '../../../internal/FormInstruction';
@@ -31,6 +27,7 @@ import { AddressData } from '../../../../types/global-types';
 import { CbObjOnFocus } from '../../../internal/SecuredFields/lib/types';
 import { FieldErrorAnalyticsObject } from '../../../../core/Analytics/types';
 import { PREFIX } from '../../../internal/Icon/constants';
+import useSRPanelForCardInputErrors from './useSRPanelForCardInputErrors';
 
 const CardInput = (props: CardInputProps) => {
     const sfp = useRef(null);
@@ -38,12 +35,12 @@ const CardInput = (props: CardInputProps) => {
     const getImage = useImage();
 
     /** SR stuff */
-    const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
-
-    // Generate a setSRMessages function - implemented as a partial, since the initial set of arguments don't change.
-    const setSRMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({
-        fieldTypeMappingFn: mapFieldKey
-    });
+    // const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
+    //
+    // // Generate a setSRMessages function - implemented as a partial, since the initial set of arguments don't change.
+    // const setSRMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({
+    //     fieldTypeMappingFn: mapFieldKey
+    // });
     /** end SR stuff */
 
     const billingAddressRef = useRef(null);
@@ -341,7 +338,22 @@ const CardInput = (props: CardInputProps) => {
     }, [formData, formValid, formErrors]);
 
     // Get the previous value
-    const previousSortedErrors = usePrevious(sortedErrorList);
+    // const previousSortedErrors = usePrevious(sortedErrorList);
+
+    const {
+        sortedErrorList: currentErrorsSortedByLayout,
+        previousSortedErrors,
+        clearSRPanel
+    } = useSRPanelForCardInputErrors({
+        errors,
+        // data,
+        props,
+        isValidating,
+        retrieveLayout,
+        specifications,
+        billingAddress,
+        sfp
+    });
 
     /**
      * Main 'componentDidUpdate' handler
@@ -362,63 +374,63 @@ const CardInput = (props: CardInputProps) => {
         const mergedErrors = { ...errors, ...sfStateErrorsObj }; // maps sfErrors AND solves race condition problems for sfp from showValidation
 
         // Extract and then flatten billingAddress errors into a new object with *all* the field errors at top level
-        const { billingAddress: extractedAddressErrors, ...errorsWithoutAddress } = mergedErrors;
-
-        const errorsForPanel = { ...errorsWithoutAddress, ...extractedAddressErrors };
-
-        // Pass dynamic props (errors, layout etc) to SRPanel via partial
-        const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
-            errors: errorsForPanel,
-            isValidating: isValidating.current,
-            layout: retrieveLayout(),
-            // If we don't have country specific address labels, we might have a label related to a partialAddressSchema (i.e. zipCode)
-            countrySpecificLabels: specifications.getAddressLabelsForCountry(billingAddress?.country) ?? partialAddressSchema?.default?.labels
-        });
-
-        /**
-         * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
-         */
-        const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
-
-        // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
-        setSortedErrorList(currentErrorsSortedByLayout);
-
-        switch (srPanelResp?.action) {
-            // A call to focus the first field in error will always follow the call to validate the whole form
-            case ERROR_ACTION_FOCUS_FIELD:
-                if (shouldMoveFocusSR) setFocusOnFirstField(isValidating.current, sfp, srPanelResp?.fieldToFocus);
-                // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
-                setTimeout(() => {
-                    isValidating.current = false;
-                }, 300);
-                break;
-            /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
-            case ERROR_ACTION_BLUR_SCENARIO: {
-                const difference = getArrayDifferences<SortedErrorObject, string>(currentErrorsSortedByLayout, previousSortedErrors, 'field');
-
-                const latestErrorMsg = difference?.[0];
-
-                if (latestErrorMsg) {
-                    // Use the error code to look up whether error is actually a blur based one (most are but some SF ones aren't)
-                    const isBlurBasedError = lookupBlurBasedErrors(latestErrorMsg.errorCode);
-
-                    /**
-                     *  ONLY ADD BLUR BASED ERRORS TO THE ERROR PANEL - doing this step prevents the non-blur based errors from being read out twice
-                     *  (once from the aria-live, error panel & once from the aria-describedby element)
-                     */
-                    const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
-                    // console.log('### CardInput2::componentDidUpdate:: #2 (not validating) single error:: latestSRError', latestSRError);
-                    setSRMessagesFromStrings(latestSRError);
-                } else {
-                    // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
-                    // console.log('### CardInput2::componentDidUpdate:: #3(not validating) clearing errors:: NO latestErrorMsg');
-                    clearSRPanel();
-                }
-                break;
-            }
-            default:
-                break;
-        }
+        // const { billingAddress: extractedAddressErrors, ...errorsWithoutAddress } = mergedErrors;
+        //
+        // const errorsForPanel = { ...errorsWithoutAddress, ...extractedAddressErrors };
+        //
+        // // Pass dynamic props (errors, layout etc) to SRPanel via partial
+        // const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
+        //     errors: errorsForPanel,
+        //     isValidating: isValidating.current,
+        //     layout: retrieveLayout(),
+        //     // If we don't have country specific address labels, we might have a label related to a partialAddressSchema (i.e. zipCode)
+        //     countrySpecificLabels: specifications.getAddressLabelsForCountry(billingAddress?.country) ?? partialAddressSchema?.default?.labels
+        // });
+        //
+        // /**
+        //  * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
+        //  */
+        // const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
+        //
+        // // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
+        // setSortedErrorList(currentErrorsSortedByLayout);
+        //
+        // switch (srPanelResp?.action) {
+        //     // A call to focus the first field in error will always follow the call to validate the whole form
+        //     case ERROR_ACTION_FOCUS_FIELD:
+        //         if (shouldMoveFocusSR) setFocusOnFirstField(isValidating.current, sfp, srPanelResp?.fieldToFocus);
+        //         // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
+        //         setTimeout(() => {
+        //             isValidating.current = false;
+        //         }, 300);
+        //         break;
+        //     /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
+        //     case ERROR_ACTION_BLUR_SCENARIO: {
+        //         const difference = getArrayDifferences<SortedErrorObject, string>(currentErrorsSortedByLayout, previousSortedErrors, 'field');
+        //
+        //         const latestErrorMsg = difference?.[0];
+        //
+        //         if (latestErrorMsg) {
+        //             // Use the error code to look up whether error is actually a blur based one (most are but some SF ones aren't)
+        //             const isBlurBasedError = lookupBlurBasedErrors(latestErrorMsg.errorCode);
+        //
+        //             /**
+        //              *  ONLY ADD BLUR BASED ERRORS TO THE ERROR PANEL - doing this step prevents the non-blur based errors from being read out twice
+        //              *  (once from the aria-live, error panel & once from the aria-describedby element)
+        //              */
+        //             const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
+        //             // console.log('### CardInput2::componentDidUpdate:: #2 (not validating) single error:: latestSRError', latestSRError);
+        //             setSRMessagesFromStrings(latestSRError);
+        //         } else {
+        //             // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
+        //             // console.log('### CardInput2::componentDidUpdate:: #3(not validating) clearing errors:: NO latestErrorMsg');
+        //             clearSRPanel();
+        //         }
+        //         break;
+        //     }
+        //     default:
+        //         break;
+        // }
 
         // Analytics
         if (currentErrorsSortedByLayout) {

--- a/packages/lib/src/components/Card/components/CardInput/useSRPanelForCardInputErrors.ts
+++ b/packages/lib/src/components/Card/components/CardInput/useSRPanelForCardInputErrors.ts
@@ -28,62 +28,66 @@ const useSRPanelForCardInputErrors = ({ errors, props, isValidating, retrieveLay
     const mergedErrors = { ...errors, ...sfStateErrorsObj };
 
     useEffect(() => {
-        // Extract and then flatten billingAddress errors into a new object with *all* the field errors at top level
-        const { billingAddress: extractedAddressErrors, ...errorsWithoutAddress } = mergedErrors;
+        try {
+            // Extract and then flatten billingAddress errors into a new object with *all* the field errors at top level
+            const { billingAddress: extractedAddressErrors, ...errorsWithoutAddress } = mergedErrors;
 
-        const errorsForPanel = { ...errorsWithoutAddress, ...extractedAddressErrors };
+            const errorsForPanel = { ...errorsWithoutAddress, ...extractedAddressErrors };
 
-        // Pass dynamic props (errors, layout etc) to SRPanel via partial
-        const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
-            errors: errorsForPanel,
-            isValidating: isValidating.current,
-            layout: retrieveLayout(),
-            // If we don't have country specific address labels, we might have a label related to a partialAddressSchema (i.e. zipCode)
-            countrySpecificLabels: specifications.getAddressLabelsForCountry(billingAddress?.country) ?? partialAddressSchema?.default?.labels
-        });
+            // Pass dynamic props (errors, layout etc) to SRPanel via partial
+            const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
+                errors: errorsForPanel,
+                isValidating: isValidating.current,
+                layout: retrieveLayout(),
+                // If we don't have country specific address labels, we might have a label related to a partialAddressSchema (i.e. zipCode)
+                countrySpecificLabels: specifications.getAddressLabelsForCountry(billingAddress?.country) ?? partialAddressSchema?.default?.labels
+            });
 
-        // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
-        const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
-        setSortedErrorList(currentErrorsSortedByLayout);
+            // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
+            const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
+            setSortedErrorList(currentErrorsSortedByLayout);
 
-        /**
-         * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
-         */
-        switch (srPanelResp?.action) {
-            // A call to focus the first field in error will always follow the call to validate the whole form
-            case ERROR_ACTION_FOCUS_FIELD:
-                if (shouldMoveFocusSR) setFocusOnFirstField(isValidating.current, sfp, srPanelResp?.fieldToFocus);
-                // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
-                setTimeout(() => {
-                    isValidating.current = false;
-                }, 300);
-                break;
-            /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
-            case ERROR_ACTION_BLUR_SCENARIO: {
-                const difference = getArrayDifferences<SortedErrorObject, string>(currentErrorsSortedByLayout, previousSortedErrors, 'field');
+            /**
+             * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
+             */
+            switch (srPanelResp?.action) {
+                // A call to focus the first field in error will always follow the call to validate the whole form
+                case ERROR_ACTION_FOCUS_FIELD:
+                    if (shouldMoveFocusSR) setFocusOnFirstField(isValidating.current, sfp, srPanelResp?.fieldToFocus);
+                    // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
+                    setTimeout(() => {
+                        isValidating.current = false;
+                    }, 300);
+                    break;
+                /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
+                case ERROR_ACTION_BLUR_SCENARIO: {
+                    const difference = getArrayDifferences<SortedErrorObject, string>(currentErrorsSortedByLayout, previousSortedErrors, 'field');
 
-                const latestErrorMsg = difference?.[0];
+                    const latestErrorMsg = difference?.[0];
 
-                if (latestErrorMsg) {
-                    // Use the error code to look up whether error is actually a blur based one (most are but some SF ones aren't)
-                    const isBlurBasedError = lookupBlurBasedErrors(latestErrorMsg.errorCode);
+                    if (latestErrorMsg) {
+                        // Use the error code to look up whether error is actually a blur based one (most are but some SF ones aren't)
+                        const isBlurBasedError = lookupBlurBasedErrors(latestErrorMsg.errorCode);
 
-                    /**
-                     *  ONLY ADD BLUR BASED ERRORS TO THE ERROR PANEL - doing this step prevents the non-blur based errors from being read out twice
-                     *  (once from the aria-live, error panel & once from the aria-describedby element)
-                     */
-                    const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
-                    // console.log('### CardInput2::componentDidUpdate:: #2 (not validating) single error:: latestSRError', latestSRError);
-                    setSRMessagesFromStrings(latestSRError);
-                } else {
-                    // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
-                    // console.log('### CardInput2::componentDidUpdate:: #3(not validating) clearing errors:: NO latestErrorMsg');
-                    clearSRPanel();
+                        /**
+                         *  ONLY ADD BLUR BASED ERRORS TO THE ERROR PANEL - doing this step prevents the non-blur based errors from being read out twice
+                         *  (once from the aria-live, error panel & once from the aria-describedby element)
+                         */
+                        const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
+                        // console.log('### CardInput2::componentDidUpdate:: #2 (not validating) single error:: latestSRError', latestSRError);
+                        setSRMessagesFromStrings(latestSRError);
+                    } else {
+                        // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
+                        // console.log('### CardInput2::componentDidUpdate:: #3(not validating) clearing errors:: NO latestErrorMsg');
+                        clearSRPanel();
+                    }
+                    break;
                 }
-                break;
+                default:
+                    break;
             }
-            default:
-                break;
+        } catch (_) {
+            // We don't handle the error related to the sr panel, let it fail silently.
         }
     }, [errors]);
 

--- a/packages/lib/src/components/Card/components/CardInput/useSRPanelForCardInputErrors.ts
+++ b/packages/lib/src/components/Card/components/CardInput/useSRPanelForCardInputErrors.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'preact/hooks';
+import useSRPanelContext from '../../../../core/Errors/useSRPanelContext';
+import { SetSRMessagesReturnFn } from '../../../../core/Errors/SRPanelProvider';
+import { handlePartialAddressMode, lookupBlurBasedErrors, mapFieldKey } from './utils';
+import { usePrevious } from '../../../../utils/hookUtils';
+import { SetSRMessagesReturnObject, SortedErrorObject } from '../../../../core/Errors/types';
+import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../../core/Errors/constants';
+import { setFocusOnFirstField } from './handlers';
+import { getArrayDifferences } from '../../../../utils/arrayUtils';
+
+const useSRPanelForCardInputErrors = ({ errors, props, isValidating, retrieveLayout, specifications, billingAddress, sfp }) => {
+    //
+    /** SR stuff */
+    const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
+
+    // Generate a setSRMessages function - implemented as a partial, since the initial set of arguments don't change.
+    const setSRMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({
+        fieldTypeMappingFn: mapFieldKey
+    });
+    /** end SR stuff */
+
+    const partialAddressSchema = handlePartialAddressMode(props.billingAddressMode);
+
+    const [sortedErrorList, setSortedErrorList] = useState<SortedErrorObject[]>(null);
+
+    // Get the previous value
+    const previousSortedErrors = usePrevious(sortedErrorList);
+
+    const sfStateErrorsObj = sfp.current?.mapErrorsToValidationRuleResult();
+    const mergedErrors = { ...errors, ...sfStateErrorsObj };
+
+    //
+    useEffect(() => {
+        // Extract and then flatten billingAddress errors into a new object with *all* the field errors at top level
+        const { billingAddress: extractedAddressErrors, ...errorsWithoutAddress } = mergedErrors;
+
+        const errorsForPanel = { ...errorsWithoutAddress, ...extractedAddressErrors };
+
+        // Pass dynamic props (errors, layout etc) to SRPanel via partial
+        const srPanelResp: SetSRMessagesReturnObject = setSRMessages?.({
+            errors: errorsForPanel,
+            isValidating: isValidating.current,
+            layout: retrieveLayout(),
+            // If we don't have country specific address labels, we might have a label related to a partialAddressSchema (i.e. zipCode)
+            countrySpecificLabels: specifications.getAddressLabelsForCountry(billingAddress?.country) ?? partialAddressSchema?.default?.labels
+        });
+
+        /**
+         * Need extra actions after setting SRPanel messages in order to focus field (if required) and because we have some errors that are fired onBlur
+         */
+        const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
+
+        // Store the array of sorted error objects separately so that we can use it to make comparisons between the old and new arrays
+        setSortedErrorList(currentErrorsSortedByLayout);
+
+        switch (srPanelResp?.action) {
+            // A call to focus the first field in error will always follow the call to validate the whole form
+            case ERROR_ACTION_FOCUS_FIELD:
+                if (shouldMoveFocusSR) setFocusOnFirstField(isValidating.current, sfp, srPanelResp?.fieldToFocus);
+                // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
+                setTimeout(() => {
+                    isValidating.current = false;
+                }, 300);
+                break;
+            /** On blur scenario: not validating, i.e. trying to submit form, but there might be an error, either to set or to clear */
+            case ERROR_ACTION_BLUR_SCENARIO: {
+                const difference = getArrayDifferences<SortedErrorObject, string>(currentErrorsSortedByLayout, previousSortedErrors, 'field');
+
+                const latestErrorMsg = difference?.[0];
+
+                if (latestErrorMsg) {
+                    // Use the error code to look up whether error is actually a blur based one (most are but some SF ones aren't)
+                    const isBlurBasedError = lookupBlurBasedErrors(latestErrorMsg.errorCode);
+
+                    /**
+                     *  ONLY ADD BLUR BASED ERRORS TO THE ERROR PANEL - doing this step prevents the non-blur based errors from being read out twice
+                     *  (once from the aria-live, error panel & once from the aria-describedby element)
+                     */
+                    const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
+                    // console.log('### CardInput2::componentDidUpdate:: #2 (not validating) single error:: latestSRError', latestSRError);
+                    setSRMessagesFromStrings(latestSRError);
+                } else {
+                    // called when previousSortedErrors.length >= currentErrorsSortedByLayout.length
+                    // console.log('### CardInput2::componentDidUpdate:: #3(not validating) clearing errors:: NO latestErrorMsg');
+                    clearSRPanel();
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }, [errors]);
+
+    return { sortedErrorList, previousSortedErrors, clearSRPanel };
+};
+
+export default useSRPanelForCardInputErrors;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Similar to how `OpenInvoice' works, the `CardInput` component now uses a custom hook for setting and clear errors in the `SRPanel`

## Tested scenarios
All tests pass

