### PR TITLE
Fixes LT postal code

### DIFF
--- a/.changeset/late-kings-call.md
+++ b/.changeset/late-kings-call.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixes Lithuanian postal code to support 4-5 digits and LT prefix

--- a/packages/lib/src/components/internal/Address/validate.test.ts
+++ b/packages/lib/src/components/internal/Address/validate.test.ts
@@ -1,0 +1,140 @@
+import { validatePostalCode } from './validate';
+import { ValidatorRules } from '../../../utils/Validator/types';
+
+describe('validatePostalCode', () => {
+    const validatorRules: ValidatorRules = {
+        postalCode: {
+            modes: ['blur'],
+            validate: jest.fn(),
+            errorMessage: ''
+        }
+    };
+
+    // LT
+    it('should return true for a valid LT postal code without the LT prefix', () => {
+        const result = validatePostalCode('12345', 'LT', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return true for a valid LT postal code without the LT prefix (4-digits)', () => {
+        const result = validatePostalCode('1234', 'LT', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return true for a valid LT postal code with the LT prefix', () => {
+        const result = validatePostalCode('LT-12345', 'LT', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return false for a valid LT postal code with the LT prefix but only 4 digits', () => {
+        const result = validatePostalCode('LT-1235', 'LT', validatorRules);
+        expect(result).toBe(false);
+    });
+
+    it('should return false for an invalid LT postal code with fewer than 4 digits', () => {
+        const result = validatePostalCode('123', 'LT', validatorRules);
+        expect(result).toBe(false);
+    });
+
+    it('should return false for an invalid LT postal code with fewer than 6 digits', () => {
+        const result = validatePostalCode('1234567', 'LT', validatorRules);
+        expect(result).toBe(false);
+    });
+
+    // BR
+    it('should return true for a valid BR postal code with hyphen', () => {
+        const result = validatePostalCode('12345-678', 'BR', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return true for a valid BR postal code without hyphen', () => {
+        const result = validatePostalCode('12345678', 'BR', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return false for an invalid BR postal code', () => {
+        const result = validatePostalCode('1234-5678', 'BR', validatorRules);
+        expect(result).toBe(false);
+    });
+
+    // US and the ones using createPatternByDigits
+    it('should return true for a valid US postal code with 5 digits', () => {
+        const result = validatePostalCode('12345', 'US', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    // It fails because createPatternByDigits actually just check if there's at least X amount of digits
+    // it('should return false for an invalid US postal code with more than 5 digits without a hyphen', () => {
+    //     const result = validatePostalCode('1234567', 'US', validatorRules);
+    //     expect(result).toBe(false);
+    // });
+
+    // General
+    it('should return null if the postal code is empty', () => {
+        const result = validatePostalCode('', 'AT', validatorRules);
+        expect(result).toBeNull();
+    });
+
+    it('should return true for a valid AT postal code', () => {
+        const result = validatePostalCode('1234', 'AT', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    // PT
+    it('should return true for a valid PT postal code without hyphen', () => {
+        const result = validatePostalCode('1234567', 'PT', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return true for a valid PT postal code with hyphen', () => {
+        const result = validatePostalCode('1234-567', 'PT', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return false for an invalid PT postal code with incorrect format', () => {
+        const result = validatePostalCode('123-4567', 'PT', validatorRules);
+        expect(result).toBe(false);
+    });
+
+    // it('should return true for an PT postal code with just the part before the hyphen', () => {
+    //     const result = validatePostalCode('1234', 'PT', validatorRules);
+    //     expect(result).toBe(true);
+    // });
+
+    // NL
+    it('should return true for a valid NL postal code without NL prefix', () => {
+        const result = validatePostalCode('1234AB', 'NL', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return true for a valid NL postal code with space between digits and letters', () => {
+        const result = validatePostalCode('1234 AB', 'NL', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return true for a valid NL postal code with NL prefix', () => {
+        const result = validatePostalCode('NL-1234AB', 'NL', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return false for an invalid NL postal code with missing letters', () => {
+        const result = validatePostalCode('1234', 'NL', validatorRules);
+        expect(result).toBe(false);
+    });
+
+    // Againt it seems like it's missing begining and end ^ $ symbols in the regex (same as US)
+    // it('should return false for an invalid NL postal code with incorrect letter combination', () => {
+    //     const result = validatePostalCode('1234AA1', 'NL', validatorRules);
+    //     expect(result).toBe(false);
+    // });
+
+    it('should return false for an invalid NL postal code with fewer digits', () => {
+        const result = validatePostalCode('123AB', 'NL', validatorRules);
+        expect(result).toBe(false);
+    });
+
+    // it('should return false for an invalid NL postal code with too many digits', () => {
+    //     const result = validatePostalCode('12345AB', 'NL', validatorRules);
+    //     expect(result).toBe(false);
+    // });
+});

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -9,7 +9,7 @@ const createPatternByDigits = (digits: number) => {
     };
 };
 
-const validatePostalCode = (val: string, countryCode: string, validatorRules: ValidatorRules) => {
+export const validatePostalCode = (val: string, countryCode: string, validatorRules: ValidatorRules) => {
     if (countryCode) {
         // If there is no value, we display the 'required' error message
         if (isEmpty(val)) return null;
@@ -56,7 +56,7 @@ const postalCodePatterns = {
     IS: createPatternByDigits(3),
     IT: createPatternByDigits(5),
     LI: createPatternByDigits(4),
-    LT: { pattern: /^(LT-\d{5})$/ },
+    LT: { pattern: /^(LT-\d{5}|\d{4,5})$/ },
     LU: createPatternByDigits(4),
     LV: { pattern: /^(LV-)[0-9]{4}$/ },
     MC: { pattern: /^980\d{2}$/ },

--- a/packages/lib/storybook/helpers/checkout-handlers.ts
+++ b/packages/lib/storybook/helpers/checkout-handlers.ts
@@ -75,7 +75,7 @@ export async function handleResponse(response, component, checkout?, paymentData
 }
 
 export function handleChange(state: any, _component: UIElement) {
-    console.groupCollapsed(`onChange - ${state.data.paymentMethod.type}`);
+    console.groupCollapsed(`onChange - ${state.data.paymentMethod?.type}`);
     console.log('isValid', state.isValid);
     console.log('data', state.data);
     // @ts-ignore Logging internal prop

--- a/packages/lib/storybook/stories/internals/Address.stories.tsx
+++ b/packages/lib/storybook/stories/internals/Address.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta } from '@storybook/preact';
+import Address from '../../../src/components/internal/Address';
+import { getStoryContextCheckout } from '../../utils/get-story-context-checkout';
+import { Container } from '../Container';
+import AddressElement from '../../../src/components/Address/Address';
+
+const meta: Meta = {
+    title: 'Internals/Address',
+    component: Address,
+    argTypes: {
+        size: {
+            options: ['small', 'medium', 'large'],
+            control: { type: 'radio' }
+        }
+    },
+    args: {
+        size: 'large'
+    }
+};
+
+export const Default = {
+    render: (args, context) => {
+        const { componentConfiguration } = args;
+        const checkout = getStoryContextCheckout(context);
+        const address = new AddressElement(checkout, componentConfiguration);
+        return <Container element={address} />;
+    },
+    args: {
+        countryCode: 'NL',
+        amount: 2000,
+        useSessions: false
+    },
+    parameters: {
+        controls: { exclude: ['useSessions', 'countryCode', 'shopperLocale', 'amount', 'showPayButton'] }
+    }
+};
+
+export default meta;


### PR DESCRIPTION
## Summary

Makes postal code validation rules same as description. Also add AddressElement to Storybook.  Adds some test to validate.

### Discussion

As I was writing the test I decided to write some additional tests for some more countries, and quickly found out that are some scenarios that we might not be validating correctly (with the validator alone). 

It's okay because these scenarios get validated correctly at the end but I left the tests in there so we can maybe decide to fix this in the future.

Also for future reference there's [this giant list from the European Central Bank](https://www.ecb.europa.eu/stats/money/aggregates/anacredit/shared/pdf/List_postal_code_formatting_rules_and_regular_expressions.xlsx) that has a pretty comprehensive list of regex and validation rules.

## Tested scenarios
<!-- Description of tested scenarios -->

* Added tests
* Tested in storybook the LT-XXXX, XXXX, XXXXX variations.

**Fixed issue**:  <!-- #-prefixed issue number -->
#2362