### PR TITLE
Add missing currency information for Iceland and Bulgaria

### DIFF
--- a/.changeset/dirty-items-unite.md
+++ b/.changeset/dirty-items-unite.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Adding missing currency information for Iceland and Bulgaria

--- a/packages/lib/src/utils/constants/currency-decimals.ts
+++ b/packages/lib/src/utils/constants/currency-decimals.ts
@@ -10,6 +10,7 @@ const CURRENCY_DECIMALS = {
     GHC: 1,
     GNF: 1,
     KMF: 1,
+    ISK: 1,
     PYG: 1,
     RWF: 1,
     UGX: 1,

--- a/packages/lib/storybook/utils/get-currency.ts
+++ b/packages/lib/storybook/utils/get-currency.ts
@@ -1,6 +1,7 @@
 const currencies: Record<string, string> = {
     AR: 'ARS',
     AU: 'AUD',
+    BG: 'BGN',
     BR: 'BRL',
     CA: 'CAD',
     CH: 'CHF',
@@ -13,6 +14,7 @@ const currencies: Record<string, string> = {
     HU: 'HUN',
     ID: 'IDR',
     IN: 'INR',
+    IS: 'ISK',
     JP: 'JPY',
     KR: 'KRW',
     MG: 'MGA',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In v6 we added new locales: Iceland and Bulgaria.
This PR also adds the necessary currency information for these two, non-Euro, countries

## Tested scenarios
Manually tested in Chrome, Firefox  & Safari that currency is identified and formatted


