### PR TITLE
WIP: Handling multiple instances of the Klarna Widget

### DIFF
--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -58,10 +58,19 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
     };
 
     private setActivePaymentMethod = paymentMethod => {
+        // console.log('\n### DropinComponent::setActivePaymentMethod:: cachedPaymentMethods', this.state.cachedPaymentMethods);
         this.setState(prevState => ({
             activePaymentMethod: paymentMethod,
             cachedPaymentMethods: { ...prevState.cachedPaymentMethods, [paymentMethod._id]: true }
         }));
+
+        for (const [key] of Object.entries(this.state.cachedPaymentMethods)) {
+            if (key === paymentMethod._id) {
+                // console.log('### DropinComponent::setActivePaymentMethod:: payment method is cached=', key);
+                paymentMethod.onPaymentMethodActive();
+                break;
+            }
+        }
     };
 
     componentDidUpdate(prevProps, prevState) {

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -84,9 +84,9 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
         const showBrands = !paymentMethod.props.oneClick && paymentMethod.brands && paymentMethod.brands.length > 0;
 
         return (
-            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-            <div key={paymentMethod._id} className={paymentMethodClassnames} onClick={this.handleOnListItemClick}>
-                <div className="adyen-checkout__payment-method__header">
+            <div key={paymentMethod._id} className={paymentMethodClassnames}>
+                {/*eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions*/}
+                <div className="adyen-checkout__payment-method__header" onClick={this.handleOnListItemClick}>
                     <ExpandButton buttonId={buttonId} showRadioButton={showRadioButton} isSelected={isSelected} expandContentId={containerId}>
                         <PaymentMethodIcon
                             // Only add alt attribute to storedPaymentMethods (to avoid SR reading the PM name twice)

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -22,7 +22,7 @@ describe('KlarnaPayments', () => {
         expect(screen.queryByRole('button', { name: 'Continue to Pay By Bank' })).toBeFalsy();
     });
 
-    test('should call setStatus if elementRef is a drop-in', async () => {
+    test('should call setStatus if elementRef is a drop-in', () => {
         const KlarnaPaymentsEle = new KlarnaPayments(global.core, {
             ...coreProps,
             ...{ paymentData: '', paymentMethodType: '', sdkData: undefined, useKlarnaWidget: false, showPayButton: false }
@@ -30,10 +30,7 @@ describe('KlarnaPayments', () => {
         KlarnaPaymentsEle.elementRef = new Dropin(global.core);
         render(KlarnaPaymentsEle.render());
         const spy = jest.spyOn(KlarnaPaymentsEle.elementRef, 'setStatus');
-        // @ts-ignore to test
-        await waitFor(() => KlarnaPaymentsEle.componentRef);
-        // @ts-ignore to test
-        KlarnaPaymentsEle.componentRef.props.onLoaded();
+        KlarnaPaymentsEle.onLoaded();
         expect(spy).toHaveBeenCalled();
     });
 
@@ -55,7 +52,7 @@ describe('KlarnaPayments', () => {
         // @ts-ignore to test
         await waitFor(() => KlarnaPaymentsEle.componentRef);
         // @ts-ignore to test
-        KlarnaPaymentsEle.componentRef.props.onComplete();
+        KlarnaPaymentsEle.componentRef.onComplete();
         expect(onAdditionalDetailsMock).toHaveBeenCalled();
     });
 });

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -53,6 +53,7 @@ class KlarnaPayments extends UIElement<KlarnConfiguration> {
 
     protected onPaymentMethodActive() {
         // TODO do something to reinit the PM
+        console.log('\n### KlarnaPayments::onPaymentMethodActive:: do something to reinit the PM');
     }
 
     render() {

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -51,6 +51,10 @@ class KlarnaPayments extends UIElement<KlarnConfiguration> {
         this.setElementStatus('ready');
     }
 
+    protected onPaymentMethodActive() {
+        // TODO do something to reinit the PM
+    }
+
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -52,8 +52,8 @@ class KlarnaPayments extends UIElement<KlarnConfiguration> {
     }
 
     protected onPaymentMethodActive() {
-        // TODO do something to reinit the PM
-        console.log('\n### KlarnaPayments::onPaymentMethodActive:: do something to reinit the PM');
+        // Reinit the KlarnaSDK widget
+        this.componentRef.initWidget();
     }
 
     render() {
@@ -61,9 +61,7 @@ class KlarnaPayments extends UIElement<KlarnConfiguration> {
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                 <KlarnaContainer
                     {...this.props}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                     displayName={this.displayName}
                     onComplete={state => this.handleAdditionalDetails(state)}
                     onError={this.props.onError}

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -53,7 +53,7 @@ class KlarnaPayments extends UIElement<KlarnConfiguration> {
 
     protected onPaymentMethodActive() {
         // Reinit the KlarnaSDK widget
-        this.componentRef.initWidget();
+        this.componentRef?.initWidget();
     }
 
     render() {

--- a/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
@@ -19,7 +19,7 @@ export function KlarnaContainer(props) {
 
     klarnaContainerRef.current.setAction = setAction;
     klarnaContainerRef.current.setStatus = setStatus;
-    klarnaContainerRef.current.props = props; // Needed for unit tests
+    klarnaContainerRef.current.onComplete = props.onComplete; // Needed for unit tests
 
     if (action.sdkData) {
         return (

--- a/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
@@ -1,21 +1,29 @@
 import { h } from 'preact';
 import { KlarnaWidget } from '../KlarnaWidget/KlarnaWidget';
-import { useState } from 'preact/hooks';
+import { useState, useRef } from 'preact/hooks';
+import { KlarnaAction, KlarnaContainerRef } from '../../types';
 
 export function KlarnaContainer(props) {
-    const [action, setAction] = useState({
+    const [action, setAction] = useState<KlarnaAction>({
         sdkData: props.sdkData,
         paymentMethodType: props.paymentMethodType,
         paymentData: props.paymentData
     });
     const [status, setStatus] = useState('ready');
 
-    this.setAction = setAction;
-    this.setStatus = setStatus;
+    const klarnaContainerRef = useRef<KlarnaContainerRef>({});
+    // Just call once to create the object by which we expose the members expected by the parent comp
+    if (!Object.keys(klarnaContainerRef.current).length) {
+        props.setComponentRef(klarnaContainerRef.current);
+    }
+
+    klarnaContainerRef.current.setAction = setAction;
+    klarnaContainerRef.current.setStatus = setStatus;
 
     if (action.sdkData) {
         return (
             <KlarnaWidget
+                containerRef={klarnaContainerRef.current}
                 sdkData={action.sdkData}
                 paymentMethodType={action.paymentMethodType}
                 paymentData={action.paymentData}
@@ -36,7 +44,7 @@ export function KlarnaContainer(props) {
             status,
             disabled: status === 'loading',
             classNameModifiers: ['standalone'],
-            label: `${this.props.i18n.get('continueTo')} ${props.displayName}`
+            label: `${props.i18n.get('continueTo')} ${props.displayName}`
         });
     }
 

--- a/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
@@ -19,6 +19,7 @@ export function KlarnaContainer(props) {
 
     klarnaContainerRef.current.setAction = setAction;
     klarnaContainerRef.current.setStatus = setStatus;
+    klarnaContainerRef.current.props = props; // Needed for unit tests
 
     if (action.sdkData) {
         return (

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/preact';
 import { KlarnaWidget } from './KlarnaWidget';
 import Script from '../../../../utils/Script';
 import { KLARNA_WIDGET_URL } from '../../constants';
-import { KlarnaWidgetAuthorizeResponse } from '../../types';
+import { KlarnaWidgetAuthorizeResponse, KlarnaWidgetProps } from '../../types';
 
 jest.mock('../../../../utils/Script', () => {
     return jest.fn().mockImplementation(() => {
@@ -34,14 +34,15 @@ describe('KlarnaWidget', () => {
             Pay with Klarna
         </button>
     );
-    const props = {
+    const props: KlarnaWidgetProps = {
         onLoaded,
         onComplete,
         onError,
         paymentData,
         paymentMethodType,
         sdkData,
-        payButton
+        payButton,
+        containerRef: null
     };
 
     beforeAll(() => {

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -86,29 +86,12 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
 
     // Add Klarna Payments Widget SDK
     useEffect(() => {
-        /**
-         * If the callback has already been defined by another instance of the widget, then it will not be called again by any second instance.
-         * So we set a boolean telling us to initialise the widget ourselves once the script is loaded
-         *
-         * Alternatively, we *never* define the callback function; and *always* initialise the widget ourselves once the script is loaded
-         * (Checking with Klarna on whether defining this callback is advised/mandatory)
-         */
-        const initOnLoad = !!window.klarnaAsyncCallback;
-
-        window.klarnaAsyncCallback = function () {
-            console.log('### KlarnaWidget::klarnaWidget:: klarna async function called');
-            initializeKlarnaWidget();
-        };
-
         console.log('\n### KlarnaWidget:::: useEffect sdkData.payment_method_category=', sdkData.payment_method_category);
 
         const script = new Script(KLARNA_WIDGET_URL);
         void script.load()?.then(() => {
             console.log('### KlarnaWidget:::: useEffect script: LOADED ');
-            if (initOnLoad) {
-                console.log('### KlarnaWidget:::: manually init widget');
-                initializeKlarnaWidget();
-            }
+            initializeKlarnaWidget();
         });
 
         return () => {

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -44,7 +44,9 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
         );
     };
 
-    (props.containerRef as KlarnaContainerRef).initWidget = initializeKlarnaWidget;
+    if (props.containerRef) {
+        (props.containerRef as KlarnaContainerRef).initWidget = initializeKlarnaWidget;
+    }
 
     const authorizeKlarna = () => {
         setStatus('loading');
@@ -101,7 +103,7 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
         console.log('\n### KlarnaWidget:::: useEffect sdkData.payment_method_category=', sdkData.payment_method_category);
 
         const script = new Script(KLARNA_WIDGET_URL);
-        void script.load().then(() => {
+        void script.load()?.then(() => {
             console.log('### KlarnaWidget:::: useEffect script: LOADED ');
             if (initOnLoad) {
                 console.log('### KlarnaWidget:::: manually init widget');

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -89,10 +89,7 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
          * Alternatively, we *never* define the callback function; and *always* initialise the widget ourselves once the script is loaded
          * (Checking with Klarna on whether defining this callback is advised/mandatory)
          */
-        let initOnLoad = false;
-        if (window.klarnaAsyncCallback) {
-            initOnLoad = true;
-        }
+        const initOnLoad = !!window.klarnaAsyncCallback;
 
         window.klarnaAsyncCallback = function () {
             console.log('### KlarnaWidget::klarnaWidget:: klarna async function called');

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -1,7 +1,7 @@
 import Script from '../../../../utils/Script';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { h } from 'preact';
-import { KlarnaWidgetAuthorizeResponse, KlarnaWidgetProps } from '../../types';
+import { KlarnaContainerRef, KlarnaWidgetAuthorizeResponse, KlarnaWidgetProps } from '../../types';
 import { KLARNA_WIDGET_URL } from '../../constants';
 import './KlarnaWidget.scss';
 
@@ -43,6 +43,8 @@ export function KlarnaWidget({ sdkData, paymentMethodType, payButton, ...props }
             }
         );
     };
+
+    (props.containerRef as KlarnaContainerRef).initWidget = initializeKlarnaWidget;
 
     const authorizeKlarna = () => {
         setStatus('loading');

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -64,5 +64,5 @@ export interface KlarnaAction {
 export interface KlarnaContainerRef extends ComponentMethodsRef {
     initWidget?: () => void;
     setAction?(action: KlarnaAction): void;
-    props?: any;
+    onComplete?: (state: any) => void;
 }

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -1,4 +1,4 @@
-import { UIElementProps } from '../internal/UIElement/types';
+import { ComponentMethodsRef, UIElementProps } from '../internal/UIElement/types';
 
 declare global {
     interface Window {
@@ -37,6 +37,7 @@ export interface KlarnaWidgetProps extends KlarnaPaymentsShared {
 
     onComplete: (detailsData) => void;
     onError: (error) => void;
+    containerRef: any;
 }
 
 export type KlarnConfiguration = UIElementProps &
@@ -49,4 +50,18 @@ export interface KlarnaWidgetAuthorizeResponse {
     show_form: boolean;
     authorization_token: string;
     error?: any;
+}
+
+export interface KlarnaAction {
+    sdkData: {
+        client_token: string;
+        payment_method_category: string;
+    };
+    paymentMethodType: string;
+    paymentData: string;
+}
+
+export interface KlarnaContainerRef extends ComponentMethodsRef {
+    initWidget?: () => void;
+    setAction?(action: KlarnaAction): void;
 }

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -64,4 +64,5 @@ export interface KlarnaAction {
 export interface KlarnaContainerRef extends ComponentMethodsRef {
     initWidget?: () => void;
     setAction?(action: KlarnaAction): void;
+    props?: any;
 }

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -124,6 +124,10 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         return this;
     }
 
+    protected onPaymentMethodActive() {
+        return null;
+    }
+
     protected onChange(): void {
         this.props.onChange?.(
             {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
PR to handle the issue with multiple instances of the Klarna widget being present in the PM list

There are 2 issues:
1. When we initialise the `KlarnaWidget` it loads the KlarnaSDK, which in turn calls the callback we create (`window.klarnaAsyncCallback`), which initialises the KlarnaSDK.
- _However_, if there is a second `KlarnaWidget` in the PM list, initialising that _will not_ see the KlarnaSDK calling our callback for a second time, and so the KlarnaSDK is not re-initialised with the right `sdkData.client_token` to make the correct payment.
- This means that if you pay with the second widget, the payment from the first widget gets authorised.
2. Having solved the first problem there is now the (edge) use case that, if the shopper opens the first widget, opens the second widget, and then _returns to the first widget_ - the first widget (which is cached and never re-initialised) will, once again, not re-initialise the KlarnaSDK with the right `sdkData.client_token`
- This means that if you pay with the first widget, the payment from the second widget gets authorised.

So..
- When we initialise a second `KlarnaWidget` component it checks if it "manually" needs to initialise the KlarnaSDK widget _(fixes issue 1)_
- We now detect when a (cached) component is made active for a second (and subsequent) time, and we call a function it inherits from `UIElement` to allow it to run some custom logic (`onPaymentMethodActive`). 
This allows the `KlarnaWidget` to "manually" re-initialise the KlarnaSDK.  _(fixes issue 2)_

## Tested scenarios
... TODO: outline the manual testing undertaken
Existing unit tests adjusted, and all pass


**Fixes issue**:  COWEB-1468

