### PR TITLE
Bumping sf version to 5.2.1

### DIFF
--- a/packages/e2e-playwright/models/redirect.ts
+++ b/packages/e2e-playwright/models/redirect.ts
@@ -29,7 +29,7 @@ class Redirect {
 
         this.selectYourBankButton = page.getByRole('button', { name: SELECT_YOUR_BANK });
 
-        this.selectTestBankButton = page.getByRole('button', { name: TEST_BANK_NAME });
+        this.selectTestBankButton = page.getByText(TEST_BANK_NAME);
 
         this.simulateSuccessButton = page.getByRole('button', { name: SIMULATION_TYPE_SUCCESS });
         this.simulateFailureButton = page.getByRole('button', { name: SIMULATION_TYPE_FAILURE });

--- a/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
@@ -17,7 +17,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '5.2.0';
+export const SF_VERSION = '5.2.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Bumped sf version to 5.2.1 - so now Enter key presses in securedFields always force validation/submit

Also fixed playwright redirect.spec.ts after third party change to the markup in the redirect page for iDEAL
