### PR TITLE
Upped SF version to 5.3.1

### DIFF
--- a/.changeset/olive-ducks-happen.md
+++ b/.changeset/olive-ducks-happen.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed issue where onBlur validation didn't fire if year in expiryDate was just one digit

--- a/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
@@ -17,7 +17,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '5.3.0';
+export const SF_VERSION = '5.3.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed issue where onBlur validation didn't fire if year in expiryDate was just one digit

## Tested scenarios
Manually tested and added new unit test in SF repo

