### PR TITLE
Send browser info on setup

### DIFF
--- a/.changeset/polite-timers-sniff.md
+++ b/.changeset/polite-timers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+send browserInfo in setup call

--- a/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
+++ b/packages/lib/src/core/CheckoutSession/CheckoutSession.ts
@@ -12,11 +12,13 @@ import {
     CheckoutSessionOrdersResponse,
     CheckoutSessionPaymentResponse,
     CheckoutSessionSetupResponse,
-    SessionConfiguration
+    SessionConfiguration,
+    SetupSessionOptions
 } from './types';
 import cancelOrder from '../Services/sessions/cancel-order';
 import { onOrderCancelData } from '../../components/Dropin/types';
 import type { AdditionalDetailsData } from '../types';
+import collectBrowserInfo from '../../utils/browserInfo';
 
 class Session {
     private readonly session: CheckoutSession;
@@ -66,8 +68,9 @@ class Session {
     /**
      * Fetches data from a session
      */
-    setupSession(options): Promise<CheckoutSessionSetupResponse> {
-        return setupSession(this, options).then(response => {
+    setupSession(options: SetupSessionOptions): Promise<CheckoutSessionSetupResponse> {
+        const mergedOptions = { ...options, browserInfo: collectBrowserInfo() }
+        return setupSession(this, mergedOptions).then(response => {
             if (response.configuration) {
                 this.configuration = { ...response.configuration };
             }

--- a/packages/lib/src/core/CheckoutSession/types.ts
+++ b/packages/lib/src/core/CheckoutSession/types.ts
@@ -1,5 +1,5 @@
 import { InstallmentOptions } from '../../components/Card/components/CardInput/components/types';
-import { PaymentAction, PaymentAmount, ResultCode } from '../../types/global-types';
+import { BrowserInfo, Order, PaymentAction, PaymentAmount, ResultCode } from '../../types/global-types';
 
 export type CheckoutSession = {
     id: string;
@@ -57,3 +57,8 @@ export type CheckoutSessionOrdersResponse = {
     orderData: string;
     pspReference: string;
 };
+
+export type SetupSessionOptions = {
+    browserInfo?: BrowserInfo,
+    order?: Order
+}

--- a/packages/lib/src/core/Services/sessions/setup-session.ts
+++ b/packages/lib/src/core/Services/sessions/setup-session.ts
@@ -1,11 +1,12 @@
 import { httpPost } from '../http';
 import Session from '../../CheckoutSession';
-import { CheckoutSessionSetupResponse } from '../../CheckoutSession/types';
+import { CheckoutSessionSetupResponse, SetupSessionOptions } from '../../CheckoutSession/types';
 import { API_VERSION } from './constants';
 
-function setupSession(session: Session, options): Promise<CheckoutSessionSetupResponse> {
+function setupSession(session: Session, options: SetupSessionOptions): Promise<CheckoutSessionSetupResponse> {
     const path = `${API_VERSION}/sessions/${session.id}/setup?clientKey=${session.clientKey}`;
     const data = {
+        browserInfo: options.browserInfo,
         sessionData: session.data,
         ...(options.order
             ? {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Forward browserInfo from the SDK onto the internal /setup request, so it can be passed on by the backend to the Checkout.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
COWEB-1391