### PR TITLE
Always make call to analytics setup endpoint

### DIFF
--- a/.changeset/stale-toys-smash.md
+++ b/.changeset/stale-toys-smash.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Always make call to analytics setup endpoint

--- a/packages/e2e-playwright/tests/issuerList/issuer-list.spec.ts
+++ b/packages/e2e-playwright/tests/issuerList/issuer-list.spec.ts
@@ -38,42 +38,44 @@ test.describe('Issuer List', () => {
         await expect(issuerList.submitButton).toHaveText('Continue to Nest Bank');
     });
 
-    // test('it should have the expected data in state, ready for the /payments call', async ({ issuerListPage }) => {
-    //     const { issuerList, page } = issuerListPage;
+    test('it should have the expected data in state, ready for the /payments call', async ({ issuerListPage }) => {
+        const { issuerList, page } = issuerListPage;
 
-    //     // Open the drop down and select an item
-    //     await issuerList.clickOnSelector();
-    //     await pressKeyboardToNextItem(page); // Arrow down
-    //     await pressKeyboardToSelectItem(page); // Enter key
+        // Open the drop down and select an item
+        await issuerList.clickOnSelector();
+        await pressKeyboardToNextItem(page); // Arrow down
+        await pressKeyboardToSelectItem(page); // Enter key
 
-    //     let issuerListData = await page.evaluate('window.dotpay.data');
+        let issuerListData = await page.evaluate('window.dotpay.data');
 
-    //     // @ts-ignore
-    //     expect(issuerListData.paymentMethod).toEqual({
-    //         type: 'dotpay',
-    //         issuer: '73',
-    //         checkoutAttemptId: 'do-not-track'
-    //     });
-    // });
+        // @ts-ignore
+        const { checkoutAttemptId, ...rest } = issuerListData.paymentMethod; // strip checkoutAttemptId since we can't know its value
 
-    // test('should select highlighted issuer, update pay button label, and see the expected data in state', async ({ issuerListPage }) => {
-    //     const { issuerList, page } = issuerListPage;
+        expect(rest).toEqual({
+            type: 'dotpay',
+            issuer: '73'
+        });
+    });
 
-    //     await issuerList.selectHighlightedIssuer('BLIK');
-    //     await expect(issuerList.submitButton).toHaveText('Continue to BLIK');
+    test('should select highlighted issuer, update pay button label, and see the expected data in state', async ({ issuerListPage }) => {
+        const { issuerList, page } = issuerListPage;
 
-    //     await issuerList.selectHighlightedIssuer('Idea Cloud');
-    //     await expect(issuerList.submitButton).toHaveText('Continue to Idea Cloud');
+        await issuerList.selectHighlightedIssuer('BLIK');
+        await expect(issuerList.submitButton).toHaveText('Continue to BLIK');
 
-    //     await expect(issuerList.highlightedIssuerButtonGroup.getByRole('button', { pressed: true })).toHaveText('Idea Cloud');
+        await issuerList.selectHighlightedIssuer('Idea Cloud');
+        await expect(issuerList.submitButton).toHaveText('Continue to Idea Cloud');
 
-    //     let issuerListData = await page.evaluate('window.dotpay.data');
+        await expect(issuerList.highlightedIssuerButtonGroup.getByRole('button', { pressed: true })).toHaveText('Idea Cloud');
 
-    //     // @ts-ignore
-    //     expect(issuerListData.paymentMethod).toEqual({
-    //         type: 'dotpay',
-    //         issuer: '81',
-    //         checkoutAttemptId: 'do-not-track'
-    //     });
-    // });
+        let issuerListData = await page.evaluate('window.dotpay.data');
+
+        // @ts-ignore
+        const { checkoutAttemptId, ...rest } = issuerListData.paymentMethod; // strip checkoutAttemptId since we can't know its value
+
+        expect(rest).toEqual({
+            type: 'dotpay',
+            issuer: '81'
+        });
+    });
 });

--- a/packages/lib/src/components/ApplePay/ApplePay.test.ts
+++ b/packages/lib/src/components/ApplePay/ApplePay.test.ts
@@ -1,6 +1,7 @@
 import ApplePay from './ApplePay';
 import ApplePayService from './ApplePayService';
 import { mock } from 'jest-mock-extended';
+import { NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
 
 jest.mock('./ApplePayService');
 
@@ -366,7 +367,7 @@ describe('ApplePay', () => {
                 },
                 paymentMethod: {
                     applePayToken: 'InBheW1lbnQtZGF0YSI=',
-                    checkoutAttemptId: 'do-not-track',
+                    checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID,
                     type: 'applepay'
                 }
             });

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -2,7 +2,7 @@ import GooglePay from './GooglePay';
 import GooglePayService from './GooglePayService';
 
 import Analytics from '../../core/Analytics';
