### PR TITLE
Calling actions.reject() in beforeSubmit should not lead to onPaymentFailed

### DIFF
--- a/.changeset/curly-balloons-rush.md
+++ b/.changeset/curly-balloons-rush.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Calling actions.reject() in the beforeSubmit callback should leave the UI in the current state. Fixes situation where it leads to a call to handleFailedResult which ultimately leads to a call to the onPaymentFailed callback and sets the UI to an error state

--- a/packages/lib/src/components/internal/UIElement/UIElement.beforeSubmit.test.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.beforeSubmit.test.tsx
@@ -1,0 +1,127 @@
+import { h } from 'preact';
+import CardElement from '../../Card';
+
+let onPaymentCompleted;
+let onPaymentFailed;
+
+beforeEach(() => {
+    onPaymentCompleted = jest.fn(res => {
+        console.log('### UIElement.test:::: onPaymentCompleted callback called res=', res);
+    });
+    onPaymentFailed = jest.fn(res => {
+        console.log('### UIElement.test:::: onPaymentFailed callback called res=', res);
+    });
+});
+
+describe('Testing beforeSubmit', () => {
+    test('Because beforeSubmit resolves...', done => {
+        const beforeSubmit = jest.fn((data, component, actions) => {
+            console.log('### UIElement.test:::: beforeSubmit callback called');
+
+            actions.resolve(data);
+        });
+
+        const elementRef = {
+            state: {
+                status: null
+            },
+            setStatus: status => {
+                elementRef.state.status = status;
+            }
+        };
+
+        // Session flow - session configuration should override merchant configuration
+        const cardElement = new CardElement(global.core, {
+            amount: { value: 0, currency: 'USD' },
+            // @ts-ignore it's just a test
+            session: { configuration: {} },
+            beforeSubmit,
+            onPaymentCompleted,
+            elementRef
+        });
+
+        const paymentResponse = {
+            resultCode: 'Authorised',
+            sessionData: 'Ab02b4c0uKS50x...',
+            sessionResult: 'X3XtfGC9...'
+        };
+
+        // @ts-ignore
+        cardElement.submitUsingSessionsFlow = () => {
+            console.log('### UIElement.beforeSubmit.test::submitUsingSessionsFlow:: MOCK');
+            return Promise.resolve(paymentResponse);
+        };
+
+        cardElement.setState({ isValid: true });
+
+        cardElement.submit();
+
+        console.log('### Card.test:::: cardElement.elementRef.state', cardElement.elementRef.state);
+
+        // initially submit should lead to UIElement.makePaymentsCall() which sets status to 'loading'
+        expect(cardElement.elementRef.state.status).toEqual('loading');
+
+        setTimeout(() => {
+            expect(beforeSubmit).toHaveBeenCalled();
+
+            console.log('### Card.test::2222:: cardElement.elementRef.state', cardElement.elementRef.state);
+
+            // state.status doesn't get reset
+            expect(cardElement.elementRef.state.status).toEqual('loading');
+
+            expect(onPaymentCompleted).toHaveBeenCalledWith(paymentResponse, elementRef);
+
+            done();
+        }, 0);
+    });
+
+    test('Because beforeSubmit rejects the status gets set back to "ready"', done => {
+        const beforeSubmit = jest.fn((data, component, actions) => {
+            console.log('### Card.test:::: beforeSubmit callback called');
+
+            actions.reject();
+        });
+
+        const elementRef = {
+            state: {
+                status: null
+            },
+            setStatus: status => {
+                elementRef.state.status = status;
+            }
+        };
+
+        // Session flow - session configuration should override merchant configuration
+        const cardElement = new CardElement(global.core, {
+            amount: { value: 0, currency: 'USD' },
+            // @ts-ignore it's just a test
+            session: { configuration: {} },
+            beforeSubmit,
+            onPaymentCompleted,
+            onPaymentFailed,
+            elementRef
+        });
+
+        cardElement.setState({ isValid: true });
+
+        cardElement.submit();
+
+        console.log('### Card.test:::: cardElement.elementRef.state', cardElement.elementRef.state);
+
+        // initially submit should lead to UIElement.makePaymentsCall() which sets status to 'loading'
+        expect(cardElement.elementRef.state.status).toEqual('loading');
+
+        setTimeout(() => {
+            expect(beforeSubmit).toHaveBeenCalled();
+
+            console.log('### Card.test:::: cardElement.elementRef.state', cardElement.elementRef.state);
+
+            expect(cardElement.elementRef.state.status).toEqual('ready');
+
+            expect(onPaymentCompleted).not.toHaveBeenCalled();
+            expect(onPaymentFailed).not.toHaveBeenCalled();
+
+            done();
+        }, 0);
+    });
+});

