### PR TITLE
Compiling modern bundle using es2020

### DIFF
--- a/.changeset/old-fishes-battle.md
+++ b/.changeset/old-fishes-battle.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Lowered ECMAScript version to 2020 in order to support older iOS versions

--- a/packages/lib/config/rollup.dev.js
+++ b/packages/lib/config/rollup.dev.js
@@ -18,7 +18,7 @@ export default () => {
                 replaceValues({ bundleType: BUNDLE_TYPES.esm, buildType: 'development' }),
                 convertJsonToESM(),
                 compileCSS({}),
-                compileJavascript({ target: 'es2022' })
+                compileJavascript({ target: 'es2020' })
             ],
             output: [
                 {

--- a/packages/lib/config/rollup.plugins.js
+++ b/packages/lib/config/rollup.plugins.js
@@ -47,8 +47,12 @@ export const compileCSS = ({ extract = 'adyen.css' } = {}) =>
         extract: extract
     });
 
-export const compileJavascript = ({ target = 'es2022', sourceMaps = false } = {}) =>
-    swc(
+export const compileJavascript = ({ target, sourceMaps = false } = {}) => {
+    if (!target) {
+        throw Error('Rollup plugins: compileJavascript task - "target" is missing');
+    }
+
+    return swc(
         defineRollupSwcOption({
             tsconfig: '../tsconfig.json',
             jsc: {
@@ -70,6 +74,7 @@ export const compileJavascript = ({ target = 'es2022', sourceMaps = false } = {}
             inlineSourcesContent: false
         })
     );
+};
 
 export const minify = ({ isESM } = { isESM: true }) => terser({ module: isESM });
 

--- a/packages/lib/config/rollup.prod.js
+++ b/packages/lib/config/rollup.prod.js
@@ -34,7 +34,7 @@ export default () => {
                 replaceValues({ bundleType: BUNDLE_TYPES.esm, buildType: 'production' }),
                 convertJsonToESM(),
                 compileCSS(),
-                compileJavascript({ target: 'es2022', sourceMaps: true }),
+                compileJavascript({ target: 'es2020', sourceMaps: true }),
                 minify()
             ],
             output: [
@@ -99,7 +99,7 @@ export default () => {
                 replaceValues({ bundleType: BUNDLE_TYPES.umd, buildType: 'production' }),
                 convertJsonToESM(),
                 compileCSS(),
-                compileJavascript({ sourceMaps: true }),
+                compileJavascript({ target: 'es2020', sourceMaps: true }),
                 minify({ isESM: false })
             ],
             output: {

--- a/packages/lib/xxxx.browserslistrc
+++ b/packages/lib/xxxx.browserslistrc
@@ -1,1 +1,0 @@
-defaults

--- a/packages/lib/xxxx.browserslistrc
+++ b/packages/lib/xxxx.browserslistrc
@@ -1,0 +1,1 @@
+defaults


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Lowered the ECMAScript version of the modern bundle from `es2022` to `es2020` in order to support old iOS versions.

## Tested scenarios
Tested on Browserstack:
- iOS 14.1
- iOS 13
- iOS 12 (requires the merchant to polyfill [Promise.allSettled](https://caniuse.com/?search=Promise.allSettled))
- iOS 11 (requires the merchant to parse the bundle to support the [spread in object literals](https://caniuse.com/mdn-javascript_operators_spread_spread_in_object_literals))



**Fixed issue**:  <!-- #-prefixed issue number -->
