### PR TITLE
Show ANCV id in order item

### DIFF
--- a/.changeset/sour-forks-care.md
+++ b/.changeset/sour-forks-care.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Display ANCV ID while displaying used payment methods on Dropin

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -3,8 +3,16 @@ import PaymentMethodIcon from './PaymentMethodIcon';
 import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useImage from '../../../../core/Context/useImage';
 import './OrderPaymentMethods.scss';
+import { Order, OrderStatus } from '../../../../types';
 
-export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLogoConfiguration }) => {
+type OrderPaymentMethodsProps = {
+    order: Order;
+    orderStatus: OrderStatus;
+    onOrderCancel: (order) => void;
+    brandLogoConfiguration: any;
+};
+
+export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLogoConfiguration }: OrderPaymentMethodsProps) => {
     const { i18n } = useCoreContext();
     const getImage = useImage();
 
@@ -20,7 +28,7 @@ export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLo
                                     type={orderPaymentMethod.type}
                                     src={brandLogoConfiguration[orderPaymentMethod.type] || getImage()(orderPaymentMethod.type)}
                                 />
-                                •••• {orderPaymentMethod.lastFour}
+                                {orderPaymentMethod.label ? `${orderPaymentMethod.label}` : `•••• ${orderPaymentMethod.lastFour}`}
                             </div>
 
                             {onOrderCancel && (

--- a/packages/lib/src/types/global-types.ts
+++ b/packages/lib/src/types/global-types.ts
@@ -246,8 +246,10 @@ export interface OrderStatus {
     expiresAt: string;
     paymentMethods: {
         amount?: PaymentAmount;
-        lastFour: string;
+        lastFour?: string;
         type: string;
+        name?: string;
+        label?: string;
     }[];
     pspReference: string;
     reference: string;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

We need to distinguish multiple ANCV payment in the order. For this we are going to use generic `label` field that comes from the backend.

## Tested scenarios
<!-- Description of tested scenarios -->

- Created ANCV partial payment, it shows ANCV ID in Order Item

**Fixed issue**:  <!-- #-prefixed issue number -->
