### PR TITLE
Add fix to reshow card icon if previously it failed to load

### DIFF
--- a/.changeset/strong-boxes-suffer.md
+++ b/.changeset/strong-boxes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Add fix to reshow card icon if previously it had failed to load

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.scss
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.scss
@@ -120,6 +120,10 @@
     display: none;
 }
 
+.adyen-checkout__field--cardNumber .adyen-checkout-card-input__icon--hidden {
+    display: none;
+}
+
 .adyen-checkout__field--securityCode.adyen-checkout__field--error .adyen-checkout__card__cvc__hint,
 .adyen-checkout__field--securityCode.adyen-checkout__field--valid .adyen-checkout__card__cvc__hint {
     opacity: 0;

--- a/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
@@ -7,13 +7,19 @@ export default function BrandIcon({ brand, brandsConfiguration = {} }: BrandIcon
     const getImage = useImage();
     const imageName = brand === 'card' ? 'nocard' : brand;
     const imageUrl = brandsConfiguration[brand]?.icon ?? getCardImageUrl(imageName, getImage);
+
     const handleError = e => {
         e.target.style.cssText = 'display: none';
+    };
+
+    const handleLoad = e => {
+        e.target.style.cssText = 'display: block';
     };
 
     return (
         <img
             className="adyen-checkout-card-input__icon adyen-checkout__card__cardNumber__brandIcon"
+            onLoad={handleLoad}
             onError={handleError}
             alt={getFullBrandName(brand)}
             src={imageUrl}

--- a/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/BrandIcon.tsx
@@ -2,27 +2,29 @@ import { h } from 'preact';
 import { getCardImageUrl, getFullBrandName } from '../utils';
 import { BrandIconProps } from './types';
 import useImage from '../../../../../core/Context/useImage';
+import { useState } from 'preact/hooks';
+import classNames from 'classnames';
 
 export default function BrandIcon({ brand, brandsConfiguration = {} }: BrandIconProps) {
     const getImage = useImage();
     const imageName = brand === 'card' ? 'nocard' : brand;
     const imageUrl = brandsConfiguration[brand]?.icon ?? getCardImageUrl(imageName, getImage);
 
-    const handleError = e => {
-        e.target.style.cssText = 'display: none';
+    const [hasLoaded, setHasLoaded] = useState(false);
+
+    const handleError = () => {
+        setHasLoaded(false);
     };
 
-    const handleLoad = e => {
-        e.target.style.cssText = 'display: block';
+    const handleLoad = () => {
+        setHasLoaded(true);
     };
 
-    return (
-        <img
-            className="adyen-checkout-card-input__icon adyen-checkout__card__cardNumber__brandIcon"
-            onLoad={handleLoad}
-            onError={handleError}
-            alt={getFullBrandName(brand)}
-            src={imageUrl}
-        />
-    );
+    const fieldClassnames = classNames({
+        'adyen-checkout-card-input__icon': true,
+        'adyen-checkout__card__cardNumber__brandIcon': true,
+        'adyen-checkout-card-input__icon--hidden': !hasLoaded
+    });
+
+    return <img className={fieldClassnames} onLoad={handleLoad} onError={handleError} alt={getFullBrandName(brand)} src={imageUrl} />;
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
If an icon in the Credit card PAN field failed to load - an error handler set inline an style `display:none`.
And this inline style was never removed in the event of a subsequent, successful, icon load.
This PR fixes that

## Tested scenarios
New e2e test that was previously flaky or failing due to this - now passes consistently
Manually tested.

