### PR TITLE
Using pressSequentially instead of type

### DIFF
--- a/packages/e2e-playwright/models/card.ts
+++ b/packages/e2e-playwright/models/card.ts
@@ -144,7 +144,7 @@ class Card extends Base {
     }
 
     async typeCardNumber(cardNumber: string) {
-        await this.cardNumberInput.type(cardNumber, { delay: USER_TYPE_DELAY });
+        await this.cardNumberInput.pressSequentially(cardNumber, { delay: USER_TYPE_DELAY });
     }
 
     async deleteCardNumber() {
@@ -166,7 +166,7 @@ class Card extends Base {
     }
 
     async typeExpiryDate(expiryDate: string) {
-        await this.expiryDateInput.type(expiryDate, { delay: USER_TYPE_DELAY });
+        await this.expiryDateInput.pressSequentially(expiryDate, { delay: USER_TYPE_DELAY });
     }
 
     async fillCvc(cvc: string) {
@@ -176,7 +176,7 @@ class Card extends Base {
     }
 
     async typeCvc(cvc: string) {
-        await this.cvcInput.type(cvc, { delay: USER_TYPE_DELAY });
+        await this.cvcInput.pressSequentially(cvc, { delay: USER_TYPE_DELAY });
     }
 
     async selectListItem(who: string) {

--- a/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.kcp.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.kcp.spec.ts
@@ -1,12 +1,9 @@
-import { mergeTests, expect } from '@playwright/test';
-import { test as cardWithKCP } from '../../../../../fixtures/card.fixture';
+import { test, expect } from '../../../../../fixtures/card.fixture';
 import { getStoryUrl } from '../../../../utils/getStoryUrl';
 import { URL_MAP } from '../../../../../fixtures/URL_MAP';
 import { binLookupMock } from '../../../../../mocks/binLookup/binLookup.mock';
 import { kcpMockOptionalDateAndCvcWithPanLengthMock } from '../../../../../mocks/binLookup/binLookup.data';
 import { REGULAR_TEST_CARD } from '../../../../utils/constants';
-
-const test = mergeTests(cardWithKCP);
 
 const componentConfig = {
     brands: ['mc', 'visa', 'amex', 'korean_local_card'],

--- a/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.ssn.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.ssn.spec.ts
@@ -1,12 +1,9 @@
-import { mergeTests, expect } from '@playwright/test';
-import { test as cardWithSSN } from '../../../../../fixtures/card.fixture';
+import { test, expect } from '../../../../../fixtures/card.fixture';
 import { getStoryUrl } from '../../../../utils/getStoryUrl';
 import { URL_MAP } from '../../../../../fixtures/URL_MAP';
 import { binLookupMock } from '../../../../../mocks/binLookup/binLookup.mock';
 import { optionalDateAndCvcWithPanLengthMock } from '../../../../../mocks/binLookup/binLookup.data';
 import { REGULAR_TEST_CARD } from '../../../../utils/constants';
-
-const test = mergeTests(cardWithSSN);
 
 test.describe('Test Card, binLookup w. panLength property & social security number', () => {
     test('#1 Fill out PAN see that focus moves to social security number since expiryDate & cvc are optional', async ({ cardWithSSN, page }) => {


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Using `pressSequentially` instead of `type` in `card` model. 
Stop using `mergeTests` unnecessarily.

## Tested scenarios
Affected test still run