### PR TITLE
Analytics config data dropin

### DIFF
--- a/.changeset/dirty-spiders-travel.md
+++ b/.changeset/dirty-spiders-travel.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Send certain analytic config data for the `Dropin`. Modify some analytic config data for the `Card`.

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -36,12 +36,22 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                 this.setState({ instantPaymentElements, elements, storedPaymentElements, orderStatus });
                 this.setStatus('ready');
 
-                this.props.modules?.analytics.sendAnalytics('dropin', { type: ANALYTICS_RENDERED_STR });
+                this.props.modules?.analytics.sendAnalytics('dropin', {
+                    type: ANALYTICS_RENDERED_STR,
+                    configData: this.analyticConfigData
+                });
             }
         );
 
         this.onOrderCancel = this.getOnOrderCancel();
     };
+
+    get analyticConfigData() {
+        return {
+            openFirstStoredPaymentMethod: this.props.openFirstStoredPaymentMethod,
+            showStoredPaymentMethods: this.props.showStoredPaymentMethods
+        };
+    }
 
     public setStatus = (status: UIElementStatus, props: DropinStatusProps = {}) => {
         this.setState({ status: { type: status, props } });

--- a/packages/lib/src/core/Analytics/Analytics.utils.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.utils.test.ts
@@ -43,12 +43,12 @@ describe('Testing creating a configData object for the Card components', () => {
         const ANALYTICS_DATA_PROP = 'billingAddressAllowedCountries';
         const CARD_CONFIG_PROP = ANALYTICS_DATA_PROP;
 
-        test('Expect the prop, when not specifically set, to equal the default (as a JSON string)', () => {
+        test('Expect the prop, when not specifically set, to equal undefined', () => {
             const configData = getCardConfigData(defaultCardProps);
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual('');
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual(undefined);
         });
 
-        test('Expect the prop, passed as an array, to equal that array (as a JSON string)', () => {
+        test('Expect the prop, passed as an array, to equal comma seperated string', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['US', 'PR'] });
             expect(configData[ANALYTICS_DATA_PROP]).toEqual('US,PR');
         });
@@ -127,12 +127,12 @@ describe('Testing creating a configData object for the Card components', () => {
         const ANALYTICS_DATA_PROP = 'billingAddressRequiredFields';
         const CARD_CONFIG_PROP = ANALYTICS_DATA_PROP;
 
-        test('Expect the prop, when not specifically set, to equal the default (as a JSON string)', () => {
+        test('Expect the prop, when not specifically set, to equal the default (as a comma seperated string)', () => {
             const configData = getCardConfigData(defaultCardProps);
             expect(configData[ANALYTICS_DATA_PROP]).toEqual(CardDefaultProps[CARD_CONFIG_PROP].toString());
         });
 
-        test('Expect the prop, passed as an array, to equal that array (as a JSON string)', () => {
+        test('Expect the prop, passed as an array, to equal that array (as a comma seperated string)', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['postalCode', 'country'] });
             expect(configData[ANALYTICS_DATA_PROP]).toEqual('postalCode,country');
         });
@@ -145,17 +145,17 @@ describe('Testing creating a configData object for the Card components', () => {
         const ANALYTICS_DATA_PROP = 'brands';
         const CARD_CONFIG_PROP = ANALYTICS_DATA_PROP;
 
-        test('Expect the prop, when not specifically set, to equal the default (as a JSON string)', () => {
+        test('Expect the prop, when not specifically set, to equal the default (as a comma seperated string)', () => {
             const configData = getCardConfigData(defaultCardProps);
             expect(configData[ANALYTICS_DATA_PROP]).toEqual(DEFAULT_CARD_GROUP_TYPES.toString());
         });
 
-        test('Expect the prop, passed as an array, to equal that array (as a JSON string)', () => {
+        test('Expect the prop, passed as an array, to equal that array (as a comma seperated string)', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['mc', 'bcmc', 'uatp', 'visa'] });
             expect(configData[ANALYTICS_DATA_PROP]).toEqual(['mc', 'bcmc', 'uatp', 'visa'].toString());
         });
 
-        test('Expect the prop, passed as an array with one value, to equal that array (as a JSON string)', () => {
+        test('Expect the prop, passed as an array with one value, to equal that array (as a string)', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['mc'] });
             expect(configData[ANALYTICS_DATA_PROP]).toEqual('mc');
         });

--- a/packages/lib/src/core/Analytics/Analytics.utils.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.utils.test.ts
@@ -45,12 +45,12 @@ describe('Testing creating a configData object for the Card components', () => {
 
         test('Expect the prop, when not specifically set, to equal the default (as a JSON string)', () => {
             const configData = getCardConfigData(defaultCardProps);
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual(JSON.stringify(CardDefaultProps[CARD_CONFIG_PROP]));
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual('');
         });
 
         test('Expect the prop, passed as an array, to equal that array (as a JSON string)', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['US', 'PR'] });
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual(JSON.stringify(['US', 'PR']));
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual('US,PR');
         });
     });
 
@@ -129,12 +129,12 @@ describe('Testing creating a configData object for the Card components', () => {
 
         test('Expect the prop, when not specifically set, to equal the default (as a JSON string)', () => {
             const configData = getCardConfigData(defaultCardProps);
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual(JSON.stringify(CardDefaultProps[CARD_CONFIG_PROP]));
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual(CardDefaultProps[CARD_CONFIG_PROP].toString());
         });
 
         test('Expect the prop, passed as an array, to equal that array (as a JSON string)', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['postalCode', 'country'] });
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual(JSON.stringify(['postalCode', 'country']));
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual('postalCode,country');
         });
     });
 
@@ -147,17 +147,17 @@ describe('Testing creating a configData object for the Card components', () => {
 
         test('Expect the prop, when not specifically set, to equal the default (as a JSON string)', () => {
             const configData = getCardConfigData(defaultCardProps);
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual(JSON.stringify(DEFAULT_CARD_GROUP_TYPES));
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual(DEFAULT_CARD_GROUP_TYPES.toString());
         });
 
         test('Expect the prop, passed as an array, to equal that array (as a JSON string)', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['mc', 'bcmc', 'uatp', 'visa'] });
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual(JSON.stringify(['mc', 'bcmc', 'uatp', 'visa']));
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual(['mc', 'bcmc', 'uatp', 'visa'].toString());
         });
 
         test('Expect the prop, passed as an array with one value, to equal that array (as a JSON string)', () => {
             const configData = getCardConfigData({ ...defaultCardProps, [CARD_CONFIG_PROP]: ['mc'] });
-            expect(configData[ANALYTICS_DATA_PROP]).toEqual(JSON.stringify(['mc']));
+            expect(configData[ANALYTICS_DATA_PROP]).toEqual('mc');
         });
     });
 

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -37,7 +37,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             // Called from BaseElement (when component mounted) or, from DropinComponent (after mounting, when it has finished resolving all the PM promises)
             // &/or, from DropinComponent when a PM is selected
             case ANALYTICS_RENDERED_STR: {
-                const { isStoredPaymentMethod, brand } = analyticsObj;
+                const { isStoredPaymentMethod, brand, configData: originalConfigData } = analyticsObj;
 
                 // Expected from Wallet PMs
                 const { isExpress, expressPage } = uiElementProps;
@@ -59,7 +59,8 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                     ...(brand && { brand }),
                     ...(typeof isExpress === 'boolean' && { isExpress }),
                     ...(isExpress === true && hasExpressPage && { expressPage }), // We only care about the expressPage value if isExpress is true
-                    ...(configData && { configData })
+                    ...(configData && { configData }),
+                    ...(originalConfigData && { configData: originalConfigData })
                 };
 
                 analyticsModule.createAnalyticsEvent({

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -140,18 +140,18 @@ export const getCardConfigData = (cardProps: CardConfiguration): CardConfigData 
     }
 
     // Probably just for development - in real life we wouldn't expect the number of supported brands to push the endpoint limit on 128 chars
-    let brandsStr = JSON.stringify(brands);
+    let brandsStr = brands.toString();
     if (brandsStr.length > 128) {
-        brandsStr = brandsStr.substring(0, 124) + '...]';
+        brandsStr = brandsStr.substring(0, 124);
     }
 
     // @ts-ignore commenting out props until endpoint is ready
     const configData: CardConfigData = {
         autoFocus,
-        billingAddressAllowedCountries: JSON.stringify(billingAddressAllowedCountries),
+        billingAddressAllowedCountries: billingAddressAllowedCountries.toString(),
         billingAddressMode: billingAddressModeValue,
         billingAddressRequired,
-        billingAddressRequiredFields: JSON.stringify(billingAddressRequiredFields),
+        billingAddressRequiredFields: billingAddressRequiredFields.toString(),
         brands: brandsStr,
         challengeWindowSize,
         disableIOSArrowKeys,

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -144,11 +144,10 @@ export const getCardConfigData = (cardProps: CardConfiguration): CardConfigData 
     if (brandsStr.length > 128) {
         brandsStr = brandsStr.substring(0, 124);
     }
-
     // @ts-ignore commenting out props until endpoint is ready
     const configData: CardConfigData = {
         autoFocus,
-        billingAddressAllowedCountries: billingAddressAllowedCountries.toString(),
+        ...(billingAddressAllowedCountries?.length > 0 && { billingAddressAllowedCountries: billingAddressAllowedCountries.toString() }),
         billingAddressMode: billingAddressModeValue,
         billingAddressRequired,
         billingAddressRequiredFields: billingAddressRequiredFields.toString(),


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- For card config data, do not use `JSON.stringify` for `billingAddressAllowedCountries`, `billingAddressRequiredFields`, `brands`
- Omit the field `billingAddressAllowedCountries` when empty
- Send dropin config data: `openFirstStoredPaymentMethod` and `showStoredPaymentMethods` 

## Tested scenarios
Added unit test


**Fixed issue**:  COWEB-1406