-import { ANALYTICS_EVENT_INFO, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
+import { ANALYTICS_EVENT_INFO, ANALYTICS_SELECTED_STR, NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
 
 const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
 
@@ -95,7 +95,7 @@ describe('GooglePay', () => {
 
             expect(state.data.origin).toBe('http://localhost');
             expect(state.data.paymentMethod).toStrictEqual({
-                checkoutAttemptId: 'do-not-track',
+                checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID,
                 googlePayCardNetwork: 'VISA',
                 googlePayToken: 'google-pay-token',
                 type: 'googlepay'
@@ -161,7 +161,7 @@ describe('GooglePay', () => {
 
             expect(state.data.origin).toBe('http://localhost');
             expect(state.data.paymentMethod).toStrictEqual({
-                checkoutAttemptId: 'do-not-track',
+                checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID,
                 googlePayCardNetwork: 'VISA',
                 googlePayToken: 'google-pay-token',
                 type: 'googlepay'

--- a/packages/lib/src/components/PayPal/Paypal.test.ts
+++ b/packages/lib/src/components/PayPal/Paypal.test.ts
@@ -1,12 +1,13 @@
 import Paypal from './Paypal';
 import { render, screen } from '@testing-library/preact';
+import { NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
 
 describe('Paypal', () => {
     test('Returns a data object', () => {
         const paypal = new Paypal(global.core);
         expect(paypal.data).toEqual({
             clientStateDataIndicator: true,
-            paymentMethod: { subtype: 'sdk', type: 'paypal', userAction: 'pay', checkoutAttemptId: 'do-not-track' }
+            paymentMethod: { subtype: 'sdk', type: 'paypal', userAction: 'pay', checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID }
         });
     });
 
@@ -14,7 +15,7 @@ describe('Paypal', () => {
         const paypal = new Paypal(global.core, { isExpress: true });
         expect(paypal.data).toEqual({
             clientStateDataIndicator: true,
-            paymentMethod: { subtype: 'express', type: 'paypal', userAction: 'pay', checkoutAttemptId: 'do-not-track' }
+            paymentMethod: { subtype: 'express', type: 'paypal', userAction: 'pay', checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID }
         });
     });
 
@@ -22,7 +23,7 @@ describe('Paypal', () => {
         const paypal = new Paypal(global.core);
         expect(paypal.data).toEqual({
             clientStateDataIndicator: true,
-            paymentMethod: { subtype: 'sdk', type: 'paypal', userAction: 'pay', checkoutAttemptId: 'do-not-track' }
+            paymentMethod: { subtype: 'sdk', type: 'paypal', userAction: 'pay', checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID }
         });
     });
 
@@ -30,7 +31,7 @@ describe('Paypal', () => {
         const paypal = new Paypal(global.core, { isExpress: true, userAction: 'continue' });
         expect(paypal.data).toEqual({
             clientStateDataIndicator: true,
-            paymentMethod: { subtype: 'express', type: 'paypal', userAction: 'continue', checkoutAttemptId: 'do-not-track' }
+            paymentMethod: { subtype: 'express', type: 'paypal', userAction: 'continue', checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID }
         });
     });
 

--- a/packages/lib/src/components/Pix/Pix.test.ts
+++ b/packages/lib/src/components/Pix/Pix.test.ts
@@ -1,10 +1,11 @@
 import Pix from './Pix';
 import { render, screen, waitFor } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
+import { NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
 
 test('should return only payment type if personalDetails is not required', () => {
     const pixElement = new Pix(global.core);
-    expect(pixElement.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { type: 'pix', checkoutAttemptId: 'do-not-track' } });
+    expect(pixElement.data).toEqual({ clientStateDataIndicator: true, paymentMethod: { type: 'pix', checkoutAttemptId: NO_CHECKOUT_ATTEMPT_ID } });
 });
 
 test('should show personal details form if enabled', async () => {

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -2,7 +2,7 @@ import { ComponentChild, h, render } from 'preact';
 import getProp from '../../../utils/getProp';
 import uuid from '../../../utils/uuid';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
-import { ANALYTICS_RENDERED_STR } from '../../../core/Analytics/constants';
+import { ANALYTICS_RENDERED_STR, NO_CHECKOUT_ATTEMPT_ID } from '../../../core/Analytics/constants';
 
 import type { ICore } from '../../../core/types';
 import type { BaseElementProps, IBaseElement } from './types';
@@ -94,8 +94,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
      */
     public get data(): PaymentData {
         const clientData = getProp(this.props, 'modules.risk.data');
-        const useAnalytics = !!getProp(this.props, 'modules.analytics.getEnabled')?.();
-        const checkoutAttemptId = useAnalytics ? getProp(this.props, 'modules.analytics.getCheckoutAttemptId')?.() : 'do-not-track';
+        const checkoutAttemptId = getProp(this.props, 'modules.analytics.getCheckoutAttemptId')?.() ?? NO_CHECKOUT_ATTEMPT_ID; // NOTE: we never expect to see this "failed" value, but, just in case...
         const order = this.state.order || this.props.order;
         const componentData = this.formatData();
 
@@ -156,7 +155,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
             if (this.props.modules && this.props.modules.analytics) {
                 this.setUpAnalytics({
                     containerWidth: node && node.offsetWidth,
-                    component: !this.props.isDropin ? this.constructor['analyticsType'] ?? this.constructor['type'] : 'dropin',
+                    component: !this.props.isDropin ? (this.constructor['analyticsType'] ?? this.constructor['type']) : 'dropin',
                     flavor: !this.props.isDropin ? 'components' : 'dropin'
                 }).then(() => {
                     // Once the initial analytics set up call has been made...

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -62,11 +62,11 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
          * @param initialEvent -
          */
         setUp: async (initialEvent: AnalyticsInitialEvent) => {
-            const { enabled, payload } = props; // TODO what is payload, is it ever used?
+            const { payload } = props; // TODO what is payload, is it ever used?
 
             const analyticsData = processAnalyticsData(props.analyticsData);
 
-            if (enabled === true && !capturedCheckoutAttemptId) {
+            if (!capturedCheckoutAttemptId) {
                 try {
                     const checkoutAttemptId = await collectId({
                         ...initialEvent,
@@ -86,6 +86,8 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
         getEventsQueue: () => eventsQueue,
 
         createAnalyticsEvent: ({ event, data }: CreateAnalyticsEventObject): AnalyticsObject => {
+            if (!props.enabled) return;
+
             const aObj: AnalyticsObject = createAnalyticsObject({
                 event,
                 ...data
@@ -102,7 +104,7 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
         sendAnalytics: null
     };
 
-    anlModule.sendAnalytics = analyticsPreProcessor(anlModule);
+    anlModule.sendAnalytics = props.enabled === true ? analyticsPreProcessor(anlModule) : () => {};
 
     return anlModule;
 };

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -99,3 +99,5 @@ export const errorCodeMapping: Record<string, string> = {
 export const ANALYTICS_EXPRESS_PAGES_ARRAY = ['cart', 'minicart', 'pdp', 'checkout'];
 
 export const ALLOWED_ANALYTICS_DATA = ['applicationInfo', 'checkoutAttemptId'];
+
+export const NO_CHECKOUT_ATTEMPT_ID = 'fetch-checkoutAttemptId-failed';

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -194,17 +194,5 @@ export const getCardConfigData = (cardProps: CardConfiguration): CardConfigData 
         hasOnLoad: onLoad !== CardInputDefaultProps.onLoad
     };
 
-    // TODO - keep until endpoint can accept more entries in the configData object (current limit: 32);
-    if (Object.keys(configData).length > 32) {
-        const strippedConfigData = Object.entries(configData).reduce((acc, [key, value], index) => {
-            if (index < 32) {
-                acc[key] = value;
-            }
-            return acc;
-        }, {});
-
-        return strippedConfigData as CardConfigData;
-    }
-
     return configData;
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This PR restores the changes from the (previously approved PR) #2792:

>Currently we do not send the initial setup call on the SDK side if merchants disable analytics.
>This is reducing our visibility on merchant integrations.
>
>So now we will always make the initial setup call - as this call is really just about the SDK usage and does not track any shopper interactions.
>We now only use the merchant setting `analytics.enabled = false` to prevent subsequent `info`, `log` and `error` analytics events

In addition, since we will always have a `checkoutAttemptId`, `BaseElement` no longer sends `"do-not-track"` when adding the `checkoutAttemptId` to the component's `paymentMethod` data.
In the case that the retrieval of a `checkoutAttemptId` fails - the value `"fetch-checkoutAttemptId-failed"` is sent

## Tested scenarios
Adjusted unit tests accordingly

Relates to issue: COWEB-1412, #2792
