### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/packages"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
As we removed renovate, we should use Dependabot to alert about dependencies.

This change also aims to test if we can narrow down the security checks only for the /packages folder instead of for the whole repository.

More about dependabot config can be found [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)