### PR TITLE
fix husky

### DIFF
--- a/packages/lib/.husky/pre-commit
+++ b/packages/lib/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-#. "$(dirname "$0")/_/husky.sh"
-
 # helper if you are running repo inside a container
 if which vagrant; then
   vagrant ssh -- -t <<HEREDOC

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -74,7 +74,7 @@
     "lint:fix": "npm run lint -- --fix",
     "prettier:fix": "prettier \"src/**/*.{js,ts,tsx}\" \"package.json\" --write --loglevel silent",
     "prepublishOnly": "npm run build",
-    "prepare": "cd ../.. && husky install packages/lib/.husky",
+    "prepare": "cd ../.. && husky packages/lib/.husky",
     "size": "npm run build && size-limit"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Seems like husky (precommit hooks) was broken on since v6 since we moved from `husky` v8 to v9. 
This was causing that lint-staged didn't run, so no `eslint`, `styleint` or `prettier`.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
