### PR TITLE
[v5] fix(UPIComponent): initial value for isValid

### DIFF
--- a/.changeset/lovely-dodos-visit.md
+++ b/.changeset/lovely-dodos-visit.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fix `UPIComponent` initial value for `isValid`. It should only be default to `true` for UPI QR.

--- a/packages/lib/src/components/UPI/components/UPIComponent/UPIComponent.tsx
+++ b/packages/lib/src/components/UPI/components/UPIComponent/UPIComponent.tsx
@@ -35,7 +35,7 @@ export default function UPIComponent({ defaultMode, onChange, onUpdateMode, payB
     const { i18n } = useCoreContext();
     const getImage = useImage();
     const [status, setStatus] = useState<UIElementStatus>('ready');
-    const [isValid, setIsValid] = useState<boolean>(true);
+    const [isValid, setIsValid] = useState<boolean>(defaultMode === UpiMode.QrCode);
     const [mode, setMode] = useState<UpiMode>(defaultMode);
     const [vpa, setVpa] = useState<string>('');
     const [vpaInputHandlers, setVpaInputHandlers] = useState<VpaInputHandlers>(null);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix UPIComponent initial value for `isValid`. It should only be `true` for UPI QR.

## Tested scenarios
- Added unit tests.
- Inspect `onChange` on the playground, it should output correct `isValid` value.


**Fixed issue**:  #2915
