### PR TITLE
Fix address lookup reseting state after country (#2926)

### DIFF
--- a/.changeset/cold-jeans-yawn.md
+++ b/.changeset/cold-jeans-yawn.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fix address lookup reseting state field after country change

--- a/packages/lib/src/utils/useForm/reducer.ts
+++ b/packages/lib/src/utils/useForm/reducer.ts
@@ -54,12 +54,15 @@ export function init({ schema, defaultData, processField, fieldProblems }) {
 }
 
 export function getReducer(processField) {
-    return function reducer(state, { type, key, value, mode, schema, defaultData, formValue, selectedSchema, fieldProblems }: any) {
+    return function reducer(state, { type, key, value, mode, schema, defaultData, formValue, selectedSchema, fieldProblems, data }) {
         const validationSchema: string[] = selectedSchema || state.schema;
 
         switch (type) {
             case 'setData': {
                 return { ...state, data: { ...state['data'], [key]: value } };
+            }
+            case 'mergeData': {
+                return { ...state, data: { ...state['data'], ...data } };
             }
             case 'setValid': {
                 return { ...state, valid: { ...state['valid'], [key]: value } };

--- a/packages/lib/src/utils/useForm/types.ts
+++ b/packages/lib/src/utils/useForm/types.ts
@@ -35,6 +35,7 @@ export interface Form<FormSchema> extends FormState<FormSchema> {
     triggerValidation: (schema?: any) => void;
     setSchema: (schema: any) => void;
     setData: (key: string, value: any) => void;
+    mergeData: (data: FormSchema) => void;
     setValid: (key: string, value: any) => void;
     setErrors: (key: string, value: any) => void;
     mergeForm: (formValue: any) => void;

--- a/packages/lib/src/utils/useForm/useForm.ts
+++ b/packages/lib/src/utils/useForm/useForm.ts
@@ -55,6 +55,7 @@ function useForm<FormSchema>(props: FormProps): Form<FormSchema> {
     const setErrors = useCallback((key, value) => dispatch({ type: 'setErrors', key, value }), []);
     const setValid = useCallback((key, value) => dispatch({ type: 'setValid', key, value }), []);
     const setData = useCallback((key, value) => dispatch({ type: 'setData', key, value }), []);
+    const mergeData = useCallback(data => dispatch({ type: 'mergeData', data }), []);
     const setSchema = useCallback(schema => dispatch({ type: 'setSchema', schema, defaultData }), [state.schema]);
     const mergeForm = useCallback(formValue => dispatch({ type: 'mergeForm', formValue }), []);
     const setFieldProblems = useCallback(fieldProblems => dispatch({ type: 'setFieldProblems', fieldProblems }), [state.schema]);
@@ -69,6 +70,7 @@ function useForm<FormSchema>(props: FormProps): Form<FormSchema> {
         triggerValidation,
         setSchema,
         setData,
+        mergeData,
         setValid,
         setErrors,
         isValid,


### PR DESCRIPTION
## Summary

(cherry picked from commit c5eba2a12b3bc0a68c721d6c489e68ad4d8c227f) #2926

This PR attempts to fix the bug reported in the issue where address or field were not being pre-filled correctly.

The issue was caused by the logic that applies on the country change hook, that resets the stateOrProvince Select, and re-triggers postal code validation.

This hook exists because we want to reset the stateOrProvince field when a country changes. This was also triggering when setting country via setSearchData, which lead to a race condition where stateOrProvince would be reset right after being set by setSearchData, because of the country change.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
#2832
