### PR TITLE
Send error events for redirect errors

### DIFF
--- a/.changeset/new-bags-crash.md
+++ b/.changeset/new-bags-crash.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Send redirection error events to analytics.

--- a/packages/lib/src/components/Card/Card.Analytics.test.tsx
+++ b/packages/lib/src/components/Card/Card.Analytics.test.tsx
@@ -8,8 +8,7 @@ let analyticsEventObject;
 
 import {
     ANALYTICS_CONFIGURED_STR,
-    ANALYTICS_EVENT_INFO,
-    ANALYTICS_EVENT_LOG,
+    ANALYTICS_EVENT,
     ANALYTICS_FOCUS_STR,
     ANALYTICS_RENDERED_STR,
     ANALYTICS_SUBMIT_STR,
@@ -47,7 +46,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
 
         // With configData removed inspect what's left
         expect(analyticsEventObject).toEqual({
-            event: ANALYTICS_EVENT_INFO,
+            event: ANALYTICS_EVENT.info,
             data: { component: card.constructor['type'], type: ANALYTICS_RENDERED_STR }
         });
     });
@@ -65,7 +64,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
 
         // With configData removed inspect what's left
         expect(analyticsEventObject).toEqual({
-            event: ANALYTICS_EVENT_INFO,
+            event: ANALYTICS_EVENT.info,
             data: { component: card.constructor['type'], type: ANALYTICS_RENDERED_STR, isStoredPaymentMethod: true, brand: 'mc' }
         });
     });
@@ -76,7 +75,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
         });
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_INFO,
+            event: ANALYTICS_EVENT.info,
             data: { component: card.constructor['type'], type: ANALYTICS_CONFIGURED_STR }
         });
     });
@@ -89,7 +88,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
         });
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_INFO,
+            event: ANALYTICS_EVENT.info,
             data: { component: card.constructor['type'], type: ANALYTICS_CONFIGURED_STR, isStoredPaymentMethod: true, brand: 'mc' }
         });
     });
@@ -109,7 +108,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
         });
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_INFO,
+            event: ANALYTICS_EVENT.info,
             data: { component: card.constructor['type'], type: ANALYTICS_FOCUS_STR, target: 'card_number' }
         });
     });
@@ -129,7 +128,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
         });
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_INFO,
+            event: ANALYTICS_EVENT.info,
             data: { component: card.constructor['type'], type: ANALYTICS_UNFOCUS_STR, target: 'card_number' }
         });
     });
