### PR TITLE
v6 - Fixing styles import path for Webpack4 projects

### DIFF
--- a/.changeset/rotten-flies-bathe.md
+++ b/.changeset/rotten-flies-bathe.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixing adyen.css file exposure for Webpack 4 projects

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,3 @@
-# This workflow will run tests using node and then publish a package when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
 name: Publish Package
 
 on:

--- a/packages/lib/.gitignore
+++ b/packages/lib/.gitignore
@@ -1,6 +1,8 @@
-dist
+# Misc
 /*.tgz
 .stylelintcache
-lib-test
-translations
-/package
+/storybook-static
+
+# Build
+/dist
+/styles

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -51,6 +51,7 @@
     "dist/cjs/**",
     "dist/es/**",
     "dist/es-legacy/**",
+    "styles/**",
     "LICENSE",
     "README"
   ],
@@ -73,7 +74,7 @@
     "styles:fix": "npm run lint-styles -- --fix",
     "lint:fix": "npm run lint -- --fix",
     "prettier:fix": "prettier \"src/**/*.{js,ts,tsx}\" \"package.json\" --write --loglevel silent",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && rm -rf ./styles && mkdir ./styles && cp ./dist/es/adyen.css ./styles/adyen.css",
     "prepare": "cd ../.. && husky packages/lib/.husky",
     "size": "npm run build && size-limit"
   },


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Webpack 4 does not use the 'exports' field in the 'package.json' for the module resolution. This leads to projects using webpack4  not being able to import the styles from `@adyen/adyen-web/styles/adyen.css` . 
The temporary solution is to import directly using the file path `@adyen/adyen-web/dis/es/adyen.css`.

To solve that, the prepublish pipeline was adjusted to create a folder 'styles' and then push the CSS file there. 
By doing that, Webpack 4 projects can directly import by doing  `@adyen/adyen-web/styles/adyen.css` , as it is a valid file path.

## What was done:
- Added the 'styles' folder to the package.json 'files' entry, so it gets added to the tarball file
- In the prepublish script, the project is build and then the styles folder is created and the file is placed there
