### PR TITLE
v5 -  Adding tag to npm publish pipeline

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
       # Copy LICENSE to adyen-web package
       - run: cp LICENSE packages/lib/
       # Build and publish to npm
-      - run: cd packages/lib && npm publish --access public
+      - run: cd packages/lib && npm publish --access public --tag v5
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           CI: true


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
v5 releases are being marked as 'latest' on npm. If the tag is not specified, the fallback is 'latest'.
This PR changes the publish pipeline to tag it as `v5`. 


- More can be [read here](https://www.iliascreates.com/blog/post/npm-distribution-tags/) about distribution tags
- [npm-publish](https://docs.npmjs.com/cli/v8/commands/npm-publish#tag) docs