### PR TITLE
Always make analytics /setup call

### DIFF
--- a/.changeset/weak-kings-guess.md
+++ b/.changeset/weak-kings-guess.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Always make the analytics /setup call. Only use the "enabled" boolean to control the sending of subsequent events.

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -62,11 +62,11 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
          * @param initialEvent -
          */
         setUp: async (initialEvent: AnalyticsInitialEvent) => {
-            const { enabled, payload } = props; // TODO what is payload, is it ever used?
+            const { payload } = props; // TODO what is payload, is it ever used?
 
             const analyticsData = processAnalyticsData(props.analyticsData);
 
-            if (enabled === true && !capturedCheckoutAttemptId) {
+            if (!capturedCheckoutAttemptId) {
                 try {
                     const checkoutAttemptId = await collectId({
                         ...initialEvent,
@@ -86,6 +86,8 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
         getEventsQueue: () => eventsQueue,
 
         createAnalyticsEvent: ({ event, data }: CreateAnalyticsEventObject): AnalyticsObject => {
+            if (!props.enabled) return;
+
             const aObj: AnalyticsObject = createAnalyticsObject({
                 event,
                 ...data
@@ -102,7 +104,7 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
         sendAnalytics: null
     };
 
-    anlModule.sendAnalytics = analyticsPreProcessor(anlModule);
+    anlModule.sendAnalytics = props.enabled === true ? analyticsPreProcessor(anlModule) : () => {};
 
     return anlModule;
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently we do not send the initial setup call on the SDK side if merchants disable analytics.
This is reducing our visibility on merchant integrations.

So now we will always make the initial setup call - as this call is really just about the SDK usage and does not track any shopper interactions.
We now only use the merchant setting `analytics.enabled = false` to prevent subsequent `info`, `log` and `error` analytics events

## Tested scenarios
Adjusted unit tests accordingly

Relates to issue: COWEB-1412
