### PR TITLE
[V6] Fix onOrderCancel in generic options

### DIFF
--- a/packages/lib/src/core/config.ts
+++ b/packages/lib/src/core/config.ts
@@ -30,6 +30,7 @@ export const GENERIC_OPTIONS = [
     'onEnterKeyPressed',
     'onError',
     'onBalanceCheck',
+    'onOrderCancel',
     'onOrderRequest',
     'onOrderUpdated',
     'onPaymentMethodsRequest'


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Fix so `onOrderCancel` can be passed as part of core configs like the rest of the order callbacks. 

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
