### PR TITLE
[V6] fix pm details not hidden

### DIFF
--- a/packages/lib/src/components/Dropin/components/DropinComponent.scss
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.scss
@@ -72,10 +72,12 @@
     display: grid;
     grid-template-rows: 0fr;
     transition: grid-template-rows 250ms ease;
+    visibility: hidden;
 }
 
 .adyen-checkout-pm-details-wrapper[aria-hidden='false'] {
     grid-template-rows: 1fr;
+    visibility: visible;
 
     .adyen-checkout__payment-method__details{
         overflow: visible;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Okay found the issue, comes form the new dropin expanding animations CSS (which is very clever). 

Unfortunately aria-hidden is a bit tricky and doesn't actually hide things in terms of focus, just a11y tree.

Had to experiment with a few fixes to not break the animation but I think adding visibility: none does the trick in the most simple and clean way.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
