### PR TITLE
Fix 'auto' being tree-shaken in production builds

### DIFF
--- a/.changeset/big-geese-complain.md
+++ b/.changeset/big-geese-complain.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix issue where 'auto' bundle was tree-shaken by bundlers in prod builds

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -5,7 +5,9 @@
   "homepage": "https://docs.adyen.com/checkout",
   "type": "module",
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "./auto/auto.js",
+    "./auto/auto.cjs"
   ],
   "main": "dist/cjs/index.cjs",
   "module": "dist/es-legacy/index.js",


### PR DESCRIPTION

## Summary
'auto.js' code is being tree-shaken by bundlers (ex: webpack, rollup) when creating the prod build.

'auto.js' contains side effects as it manipulates the internal state of `AdyenCheckout` by adding components to it and setting the bundle to 'auto' . Therefore, it should be flagged in the `package.json` as it has `sideEffects`  in order to not be excluded by the bundlers.

## Tested scenarios
Tested that 'auto' works on build bundle:
- open-wc setup (which uses rollup)
- vite 5.1.6 setup (which uses rollup)
- nuxt 3.13.2 setup (which uses vite which uses rollup)
- next 14.2 setup (which uses webpack 5)
- react-scripts 4.x (which uses webpack 4)

**Fixed issue**: #2818 
