### PR TITLE
v6 - Fixing Card 'payButton' typescript type

### DIFF
--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -13,7 +13,7 @@ import ClickToPayWrapper from './components/ClickToPayWrapper';
 import { ComponentFocusObject } from '../../types/global-types';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import { TxVariants } from '../tx-variants';
-import { type PayButtonFunctionProps, UIElementStatus } from '../internal/UIElement/types';
+import type { PayButtonFunctionProps, UIElementStatus } from '../internal/UIElement/types';
 import UIElement from '../internal/UIElement';
 import PayButton from '../internal/PayButton';
 import type { ICore } from '../../core/types';

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -13,10 +13,9 @@ import ClickToPayWrapper from './components/ClickToPayWrapper';
 import { ComponentFocusObject } from '../../types/global-types';
 import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 import { TxVariants } from '../tx-variants';
-import { UIElementStatus } from '../internal/UIElement/types';
+import { type PayButtonFunctionProps, UIElementStatus } from '../internal/UIElement/types';
 import UIElement from '../internal/UIElement';
 import PayButton from '../internal/PayButton';
-import { PayButtonProps } from '../internal/PayButton/PayButton';
 import type { ICore } from '../../core/types';
 import {
     ANALYTICS_FOCUS_STR,
@@ -70,7 +69,7 @@ export class CardElement extends UIElement<CardConfiguration> {
         this.clickToPayRef = ref;
     };
 
-    formatProps(props: CardConfiguration) {
+    formatProps(props: CardConfiguration): CardConfiguration {
         // The value from a session should be used, before falling back to the merchant configuration
         const enableStoreDetails = props.session?.configuration?.enableStoreDetails ?? props.enableStoreDetails;
 
@@ -324,8 +323,7 @@ export class CardElement extends UIElement<CardConfiguration> {
         return collectBrowserInfo();
     }
 
-    // Override
-    protected payButton = (props: PayButtonProps) => {
+    protected override payButton = (props: PayButtonFunctionProps) => {
         const isZeroAuth = this.props.amount?.value === 0;
         const isStoredCard = this.props.storedPaymentMethodId?.length > 0;
         return (


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Card component overrides UIElement `payButton` function but it wasn't using the same Typescript types. The Angular setup complains about it and does not let the project build, forcing the dev to use @ts-ignore