### PR TITLE
[v6] fixes pm list markup removing ul for div

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -84,8 +84,8 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         const showBrands = !paymentMethod.props.oneClick && paymentMethod.brands && paymentMethod.brands.length > 0;
 
         return (
-            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
-            <li key={paymentMethod._id} className={paymentMethodClassnames} onClick={this.handleOnListItemClick}>
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+            <div key={paymentMethod._id} className={paymentMethodClassnames} onClick={this.handleOnListItemClick}>
                 <div className="adyen-checkout__payment-method__header">
                     <ExpandButton buttonId={buttonId} showRadioButton={showRadioButton} isSelected={isSelected} expandContentId={containerId}>
                         <PaymentMethodIcon
@@ -137,7 +137,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
                         <PaymentMethodDetails paymentMethodComponent={paymentMethod.render()} isLoaded={isLoaded} />
                     </div>
                 </div>
-            </li>
+            </div>
         );
     }
 }

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
@@ -51,8 +51,7 @@ function PaymentMethodsContainer({
                     {label}
                 </label>
             )}
-            {/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */}
-            <ul
+            <div
                 id={selectListId}
                 className={paymentMethodListClassnames}
                 role="radiogroup"
@@ -84,7 +83,7 @@ function PaymentMethodsContainer({
                         />
                     );
                 })}
-            </ul>
+            </div>
         </div>
     );
 }

--- a/packages/lib/src/core/core.misc.test.ts
+++ b/packages/lib/src/core/core.misc.test.ts
@@ -69,12 +69,13 @@ test('should render payButton', async () => {
     render(dropinElement.render());
 
     // get all possible payment method selector buttons
-    const paymentMethodListItemArray = await screen.findAllByRole('listitem');
+    const paymentMethodListItemArray = await screen.findAllByRole('radio');
 
     // go trough and select each element in the dropin, check if it has payButton
     for (const paymentMethodListItem of paymentMethodListItemArray) {
         paymentMethodListItem.click();
-        expect(await within(paymentMethodListItem).findAllByRole('button')).toHaveLength(1);
+        // eslint-disable-next-line testing-library/no-node-access
+        expect(await within(paymentMethodListItem.parentElement.parentElement).findAllByRole('button')).toHaveLength(1);
     }
 });
 
@@ -83,12 +84,13 @@ test('should NOT render payButton', async () => {
     render(dropinElement.render());
 
     // get all possible payment method selector buttons
-    const paymentMethodListItemArray = await screen.findAllByRole('listitem');
+    const paymentMethodListItemArray = await screen.findAllByRole('radio');
 
     // go trough and select each element in the dropin, check if it has payButton
     for (const paymentMethodListItem of paymentMethodListItemArray) {
         paymentMethodListItem.click();
-        const element = within(paymentMethodListItem).queryByRole('button');
+        // eslint-disable-next-line testing-library/no-node-access
+        const element = within(paymentMethodListItem.parentElement.parentElement).queryByRole('button');
         // @ts-ignore toBeInDocument
         expect(element).not.toBeInTheDocument();
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Changes the payment method list from `ul` > `li` markup to non semantic `div` with `role=radiogroup` and buttons `role=radio`. 

The order payment method list stays the same as there's no interaction.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
