### PR TITLE
Re-treat Icelandic Krona as a currency with minor units

### DIFF
--- a/.changeset/fluffy-stingrays-invent.md
+++ b/.changeset/fluffy-stingrays-invent.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Revert Icelandic Krona to be treated as a currency with minor units, in order to align with our documentation

--- a/packages/lib/src/utils/constants/currency-decimals.ts
+++ b/packages/lib/src/utils/constants/currency-decimals.ts
@@ -10,7 +10,6 @@ const CURRENCY_DECIMALS = {
     GHC: 1,
     GNF: 1,
     KMF: 1,
-    ISK: 1,
     PYG: 1,
     RWF: 1,
     UGX: 1,

--- a/packages/lib/src/utils/constants/currency-minor-units.ts
+++ b/packages/lib/src/utils/constants/currency-minor-units.ts
@@ -1,5 +1,6 @@
 /** Work around solution until chromium bug is fixed https://bugs.chromium.org/p/chromium/issues/detail?id=1381996
- * We need to hardcode minimumFractionDigits for the following currencies
+ * We need to hardcode minimumFractionDigits for the following currencies in order to force them to have 2 decimal places and
+ * not be rounded up to a major unit
  */
 export const currencyMinorUnitsConfig = {
     RSD: { minimumFractionDigits: 2 },

--- a/packages/playground/src/config/getCurrency.js
+++ b/packages/playground/src/config/getCurrency.js
@@ -13,6 +13,7 @@ const currencies = {
     HU: 'HUN',
     ID: 'IDR',
     IN: 'INR',
+    IS: 'ISK',
     JP: 'JPY',
     KR: 'KRW',
     MG: 'MGA',


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Revert Icelandic Krona to be treated as a currency with minor units, in order to align with our documentation

**Fixed issue**:  #2922
**Relates to**:  #2811