### PR TITLE
ApplePaySession is not always available in Window

### DIFF
--- a/.changeset/swift-emus-complain.md
+++ b/.changeset/swift-emus-complain.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Change ApplePaySession type to optional in window interface

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -3,7 +3,7 @@ import { AddressData } from '../../types/global-types';
 
 declare global {
     interface Window {
-        ApplePaySession: ApplePaySession;
+        ApplePaySession?: ApplePaySession;
     }
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Since it's declared globally we can not expect ApplePaySession to always be available in the Window interface.