@@ -141,7 +140,7 @@ describe('Card: calls that generate "info" analytics should produce objects with
         });
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_INFO,
+            event: ANALYTICS_EVENT.info,
             data: {
                 component: card.constructor['type'],
                 type: ANALYTICS_VALIDATION_ERROR_STR,
@@ -170,7 +169,7 @@ describe('Card: calls that generate "log" analytics should produce objects with 
         card.submitAnalytics({ type: ANALYTICS_SUBMIT_STR });
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_LOG,
+            event: ANALYTICS_EVENT.log,
             data: {
                 component: card.constructor['type'],
                 type: ANALYTICS_SUBMIT_STR,

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -2,7 +2,7 @@ import GooglePay from './GooglePay';
 import GooglePayService from './GooglePayService';
 
 import Analytics from '../../core/Analytics';
-import { ANALYTICS_EVENT_INFO, ANALYTICS_SELECTED_STR, NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
+import { ANALYTICS_EVENT, ANALYTICS_SELECTED_STR, NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
 
 const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
 
@@ -458,7 +458,7 @@ describe('GooglePay', () => {
             gpay.submit();
 
             expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-                event: ANALYTICS_EVENT_INFO,
+                event: ANALYTICS_EVENT.info,
                 data: {
                     component: gpay.props.type,
                     type: ANALYTICS_SELECTED_STR,

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -6,6 +6,7 @@ import RedirectButton from '../internal/RedirectButton';
 import { TxVariants } from '../tx-variants';
 import { RedirectConfiguration } from './types';
 import collectBrowserInfo from '../../utils/browserInfo';
+import { ANALYTICS_ERROR_CODE, ANALYTICS_ERROR_TYPE, ANALYTICS_EVENT } from '../../core/Analytics/constants';
 
 class RedirectElement extends UIElement<RedirectConfiguration> {
     public static type = TxVariants.redirect;
@@ -23,6 +24,15 @@ class RedirectElement extends UIElement<RedirectConfiguration> {
         };
     }
 
+    private handleRedirectError = () => {
+        super.submitAnalytics({
+            component: this.props.paymentMethodType,
+            type: ANALYTICS_EVENT.error,
+            errorType: ANALYTICS_ERROR_TYPE.redirect,
+            code: ANALYTICS_ERROR_CODE.redirect
+        });
+    };
+
     get isValid() {
         return true;
     }
@@ -33,7 +43,14 @@ class RedirectElement extends UIElement<RedirectConfiguration> {
 
     render() {
         if (this.props.url && this.props.method) {
-            return <RedirectShopper url={this.props.url} {...this.props} onActionHandled={this.onActionHandled} />;
+            return (
+                <RedirectShopper
+                    url={this.props.url}
+                    {...this.props}
+                    onActionHandled={this.onActionHandled}
+                    onRedirectError={this.handleRedirectError}
+                />
+            );
         }
 
         if (this.props.showPayButton) {

--- a/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
+++ b/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
@@ -10,12 +10,14 @@ interface RedirectShopperProps {
     redirectFromTopWhenInIframe?: boolean;
     paymentMethodType?: string;
     onActionHandled?: (rtnObj: ActionHandledReturnObject) => void;
+    onRedirectError?: () => void;
 }
 
 class RedirectShopper extends Component<RedirectShopperProps> {
     private postForm;
     public static defaultProps = {
         beforeRedirect: resolve => resolve(),
+        onRedirectError: () => {},
         method: 'GET'
     };
 
@@ -49,7 +51,9 @@ class RedirectShopper extends Component<RedirectShopperProps> {
                 })
         );
 
-        dispatchEvent.then(doRedirect).catch(() => {});
+        dispatchEvent.then(doRedirect).catch(() => {
+            this.props.onRedirectError();
+        });
     }
 
     render({ url, method, data = {} }) {

--- a/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
+++ b/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
@@ -61,6 +61,7 @@ class RedirectShopper extends Component<RedirectShopperProps> {
             return (
                 <form
                     method="post"
+                    data-testid="redirect-shopper-form"
                     action={url}
                     style={{ display: 'none' }}
                     ref={ref => {

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.test.tsx
@@ -1,6 +1,6 @@
 import { ThreeDS2Challenge } from './index';
 import Analytics from '../../core/Analytics';
-import { ANALYTICS_API_ERROR, Analytics3DS2Errors, ANALYTICS_EVENT_ERROR, ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
+import { ANALYTICS_ERROR_TYPE, Analytics3DS2Errors, ANALYTICS_RENDERED_STR, ANALYTICS_EVENT } from '../../core/Analytics/constants';
 import { THREEDS2_CHALLENGE_ERROR, THREEDS2_ERROR } from './constants';
 
 const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
@@ -31,11 +31,11 @@ describe('ThreeDS2Challenge: calls that generate analytics should produce object
         const view = challenge.render();
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_ERROR,
+            event: ANALYTICS_EVENT.error,
             data: {
                 component: challenge.constructor['type'],
                 type: THREEDS2_ERROR,
-                errorType: ANALYTICS_API_ERROR,
+                errorType: ANALYTICS_ERROR_TYPE.apiError,
                 message: `${THREEDS2_CHALLENGE_ERROR}: Missing 'paymentData' property from threeDS2 action`,
                 code: Analytics3DS2Errors.ACTION_IS_MISSING_PAYMENT_DATA
             }

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -7,7 +7,7 @@ import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import { TxVariants } from '../tx-variants';
 import { ThreeDS2ChallengeConfiguration } from './types';
 import AdyenCheckoutError, { API_ERROR } from '../../core/Errors/AdyenCheckoutError';
-import { ANALYTICS_API_ERROR, Analytics3DS2Errors, ANALYTICS_RENDERED_STR, Analytics3DS2Events } from '../../core/Analytics/constants';
+import { ANALYTICS_ERROR_TYPE, Analytics3DS2Errors, ANALYTICS_RENDERED_STR, Analytics3DS2Events } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 import { CoreProvider } from '../../core/Context/CoreProvider';
 import { ActionHandledReturnObject } from '../../types/global-types';
@@ -61,7 +61,7 @@ class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeConfiguration> {
             this.submitAnalytics({
                 type: THREEDS2_ERROR,
                 code: Analytics3DS2Errors.ACTION_IS_MISSING_PAYMENT_DATA,
-                errorType: ANALYTICS_API_ERROR,
+                errorType: ANALYTICS_ERROR_TYPE.apiError,
                 message: `${THREEDS2_CHALLENGE_ERROR}: Missing 'paymentData' property from threeDS2 action`
             });
 

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.test.tsx
@@ -1,6 +1,6 @@
 import { ThreeDS2DeviceFingerprint } from './index';
 import Analytics from '../../core/Analytics';
-import { ANALYTICS_API_ERROR, Analytics3DS2Errors, ANALYTICS_EVENT_ERROR, ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
+import { Analytics3DS2Errors, ANALYTICS_RENDERED_STR, ANALYTICS_EVENT, ANALYTICS_ERROR_TYPE } from '../../core/Analytics/constants';
 import { THREEDS2_ERROR, THREEDS2_FINGERPRINT_ERROR } from './constants';
 
 const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
@@ -32,11 +32,11 @@ describe('ThreeDS2DeviceFingerprint: calls that generate analytics should produc
         const view = fingerprint.render();
 
         expect(analyticsModule.createAnalyticsEvent).toHaveBeenCalledWith({
-            event: ANALYTICS_EVENT_ERROR,
+            event: ANALYTICS_EVENT.error,
             data: {
                 component: fingerprint.constructor['type'],
                 type: THREEDS2_ERROR,
-                errorType: ANALYTICS_API_ERROR,
+                errorType: ANALYTICS_ERROR_TYPE.apiError,
                 message: `${THREEDS2_FINGERPRINT_ERROR}: Missing 'paymentData' property from threeDS2 action`,
                 code: Analytics3DS2Errors.ACTION_IS_MISSING_PAYMENT_DATA
             }

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -6,7 +6,7 @@ import { existy } from '../../utils/commonUtils';
 import { TxVariants } from '../tx-variants';
 import { ThreeDS2DeviceFingerprintConfiguration } from './types';
 import AdyenCheckoutError, { API_ERROR } from '../../core/Errors/AdyenCheckoutError';
-import { ANALYTICS_API_ERROR, Analytics3DS2Errors, ANALYTICS_RENDERED_STR, Analytics3DS2Events } from '../../core/Analytics/constants';
+import { ANALYTICS_ERROR_TYPE, Analytics3DS2Errors, ANALYTICS_RENDERED_STR, Analytics3DS2Events } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 import { THREEDS2_ERROR, THREEDS2_FINGERPRINT, THREEDS2_FINGERPRINT_ERROR, THREEDS2_FULL } from './constants';
 import { ActionHandledReturnObject } from '../../types/global-types';
@@ -53,7 +53,7 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintConfi
             this.submitAnalytics({
                 type: THREEDS2_ERROR,
                 code: Analytics3DS2Errors.ACTION_IS_MISSING_PAYMENT_DATA,
-                errorType: ANALYTICS_API_ERROR,
+                errorType: ANALYTICS_ERROR_TYPE.apiError,
                 message: `${THREEDS2_FINGERPRINT_ERROR}: Missing 'paymentData' property from threeDS2 action`
             });
 

--- a/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
+++ b/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
@@ -3,7 +3,7 @@ import { pick } from '../../utils/commonUtils';
 import { ThreeDS2FingerprintResponse } from './types';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { THREEDS2_ERROR, THREEDS2_FINGERPRINT_SUBMIT } from './constants';
-import { ANALYTICS_API_ERROR, Analytics3DS2Errors, ANALYTICS_SDK_ERROR } from '../../core/Analytics/constants';
+import { ANALYTICS_ERROR_TYPE, Analytics3DS2Errors } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 
 /**
@@ -39,7 +39,7 @@ export default function callSubmit3DS2Fingerprint({ data }): void {
                     analyticsErrorObject = {
                         type: THREEDS2_ERROR,
                         code: Analytics3DS2Errors.NO_DETAILS_FOR_FRICTIONLESS_OR_REFUSED,
-                        errorType: ANALYTICS_API_ERROR,
+                        errorType: ANALYTICS_ERROR_TYPE.apiError,
                         message: `${THREEDS2_FINGERPRINT_SUBMIT}: no details object in a response indicating either a "frictionless" flow, or a "refused" response`
                     };
 
@@ -62,7 +62,7 @@ export default function callSubmit3DS2Fingerprint({ data }): void {
                 analyticsErrorObject = {
                     type: THREEDS2_ERROR,
                     code: Analytics3DS2Errors.NO_ACTION_FOR_CHALLENGE,
-                    errorType: ANALYTICS_API_ERROR,
+                    errorType: ANALYTICS_ERROR_TYPE.apiError,
                     message: `${THREEDS2_FINGERPRINT_SUBMIT}: no action object in a response indicating a "challenge" flow`
                 };
                 this.submitAnalytics(analyticsErrorObject);
@@ -82,7 +82,7 @@ export default function callSubmit3DS2Fingerprint({ data }): void {
                 analyticsErrorObject = {
                     type: THREEDS2_ERROR,
                     code: Analytics3DS2Errors.NO_COMPONENT_FOR_ACTION,
-                    errorType: ANALYTICS_SDK_ERROR,
+                    errorType: ANALYTICS_ERROR_TYPE.sdkError,
                     message: `${THREEDS2_FINGERPRINT_SUBMIT}: no component defined to handle the action response`
                 };
                 this.submitAnalytics(analyticsErrorObject);

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.test.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 import PrepareChallenge3DS2 from './PrepareChallenge3DS2';
 import { CoreProvider } from '../../../../core/Context/CoreProvider';
 import { THREEDS2_ERROR, THREEDS2_FULL, TIMEOUT } from '../../constants';
-import { Analytics3DS2Errors, Analytics3DS2Events, ANALYTICS_API_ERROR, ANALYTICS_NETWORK_ERROR } from '../../../../core/Analytics/constants';
+import { Analytics3DS2Errors, Analytics3DS2Events, ANALYTICS_ERROR_TYPE } from '../../../../core/Analytics/constants';
 
 const challengeToken = {
     acsReferenceNumber: 'ADYEN-ACS-SIMULATOR',
@@ -33,7 +33,7 @@ let errorMessage: string;
 
 const baseAnalyticsError = {
     type: THREEDS2_ERROR,
-    errorType: ANALYTICS_API_ERROR
+    errorType: ANALYTICS_ERROR_TYPE.apiError
 };
 
 let onSubmitAnalytics: any;
@@ -155,7 +155,7 @@ describe('PrepareChallenge3DS2 - flow completes with errors that are considered 
                 type: THREEDS2_ERROR,
                 message: 'threeDS2Challenge: timeout',
                 code: Analytics3DS2Errors.THREEDS2_TIMEOUT,
-                errorType: ANALYTICS_NETWORK_ERROR
+                errorType: ANALYTICS_ERROR_TYPE.network
             });
 
             // analytics to say process is complete
@@ -196,7 +196,7 @@ describe('PrepareChallenge3DS2 - flow completes with errors that are considered 
                 type: THREEDS2_ERROR,
                 message: 'threeDS2Challenge: no transStatus could be retrieved',
                 code: Analytics3DS2Errors.NO_TRANSSTATUS,
-                errorType: ANALYTICS_API_ERROR
+                errorType: ANALYTICS_ERROR_TYPE.apiError
             });
 
             // analytics to say process is complete

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -19,7 +19,7 @@ import {
     THREEDS2_ERROR
 } from '../../constants';
 import { isValidHttpUrl } from '../../../../utils/isValidURL';
-import { ANALYTICS_API_ERROR, ANALYTICS_NETWORK_ERROR, Analytics3DS2Errors, Analytics3DS2Events } from '../../../../core/Analytics/constants';
+import { ANALYTICS_ERROR_TYPE, Analytics3DS2Errors, Analytics3DS2Events } from '../../../../core/Analytics/constants';
 import { ErrorObject } from '../../../../core/Errors/types';
 
 class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareChallenge3DS2State> {
@@ -91,7 +91,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                 const errorCodeObject: SendAnalyticsObject = {
                     type: THREEDS2_ERROR,
                     code: Analytics3DS2Errors.TOKEN_IS_MISSING_ACSURL,
-                    errorType: ANALYTICS_API_ERROR,
+                    errorType: ANALYTICS_ERROR_TYPE.apiError,
                     message: `${THREEDS2_CHALLENGE_ERROR}: Decoded token is missing a valid acsURL property`
                     // metadata: { acsURL } // NEW TODO - check acsURL isn't secret
                 };
@@ -118,7 +118,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                 this.props.onSubmitAnalytics({
                     type: THREEDS2_ERROR,
                     code: Analytics3DS2Errors.TOKEN_IS_MISSING_OTHER_PROPS,
-                    errorType: ANALYTICS_API_ERROR,
+                    errorType: ANALYTICS_ERROR_TYPE.apiError,
                     message: `${THREEDS2_CHALLENGE_ERROR}: Decoded token is missing one or more of the following properties (acsTransID | messageVersion | threeDSServerTransID)`
                 } as SendAnalyticsObject);
 
@@ -155,7 +155,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             this.props.onSubmitAnalytics({
                 type: THREEDS2_ERROR,
                 code: errorCode,
-                errorType: ANALYTICS_API_ERROR,
+                errorType: ANALYTICS_ERROR_TYPE.apiError,
                 message: `${THREEDS2_CHALLENGE_ERROR}: ${errorMsg}` // can be: 'Missing "token" property from threeDS2 action', 'not base64', 'malformed URI sequence' or 'Could not JSON parse token'
             });
 
@@ -183,7 +183,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
             if (finalResObject.errorCode) {
                 const errorTypeAndCode = {
                     code: finalResObject.errorCode === 'timeout' ? Analytics3DS2Errors.THREEDS2_TIMEOUT : Analytics3DS2Errors.NO_TRANSSTATUS,
-                    errorType: finalResObject.errorCode === 'timeout' ? ANALYTICS_NETWORK_ERROR : ANALYTICS_API_ERROR
+                    errorType: finalResObject.errorCode === 'timeout' ? ANALYTICS_ERROR_TYPE.network : ANALYTICS_ERROR_TYPE.apiError
                 };
 
                 // Challenge process has timed out,
@@ -308,7 +308,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                             this.props.onSubmitAnalytics({
                                 type: THREEDS2_ERROR,
                                 code: Analytics3DS2Errors.CHALLENGE_RESOLVED_WITHOUT_RESULT_PROP,
-                                errorType: ANALYTICS_API_ERROR,
+                                errorType: ANALYTICS_ERROR_TYPE.apiError,
                                 message: `${THREEDS2_CHALLENGE_ERROR}: challenge resolved without a "result" object`
                             });
 

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.test.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { h } from 'preact';
 import PrepareFingerprint3DS2 from './PrepareFingerprint3DS2';
 import { THREEDS2_ERROR, THREEDS2_FINGERPRINT_ERROR, THREEDS2_FULL, TIMEOUT } from '../../constants';
-import { Analytics3DS2Errors, Analytics3DS2Events, ANALYTICS_API_ERROR, ANALYTICS_NETWORK_ERROR } from '../../../../core/Analytics/constants';
+import { Analytics3DS2Errors, Analytics3DS2Events, ANALYTICS_ERROR_TYPE } from '../../../../core/Analytics/constants';
 
 const fingerPrintToken = {
     threeDSMessageVersion: '2.1.0',
@@ -32,7 +32,7 @@ const onError: any = () => {};
 
 const baseAnalyticsError = {
     type: THREEDS2_ERROR,
-    errorType: ANALYTICS_API_ERROR
+    errorType: ANALYTICS_ERROR_TYPE.apiError
 };
 
 let completeFunction: any;
@@ -147,7 +147,7 @@ describe('ThreeDS2DeviceFingerprint - flow completes with errors that are consid
                 type: THREEDS2_ERROR,
                 message: 'threeDS2Fingerprint: timeout',
                 code: Analytics3DS2Errors.THREEDS2_TIMEOUT,
-                errorType: ANALYTICS_NETWORK_ERROR
+                errorType: ANALYTICS_ERROR_TYPE.network
             });
 
             // analytics to say process is complete

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -15,7 +15,7 @@ import {
     THREEDS2_ERROR,
     TIMEOUT
 } from '../../constants';
-import { ANALYTICS_API_ERROR, ANALYTICS_NETWORK_ERROR, Analytics3DS2Errors, Analytics3DS2Events } from '../../../../core/Analytics/constants';
+import { ANALYTICS_ERROR_TYPE, Analytics3DS2Errors, Analytics3DS2Events } from '../../../../core/Analytics/constants';
 
 class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State> {
     public static type = 'scheme';
@@ -163,7 +163,7 @@ class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, Prep
             if (finalResObject.errorCode) {
                 const errorTypeAndCode = {
                     code: finalResObject.errorCode === TIMEOUT ? Analytics3DS2Errors.THREEDS2_TIMEOUT : finalResObject.errorCode,
-                    errorType: finalResObject.errorCode === TIMEOUT ? ANALYTICS_NETWORK_ERROR : ANALYTICS_API_ERROR
+                    errorType: finalResObject.errorCode === TIMEOUT ? ANALYTICS_ERROR_TYPE.network : ANALYTICS_ERROR_TYPE.apiError
                 };
 
                 /**

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -161,15 +161,23 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
          * - otherwise, distinguish cards from non-cards: cards will use their static type property, everything else will use props.type
          */
         try {
-            let component = this.constructor['analyticsType'];
-            if (!component) {
-                component = this.constructor['type'] === 'scheme' || this.constructor['type'] === 'bcmc' ? this.constructor['type'] : this.props.type;
-            }
-
-            this.props.modules.analytics.sendAnalytics(component, analyticsObj, uiElementProps);
+            this.props.modules.analytics.sendAnalytics(this.getComponent(analyticsObj), analyticsObj, uiElementProps);
         } catch (error) {
             console.warn('Failed to submit the analytics event. Error:', error);
         }
+    }
+
+    private getComponent({ component }: SendAnalyticsObject): string {
+        if (component) {
+            return component;
+        }
+        if (this.constructor['analyticsType']) {
+            return this.constructor['analyticsType'];
+        }
+        if (this.constructor['type'] === 'scheme' || this.constructor['type'] === 'bcmc') {
+            return this.constructor['type'];
+        }
+        return this.props.type;
     }
 
     public submit(): void {

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -3,7 +3,7 @@ import collectId from '../Services/analytics/collect-id';
 import { PaymentAmount } from '../../types';
 import wait from '../../utils/wait';
 import { DEFAULT_DEBOUNCE_TIME_MS } from '../../utils/debounce';
-import { ANALYTICS_EVENT, AnalyticsObject, CreateAnalyticsObject } from './types';
+import { AnalyticsEvent, AnalyticsObject, CreateAnalyticsObject } from './types';
 import { ANALYTICS_VALIDATION_ERROR_STR } from './constants';
 
 jest.mock('../Services/analytics/collect-id');
@@ -21,7 +21,7 @@ const setUpEvent = {
 };
 
 const analyticsEventObj = {
-    event: 'info' as ANALYTICS_EVENT,
+    event: 'info' as AnalyticsEvent,
     component: 'cardComponent',
     type: 'Focus',
     target: 'PAN input'

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -1,14 +1,7 @@
 import CollectId from '../Services/analytics/collect-id';
 import EventsQueue, { EventsQueueModule } from './EventsQueue';
-import { ANALYTICS_EVENT, AnalyticsInitialEvent, AnalyticsObject, AnalyticsProps, CreateAnalyticsEventObject } from './types';
-import {
-    ANALYTIC_LEVEL,
-    ANALYTICS_EVENT_ERROR,
-    ANALYTICS_EVENT_INFO,
-    ANALYTICS_EVENT_LOG,
-    ANALYTICS_INFO_TIMER_INTERVAL,
-    ANALYTICS_PATH
-} from './constants';
+import { AnalyticsEvent, AnalyticsInitialEvent, AnalyticsObject, AnalyticsProps, CreateAnalyticsEventObject } from './types';
+import { ANALYTIC_LEVEL, ANALYTICS_INFO_TIMER_INTERVAL, ANALYTICS_PATH, ANALYTICS_EVENT } from './constants';
 import { debounce } from '../../utils/debounce';
 import { AnalyticsModule } from '../../types/global-types';
 import { createAnalyticsObject, processAnalyticsData } from './utils';
@@ -36,8 +29,8 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
         return Promise.resolve(null);
     };
 
-    const addAnalyticsEvent = (type: ANALYTICS_EVENT, obj: AnalyticsObject) => {
-        const arrayName = type === ANALYTICS_EVENT_INFO ? type : `${type}s`;
+    const addAnalyticsEvent = (type: AnalyticsEvent, obj: AnalyticsObject) => {
+        const arrayName = type === ANALYTICS_EVENT.info ? type : `${type}s`;
         eventsQueue.add(`${arrayName}`, obj);
 
         /**
@@ -45,7 +38,7 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
          *  - info events are stored until a log or error comes along,
          *  but, if after a set time, no other analytics event (log or error) has come along then we send the info events anyway
          */
-        if (type === ANALYTICS_EVENT_INFO) {
+        if (type === ANALYTICS_EVENT.info) {
             clearTimeout(sendEventsTimerId);
             sendEventsTimerId = setTimeout(() => void sendAnalyticsEvents(), ANALYTICS_INFO_TIMER_INTERVAL);
         }
@@ -56,7 +49,7 @@ const Analytics = ({ locale, clientKey, analytics, amount, analyticsContext, bun
          *  ...but... tests with the 3DS2 process show that many logs can happen almost at the same time (or you can have an error followed immediately by a log),
          *  so instead of making several sequential api calls we see if we can "batch" them using debounce
          */
-        if (type === ANALYTICS_EVENT_LOG || type === ANALYTICS_EVENT_ERROR) {
+        if (type === ANALYTICS_EVENT.log || type === ANALYTICS_EVENT.error) {
             clearTimeout(sendEventsTimerId); // clear any timer that might be about to dispatch the info events array
 
             debounce(sendAnalyticsEvents)();

--- a/packages/lib/src/core/Analytics/EventsQueue.ts
+++ b/packages/lib/src/core/Analytics/EventsQueue.ts
@@ -24,7 +24,7 @@ const EventsQueue = ({ analyticsContext, clientKey, analyticsPath }: EventQueueP
         logs: []
     };
 
-    const runQueue = (checkoutAttemptId: string): Promise<any> => {
+    const runQueue = async (checkoutAttemptId: string): Promise<any> => {
         if (!caActions.info.length && !caActions.logs.length && !caActions.errors.length) {
             return Promise.resolve(null);
         }
@@ -35,7 +35,7 @@ const EventsQueue = ({ analyticsContext, clientKey, analyticsPath }: EventQueueP
             path: `${analyticsPath}/${checkoutAttemptId}?clientKey=${clientKey}`
         };
 
-        const promise = httpPost(options, caActions)
+        return httpPost(options, caActions)
             .then(() => {
                 // Succeed, silently
                 return undefined;
@@ -44,11 +44,9 @@ const EventsQueue = ({ analyticsContext, clientKey, analyticsPath }: EventQueueP
                 // Caught, silently, at http level. We do not expect this catch block to ever fire, but... just in case...
                 console.debug('### EventsQueue:::: send has failed');
             });
-
-        return promise;
     };
 
-    const eqModule: EventsQueueModule = {
+    return {
         add: (type, actionObj) => {
             caActions[type].push(actionObj);
         },
@@ -66,8 +64,6 @@ const EventsQueue = ({ analyticsContext, clientKey, analyticsPath }: EventQueueP
         // Expose getter for testing purposes
         getQueue: () => caActions
     };
-
-    return eqModule;
 };
 
 export default EventsQueue;

--- a/packages/lib/src/core/Analytics/EventsQueue.ts
+++ b/packages/lib/src/core/Analytics/EventsQueue.ts
@@ -24,7 +24,7 @@ const EventsQueue = ({ analyticsContext, clientKey, analyticsPath }: EventQueueP
         logs: []
     };
 
-    const runQueue = async (checkoutAttemptId: string): Promise<any> => {
+    const runQueue = (checkoutAttemptId: string): Promise<any> => {
         if (!caActions.info.length && !caActions.logs.length && !caActions.errors.length) {
             return Promise.resolve(null);
         }

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.test.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.test.ts
@@ -1,7 +1,7 @@
 import Analytics from './Analytics';
 import { PaymentAmount } from '../../types';
 import { analyticsPreProcessor } from './analyticsPreProcessor';
-import { ANALYTICS_EVENT_INFO, ANALYTICS_RENDERED_STR } from './constants';
+import { ANALYTICS_EVENT, ANALYTICS_RENDERED_STR } from './constants';
 
 let analytics;
 let sendAnalytics;
@@ -20,7 +20,7 @@ describe('Testing AnalyticsPreProcessor: process and output', () => {
             sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: true, expressPage: 'cart' });
 
             expect(analytics.createAnalyticsEvent).toBeCalledWith({
-                event: ANALYTICS_EVENT_INFO,
+                event: ANALYTICS_EVENT.info,
                 data: {
                     component: 'paywithgoogle',
                     type: 'rendered',
@@ -34,7 +34,7 @@ describe('Testing AnalyticsPreProcessor: process and output', () => {
             sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: null, expressPage: 'cart' });
 
             expect(analytics.createAnalyticsEvent).toBeCalledWith({
-                event: ANALYTICS_EVENT_INFO,
+                event: ANALYTICS_EVENT.info,
                 data: {
                     component: 'paywithgoogle',
                     type: 'rendered'
@@ -46,7 +46,7 @@ describe('Testing AnalyticsPreProcessor: process and output', () => {
             sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: undefined, expressPage: 'cart' });
 
             expect(analytics.createAnalyticsEvent).toBeCalledWith({
-                event: ANALYTICS_EVENT_INFO,
+                event: ANALYTICS_EVENT.info,
                 data: {
                     component: 'paywithgoogle',
                     type: 'rendered'
@@ -58,7 +58,7 @@ describe('Testing AnalyticsPreProcessor: process and output', () => {
             sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: 'true', expressPage: 'cart' });
 
             expect(analytics.createAnalyticsEvent).toBeCalledWith({
-                event: ANALYTICS_EVENT_INFO,
+                event: ANALYTICS_EVENT.info,
                 data: {
                     component: 'paywithgoogle',
                     type: 'rendered'
@@ -70,7 +70,7 @@ describe('Testing AnalyticsPreProcessor: process and output', () => {
             sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: false, expressPage: 'cart' });
 
             expect(analytics.createAnalyticsEvent).toBeCalledWith({
-                event: ANALYTICS_EVENT_INFO,
+                event: ANALYTICS_EVENT.info,
                 data: {
                     component: 'paywithgoogle',
                     type: 'rendered',
@@ -83,7 +83,7 @@ describe('Testing AnalyticsPreProcessor: process and output', () => {
             sendAnalytics('paywithgoogle', { type: ANALYTICS_RENDERED_STR }, { isExpress: true, expressPage: 'foobar' });
 
             expect(analytics.createAnalyticsEvent).toBeCalledWith({
-                event: ANALYTICS_EVENT_INFO,
+                event: ANALYTICS_EVENT.info,
                 data: {
                     component: 'paywithgoogle',
                     type: 'rendered',

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -145,7 +145,8 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             /**
              * ERRORS
              */
-            case THREEDS2_ERROR: {
+            case THREEDS2_ERROR:
+            case ANALYTICS_EVENT.error: {
                 const { message, code, errorType } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
                     event: ANALYTICS_EVENT.error,

--- a/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
+++ b/packages/lib/src/core/Analytics/analyticsPreProcessor.ts
@@ -5,9 +5,6 @@ import {
     ANALYTICS_CONFIGURED_STR,
     ANALYTICS_DISPLAYED_STR,
     ANALYTICS_DOWNLOAD_STR,
-    ANALYTICS_EVENT_ERROR,
-    ANALYTICS_EVENT_INFO,
-    ANALYTICS_EVENT_LOG,
     ANALYTICS_FOCUS_STR,
     ANALYTICS_INPUT_STR,
     ANALYTICS_RENDERED_STR,
@@ -15,7 +12,8 @@ import {
     ANALYTICS_SUBMIT_STR,
     ANALYTICS_UNFOCUS_STR,
     ANALYTICS_VALIDATION_ERROR_STR,
-    ANALYTICS_EXPRESS_PAGES_ARRAY
+    ANALYTICS_EXPRESS_PAGES_ARRAY,
+    ANALYTICS_EVENT
 } from './constants';
 import { THREEDS2_ERROR, THREEDS2_FULL } from '../../components/ThreeDS2/constants';
 import AdyenCheckoutError, { SDK_ERROR } from '../Errors/AdyenCheckoutError';
@@ -65,7 +63,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                 };
 
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_INFO,
+                    event: ANALYTICS_EVENT.info,
                     data
                 });
 
@@ -77,7 +75,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                 const data = { component, type, isStoredPaymentMethod, brand };
 
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_INFO,
+                    event: ANALYTICS_EVENT.info,
                     data
                 });
                 break;
@@ -89,7 +87,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case ANALYTICS_INPUT_STR: // issuerList
             case ANALYTICS_DOWNLOAD_STR: // QR codes
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_INFO,
+                    event: ANALYTICS_EVENT.info,
                     data: { component, type, target }
                 });
                 break;
@@ -99,7 +97,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case ANALYTICS_SELECTED_STR: {
                 const { issuer } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_INFO,
+                    event: ANALYTICS_EVENT.info,
                     data: { component, type, target, issuer }
                 });
                 break;
@@ -108,7 +106,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case ANALYTICS_VALIDATION_ERROR_STR: {
                 const { validationErrorCode, validationErrorMessage } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_INFO,
+                    event: ANALYTICS_EVENT.info,
                     data: { component, type, target, validationErrorCode, validationErrorMessage }
                 });
                 break;
@@ -119,7 +117,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
              */
             case ANALYTICS_SUBMIT_STR:
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_LOG,
+                    event: ANALYTICS_EVENT.log,
                     data: { component, type, message: 'Shopper clicked pay' }
                 });
                 break;
@@ -127,7 +125,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case ANALYTICS_ACTION_STR: {
                 const { subtype, message } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_LOG,
+                    event: ANALYTICS_EVENT.log,
                     data: { component, type, subtype, message }
                 });
                 break;
@@ -138,7 +136,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
                 const { message, metadata, subtype, result } = analyticsObj;
 
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_LOG,
+                    event: ANALYTICS_EVENT.log,
                     data: { component, type, message, metadata, subtype, result }
                 });
                 break;
@@ -150,7 +148,7 @@ export const analyticsPreProcessor = (analyticsModule: AnalyticsModule) => {
             case THREEDS2_ERROR: {
                 const { message, code, errorType } = analyticsObj;
                 analyticsModule.createAnalyticsEvent({
-                    event: ANALYTICS_EVENT_ERROR,
+                    event: ANALYTICS_EVENT.error,
                     data: { component, type, message, code, errorType }
                 });
                 break;

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -30,6 +30,10 @@ export const ANALYTICS_ERROR_TYPE = {
     threeDS2: 'ThreeDS2'
 };
 
+export const ANALYTICS_ERROR_CODE = {
+    redirect: '600'
+};
+
 export const ANALYTICS_ACTION_STR = 'action';
 export const ANALYTICS_SUBMIT_STR = 'submit';
 export const ANALYTICS_SELECTED_STR = 'selected';

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -20,7 +20,7 @@ export const ANALYTICS_EVENT = {
 
 export const ANALYTICS_ERROR_TYPE = {
     network: 'Network',
-    implementation: 'Implementation',
+    implementation: 'ImplementationError',
     internal: 'Internal',
     apiError: 'ApiError',
     sdkError: 'SdkError',

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -12,9 +12,23 @@ export const ANALYTICS_INFO_TIMER_INTERVAL = process.env.NODE_ENV === 'developme
 
 export const ANALYTICS_SEARCH_DEBOUNCE_TIME = 3000;
 
-export const ANALYTICS_EVENT_LOG = 'log';
-export const ANALYTICS_EVENT_ERROR = 'error';
-export const ANALYTICS_EVENT_INFO = 'info';
+export const ANALYTICS_EVENT = {
+    log: 'log',
+    error: 'error',
+    info: 'info'
+};
+
+export const ANALYTICS_ERROR_TYPE = {
+    network: 'Network',
+    implementation: 'Implementation',
+    internal: 'Internal',
+    apiError: 'ApiError',
+    sdkError: 'SdkError',
+    thirdParty: 'ThirdParty',
+    generic: 'Generic',
+    redirect: 'Redirect',
+    threeDS2: 'ThreeDS2'
+};
 
 export const ANALYTICS_ACTION_STR = 'action';
 export const ANALYTICS_SUBMIT_STR = 'submit';
@@ -38,11 +52,6 @@ export const ANALYTICS_INSTANT_PAYMENT_BUTTON = 'instant_payment_button';
 export const ANALYTICS_FEATURED_ISSUER = 'featured_issuer';
 export const ANALYTICS_LIST = 'list';
 export const ANALYTICS_LIST_SEARCH = 'list_search';
-
-export const ANALYTICS_IMPLEMENTATION_ERROR = 'ImplementationError';
-export const ANALYTICS_API_ERROR = 'ApiError';
-export const ANALYTICS_SDK_ERROR = 'SdkError';
-export const ANALYTICS_NETWORK_ERROR = 'Network';
 
 export enum Analytics3DS2Errors {
     ACTION_IS_MISSING_PAYMENT_DATA = '700', // Missing 'paymentData' property from threeDS2 action

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -1,6 +1,7 @@
 import { PaymentAmount } from '../../types';
 import { CoreConfiguration } from '../types';
 import { SocialSecurityMode } from '../../components/Card/types';
+import { ANALYTICS_EVENT } from './constants';
 
 export interface Experiment {
     controlGroup: boolean;
@@ -85,9 +86,9 @@ export interface AnalyticsObject {
     configData?: Record<string, string | boolean>;
 }
 
-export type ANALYTICS_EVENT = 'log' | 'error' | 'info';
+export type AnalyticsEvent = (typeof ANALYTICS_EVENT)[keyof typeof ANALYTICS_EVENT];
 
-export type CreateAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'id'> & { event: ANALYTICS_EVENT };
+export type CreateAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'id'> & { event: AnalyticsEvent };
 
 export type AnalyticsInitialEvent = {
     containerWidth: number;
@@ -108,7 +109,7 @@ export type AnalyticsConfig = {
 export type CreateAnalyticsEventData = Omit<AnalyticsObject, 'timestamp' | 'id'>;
 
 export type CreateAnalyticsEventObject = {
-    event: ANALYTICS_EVENT;
+    event: AnalyticsEvent;
     data: CreateAnalyticsEventData;
 };
 

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -115,7 +115,9 @@ export type CreateAnalyticsEventObject = {
 
 export type EventQueueProps = Pick<AnalyticsConfig, 'analyticsContext' | 'clientKey'> & { analyticsPath: string };
 
-export type SendAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'component' | 'id'>;
+export interface SendAnalyticsObject extends Omit<AnalyticsObject, 'timestamp' | 'id' | 'component'> {
+    component?: string;
+}
 
 export type FieldErrorAnalyticsObject = {
     fieldType: string;

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -115,9 +115,7 @@ export type CreateAnalyticsEventObject = {
 
 export type EventQueueProps = Pick<AnalyticsConfig, 'analyticsContext' | 'clientKey'> & { analyticsPath: string };
 
-export interface SendAnalyticsObject extends Omit<AnalyticsObject, 'timestamp' | 'id' | 'component'> {
-    component?: string;
-}
+export type SendAnalyticsObject = Omit<AnalyticsObject, 'timestamp' | 'id' | 'component'> & { component?: string };
 
 export type FieldErrorAnalyticsObject = {
     fieldType: string;

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -30,30 +30,33 @@ export const getUTCTimestamp = () => Date.now();
  *
  *  All objects can also have a "metadata" object of key-value pairs
  */
-export const createAnalyticsObject = (aObj: CreateAnalyticsObject): AnalyticsObject => ({
-    timestamp: String(getUTCTimestamp()),
-    component: aObj.component,
-    id: uuid(),
-    /** ERROR */
-    ...(aObj.event === 'error' && { code: aObj.code, errorType: aObj.errorType, message: aObj.message }), // error event
-    /** LOG */
-    ...(aObj.event === 'log' && { type: aObj.type, message: aObj.message }), // log event
-    ...(aObj.event === 'log' && (aObj.type === ANALYTICS_ACTION_STR || aObj.type === THREEDS2_FULL) && { subType: aObj.subtype }), // only added if we have a log event of Action type or ThreeDS2
-    ...(aObj.event === 'log' && aObj.type === THREEDS2_FULL && { result: aObj.result }), // only added if we have a log event of ThreeDS2 type
-    /** INFO */
-    ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // info event
-    ...(aObj.event === 'info' && aObj.issuer && { issuer: aObj.issuer }), // relates to issuerLists
-    ...(aObj.event === 'info' && { isExpress: aObj.isExpress, expressPage: aObj.expressPage }), // relates to Plugins & detecting Express PMs
-    ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info event about a storedPM
-    ...(aObj.event === 'info' &&
-        aObj.type === ANALYTICS_VALIDATION_ERROR_STR && {
-            validationErrorCode: mapErrorCodesForAnalytics(aObj.validationErrorCode, aObj.target),
-            validationErrorMessage: aObj.validationErrorMessage
-        }), // only added if we have an info event describing a validation error
-    ...(aObj.configData && { configData: aObj.configData }),
-    /** All */
-    ...(aObj.metadata && { metadata: aObj.metadata })
-});
+
+export const createAnalyticsObject = (aObj: CreateAnalyticsObject): AnalyticsObject => {
+    return {
+        timestamp: String(getUTCTimestamp()),
+        component: aObj.component,
+        id: uuid(),
+        /** ERROR */
+        ...(aObj.event === 'error' && { code: aObj.code, errorType: aObj.errorType, message: aObj.message }), // error event
+        /** LOG */
+        ...(aObj.event === 'log' && { type: aObj.type, message: aObj.message }), // log event
+        ...(aObj.event === 'log' && (aObj.type === ANALYTICS_ACTION_STR || aObj.type === THREEDS2_FULL) && { subType: aObj.subtype }), // only added if we have a log event of Action type or ThreeDS2
+        ...(aObj.event === 'log' && aObj.type === THREEDS2_FULL && { result: aObj.result }), // only added if we have a log event of ThreeDS2 type
+        /** INFO */
+        ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // info event
+        ...(aObj.event === 'info' && aObj.issuer && { issuer: aObj.issuer }), // relates to issuerLists
+        ...(aObj.event === 'info' && { isExpress: aObj.isExpress, expressPage: aObj.expressPage }), // relates to Plugins & detecting Express PMs
+        ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info event about a storedPM
+        ...(aObj.event === 'info' &&
+            aObj.type === ANALYTICS_VALIDATION_ERROR_STR && {
+                validationErrorCode: mapErrorCodesForAnalytics(aObj.validationErrorCode, aObj.target),
+                validationErrorMessage: aObj.validationErrorMessage
+            }), // only added if we have an info event describing a validation error
+        ...(aObj.configData && { configData: aObj.configData }),
+        /** All */
+        ...(aObj.metadata && { metadata: aObj.metadata })
+    };
+};
 
 const mapErrorCodesForAnalytics = (errorCode: string, target: string) => {
     // Some of the more generic error codes required combination with target to retrieve a specific code

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -30,33 +30,30 @@ export const getUTCTimestamp = () => Date.now();
  *
  *  All objects can also have a "metadata" object of key-value pairs
  */
-
-export const createAnalyticsObject = (aObj: CreateAnalyticsObject): AnalyticsObject => {
-    return {
-        timestamp: String(getUTCTimestamp()),
-        component: aObj.component,
-        id: uuid(),
-        /** ERROR */
-        ...(aObj.event === 'error' && { code: aObj.code, errorType: aObj.errorType, message: aObj.message }), // error event
-        /** LOG */
-        ...(aObj.event === 'log' && { type: aObj.type, message: aObj.message }), // log event
-        ...(aObj.event === 'log' && (aObj.type === ANALYTICS_ACTION_STR || aObj.type === THREEDS2_FULL) && { subType: aObj.subtype }), // only added if we have a log event of Action type or ThreeDS2
-        ...(aObj.event === 'log' && aObj.type === THREEDS2_FULL && { result: aObj.result }), // only added if we have a log event of ThreeDS2 type
-        /** INFO */
-        ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // info event
-        ...(aObj.event === 'info' && aObj.issuer && { issuer: aObj.issuer }), // relates to issuerLists
-        ...(aObj.event === 'info' && { isExpress: aObj.isExpress, expressPage: aObj.expressPage }), // relates to Plugins & detecting Express PMs
-        ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info event about a storedPM
-        ...(aObj.event === 'info' &&
-            aObj.type === ANALYTICS_VALIDATION_ERROR_STR && {
-                validationErrorCode: mapErrorCodesForAnalytics(aObj.validationErrorCode, aObj.target),
-                validationErrorMessage: aObj.validationErrorMessage
-            }), // only added if we have an info event describing a validation error
-        ...(aObj.configData && { configData: aObj.configData }),
-        /** All */
-        ...(aObj.metadata && { metadata: aObj.metadata })
-    };
-};
+export const createAnalyticsObject = (aObj: CreateAnalyticsObject): AnalyticsObject => ({
+    timestamp: String(getUTCTimestamp()),
+    component: aObj.component,
+    id: uuid(),
+    /** ERROR */
+    ...(aObj.event === 'error' && { code: aObj.code, errorType: aObj.errorType, message: aObj.message }), // error event
+    /** LOG */
+    ...(aObj.event === 'log' && { type: aObj.type, message: aObj.message }), // log event
+    ...(aObj.event === 'log' && (aObj.type === ANALYTICS_ACTION_STR || aObj.type === THREEDS2_FULL) && { subType: aObj.subtype }), // only added if we have a log event of Action type or ThreeDS2
+    ...(aObj.event === 'log' && aObj.type === THREEDS2_FULL && { result: aObj.result }), // only added if we have a log event of ThreeDS2 type
+    /** INFO */
+    ...(aObj.event === 'info' && { type: aObj.type, target: aObj.target }), // info event
+    ...(aObj.event === 'info' && aObj.issuer && { issuer: aObj.issuer }), // relates to issuerLists
+    ...(aObj.event === 'info' && { isExpress: aObj.isExpress, expressPage: aObj.expressPage }), // relates to Plugins & detecting Express PMs
+    ...(aObj.event === 'info' && aObj.isStoredPaymentMethod && { isStoredPaymentMethod: aObj.isStoredPaymentMethod, brand: aObj.brand }), // only added if we have an info event about a storedPM
+    ...(aObj.event === 'info' &&
+        aObj.type === ANALYTICS_VALIDATION_ERROR_STR && {
+            validationErrorCode: mapErrorCodesForAnalytics(aObj.validationErrorCode, aObj.target),
+            validationErrorMessage: aObj.validationErrorMessage
+        }), // only added if we have an info event describing a validation error
+    ...(aObj.configData && { configData: aObj.configData }),
+    /** All */
+    ...(aObj.metadata && { metadata: aObj.metadata })
+});
 
 const mapErrorCodesForAnalytics = (errorCode: string, target: string) => {
     // Some of the more generic error codes required combination with target to retrieve a specific code


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Send the redirect error event to the analytics when `doRedirect` throws an error
- Refine some types
- Fix some lint warnings

## Tested scenarios
- Added unit test
- Tested when manually simulate an error from `doRedirect`


**Fixed issue**:  COWEB-1463
