### PR TITLE
ci: trigger the release build automatically

### DIFF
--- a/.github/workflows/check-release-build.yml
+++ b/.github/workflows/check-release-build.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get commit message
         id: get_commit_message
-        run: echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+        run: echo "message=$(git log -1 --format=%s)" >> $GITHUB_OUTPUT
 
       - name: Check commit message
         id: check_commit_message

--- a/.github/workflows/check-release-build.yml
+++ b/.github/workflows/check-release-build.yml
@@ -1,0 +1,36 @@
+## If the latest commit message contains '[ci] release main', trigger release-build.yml
+name: Check Commit Message
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-commit-message:
+    runs-on: ubuntu-latest
+    outputs:
+      trigger_release: ${{ steps.check_commit_message.outputs.trigger_release }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get commit message
+        id: get_commit_message
+        run: echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+
+      - name: Check commit message
+        id: check_commit_message
+        run: |
+          if [[ "${{ steps.get_commit_message.outputs.message }}" == *"[ci] release main"* ]]; then
+            echo "Commit message contains '[ci] release main', triggering release build..."
+            echo "trigger_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "Commit message does not contain '[ci] release main', skipping release build..."
+            exit 1
+          fi
+
+  trigger-release-build:
+    needs: check-commit-message
+    if: needs.check-commit-message.outputs.trigger_release == 'true'
+    uses: ./.github/workflows/release-build.yml

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,6 +5,7 @@ name: Build UMD and Translations
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-umd-and-translations:
@@ -32,7 +33,3 @@ jobs:
         with:
           name: umd-and-translations
           path: packages/lib/dist/umd
-
-
-      
-


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Add `.github/workflows/check-release-build.yml` to check the latest commit message of `main`. If it contains '[ci] release main', trigger release-build.yml
