### PR TITLE
Feat: enable logos for SK and CZ online banking

### DIFF
--- a/.changeset/thirty-boats-applaud.md
+++ b/.changeset/thirty-boats-applaud.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Feat: enable logos for SK and CZ online banking

--- a/examples/angular/src/utils/getCurrency.ts
+++ b/examples/angular/src/utils/getCurrency.ts
@@ -26,7 +26,6 @@ const currencies: Record<string, string> = {
     RU: 'RUB',
     SE: 'SEK',
     SG: 'SGD',
-    SK: 'SKK',
     TH: 'THB',
     TW: 'TWD',
     US: 'USD',

--- a/examples/nextjs/app/_utils/amount-utils.ts
+++ b/examples/nextjs/app/_utils/amount-utils.ts
@@ -26,7 +26,6 @@ const currencies = {
     RU: "RUB",
     SE: "SEK",
     SG: "SGD",
-    SK: "SKK",
     TH: "THB",
     TW: "TWD",
     US: "USD",

--- a/examples/nextjs/app/_utils/getCurrency.ts
+++ b/examples/nextjs/app/_utils/getCurrency.ts
@@ -26,7 +26,6 @@ const currencies = {
     RU: "RUB",
     SE: "SEK",
     SG: "SGD",
-    SK: "SKK",
     TH: "THB",
     TW: "TWD",
     US: "USD",

--- a/examples/nuxt/utils/getCurrency.ts
+++ b/examples/nuxt/utils/getCurrency.ts
@@ -26,7 +26,6 @@ const currencies: Record<string, string> = {
     RU: 'RUB',
     SE: 'SEK',
     SG: 'SGD',
-    SK: 'SKK',
     TH: 'THB',
     TW: 'TWD',
     US: 'USD',

--- a/packages/lib/src/components/OnlineBankingCZ/index.ts
+++ b/packages/lib/src/components/OnlineBankingCZ/index.ts
@@ -15,7 +15,7 @@ class OnlineBankingCZElement extends IssuerListContainer {
     formatProps(props) {
         return {
             ...super.formatProps(props),
-            showImage: false,
+            showImage: true,
             termsAndConditions: OnlineBankingCZElement.termsAndConditions
         };
     }

--- a/packages/lib/src/components/OnlineBankingSK/index.ts
+++ b/packages/lib/src/components/OnlineBankingSK/index.ts
@@ -15,7 +15,7 @@ class OnlineBankingSKElement extends IssuerListContainer {
     formatProps(props) {
         return {
             ...super.formatProps(props),
-            showImage: false,
+            showImage: true,
             termsAndConditions: OnlineBankingSKElement.termsAndConditions
         };
     }

--- a/packages/lib/storybook/stories/issuer-lists/OnlineBankingCZ.stories.tsx
+++ b/packages/lib/storybook/stories/issuer-lists/OnlineBankingCZ.stories.tsx
@@ -1,0 +1,24 @@
+import { MetaConfiguration, StoryConfiguration } from '../types';
+import { ComponentContainer } from '../ComponentContainer';
+import { IssuerListConfiguration } from '../../../src/components/helpers/IssuerListContainer/types';
+import { Checkout } from '../Checkout';
+import { OnlineBankingCZ } from '../../../src';
+
+type OnlineBankingCZStory = StoryConfiguration<IssuerListConfiguration>;
+
+const meta: MetaConfiguration<IssuerListConfiguration> = {
+    title: 'IssuerList/OnlineBankingCZ'
+};
+
+export const Default: OnlineBankingCZStory = {
+    render: ({ componentConfiguration, ...checkoutConfig }) => (
+        <Checkout checkoutConfig={checkoutConfig}>
+            {checkout => <ComponentContainer element={new OnlineBankingCZ(checkout, componentConfiguration)} />}
+        </Checkout>
+    ),
+    args: {
+        countryCode: 'CZ'
+    }
+};
+
+export default meta;

--- a/packages/lib/storybook/stories/issuer-lists/OnlineBankingSK.stories.tsx
+++ b/packages/lib/storybook/stories/issuer-lists/OnlineBankingSK.stories.tsx
@@ -1,0 +1,24 @@
+import { MetaConfiguration, StoryConfiguration } from '../types';
+import { ComponentContainer } from '../ComponentContainer';
+import { IssuerListConfiguration } from '../../../src/components/helpers/IssuerListContainer/types';
+import { Checkout } from '../Checkout';
+import { OnlineBankingSK } from '../../../src';
+
+type OnlineBankingSKStory = StoryConfiguration<IssuerListConfiguration>;
+
+const meta: MetaConfiguration<IssuerListConfiguration> = {
+    title: 'IssuerList/OnlineBankingSK'
+};
+
+export const Default: OnlineBankingSKStory = {
+    render: ({ componentConfiguration, ...checkoutConfig }) => (
+        <Checkout checkoutConfig={checkoutConfig}>
+            {checkout => <ComponentContainer element={new OnlineBankingSK(checkout, componentConfiguration)} />}
+        </Checkout>
+    ),
+    args: {
+        countryCode: 'SK'
+    }
+};
+
+export default meta;

--- a/packages/lib/storybook/utils/get-currency.ts
+++ b/packages/lib/storybook/utils/get-currency.ts
@@ -28,7 +28,6 @@ const currencies: Record<string, string> = {
     RU: 'RUB',
     SE: 'SEK',
     SG: 'SGD',
-    SK: 'SKK',
     TH: 'THB',
     TW: 'TWD',
     US: 'USD',

--- a/packages/playground/src/config/getCurrency.js
+++ b/packages/playground/src/config/getCurrency.js
@@ -27,7 +27,6 @@ const currencies = {
     RU: 'RUB',
     SE: 'SEK',
     SG: 'SGD',
-    SK: 'SKK',
     TH: 'THB',
     TW: 'TWD',
     US: 'USD',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Set `showImage: true` for both CZ and SK online banking. Images should be already available.

Also remove `SKK` support from the playground in favour of `EUR`. 

## Tested scenarios
<!-- Description of tested scenarios -->


CZ component.
![Screenshot 2024-11-07 at 18 23 15](https://github.com/user-attachments/assets/6f2a587f-d885-47cb-b277-b6490f72829d)

SK component tested, but missing the full response in Test env, should be correct in Live according to LPM.

**Fixed issue**:  <!-- #-prefixed issue number -->
