### PR TITLE
v6 correctly remove stored pm from the UI

### DIFF
--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -82,7 +82,9 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
 
         new Promise((resolve, reject) => this.props.onDisableStoredPaymentMethod(storedPaymentMethod.props.storedPaymentMethodId, resolve, reject))
             .then(() => {
-                this.setState(prevState => ({ elements: prevState.elements.filter(pm => pm._id !== storedPaymentMethod._id) }));
+                this.setState(prevState => ({
+                    storedPaymentElements: prevState.storedPaymentElements.filter(pm => pm._id !== storedPaymentMethod._id)
+                }));
                 this.setState({ isDisabling: false });
             })
             .catch(() => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In `handleDisableStoredPaymentMethod ` in the `DropinComponent` we were searching the wrong array of elements when looking for a storedPM that we've been instructed to remove

## Tested scenarios
A storedPM is now found and removed from the UI

