### PR TITLE
Fixes regression and allows Enter key to validate/submit

### DIFF
--- a/.changeset/cool-comics-own.md
+++ b/.changeset/cool-comics-own.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixes regression and allows Enter key to validate/submit

--- a/packages/e2e-playwright/tests/card/card.spec.ts
+++ b/packages/e2e-playwright/tests/card/card.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../pages/cards/card.fixture';
 import { REGULAR_TEST_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../utils/constants';
 import LANG from '../../../server/translations/en-US.json';
+import { pressEnter } from '../utils/keyboard';
 
 const PAN_ERROR_NOT_VALID = LANG['cc.num.902'];
 const PAN_ERROR_EMPTY = LANG['cc.num.900'];
@@ -45,6 +46,18 @@ test.describe('Card - Standard flow', () => {
         await card.typeCardNumber('4');
 
         await cardPage.pay();
+
+        await expect(card.cardNumberErrorElement).toBeVisible();
+        await expect(card.cardNumberErrorElement).toHaveText(PAN_ERROR_NOT_COMPLETE);
+    });
+
+    test('#5 Filling PAN then pressing Enter will trigger validation ', async ({ cardPage }) => {
+        const { card, page } = cardPage;
+
+        await card.isComponentVisible();
+        await card.typeCardNumber('4'); // get focus into card comp
+
+        await pressEnter(page);
 
         await expect(card.cardNumberErrorElement).toBeVisible();
         await expect(card.cardNumberErrorElement).toHaveText(PAN_ERROR_NOT_COMPLETE);

--- a/packages/e2e-playwright/tests/card/installments/card.installments.spec.ts
+++ b/packages/e2e-playwright/tests/card/installments/card.installments.spec.ts
@@ -72,7 +72,7 @@ test.describe('Cards (Installments)', () => {
         await card.installmentsDropdown.click();
         await pressKeyboardToNextItem(page);
         await pressKeyboardToNextItem(page);
-        // await pressKeyboardToSelectItem(page);
+        // await pressEnter(page);
 
         const listItem = await card.selectListItem('2');
         await listItem.click();

--- a/packages/e2e-playwright/tests/issuerList/issuer-list.spec.ts
+++ b/packages/e2e-playwright/tests/issuerList/issuer-list.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../pages/issuerList/issuer-list.fixture';
-import { pressKeyboardToNextItem, pressKeyboardToSelectItem } from '../utils/keyboard';
+import { pressKeyboardToNextItem, pressEnter } from '../utils/keyboard';
 
 test.describe('Issuer List', () => {
     test('it should be able to filter and select using the keyboard', async ({ issuerListPage }) => {
@@ -15,7 +15,7 @@ test.describe('Issuer List', () => {
 
         // select one of the filtered option
         await pressKeyboardToNextItem(page); // Arrow down
-        await pressKeyboardToSelectItem(page); // Enter key
+        await pressEnter(page); // Enter key
 
         await expect(issuerList.submitButton).toHaveText('Continue to Idea Cloud');
 
@@ -23,7 +23,7 @@ test.describe('Issuer List', () => {
         await pressKeyboardToNextItem(page);
         // 2nd selects next item
         await pressKeyboardToNextItem(page);
-        await pressKeyboardToSelectItem(page);
+        await pressEnter(page);
 
         await expect(issuerList.submitButton).toHaveText('Continue to mRaty');
     });
@@ -33,7 +33,7 @@ test.describe('Issuer List', () => {
 
         await issuerList.clickOnSelector();
         await issuerList.typeOnSelectorField('Nest');
-        await pressKeyboardToSelectItem(page);
+        await pressEnter(page);
 
         await expect(issuerList.submitButton).toHaveText('Continue to Nest Bank');
     });
@@ -44,7 +44,7 @@ test.describe('Issuer List', () => {
     //     // Open the drop down and select an item
     //     await issuerList.clickOnSelector();
     //     await pressKeyboardToNextItem(page); // Arrow down
-    //     await pressKeyboardToSelectItem(page); // Enter key
+    //     await pressEnter(page); // Enter key
 
     //     let issuerListData = await page.evaluate('window.dotpay.data');
 

--- a/packages/e2e-playwright/tests/utils/keyboard.ts
+++ b/packages/e2e-playwright/tests/utils/keyboard.ts
@@ -8,6 +8,6 @@ export const pressKeyboardToPreviousItem = async page => {
     await page.keyboard.press('ArrowUp', { delay: KEYBOARD_DELAY });
 };
 
-export const pressKeyboardToSelectItem = async page => {
+export const pressEnter = async page => {
     await page.keyboard.press('Enter', { delay: KEYBOARD_DELAY });
 };

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -57,7 +57,7 @@ export class CardElement extends UIElement<CardConfiguration> {
         _disableClickToPay: false,
         doBinLookup: true,
         // Merge most of CardInput's defaultProps
-        ...reject(['type', 'setComponentRef']).from(CardInputDefaultProps)
+        ...reject(['type', 'setComponentRef', 'onEnterKeyPressed']).from(CardInputDefaultProps)
     };
 
     public setStatus(status: UIElementStatus, props?): this {

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -188,7 +188,7 @@ export const getCardConfigData = (cardProps: CardConfiguration): CardConfigData 
         hasOnBlur: onBlur !== CardInputDefaultProps.onBlur,
         hasOnBrand: onBrand !== CardInputDefaultProps.onBrand,
         hasOnConfigSuccess: onConfigSuccess !== CardInputDefaultProps.onConfigSuccess,
-        hasOnEnterKeyPressed: onEnterKeyPressed !== CardInputDefaultProps.onEnterKeyPressed,
+        hasOnEnterKeyPressed: !!onEnterKeyPressed,
         hasOnFieldValid: onFieldValid !== CardInputDefaultProps.onFieldValid,
         hasOnFocus: onFocus !== CardInputDefaultProps.onFocus,
         hasOnLoad: onLoad !== CardInputDefaultProps.onLoad


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixes regression caused by #2750 and allows Enter key once again to trigger validation or submission on the Card component

## Tested scenarios
Added new e2e test


**Relates to issue**:  #2750