--- a/packages/lib/src/components/internal/UIElement/UIElement.beforeSubmit.test.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.beforeSubmit.test.tsx
@@ -1,6 +1,15 @@
 import { h } from 'preact';
 import CardElement from '../../Card';
 
+const elementRef = {
+    state: {
+        status: null
+    },
+    setStatus: status => {
+        elementRef.state.status = status;
+    }
+};
+
 let onPaymentCompleted;
 let onPaymentFailed;
 
@@ -21,16 +30,6 @@ describe('Testing beforeSubmit', () => {
             actions.resolve(data);
         });
 
-        const elementRef = {
-            state: {
-                status: null
-            },
-            setStatus: status => {
-                elementRef.state.status = status;
-            }
-        };
-
-        // Session flow - session configuration should override merchant configuration
         const cardElement = new CardElement(global.core, {
             amount: { value: 0, currency: 'USD' },
             // @ts-ignore it's just a test
@@ -46,7 +45,7 @@ describe('Testing beforeSubmit', () => {
             sessionResult: 'X3XtfGC9...'
         };
 
-        // @ts-ignore
+        // @ts-ignore it's a test
         cardElement.submitUsingSessionsFlow = () => {
             console.log('### UIElement.beforeSubmit.test::submitUsingSessionsFlow:: MOCK');
             return Promise.resolve(paymentResponse);
@@ -82,16 +81,6 @@ describe('Testing beforeSubmit', () => {
             actions.reject();
         });
 
-        const elementRef = {
-            state: {
-                status: null
-            },
-            setStatus: status => {
-                elementRef.state.status = status;
-            }
-        };
-
-        // Session flow - session configuration should override merchant configuration
         const cardElement = new CardElement(global.core, {
             amount: { value: 0, currency: 'USD' },
             // @ts-ignore it's just a test

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -373,7 +373,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     };
 
     /**
-     * Handles a session /payments or /payments/details response.
+     * Handles a /payments or /payments/details response.
      * The component will handle automatically actions, orders, and final results.
      *
      * @param rawResponse -

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -190,7 +190,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
                 ? new Promise((resolve, reject) =>
                       this.props.beforeSubmit(this.data, this.elementRef, {
                           resolve,
-                          reject
+                          reject: () => reject('beforeSubmitRejected')
                       })
                   )
                 : Promise.resolve(this.data);
@@ -343,13 +343,15 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
      *
      * @param result
      */
-    protected handleFailedResult = (result?: PaymentResponseData): void => {
+    protected handleFailedResult = (result?: PaymentResponseData | string): void => {
+        if (result === 'beforeSubmitRejected') return;
+
         if (assertIsDropin(this.elementRef)) {
             this.elementRef.displayFinalAnimation('error');
         }
 
-        cleanupFinalResult(result);
-        this.props.onPaymentFailed?.(result, this.elementRef);
+        cleanupFinalResult(result as PaymentResponseData);
+        this.props.onPaymentFailed?.(result as PaymentResponseData, this.elementRef);
     };
 
     protected handleSuccessResult = (result: PaymentResponseData): void => {

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -354,13 +354,13 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
      *
      * @param result
      */
-    protected handleFailedResult = (result?: PaymentResponseData | string): void => {
+    protected handleFailedResult = (result?: PaymentResponseData): void => {
         if (assertIsDropin(this.elementRef)) {
             this.elementRef.displayFinalAnimation('error');
         }
 
-        cleanupFinalResult(result as PaymentResponseData);
-        this.props.onPaymentFailed?.(result as PaymentResponseData, this.elementRef);
+        cleanupFinalResult(result);
+        this.props.onPaymentFailed?.(result, this.elementRef);
     };
 
     protected handleSuccessResult = (result: PaymentResponseData): void => {

--- a/packages/lib/src/core/Errors/CancelError.ts
+++ b/packages/lib/src/core/Errors/CancelError.ts
@@ -1,0 +1,7 @@
+class CancelError extends Error {
+    constructor(message?: string) {
+        super(message);
+    }
+}
+
+export default CancelError;


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Calling `actions.reject()` in the `beforeSubmit` callback should leave the UI in the current state.
It should not lead to a call to `handleFailedResult` which ultimately leads to a call to the `onPaymentFailed` callback and sets the UI to an error state.
This PR keeps v6 behaviour consistent with v5

## Tested scenarios
Can call `actions.reject()` from `beforeSubmit` and the UI stays in its current state
Added unit tests for `beforeSubmit` resolving and rejecting

**Fixed issue**:  COWEB-1448
