### PR TITLE
Fastlane recognized flow component

### DIFF
--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -323,7 +323,8 @@ describe('Dropin', () => {
                         customerId: 'sss',
                         lastFour: '1111',
                         brand: 'visa',
-                        email: 'email@adyen.com'
+                        email: 'email@adyen.com',
+                        fastlaneSessionId: 'session-id'
                     }
                 }
             });
@@ -388,7 +389,8 @@ describe('Dropin', () => {
                         customerId: 'sss',
                         lastFour: '1111',
                         brand: 'visa',
-                        email: 'email@adyen.com'
+                        email: 'email@adyen.com',
+                        fastlaneSessionId: 'session-id'
                     }
                 }
             });

--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -6,14 +6,15 @@ import { AdyenCheckout } from '../../index';
 import ThreeDS2DeviceFingerprint from '../ThreeDS2/ThreeDS2DeviceFingerprint';
 import ThreeDS2Challenge from '../ThreeDS2/ThreeDS2Challenge';
 import Dropin from './Dropin';
-import { CoreConfiguration, ICore } from '../../core/types';
-
+import Fastlane from '../PayPalFastlane';
 import enUS from '../../../../server/translations/en-US.json';
 import getTranslations from '../../core/Services/get-translations';
-import { PaymentActionsType } from '../../types/global-types';
 import { SRPanel } from '../../core/Errors/SRPanel';
 import { ANALYTICS_RENDERED_STR } from '../../core/Analytics/constants';
-import Fastlane from '../PayPalFastlane';
+
+import type { CoreConfiguration, ICore } from '../../core/types';
+import type { PaymentActionsType } from '../../types/global-types';
+
 jest.mock('../../core/Services/get-translations');
 const mockedGetTranslations = getTranslations as jest.Mock;
 mockedGetTranslations.mockResolvedValue(enUS);

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -125,12 +125,14 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
 
         const commonProps = getCommonProps({ ...this.props, elementRef: this.elementRef });
 
+        const elements = showPaymentMethods ? createElements(paymentMethods, paymentMethodsConfiguration, commonProps, this.core) : [];
+        const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, paymentMethodsConfiguration, commonProps, this.core);
         const storedElements = showStoredPaymentMethods
             ? createStoredElements(storedPaymentMethods, paymentMethodsConfiguration, commonProps, this.core)
             : [];
-        const elements = showPaymentMethods ? createElements(paymentMethods, paymentMethodsConfiguration, commonProps, this.core) : [];
-        const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, paymentMethodsConfiguration, commonProps, this.core);
-        const fastlanePaymentElement = createElements([fastlanePaymentMethod], paymentMethodsConfiguration, commonProps, this.core);
+        const fastlanePaymentElement = fastlanePaymentMethod
+            ? createElements([fastlanePaymentMethod], paymentMethodsConfiguration, commonProps, this.core)
+            : [];
 
         return [storedElements, elements, instantPaymentElements, fastlanePaymentElement];
     };

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -118,7 +118,7 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
     private handleCreate = () => {
         const { paymentMethodsConfiguration, showStoredPaymentMethods, showPaymentMethods, instantPaymentTypes } = this.props;
 
-        const { paymentMethods, storedPaymentMethods, instantPaymentMethods } = splitPaymentMethods(
+        const { paymentMethods, storedPaymentMethods, instantPaymentMethods, fastlanePaymentMethod } = splitPaymentMethods(
             this.core.paymentMethodsResponse,
             instantPaymentTypes
         );
@@ -130,8 +130,9 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
             : [];
         const elements = showPaymentMethods ? createElements(paymentMethods, paymentMethodsConfiguration, commonProps, this.core) : [];
         const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, paymentMethodsConfiguration, commonProps, this.core);
+        const fastlanePaymentElement = createElements([fastlanePaymentMethod], paymentMethodsConfiguration, commonProps, this.core);
 
-        return [storedElements, elements, instantPaymentElements];
+        return [storedElements, elements, instantPaymentElements, fastlanePaymentElement];
     };
 
     public handleAction(action: PaymentAction, props = {}): this | null {

--- a/packages/lib/src/components/Dropin/components/DropinComponent.scss
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.scss
@@ -4,8 +4,13 @@
 .adyen-checkout__dropin {
     display: flex;
     flex-direction: column;
-    gap: token(spacer-100);
+    gap: token(spacer-070);
 }
+
+.adyen-checkout__button--dropin-show-paymentmethods {
+    align-self: start;
+}
+
 
 .adyen-checkout-payment-methods-container {
     display: flex;
@@ -32,6 +37,7 @@
         pointer-events: none;
     }
 }
+
 
 .adyen-checkout__instant-payment-methods-list {
     $instant-pm-gap: token(spacer-070);

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -14,7 +14,7 @@ import Button from '../../internal/Button';
 export class DropinComponent extends Component<DropinComponentProps, DropinComponentState> {
     public state: DropinComponentState = {
         elements: [],
-        fastlanePaymentElement: null,
+        fastlanePaymentElement: [],
         instantPaymentElements: [],
         storedPaymentElements: [],
         orderStatus: null,
@@ -41,7 +41,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                     elements,
                     instantPaymentElements,
                     storedPaymentElements,
-                    fastlanePaymentElement: fastlanePaymentElement[0],
+                    fastlanePaymentElement,
                     showPaymentMethodList: fastlanePaymentElement.length === 0
                 });
 
@@ -65,6 +65,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
     }
 
     public setStatus = (status: UIElementStatus, props: DropinStatusProps = {}) => {
+        console.log(' dropin - setstatus');
         this.setState({ status: { type: status, props } });
     };
 
@@ -158,7 +159,6 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         props,
         {
             elements,
-            // fastlaneElement,
             fastlanePaymentElement,
             instantPaymentElements,
             storedPaymentElements,
@@ -171,6 +171,8 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         const isLoading = status.type === 'loading';
         const isRedirecting = status.type === 'redirect';
         const hasPaymentMethodsToBeDisplayed = elements?.length || instantPaymentElements?.length || storedPaymentElements?.length;
+
+        console.log(' Dropin component');
 
         switch (status.type) {
             case 'success':
@@ -193,8 +195,8 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                             <Fragment>
                                 <PaymentMethodList
                                     isLoading={isLoading || isRedirecting}
-                                    isDisablingPaymentMethod={this.state.isDisabling}
-                                    paymentMethods={[fastlanePaymentElement]}
+                                    // isDisablingPaymentMethod={this.state.isDisabling}
+                                    paymentMethods={fastlanePaymentElement}
                                     // instantPaymentMethods={instantPaymentElements}
                                     // storedPaymentMethods={storedPaymentElements}
                                     activePaymentMethod={activePaymentMethod}
@@ -203,8 +205,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                                     // orderStatus={this.state.orderStatus}
                                     // onOrderCancel={this.onOrderCancel}
                                     onSelect={this.handleOnSelectPaymentMethod}
-                                    openPaymentMethod={this.props.openPaymentMethod}
-                                    openFirstPaymentMethod={this.props.openFirstPaymentMethod}
+                                    openFirstPaymentMethod
                                     // openFirstStoredPaymentMethod={this.props.openFirstStoredPaymentMethod}
                                     // onDisableStoredPaymentMethod={this.handleDisableStoredPaymentMethod}
                                     // showRemovePaymentMethodButton={this.props.showRemovePaymentMethodButton}

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -22,7 +22,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         status: { type: 'loading', props: undefined },
         activePaymentMethod: null,
         cachedPaymentMethods: {},
-        showPaymentMethodList: true
+        showDefaultPaymentMethodList: true
     };
 
     componentDidMount() {
@@ -42,7 +42,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                     instantPaymentElements,
                     storedPaymentElements,
                     fastlanePaymentElement,
-                    showPaymentMethodList: fastlanePaymentElement.length === 0
+                    showDefaultPaymentMethodList: fastlanePaymentElement.length === 0
                 });
 
                 this.setStatus('ready');
@@ -65,7 +65,6 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
     }
 
     public setStatus = (status: UIElementStatus, props: DropinStatusProps = {}) => {
-        console.log(' dropin - setstatus');
         this.setState({ status: { type: status, props } });
     };
 
@@ -114,9 +113,9 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
             });
     };
 
-    private onShowPaymentMethodListClick = () => {
+    private readonly onShowDefaultPaymentMethodListClick = () => {
         this.setState({
-            showPaymentMethodList: true
+            showDefaultPaymentMethodList: true
         });
     };
 
@@ -165,14 +164,14 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
             status,
             activePaymentMethod,
             cachedPaymentMethods,
-            showPaymentMethodList
+            showDefaultPaymentMethodList
         }
     ) {
         const isLoading = status.type === 'loading';
         const isRedirecting = status.type === 'redirect';
         const hasPaymentMethodsToBeDisplayed = elements?.length || instantPaymentElements?.length || storedPaymentElements?.length;
 
-        console.log(' Dropin component');
+        const showFastlane = !!fastlanePaymentElement && !showDefaultPaymentMethodList;
 
         switch (status.type) {
             case 'success':
@@ -190,39 +189,28 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                         {isRedirecting && status.props.component && status.props.component.render()}
                         {isLoading && status.props && status.props.component && status.props.component.render()}
 
-                        {/* CLEAN UP THIS */}
-                        {!!fastlanePaymentElement && !showPaymentMethodList && (
+                        {showFastlane && (
                             <Fragment>
                                 <PaymentMethodList
-                                    isLoading={isLoading || isRedirecting}
-                                    // isDisablingPaymentMethod={this.state.isDisabling}
+                                    isLoading={isLoading}
                                     paymentMethods={fastlanePaymentElement}
-                                    // instantPaymentMethods={instantPaymentElements}
-                                    // storedPaymentMethods={storedPaymentElements}
                                     activePaymentMethod={activePaymentMethod}
                                     cachedPaymentMethods={cachedPaymentMethods}
-                                    // order={this.props.order}
-                                    // orderStatus={this.state.orderStatus}
-                                    // onOrderCancel={this.onOrderCancel}
                                     onSelect={this.handleOnSelectPaymentMethod}
                                     openFirstPaymentMethod
-                                    // openFirstStoredPaymentMethod={this.props.openFirstStoredPaymentMethod}
-                                    // onDisableStoredPaymentMethod={this.handleDisableStoredPaymentMethod}
-                                    // showRemovePaymentMethodButton={this.props.showRemovePaymentMethodButton}
                                     showRadioButton={this.props.showRadioButton}
                                 />
-
                                 <Button
                                     classNameModifiers={['dropin-show-paymentmethods']}
                                     variant="link"
                                     inline
                                     label="Other payment methods"
-                                    onClick={this.onShowPaymentMethodListClick}
+                                    onClick={this.onShowDefaultPaymentMethodListClick}
                                 />
                             </Fragment>
                         )}
 
-                        {!!hasPaymentMethodsToBeDisplayed && showPaymentMethodList && (
+                        {!!hasPaymentMethodsToBeDisplayed && !showFastlane && (
                             <PaymentMethodList
                                 isLoading={isLoading || isRedirecting}
                                 isDisablingPaymentMethod={this.state.isDisabling}

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -211,7 +211,14 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                                     // showRemovePaymentMethodButton={this.props.showRemovePaymentMethodButton}
                                     showRadioButton={this.props.showRadioButton}
                                 />
-                                <Button variant="primary" label="Other payment methods" onClick={this.onShowPaymentMethodListClick} />
+
+                                <Button
+                                    classNameModifiers={['dropin-show-paymentmethods']}
+                                    variant="link"
+                                    inline
+                                    label="Other payment methods"
+                                    onClick={this.onShowPaymentMethodListClick}
+                                />
                             </Fragment>
                         )}
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
@@ -106,7 +106,7 @@ test('should call onSelect when mounting the Component if openFirstPaymentMethod
         />
     );
 
-    expect(onSelectMock).toHaveBeenCalledTimes(2);
+    expect(onSelectMock).toHaveBeenCalledTimes(1);
     expect(onSelectMock).toHaveBeenCalledWith(paymentMethods[0]);
 });
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -23,9 +23,9 @@ interface PaymentMethodListProps extends Omit<PaymentMethodsContainerProps, 'lab
 }
 
 const PaymentMethodList = ({
-    paymentMethods = [], // Non-stored payments
-    instantPaymentMethods = [],
-    storedPaymentMethods = [],
+    paymentMethods,
+    instantPaymentMethods,
+    storedPaymentMethods,
     openFirstStoredPaymentMethod,
     openFirstPaymentMethod,
     openPaymentMethod,
@@ -37,13 +37,13 @@ const PaymentMethodList = ({
 }: PaymentMethodListProps) => {
     const { i18n } = useCoreContext();
     const brandLogoConfiguration = useBrandLogoConfiguration(paymentMethods);
-    const hasInstantPaymentMethods = instantPaymentMethods.length > 0;
-    const hasStoredPaymentMethods = storedPaymentMethods.length > 0;
+    const hasInstantPaymentMethods = instantPaymentMethods?.length > 0;
+    const hasStoredPaymentMethods = storedPaymentMethods?.length > 0;
     const pmListLabel = hasInstantPaymentMethods || hasStoredPaymentMethods ? i18n.get('paymentMethodsList.otherPayments.label') : '';
 
     useEffect(() => {
         if (openPaymentMethod?.type) {
-            const paymentMethod = paymentMethods.find(paymentMethod => paymentMethod.type === openPaymentMethod?.type);
+            const paymentMethod = paymentMethods?.find(paymentMethod => paymentMethod.type === openPaymentMethod?.type);
             if (!paymentMethod) {
                 console.warn(`Drop-in: payment method type "${openPaymentMethod?.type}" not found`);
             } else {
@@ -53,8 +53,8 @@ const PaymentMethodList = ({
         }
 
         // Open first PaymentMethodItem
-        const firstStoredPayment = storedPaymentMethods[0];
-        const firstNonStoredPayment = paymentMethods[0];
+        const firstStoredPayment = storedPaymentMethods?.[0];
+        const firstNonStoredPayment = paymentMethods?.[0];
 
         if (firstStoredPayment || firstNonStoredPayment) {
             const shouldOpenFirstStored = openFirstStoredPaymentMethod && getProp(firstStoredPayment, 'props.oneClick') === true;
@@ -68,6 +68,8 @@ const PaymentMethodList = ({
             }
         }
     }, [storedPaymentMethods, paymentMethods, openFirstStoredPaymentMethod, openFirstPaymentMethod, openPaymentMethod]);
+
+    console.log('PaymentMethodList');
 
     return (
         <Fragment>

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -69,8 +69,6 @@ const PaymentMethodList = ({
         }
     }, [storedPaymentMethods, paymentMethods, openFirstStoredPaymentMethod, openFirstPaymentMethod, openPaymentMethod]);
 
-    console.log('PaymentMethodList');
-
     return (
         <Fragment>
             {orderStatus && (

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import UIElement from '../../../internal/UIElement';
 
 export interface PaymentMethodsContainerProps {
-    label: string;
+    label?: string;
     classNameModifiers?: string[];
     paymentMethods: UIElement[];
     activePaymentMethod?: UIElement;
@@ -46,7 +46,7 @@ function PaymentMethodsContainer({
 
     return (
         <div className="adyen-checkout-payment-methods-container">
-            {!!label.length && (
+            {!!label && (
                 <label htmlFor={selectListId} className="adyen-checkout-payment-methods-list-label">
                     {label}
                 </label>

--- a/packages/lib/src/components/Dropin/elements/splitPaymentMethods.test.ts
+++ b/packages/lib/src/components/Dropin/elements/splitPaymentMethods.test.ts
@@ -1,9 +1,9 @@
 import PaymentMethods from '../../../core/ProcessResponse/PaymentMethods';
-import { InstantPaymentTypes } from '../types';
 import splitPaymentMethods from './splitPaymentMethods';
+import type { InstantPaymentTypes } from '../types';
 
 describe('Dropin - splitPaymentMethods', () => {
-    test('formatProps filter out instantPaymentMethods from paymentMethods list ', () => {
+    test('should remove instantPaymentMethods from paymentMethods', () => {
         const parsedPaymentMethods = new PaymentMethods({
             paymentMethods: [
                 { name: 'Google Pay', type: 'paywithgoogle' },
@@ -13,11 +13,42 @@ describe('Dropin - splitPaymentMethods', () => {
 
         const instantPaymentTypes: InstantPaymentTypes[] = ['paywithgoogle'];
 
-        const { paymentMethods, instantPaymentMethods } = splitPaymentMethods(parsedPaymentMethods, instantPaymentTypes);
+        const { paymentMethods, instantPaymentMethods, fastlanePaymentMethod, storedPaymentMethods } = splitPaymentMethods(
+            parsedPaymentMethods,
+            instantPaymentTypes
+        );
 
         expect(paymentMethods).toHaveLength(1);
         expect(paymentMethods[0]).toStrictEqual({ type: 'alipay', name: 'AliPay' });
         expect(instantPaymentMethods).toHaveLength(1);
         expect(instantPaymentMethods[0]).toStrictEqual({ name: 'Google Pay', type: 'paywithgoogle' });
+        expect(fastlanePaymentMethod).toBeUndefined();
+        expect(storedPaymentMethods).toHaveLength(0);
+    });
+
+    test('should remove fastlane from paymentMethods', () => {
+        const parsedPaymentMethods = new PaymentMethods({
+            paymentMethods: [
+                { name: 'ApplePay', type: 'applepay' },
+                { name: 'AliPay', type: 'alipay' },
+                { name: 'KakaoPay', type: 'kakaopay' },
+                { name: 'Fastlane', type: 'fastlane', brands: ['visa'] }
+            ]
+        });
+
+        const instantPaymentTypes: InstantPaymentTypes[] = ['applepay'];
+
+        const { paymentMethods, instantPaymentMethods, fastlanePaymentMethod, storedPaymentMethods } = splitPaymentMethods(
+            parsedPaymentMethods,
+            instantPaymentTypes
+        );
+
+        expect(paymentMethods).toHaveLength(2);
+        expect(paymentMethods[0]).toStrictEqual({ type: 'alipay', name: 'AliPay' });
+        expect(paymentMethods[1]).toStrictEqual({ type: 'kakaopay', name: 'KakaoPay' });
+        expect(instantPaymentMethods).toHaveLength(1);
+        expect(instantPaymentMethods[0]).toStrictEqual({ name: 'ApplePay', type: 'applepay' });
+        expect(fastlanePaymentMethod).toStrictEqual({ name: 'Fastlane', type: 'fastlane', brands: ['visa'] });
+        expect(storedPaymentMethods).toHaveLength(0);
     });
 });

--- a/packages/lib/src/components/Dropin/elements/splitPaymentMethods.ts
+++ b/packages/lib/src/components/Dropin/elements/splitPaymentMethods.ts
@@ -1,5 +1,4 @@
 import PaymentMethods from '../../../core/ProcessResponse/PaymentMethods';
-
 import type { InstantPaymentTypes } from '../types';
 import type { PaymentMethod, StoredPaymentMethod } from '../../../types/global-types';
 
@@ -11,12 +10,13 @@ interface SplitPaymentMethods {
 }
 
 function splitPaymentMethods(paymentMethods: PaymentMethods, instantPaymentTypes: InstantPaymentTypes[]): SplitPaymentMethods {
+    const isFastlane = ({ type }: PaymentMethod) => type === 'fastlane';
+    const isInstantPaymentMethod = ({ type }: PaymentMethod) => instantPaymentTypes.includes(type as InstantPaymentTypes);
+
     return {
-        fastlanePaymentMethod: paymentMethods.paymentMethods.find(({ type }) => ['fastlane'].includes(type)),
-        instantPaymentMethods: paymentMethods.paymentMethods.filter(({ type }) => instantPaymentTypes.includes(type as InstantPaymentTypes)),
-        paymentMethods: paymentMethods.paymentMethods.filter(
-            ({ type }) => !instantPaymentTypes.includes(type as InstantPaymentTypes) && !['fastlane'].includes(type)
-        ),
+        fastlanePaymentMethod: paymentMethods.paymentMethods.find(isFastlane),
+        instantPaymentMethods: paymentMethods.paymentMethods.filter(isInstantPaymentMethod),
+        paymentMethods: paymentMethods.paymentMethods.filter(pm => !isInstantPaymentMethod(pm) && !isFastlane(pm)),
         storedPaymentMethods: paymentMethods.storedPaymentMethods
     };
 }

--- a/packages/lib/src/components/Dropin/elements/splitPaymentMethods.ts
+++ b/packages/lib/src/components/Dropin/elements/splitPaymentMethods.ts
@@ -3,8 +3,11 @@ import PaymentMethods from '../../../core/ProcessResponse/PaymentMethods';
 
 function splitPaymentMethods(paymentMethods: PaymentMethods, instantPaymentTypes: InstantPaymentTypes[]) {
     return {
+        fastlanePaymentMethod: paymentMethods.paymentMethods.find(({ type }) => ['fastlane'].includes(type)),
         instantPaymentMethods: paymentMethods.paymentMethods.filter(({ type }) => instantPaymentTypes.includes(type as InstantPaymentTypes)),
-        paymentMethods: paymentMethods.paymentMethods.filter(({ type }) => !instantPaymentTypes.includes(type as InstantPaymentTypes)),
+        paymentMethods: paymentMethods.paymentMethods.filter(
+            ({ type }) => !instantPaymentTypes.includes(type as InstantPaymentTypes) && !['fastlane'].includes(type)
+        ),
         storedPaymentMethods: paymentMethods.storedPaymentMethods
     };
 }

--- a/packages/lib/src/components/Dropin/elements/splitPaymentMethods.ts
+++ b/packages/lib/src/components/Dropin/elements/splitPaymentMethods.ts
@@ -1,7 +1,16 @@
-import { InstantPaymentTypes } from '../types';
 import PaymentMethods from '../../../core/ProcessResponse/PaymentMethods';
 
-function splitPaymentMethods(paymentMethods: PaymentMethods, instantPaymentTypes: InstantPaymentTypes[]) {
+import type { InstantPaymentTypes } from '../types';
+import type { PaymentMethod, StoredPaymentMethod } from '../../../types/global-types';
+
+interface SplitPaymentMethods {
+    fastlanePaymentMethod: PaymentMethod | undefined;
+    storedPaymentMethods: StoredPaymentMethod[];
+    paymentMethods: PaymentMethod[];
+    instantPaymentMethods: PaymentMethod[];
+}
+
+function splitPaymentMethods(paymentMethods: PaymentMethods, instantPaymentTypes: InstantPaymentTypes[]): SplitPaymentMethods {
     return {
         fastlanePaymentMethod: paymentMethods.paymentMethods.find(({ type }) => ['fastlane'].includes(type)),
         instantPaymentMethods: paymentMethods.paymentMethods.filter(({ type }) => instantPaymentTypes.includes(type as InstantPaymentTypes)),

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -161,11 +161,14 @@ export interface DropinStatusProps {
 
 export interface DropinComponentState {
     elements: any[];
+    fastlanePaymentElement: UIElement | null;
+    // fastlaneElement: UIElement | null;
     instantPaymentElements: UIElement[];
     storedPaymentElements: UIElement[];
     status: DropinStatus;
     activePaymentMethod: UIElement;
     cachedPaymentMethods: object;
+    showPaymentMethodList: boolean;
     isDisabling: boolean;
     orderStatus: OrderStatus;
 }

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -161,8 +161,7 @@ export interface DropinStatusProps {
 
 export interface DropinComponentState {
     elements: any[];
-    fastlanePaymentElement: UIElement | null;
-    // fastlaneElement: UIElement | null;
+    fastlanePaymentElement: UIElement[];
     instantPaymentElements: UIElement[];
     storedPaymentElements: UIElement[];
     status: DropinStatus;

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -167,7 +167,7 @@ export interface DropinComponentState {
     status: DropinStatus;
     activePaymentMethod: UIElement;
     cachedPaymentMethods: object;
-    showPaymentMethodList: boolean;
+    showDefaultPaymentMethodList: boolean;
     isDisabling: boolean;
     orderStatus: OrderStatus;
 }

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -1,5 +1,5 @@
 import type { Order, OrderStatus, PaymentActionsType, PaymentAmount } from '../../types/global-types';
-import type { UIElementProps, UIElementStatus } from '../internal/UIElement/types';
+import { StatusFromAction, UIElementProps, UIElementStatus } from '../internal/UIElement/types';
 import type { NewableComponent } from '../../core/core.registry';
 import type { ICore } from '../../core/types';
 
@@ -150,23 +150,24 @@ export interface DropinComponentProps extends DropinConfiguration {
     onOrderCancel?: onOrderCancelType;
 }
 
-interface DropinStatus {
-    type: UIElementStatus;
+export interface DropinStatus {
+    type: UIElementStatus | StatusFromAction;
     props?: DropinStatusProps;
 }
 
 export interface DropinStatusProps {
     component?: UIElement;
+    message?: string;
 }
 
 export interface DropinComponentState {
-    elements: any[];
+    elements: UIElement[];
     fastlanePaymentElement: UIElement[];
     instantPaymentElements: UIElement[];
     storedPaymentElements: UIElement[];
     status: DropinStatus;
     activePaymentMethod: UIElement;
-    cachedPaymentMethods: object;
+    cachedPaymentMethods: Record<string, boolean>;
     showDefaultPaymentMethodList: boolean;
     isDisabling: boolean;
     orderStatus: OrderStatus;

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/preact';
+import Fastlane from './Fastlane';
+import { mock } from 'jest-mock-extended';
+import { Resources } from '../../core/Context/Resources';
+
+describe('Fastlane', () => {
+    test('should always be valid', () => {
+        const fastlane = new Fastlane(global.core);
+        expect(fastlane.isValid).toBeTruthy();
+    });
+
+    test('should not be available if configuration is missing', async () => {
+        let fastlane = new Fastlane(global.core);
+        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
+
+        // @ts-ignore Testing with incomplete config properties
+        fastlane = new Fastlane(global.core, {
+            tokenId: 'xxx'
+        });
+        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
+
+        // @ts-ignore Testing with incomplete config properties
+        fastlane = new Fastlane(global.core, {
+            tokenId: 'xxx',
+            customerId: 'zzz'
+        });
+        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
+
+        // @ts-ignore Testing with incomplete config properties
+        fastlane = new Fastlane(global.core, {
+            tokenId: 'xxx',
+            customerId: 'zzz',
+            lastFour: '1111'
+        });
+        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
+
+        // @ts-ignore Testing with incomplete config properties
+        fastlane = new Fastlane(global.core, {
+            tokenId: 'xxx',
+            customerId: 'zzz',
+            lastFour: '1111',
+            brand: 'visa'
+        });
+        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
+
+        // @ts-ignore Testing with incomplete config properties
+        fastlane = new Fastlane(global.core, {
+            tokenId: 'xxx',
+            customerId: 'zzz',
+            lastFour: '1111',
+            brand: 'visa',
+            email: 'shopper@adyen.com'
+        });
+        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
+
+        fastlane = new Fastlane(global.core, {
+            tokenId: 'xxx',
+            customerId: 'zzz',
+            lastFour: '1111',
+            brand: 'visa',
+            email: 'shopper@adyen.com',
+            fastlaneSessionId: '1111'
+        });
+        await expect(fastlane.isAvailable()).resolves.toBeUndefined();
+    });
+
+    test('should have available card brands visible (Drop-in only)', () => {
+        const fastlane = new Fastlane(global.core);
+        expect(fastlane.props.keepBrandsVisible).toBeTruthy();
+    });
+
+    test('should return encoded blob to process the payment', () => {
+        const fastlane = new Fastlane(global.core, {
+            tokenId: 'token-id',
+            customerId: 'customer-id',
+            lastFour: '1111',
+            brand: 'visa',
+            email: 'shopper@adyen.com',
+            fastlaneSessionId: 'session-id'
+        });
+
+        const encodedBlob = btoa(
+            JSON.stringify({
+                sessionId: 'session-id',
+                tokenId: 'token-id',
+                customerId: 'customer-id'
+            })
+        );
+
+        const state = fastlane.data;
+
+        expect(state.paymentMethod.type).toBe('fastlane');
+        expect(state.paymentMethod.fastlaneData).toBe(encodedBlob);
+    });
+
+    test('should display last four, card brand and fastlane logo', async () => {
+        const resources = mock<Resources>();
+        resources.getImage.mockReturnValue((icon: string) => `https://checkout-adyen.com/${icon}`);
+
+        const fastlane = new Fastlane(global.core, {
+            modules: { resources },
+            i18n: global.i18n,
+            tokenId: 'token-id',
+            customerId: 'customer-id',
+            lastFour: '1111',
+            brand: 'visa',
+            email: 'shopper@adyen.com',
+            fastlaneSessionId: 'session-id'
+        });
+
+        render(fastlane.render());
+
+        const fastlaneImage = await screen.findByAltText('Fastlane logo');
+        const cardBrandImage = await screen.findByAltText('VISA');
+
+        expect(fastlaneImage).toHaveAttribute('src', 'https://checkout-adyen.com/paypal_fastlane_gray');
+        expect(cardBrandImage).toHaveAttribute('src', 'https://checkout-adyen.com/visa');
+        expect(screen.queryByText('•••• 1111')).toBeVisible();
+    });
+});

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -3,6 +3,7 @@ import UIElement from '../internal/UIElement';
 import { CoreProvider } from '../../core/Context/CoreProvider';
 import { TxVariants } from '../tx-variants';
 import { UIElementProps } from '../internal/UIElement/types';
+import FastlaneComponent from './components/FastlaneComponent';
 
 interface FastlaneConfiguration extends UIElementProps {
     tokenId: string;
@@ -10,6 +11,11 @@ interface FastlaneConfiguration extends UIElementProps {
     lastFour: string;
     brand: string;
     email: string;
+    /**
+     * List of brands accepted by the component
+     * @internal
+     */
+    brands?: string[];
     /**
      * Configuration returned by the backend
      * @internal
@@ -21,6 +27,10 @@ interface FastlaneConfiguration extends UIElementProps {
 
 class Fastlane extends UIElement<FastlaneConfiguration> {
     public static type = TxVariants.fastlane;
+
+    protected static defaultProps = {
+        keepBrandsVisible: true
+    };
 
     protected override formatData() {
         return {
@@ -49,13 +59,25 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
         return true;
     }
 
-    render() {
-        console.log('FASTLANE RENDER');
+    public override get icon(): string {
+        return this.props.icon ?? this.resources.getImage()('card');
+    }
 
+    public get brands(): { icon: string; name: string }[] {
+        const { brands } = this.props;
+        return brands.map(brand => ({ icon: this.props.modules.resources.getImage()(brand), name: brand }));
+    }
+
+    render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
-                <div> **** {this.props.lastFour} </div>
-                <button>pay</button>
+                <FastlaneComponent
+                    lastFour={this.props.lastFour}
+                    brand={this.props.brand}
+                    payButton={this.payButton}
+                    setComponentRef={this.setComponentRef}
+                    showPayButton={this.props.showPayButton}
+                />
             </CoreProvider>
         );
     }

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -11,7 +11,12 @@ interface FastlaneConfiguration extends UIElementProps {
     lastFour: string;
     brand: string;
     email: string;
-    sessionId: string;
+    fastlaneSessionId: string;
+    /**
+     * Display the brand images inside the Drop-in payment method header
+     * @internal
+     */
+    keepBrandsVisible?: boolean;
     /**
      * List of brands accepted by the component
      * @internal
@@ -39,7 +44,7 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
                 type: Fastlane.type,
                 fastlaneData: btoa(
                     JSON.stringify({
-                        sessionId: this.props.sessionId,
+                        sessionId: this.props.fastlaneSessionId,
                         tokenId: this.props.tokenId,
                         customerId: this.props.customerId
                     })
@@ -49,11 +54,12 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
     }
 
     public override async isAvailable(): Promise<void> {
-        const { tokenId, customerId, lastFour, brand, email } = this.props;
+        const { tokenId, customerId, lastFour, brand, email, fastlaneSessionId } = this.props;
 
-        if (tokenId && customerId && lastFour && brand && email) {
+        if (tokenId && customerId && lastFour && brand && email && fastlaneSessionId) {
             return Promise.resolve();
         }
+
         return Promise.reject();
     }
 

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -11,6 +11,7 @@ interface FastlaneConfiguration extends UIElementProps {
     lastFour: string;
     brand: string;
     email: string;
+    sessionId: string;
     /**
      * List of brands accepted by the component
      * @internal
@@ -38,6 +39,7 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
                 type: Fastlane.type,
                 fastlaneData: btoa(
                     JSON.stringify({
+                        sessionId: this.props.sessionId,
                         tokenId: this.props.tokenId,
                         customerId: this.props.customerId
                     })

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -1,0 +1,64 @@
+import { h } from 'preact';
+import UIElement from '../internal/UIElement';
+import { CoreProvider } from '../../core/Context/CoreProvider';
+import { TxVariants } from '../tx-variants';
+import { UIElementProps } from '../internal/UIElement/types';
+
+interface FastlaneConfiguration extends UIElementProps {
+    tokenId: string;
+    customerId: string;
+    lastFour: string;
+    brand: string;
+    email: string;
+    /**
+     * Configuration returned by the backend
+     * @internal
+     */
+    configuration?: {
+        brands: string[];
+    };
+}
+
+class Fastlane extends UIElement<FastlaneConfiguration> {
+    public static type = TxVariants.fastlane;
+
+    protected override formatData() {
+        return {
+            paymentMethod: {
+                type: Fastlane.type,
+                fastlaneData: btoa(
+                    JSON.stringify({
+                        tokenId: this.props.tokenId,
+                        customerId: this.props.customerId
+                    })
+                )
+            }
+        };
+    }
+
+    public override async isAvailable(): Promise<void> {
+        const { tokenId, customerId, lastFour, brand, email } = this.props;
+
+        if (tokenId && customerId && lastFour && brand && email) {
+            return Promise.resolve();
+        }
+        return Promise.reject();
+    }
+
+    public override get isValid(): boolean {
+        return true;
+    }
+
+    render() {
+        console.log('FASTLANE RENDER');
+
+        return (
+            <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
+                <div> **** {this.props.lastFour} </div>
+                <button>pay</button>
+            </CoreProvider>
+        );
+    }
+}
+
+export default Fastlane;

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -2,37 +2,11 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement';
 import { CoreProvider } from '../../core/Context/CoreProvider';
 import { TxVariants } from '../tx-variants';
-import { UIElementProps } from '../internal/UIElement/types';
 import FastlaneComponent from './components/FastlaneComponent';
-
-interface FastlaneConfiguration extends UIElementProps {
-    tokenId: string;
-    customerId: string;
-    lastFour: string;
-    brand: string;
-    email: string;
-    fastlaneSessionId: string;
-    /**
-     * Display the brand images inside the Drop-in payment method header
-     * @internal
-     */
-    keepBrandsVisible?: boolean;
-    /**
-     * List of brands accepted by the component
-     * @internal
-     */
-    brands?: string[];
-    /**
-     * Configuration returned by the backend
-     * @internal
-     */
-    configuration?: {
-        brands: string[];
-    };
-}
+import type { FastlaneConfiguration } from './types';
 
 class Fastlane extends UIElement<FastlaneConfiguration> {
-    public static type = TxVariants.fastlane;
+    public static readonly type = TxVariants.fastlane;
 
     protected static defaultProps = {
         keepBrandsVisible: true
@@ -55,11 +29,9 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
 
     public override async isAvailable(): Promise<void> {
         const { tokenId, customerId, lastFour, brand, email, fastlaneSessionId } = this.props;
-
         if (tokenId && customerId && lastFour && brand && email && fastlaneSessionId) {
             return Promise.resolve();
         }
-
         return Promise.reject();
     }
 

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
@@ -208,6 +208,7 @@ describe('FastlaneSDK', () => {
             configuration: {
                 fastlaneConfiguration: {
                     defaultToggleState: true,
+                    fastlaneSessionId: 'xxxx-yyyy',
                     privacyPolicyLink: 'https://...',
                     showConsent: true,
                     termsAndConditionsLink: 'https://...',

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
@@ -180,7 +180,7 @@ describe('FastlaneSDK', () => {
                 customerId: 'customer-context-id',
                 email: 'test@adyen.com',
                 lastFour: '1111',
-                sessionId: 'xxxx-yyyy',
+                fastlaneSessionId: 'xxxx-yyyy',
                 tokenId: 'xxxx'
             }
         });

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
@@ -2,9 +2,9 @@ import { mockDeep, mock, mockReset } from 'jest-mock-extended';
 import initializeFastlane from './initializeFastlane';
 import { httpPost } from '../../core/Services/http';
 import Script from '../../utils/Script';
-import type { Fastlane, FastlaneProfile, FastlaneShipping } from './types';
+import type { FastlaneWindowInstance, FastlaneProfile, FastlaneShipping } from './types';
 
-const fastlaneMock = mockDeep<Fastlane>();
+const fastlaneMock = mockDeep<FastlaneWindowInstance>();
 const fastlaneConstructorMock = jest.fn().mockResolvedValue(fastlaneMock);
 
 const mockScriptLoaded = jest.fn().mockImplementation(() => {

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
@@ -3,7 +3,7 @@ import requestFastlaneToken from './services/request-fastlane-token';
 import { convertAdyenLocaleToFastlaneLocale } from './utils/convert-locale';
 import Script from '../../utils/Script';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
-import {
+import type {
     ComponentConfiguration,
     FastlaneWindowInstance,
     FastlaneAuthenticatedCustomerResult,
@@ -84,6 +84,7 @@ class FastlaneSDK {
                 paymentType: 'card',
                 configuration: {
                     fastlaneConfiguration: {
+                        fastlaneSessionId: 'xxxx-yyyy',
                         showConsent: true,
                         defaultToggleState: true,
                         termsAndConditionsLink: 'https://...',

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
@@ -71,7 +71,7 @@ class FastlaneSDK {
             return {
                 paymentType: 'fastlane',
                 configuration: {
-                    sessionId: 'xxxx-yyyy',
+                    fastlaneSessionId: 'xxxx-yyyy',
                     customerId: this.authenticatedShopper.customerId,
                     email: this.authenticatedShopper.email,
                     tokenId: authResult.profileData.card.id,

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
@@ -5,7 +5,7 @@ import Script from '../../utils/Script';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import {
     ComponentConfiguration,
-    Fastlane,
+    FastlaneWindowInstance,
     FastlaneAuthenticatedCustomerResult,
     FastlaneShippingAddressSelectorResult,
     FastlaneSDKConfiguration
@@ -17,7 +17,7 @@ class FastlaneSDK {
     private readonly checkoutShopperURL: string;
     private readonly locale: string;
 
-    private fastlaneSdk: Fastlane;
+    private fastlaneSdk: FastlaneWindowInstance;
     private authenticatedShopper: { email: string; customerId: string };
 
     constructor(configuration: FastlaneSDKConfiguration) {

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
@@ -4,7 +4,7 @@ import { convertAdyenLocaleToFastlaneLocale } from './utils/convert-locale';
 import Script from '../../utils/Script';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import type {
-    ComponentConfiguration,
+    FastlanePaymentMethodConfiguration,
     FastlaneWindowInstance,
     FastlaneAuthenticatedCustomerResult,
     FastlaneShippingAddressSelectorResult,
@@ -59,7 +59,7 @@ class FastlaneSDK {
     /**
      * TODO: Waiting for PayPal to provide the specific methods to fetch sessionId and Consent UI details
      */
-    public getComponentConfiguration(authResult: FastlaneAuthenticatedCustomerResult): ComponentConfiguration {
+    public getComponentConfiguration(authResult: FastlaneAuthenticatedCustomerResult): FastlanePaymentMethodConfiguration {
         if (!authResult) {
             throw new AdyenCheckoutError(
                 'IMPLEMENTATION_ERROR',
@@ -76,7 +76,7 @@ class FastlaneSDK {
                     email: this.authenticatedShopper.email,
                     tokenId: authResult.profileData.card.id,
                     lastFour: authResult.profileData.card.paymentSource.card.lastDigits,
-                    brand: authResult.profileData.card.paymentSource.card.brand
+                    brand: authResult.profileData.card.paymentSource.card.brand.toLowerCase()
                 }
             };
         } else {

--- a/packages/lib/src/components/PayPalFastlane/components/FaslaneBrandIcon.tsx
+++ b/packages/lib/src/components/PayPalFastlane/components/FaslaneBrandIcon.tsx
@@ -1,0 +1,20 @@
+import { h } from 'preact';
+import useImage from '../../../core/Context/useImage';
+import Img from '../../internal/Img';
+import { getFullBrandName } from '../../Card/components/CardInput/utils';
+
+interface FastlaneBrandIconProps {
+    brand: string;
+}
+
+const FastlaneBrandIcon = ({ brand }: FastlaneBrandIconProps) => {
+    const getImage = useImage();
+
+    return (
+        <span className="adyen-checkout-fastlane__card-brand--wrapper">
+            <Img src={getImage()(brand)} alt={getFullBrandName(brand)} />
+        </span>
+    );
+};
+
+export default FastlaneBrandIcon;

--- a/packages/lib/src/components/PayPalFastlane/components/Fastlane.scss
+++ b/packages/lib/src/components/PayPalFastlane/components/Fastlane.scss
@@ -10,7 +10,7 @@
   border-radius: token(border-radius-s);
   overflow: hidden;
   box-shadow: token(shadow-low);
-  margin-right: 12px;
+  margin-right: token(spacer-060);
 }
 
 
@@ -20,13 +20,13 @@
 }
 
 .adyen-checkout-fastlane__card-number {
-  line-height: 20px;
-  font-size: 14px;
-  font-weight: 500;
+  line-height: token(text-body-line-height);
+  font-size: token(text-body-font-size);
+  font-weight: token(text-body-stronger-font-weight);
 }
 
 .adyen-checkout-fastlane__brand {
   display: flex;
   justify-content: center;
-  margin-top: 16px;
+  margin-top: token(spacer-070);
 }

--- a/packages/lib/src/components/PayPalFastlane/components/Fastlane.scss
+++ b/packages/lib/src/components/PayPalFastlane/components/Fastlane.scss
@@ -30,3 +30,7 @@
   justify-content: center;
   margin-top: token(spacer-070);
 }
+
+.adyen-checkout-fastlane__brand img {
+  width: 95px;
+}

--- a/packages/lib/src/components/PayPalFastlane/components/Fastlane.scss
+++ b/packages/lib/src/components/PayPalFastlane/components/Fastlane.scss
@@ -1,0 +1,32 @@
+@import 'styles/variable-generator';
+
+.adyen-checkout-fastlane__card-brand--wrapper {
+  position: relative;
+  display: flex;
+  width: token(spacer-110);
+  height: 26px;
+  justify-content: center;
+  align-items: center;
+  border-radius: token(border-radius-s);
+  overflow: hidden;
+  box-shadow: token(shadow-low);
+  margin-right: 12px;
+}
+
+
+.adyen-checkout-fastlane__card-section {
+  display: flex;
+  align-items: center;
+}
+
+.adyen-checkout-fastlane__card-number {
+  line-height: 20px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.adyen-checkout-fastlane__brand {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
+}

--- a/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
+++ b/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
@@ -37,7 +37,7 @@ const FastlaneComponent = ({ lastFour, brand, payButton, setComponentRef, showPa
             {showPayButton && payButton({ status, icon: getImage({ imageFolder: 'components/' })(`${PREFIX}lock`) })}
 
             <div className="adyen-checkout-fastlane__brand">
-                <Img width="95px" src={getImage({ imageFolder: 'components/' })(`paypal_fastlane_gray`)} alt="Fastlane logo" />
+                <Img src={getImage({ imageFolder: 'components/' })(`paypal_fastlane_gray`)} alt="Fastlane logo" />
             </div>
         </div>
     );

--- a/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
+++ b/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
@@ -27,7 +27,7 @@ const FastlaneComponent = ({ lastFour, brand, payButton, setComponentRef, showPa
     }, []);
 
     return (
-        <div className="adyen-checkout-fastlane">
+        <div className="adyen-checkout-fastlane" data-testid="payment-method-fastlane">
             <div className="adyen-checkout-fastlane__card-section">
                 <FastlaneBrandIcon brand={brand} />
                 <span className="adyen-checkout-fastlane__card-number">•••• {lastFour}</span>

--- a/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
+++ b/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
@@ -1,10 +1,11 @@
 import { h } from 'preact';
-import { ComponentMethodsRef, PayButtonFunctionProps, UIElementStatus } from '../../internal/UIElement/types';
 import { useEffect, useRef, useState } from 'preact/hooks';
+import { ComponentMethodsRef, PayButtonFunctionProps, UIElementStatus } from '../../internal/UIElement/types';
 import FastlaneBrandIcon from './FaslaneBrandIcon';
 import { PREFIX } from '../../internal/Icon/constants';
 import useImage from '../../../core/Context/useImage';
 import Img from '../../internal/Img';
+
 import './Fastlane.scss';
 
 interface FastlaneComponentProps {

--- a/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
+++ b/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
@@ -36,7 +36,7 @@ const FastlaneComponent = ({ lastFour, brand, payButton, setComponentRef, showPa
             {showPayButton && payButton({ status, icon: getImage({ imageFolder: 'components/' })(`${PREFIX}lock`) })}
 
             <div className="adyen-checkout-fastlane__brand">
-                <Img width="95px" src={getImage({ imageFolder: 'components/' })(`paypal_fastlane_gray`)} alt="Fastlane brand" />
+                <Img width="95px" src={getImage({ imageFolder: 'components/' })(`paypal_fastlane_gray`)} alt="Fastlane logo" />
             </div>
         </div>
     );

--- a/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
+++ b/packages/lib/src/components/PayPalFastlane/components/FastlaneComponent.tsx
@@ -1,0 +1,45 @@
+import { h } from 'preact';
+import { ComponentMethodsRef, PayButtonFunctionProps, UIElementStatus } from '../../internal/UIElement/types';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import FastlaneBrandIcon from './FaslaneBrandIcon';
+import { PREFIX } from '../../internal/Icon/constants';
+import useImage from '../../../core/Context/useImage';
+import Img from '../../internal/Img';
+import './Fastlane.scss';
+
+interface FastlaneComponentProps {
+    lastFour: string;
+    brand: string;
+    showPayButton: boolean;
+    setComponentRef: (ref: ComponentMethodsRef) => void;
+    payButton(props?: PayButtonFunctionProps): h.JSX.Element;
+}
+
+const FastlaneComponent = ({ lastFour, brand, payButton, setComponentRef, showPayButton }: FastlaneComponentProps) => {
+    const getImage = useImage();
+    const [status, setStatus] = useState<UIElementStatus>('ready');
+    const fastlaneRef = useRef({
+        setStatus: (status: UIElementStatus) => setStatus(status)
+    });
+
+    useEffect(() => {
+        setComponentRef(fastlaneRef.current);
+    }, []);
+
+    return (
+        <div className="adyen-checkout-fastlane">
+            <div className="adyen-checkout-fastlane__card-section">
+                <FastlaneBrandIcon brand={brand} />
+                <span className="adyen-checkout-fastlane__card-number">•••• {lastFour}</span>
+            </div>
+
+            {showPayButton && payButton({ status, icon: getImage({ imageFolder: 'components/' })(`${PREFIX}lock`) })}
+
+            <div className="adyen-checkout-fastlane__brand">
+                <Img width="95px" src={getImage({ imageFolder: 'components/' })(`paypal_fastlane_gray`)} alt="Fastlane brand" />
+            </div>
+        </div>
+    );
+};
+
+export default FastlaneComponent;

--- a/packages/lib/src/components/PayPalFastlane/index.ts
+++ b/packages/lib/src/components/PayPalFastlane/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Fastlane';

--- a/packages/lib/src/components/PayPalFastlane/services/request-fastlane-token.ts
+++ b/packages/lib/src/components/PayPalFastlane/services/request-fastlane-token.ts
@@ -9,19 +9,19 @@ export interface FastlaneTokenData {
 }
 
 function requestFastlaneToken(url: string, clientKey: string): Promise<FastlaneTokenData> {
-    const path = `utility/v1/payPalFastlane/tokens?clientKey=${clientKey}`;
-    return httpPost<FastlaneTokenData>({ loadingContext: url, path, errorLevel: 'fatal' });
+    // const path = `utility/v1/payPalFastlane/tokens?clientKey=${clientKey}`;
+    // return httpPost<FastlaneTokenData>({ loadingContext: url, path, errorLevel: 'fatal' });
 
     /**
      * TODO: Endpoint is not ready. The only way to test right now is mocking the response here
      */
-    // return Promise.resolve({
-    //     id: '2747bd08-783a-45c6-902b-3efbda5497b7',
-    //     clientId: 'AXy9hIzWB6h_LjZUHjHmsbsiicSIbL4GKOrcgomEedVjduUinIU4C2llxkW5p0OG0zTNgviYFceaXEnj',
-    //     merchantId: 'C3UCKQHMW4948',
-    //     value: 'xxxeyJraWQiOiJkMTA2ZTUwNjkzOWYxMWVlYjlkMTAyNDJhYzEyMDAwMiIsInR5cCI6IkpXVCIsImFsZyI6IkVTMjU2In0.eyJpc3MiOiJodHRwczovL2FwaS5zYW5kYm94LnBheXBhbC5jb20iLCJhdWQiOlsiaHR0cHM6Ly9hcGkuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJjaGVja291dC1wbGF5Z3JvdW5kLm5ldGxpZnkuYXBwIl0sInN1YiI6Ik02VE5BRVNaNUZHTk4iLCJhY3IiOlsiY2xpZW50Il0sInNjb3BlIjpbIkJyYWludHJlZTpWYXVsdCJdLCJvcHRpb25zIjp7fSwiYXoiOiJjY2cxOC5zbGMiLCJleHRlcm5hbF9pZCI6WyJQYXlQYWw6QzNVQ0tRSE1XNDk0OCIsIkJyYWludHJlZTozZGI4aG5rdHJ0bXpzMmd0Il0sImV4cCI6MTczMjc5NjA4NywiaWF0IjoxNzMyNzk1MTg3LCJqdGkiOiJVMkFBTEV0ZjNVbHZiQWFBT0Y5cEtla29YTEREY1NqTmtnS3kzYjJ5YnNuUWlnV01VTEtpaXFYYXBUeTdqTy1EWllhTnU1ZEZBVy05bVRybU5Cay1nTi1qS0VVdnVJSDYtR3h5dV9wMUVXZlRydjdrVmJ4V2NnM2psUDI5aGhtQSJ9.57b4zg2TeN44I5aehBkfXdUf5kqWp8sjo58LKHOFNsuBlcmuWAmqQnprNgys3aL0Y8FqBVqhp69yF_v8_Qiy2w',
-    //     expiresAt: '2024-11-01T13:34:01.804+00:00'
-    // });
+    return Promise.resolve({
+        id: '2747bd08-783a-45c6-902b-3efbda5497b7',
+        clientId: 'AXy9hIzWB6h_LjZUHjHmsbsiicSIbL4GKOrcgomEedVjduUinIU4C2llxkW5p0OG0zTNgviYFceaXEnj',
+        merchantId: 'C3UCKQHMW4948',
+        value: 'eyJraWQiOiJkMTA2ZTUwNjkzOWYxMWVlYjlkMTAyNDJhYzEyMDAwMiIsInR5cCI6IkpXVCIsImFsZyI6IkVTMjU2In0.eyJpc3MiOiJodHRwczovL2FwaS5zYW5kYm94LnBheXBhbC5jb20iLCJhdWQiOlsiaHR0cHM6Ly9hcGkuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJjaGVja291dC1wbGF5Z3JvdW5kLm5ldGxpZnkuYXBwIl0sInN1YiI6Ik02VE5BRVNaNUZHTk4iLCJhY3IiOlsiY2xpZW50Il0sInNjb3BlIjpbIkJyYWludHJlZTpWYXVsdCJdLCJvcHRpb25zIjp7fSwiYXoiOiJjY2cxOC5zbGMiLCJleHRlcm5hbF9pZCI6WyJQYXlQYWw6QzNVQ0tRSE1XNDk0OCIsIkJyYWludHJlZTozZGI4aG5rdHJ0bXpzMmd0Il0sImV4cCI6MTczMzE2MTgwNiwiaWF0IjoxNzMzMTYwOTA2LCJqdGkiOiJVMkFBSXBGY25XbEJQNEwwaWJlSk14SmR1ZTFodG0yUGFXNzlMeDRzMktVZkJXYl8wWUw4S1BIOEFQUC0yNnhISm5WRmFPQWxObGVMVzdCRktlcGRVaERMOEJMWVBHdXRkMEFBVUZEc0V1UDRUOUlzNzc2WHNyUG9BMXBxN0ZQZyJ9.VN6t5fDUJknJf6RZO9LSYVSMmkITU5XOl0VVeFeVeJiMeU-1w5S8J0vPROv4_vBrDflWtx-YRs6bcvXTDq1NHg',
+        expiresAt: '2024-11-01T13:34:01.804+00:00'
+    });
 }
 
 export default requestFastlaneToken;

--- a/packages/lib/src/components/PayPalFastlane/services/request-fastlane-token.ts
+++ b/packages/lib/src/components/PayPalFastlane/services/request-fastlane-token.ts
@@ -11,17 +11,6 @@ export interface FastlaneTokenData {
 function requestFastlaneToken(url: string, clientKey: string): Promise<FastlaneTokenData> {
     const path = `utility/v1/payPalFastlane/tokens?clientKey=${clientKey}`;
     return httpPost<FastlaneTokenData>({ loadingContext: url, path, errorLevel: 'fatal' });
-
-    /**
-     * TODO: Endpoint is not ready. The only way to test right now is mocking the response here
-     */
-    // return Promise.resolve({
-    //     id: '2747bd08-783a-45c6-902b-3efbda5497b7',
-    //     clientId: 'AXy9hIzWB6h_LjZUHjHmsbsiicSIbL4GKOrcgomEedVjduUinIU4C2llxkW5p0OG0zTNgviYFceaXEnj',
-    //     merchantId: 'C3UCKQHMW4948',
-    //     value: 'eyJraWQiOiJkMTA2ZTUwNjkzOWYxMWVlYjlkMTAyNDJhYzEyMDAwMiIsInR5cCI6IkpXVCIsImFsZyI6IkVTMjU2In0.eyJpc3MiOiJodHRwczovL2FwaS5zYW5kYm94LnBheXBhbC5jb20iLCJhdWQiOlsiaHR0cHM6Ly9hcGkuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJjaGVja291dC1wbGF5Z3JvdW5kLm5ldGxpZnkuYXBwIl0sInN1YiI6Ik02VE5BRVNaNUZHTk4iLCJhY3IiOlsiY2xpZW50Il0sInNjb3BlIjpbIkJyYWludHJlZTpWYXVsdCJdLCJvcHRpb25zIjp7fSwiYXoiOiJjY2cxOC5zbGMiLCJleHRlcm5hbF9pZCI6WyJQYXlQYWw6QzNVQ0tRSE1XNDk0OCIsIkJyYWludHJlZTozZGI4aG5rdHJ0bXpzMmd0Il0sImV4cCI6MTczMzIyODY5MSwiaWF0IjoxNzMzMjI3NzkxLCJqdGkiOiJVMkFBTGM5a2VYdFByRTh6OHZPTEptUDI2cV94akcyN24tNHJHdUhCMHB1XzE1aHY0bGlrdmFobmlXdjJzbmN0UWFEdjFscFhxTlk0U1VmYkhwR0tnTjNYTlM5OGpaUnB0WWlFbkhZN1JxS21TQUpXZVFIRFdPc3AxRllaVUd3ZyJ9.3Aw31ttXYSCmUcklNi6BrGqWPTw2Z42XDZW_r4SFTZBXz9aUXu3uy6k2cG7WChGx0vss7qFq_3XYswS8t7T9CQ',
-    //     expiresAt: '2024-11-01T13:34:01.804+00:00'
-    // });
 }
 
 export default requestFastlaneToken;

--- a/packages/lib/src/components/PayPalFastlane/services/request-fastlane-token.ts
+++ b/packages/lib/src/components/PayPalFastlane/services/request-fastlane-token.ts
@@ -9,19 +9,19 @@ export interface FastlaneTokenData {
 }
 
 function requestFastlaneToken(url: string, clientKey: string): Promise<FastlaneTokenData> {
-    // const path = `utility/v1/payPalFastlane/tokens?clientKey=${clientKey}`;
-    // return httpPost<FastlaneTokenData>({ loadingContext: url, path, errorLevel: 'fatal' });
+    const path = `utility/v1/payPalFastlane/tokens?clientKey=${clientKey}`;
+    return httpPost<FastlaneTokenData>({ loadingContext: url, path, errorLevel: 'fatal' });
 
     /**
      * TODO: Endpoint is not ready. The only way to test right now is mocking the response here
      */
-    return Promise.resolve({
-        id: '2747bd08-783a-45c6-902b-3efbda5497b7',
-        clientId: 'AXy9hIzWB6h_LjZUHjHmsbsiicSIbL4GKOrcgomEedVjduUinIU4C2llxkW5p0OG0zTNgviYFceaXEnj',
-        merchantId: 'C3UCKQHMW4948',
-        value: 'eyJraWQiOiJkMTA2ZTUwNjkzOWYxMWVlYjlkMTAyNDJhYzEyMDAwMiIsInR5cCI6IkpXVCIsImFsZyI6IkVTMjU2In0.eyJpc3MiOiJodHRwczovL2FwaS5zYW5kYm94LnBheXBhbC5jb20iLCJhdWQiOlsiaHR0cHM6Ly9hcGkuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJjaGVja291dC1wbGF5Z3JvdW5kLm5ldGxpZnkuYXBwIl0sInN1YiI6Ik02VE5BRVNaNUZHTk4iLCJhY3IiOlsiY2xpZW50Il0sInNjb3BlIjpbIkJyYWludHJlZTpWYXVsdCJdLCJvcHRpb25zIjp7fSwiYXoiOiJjY2cxOC5zbGMiLCJleHRlcm5hbF9pZCI6WyJQYXlQYWw6QzNVQ0tRSE1XNDk0OCIsIkJyYWludHJlZTozZGI4aG5rdHJ0bXpzMmd0Il0sImV4cCI6MTczMzE2MTgwNiwiaWF0IjoxNzMzMTYwOTA2LCJqdGkiOiJVMkFBSXBGY25XbEJQNEwwaWJlSk14SmR1ZTFodG0yUGFXNzlMeDRzMktVZkJXYl8wWUw4S1BIOEFQUC0yNnhISm5WRmFPQWxObGVMVzdCRktlcGRVaERMOEJMWVBHdXRkMEFBVUZEc0V1UDRUOUlzNzc2WHNyUG9BMXBxN0ZQZyJ9.VN6t5fDUJknJf6RZO9LSYVSMmkITU5XOl0VVeFeVeJiMeU-1w5S8J0vPROv4_vBrDflWtx-YRs6bcvXTDq1NHg',
-        expiresAt: '2024-11-01T13:34:01.804+00:00'
-    });
+    // return Promise.resolve({
+    //     id: '2747bd08-783a-45c6-902b-3efbda5497b7',
+    //     clientId: 'AXy9hIzWB6h_LjZUHjHmsbsiicSIbL4GKOrcgomEedVjduUinIU4C2llxkW5p0OG0zTNgviYFceaXEnj',
+    //     merchantId: 'C3UCKQHMW4948',
+    //     value: 'eyJraWQiOiJkMTA2ZTUwNjkzOWYxMWVlYjlkMTAyNDJhYzEyMDAwMiIsInR5cCI6IkpXVCIsImFsZyI6IkVTMjU2In0.eyJpc3MiOiJodHRwczovL2FwaS5zYW5kYm94LnBheXBhbC5jb20iLCJhdWQiOlsiaHR0cHM6Ly9hcGkuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJjaGVja291dC1wbGF5Z3JvdW5kLm5ldGxpZnkuYXBwIl0sInN1YiI6Ik02VE5BRVNaNUZHTk4iLCJhY3IiOlsiY2xpZW50Il0sInNjb3BlIjpbIkJyYWludHJlZTpWYXVsdCJdLCJvcHRpb25zIjp7fSwiYXoiOiJjY2cxOC5zbGMiLCJleHRlcm5hbF9pZCI6WyJQYXlQYWw6QzNVQ0tRSE1XNDk0OCIsIkJyYWludHJlZTozZGI4aG5rdHJ0bXpzMmd0Il0sImV4cCI6MTczMzIyODY5MSwiaWF0IjoxNzMzMjI3NzkxLCJqdGkiOiJVMkFBTGM5a2VYdFByRTh6OHZPTEptUDI2cV94akcyN24tNHJHdUhCMHB1XzE1aHY0bGlrdmFobmlXdjJzbmN0UWFEdjFscFhxTlk0U1VmYkhwR0tnTjNYTlM5OGpaUnB0WWlFbkhZN1JxS21TQUpXZVFIRFdPc3AxRllaVUd3ZyJ9.3Aw31ttXYSCmUcklNi6BrGqWPTw2Z42XDZW_r4SFTZBXz9aUXu3uy6k2cG7WChGx0vss7qFq_3XYswS8t7T9CQ',
+    //     expiresAt: '2024-11-01T13:34:01.804+00:00'
+    // });
 }
 
 export default requestFastlaneToken;

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -103,7 +103,7 @@ type FastlaneComponentConfiguration = {
     };
 };
 
-type CardComponentConfiguration = {
+type FastlaneCardComponentConfiguration = {
     paymentType: 'card';
     configuration: {
         fastlaneConfiguration: {
@@ -117,7 +117,7 @@ type CardComponentConfiguration = {
     };
 };
 
-export type ComponentConfiguration = FastlaneComponentConfiguration | CardComponentConfiguration;
+export type FastlanePaymentMethodConfiguration = FastlaneComponentConfiguration | FastlaneCardComponentConfiguration;
 
 export interface FastlaneSDKConfiguration {
     clientKey: string;

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -1,4 +1,5 @@
 import type { CoreConfiguration } from '../../core/types';
+import type { UIElementProps } from '../internal/UIElement/types';
 
 /**
  * PayPal Fastlane Reference:
@@ -8,7 +9,7 @@ import type { CoreConfiguration } from '../../core/types';
 /**
  * Fastlane object available in the window
  */
-export interface Fastlane {
+export interface FastlaneWindowInstance {
     identity: {
         lookupCustomerByEmail: (email: string) => Promise<{ customerContextId: string }>;
         triggerAuthenticationFlow: (customerContextId: string, options?: AuthenticationFlowOptions) => Promise<FastlaneAuthenticatedCustomerResult>;
@@ -43,6 +44,7 @@ export interface FastlaneShippingAddressSelectorResult {
     selectionChanged: boolean;
     selectedAddress: FastlaneShipping;
 }
+
 export interface FastlaneAuthenticatedCustomerResult {
     authenticationState: 'succeeded' | 'failed' | 'canceled' | 'not_found';
     profileData: FastlaneProfile;
@@ -110,6 +112,7 @@ type CardComponentConfiguration = {
             termsAndConditionsLink: string;
             privacyPolicyLink: string;
             termsAndConditionsVersion: string;
+            fastlaneSessionId: string;
         };
     };
 };
@@ -120,4 +123,30 @@ export interface FastlaneSDKConfiguration {
     clientKey: string;
     environment: CoreConfiguration['environment'];
     locale?: 'en-US' | 'es-US' | 'fr-RS' | 'zh-US';
+}
+
+export interface FastlaneConfiguration extends UIElementProps {
+    tokenId: string;
+    customerId: string;
+    lastFour: string;
+    brand: string;
+    email: string;
+    fastlaneSessionId: string;
+    /**
+     * Display the brand images inside the Drop-in payment method header
+     * @internal
+     */
+    keepBrandsVisible?: boolean;
+    /**
+     * List of brands accepted by the component
+     * @internal
+     */
+    brands?: string[];
+    /**
+     * Configuration returned by the backend
+     * @internal
+     */
+    configuration?: {
+        brands: string[];
+    };
 }

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -92,7 +92,7 @@ export interface FastlaneProfile {
 type FastlaneComponentConfiguration = {
     paymentType: 'fastlane';
     configuration: {
-        sessionId: string;
+        fastlaneSessionId: string;
         customerId: string;
         email: string;
         tokenId: string;

--- a/packages/lib/src/components/components-map.ts
+++ b/packages/lib/src/components/components-map.ts
@@ -60,6 +60,7 @@ import Duitnow from './DuitNow';
 import Trustly from './Trustly';
 import Riverty from './Riverty';
 import PayByBankUS from './PayByBankUS';
+import Fastlane from './PayPalFastlane/Fastlane';
 import { TxVariants } from './tx-variants';
 
 /**
@@ -114,6 +115,7 @@ export const ComponentsMap = {
     [TxVariants.clicktopay]: ClickToPay,
     [TxVariants.googlepay]: GooglePay,
     [TxVariants.paypal]: PayPal,
+    [TxVariants.fastlane]: Fastlane,
     [TxVariants.paywithgoogle]: GooglePay,
     /** Wallets */
 

--- a/packages/lib/src/components/components-name-map.ts
+++ b/packages/lib/src/components/components-name-map.ts
@@ -51,6 +51,7 @@ const ComponentsNameMap = {
     [TxVariants.clicktopay]: 'ClickToPay',
     [TxVariants.googlepay]: 'GooglePay',
     [TxVariants.paypal]: 'PayPal',
+    [TxVariants.fastlane]: 'Fastlane',
     [TxVariants.paywithgoogle]: 'GooglePay',
     /** Wallets */
 

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Exposing UI Components derived by UIElement
+ */
+
 /** Card */
 export { default as Card } from './Card';
 export { default as Bancontact } from './Card/Bancontact';
@@ -90,10 +94,6 @@ export { default as ANCV } from './ANCV';
 /** Giftcard */
 export { default as Giftcard } from './Giftcard';
 export { default as MealVoucherFR } from './MealVoucherFR';
-
-/** Utilities */
-export { default as initializeFastlane } from './PayPalFastlane/initializeFastlane';
-export { default as FastlaneSDK } from './PayPalFastlane/FastlaneSDK';
 
 /** Internal */
 export { default as Address } from './Address';

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -31,6 +31,7 @@ export { default as CashAppPay } from './CashAppPay';
 export { default as ClickToPay } from './ClickToPay';
 export { default as GooglePay } from './GooglePay';
 export { default as PayPal } from './PayPal';
+export { default as Fastlane } from './PayPalFastlane';
 
 /** Vouchers */
 export { default as Boleto } from './Boleto';

--- a/packages/lib/src/components/internal/Button/types.ts
+++ b/packages/lib/src/components/internal/Button/types.ts
@@ -1,6 +1,4 @@
-import { h } from 'preact';
-
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'action';
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'action' | 'link';
 
 export interface ButtonProps {
     status?: string;

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -192,8 +192,6 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     }
 
     protected makePaymentsCall(): Promise<CheckoutAdvancedFlowResponse | CheckoutSessionPaymentResponse> {
-        console.log('makePaymentsCall');
-
         this.setElementStatus('loading');
 
         if (this.props.onSubmit) {

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -192,6 +192,8 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     }
 
     protected makePaymentsCall(): Promise<CheckoutAdvancedFlowResponse | CheckoutSessionPaymentResponse> {
+        console.log('makePaymentsCall');
+
         this.setElementStatus('loading');
 
         if (this.props.onSubmit) {
@@ -446,7 +448,6 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     /**
      * Get the element icon URL for the current environment
      */
-
     public get icon(): string {
         const type = this.props.paymentMethodType || this.type;
         return this.props.icon ?? this.resources.getImage()(type);

--- a/packages/lib/src/components/internal/UIElement/types.ts
+++ b/packages/lib/src/components/internal/UIElement/types.ts
@@ -25,6 +25,8 @@ type CoreCallbacks = Pick<
     | 'onEnterKeyPressed'
 >;
 
+export type StatusFromAction = 'redirect' | 'loading' | 'custom';
+
 export type UIElementProps = BaseElementProps &
     CoreCallbacks & {
         environment?: string;
@@ -57,7 +59,7 @@ export type UIElementProps = BaseElementProps &
          * Status set when creating the Component from action
          * @internal
          */
-        statusType?: 'redirect' | 'loading' | 'custom';
+        statusType?: StatusFromAction;
 
         type?: string;
         name?: string;

--- a/packages/lib/src/components/tx-variants.ts
+++ b/packages/lib/src/components/tx-variants.ts
@@ -50,6 +50,7 @@ export enum TxVariants {
     clicktopay = 'clicktopay',
     googlepay = 'googlepay',
     paypal = 'paypal',
+    fastlane = 'fastlane',
     paywithgoogle = 'paywithgoogle',
     /** Wallets */
 

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -22,6 +22,7 @@ export * from './Klarna/types';
 export * from './Multibanco/types';
 export * from './Oxxo/types';
 export * from './PayPal/types';
+export * from './PayPalFastlane/types';
 export * from './Pix/types';
 export * from './Redirect/types';
 export * from './Sepa/types';

--- a/packages/lib/src/components/utilities.ts
+++ b/packages/lib/src/components/utilities.ts
@@ -1,0 +1,5 @@
+/**
+ * Exposing utilities that can be used by merchants
+ */
+
+export { default as initializeFastlane } from './PayPalFastlane/initializeFastlane';

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -2,4 +2,5 @@ import * as components from './components';
 
 export { components };
 export * from './components';
+export * from './components/utilities';
 export * from './core/AdyenCheckout';

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -6,3 +6,4 @@ export { CustomTranslations } from './language/types';
 
 export { default as AdyenCheckoutError } from './core/Errors/AdyenCheckoutError';
 export { default as UIElement } from './components/internal/UIElement';
+export { default as FastlaneSDK } from './components/PayPalFastlane/FastlaneSDK';

--- a/packages/lib/src/types/custom.d.ts
+++ b/packages/lib/src/types/custom.d.ts
@@ -1,4 +1,4 @@
-import { Fastlane, FastlaneOptions } from '../components/PayPalFastlane/types';
+import { FastlaneWindowInstance, FastlaneOptions } from '../components/PayPalFastlane/types';
 
 declare module '*.scss' {
     const content: { [className: string]: string };
@@ -9,7 +9,7 @@ declare global {
     interface Window {
         ApplePaySession?: ApplePaySession;
         paypal?: {
-            Fastlane?: (options?: FastlaneOptions) => Promise<Fastlane>;
+            Fastlane?: (options?: FastlaneOptions) => Promise<FastlaneWindowInstance>;
         };
         AdyenWeb: any;
         VISA_SDK?: {

--- a/packages/lib/storybook/helpers/create-advanced-checkout.ts
+++ b/packages/lib/storybook/helpers/create-advanced-checkout.ts
@@ -33,7 +33,9 @@ async function createAdvancedFlowCheckout({
               paymentMethods: paymentMethodsOverride.paymentMethods ? paymentMethodsOverride.paymentMethods : []
           };
 
-    paymentMethodsResponse.paymentMethods = paymentMethodsResponse.paymentMethods.filter(pm => allowedPaymentTypes.includes(pm.type));
+    if (allowedPaymentTypes.length > 0) {
+        paymentMethodsResponse.paymentMethods = paymentMethodsResponse.paymentMethods.filter(pm => allowedPaymentTypes.includes(pm.type));
+    }
 
     const checkout = await AdyenCheckout({
         clientKey: process.env.CLIENT_KEY,

--- a/packages/lib/storybook/stories/ComponentContainer.tsx
+++ b/packages/lib/storybook/stories/ComponentContainer.tsx
@@ -16,14 +16,9 @@ export const ComponentContainer = ({ element }: IContainer) => {
         addToWindow(element);
 
         if (element.isAvailable) {
-            element
-                .isAvailable()
-                .then(() => {
-                    element.mount(container.current);
-                })
-                .catch(error => {
-                    setErrorMessage(error.toString());
-                });
+            element.isAvailable().then(() => {
+                element.mount(container.current);
+            });
         } else {
             element.mount(container.current);
         }

--- a/packages/lib/storybook/stories/ComponentContainer.tsx
+++ b/packages/lib/storybook/stories/ComponentContainer.tsx
@@ -16,9 +16,14 @@ export const ComponentContainer = ({ element }: IContainer) => {
         addToWindow(element);
 
         if (element.isAvailable) {
-            element.isAvailable().then(() => {
-                element.mount(container.current);
-            });
+            element
+                .isAvailable()
+                .then(() => {
+                    element.mount(container.current);
+                })
+                .catch(error => {
+                    setErrorMessage(error.toString());
+                });
         } else {
             element.mount(container.current);
         }

--- a/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
@@ -21,7 +21,7 @@ export const Default: FastlaneStory = {
             paymentMethods: [
                 {
                     type: 'scheme',
-                    name: 'Card',
+                    name: 'Cards',
                     brands: ['mc', 'visa']
                 },
                 {
@@ -30,7 +30,7 @@ export const Default: FastlaneStory = {
                     type: 'paypal'
                 },
                 {
-                    name: 'Fastlane',
+                    name: 'Cards',
                     type: 'fastlane',
                     brands: ['mc', 'visa']
                 }
@@ -47,7 +47,7 @@ export const WithMockedRecognizedFlow: FastlaneStory = {
             paymentMethods: [
                 {
                     type: 'scheme',
-                    name: 'Card',
+                    name: 'Cards',
                     brands: ['mc', 'visa']
                 },
                 {
@@ -56,7 +56,7 @@ export const WithMockedRecognizedFlow: FastlaneStory = {
                     type: 'paypal'
                 },
                 {
-                    name: 'Fastlane',
+                    name: 'Cards',
                     type: 'fastlane',
                     brands: ['mc', 'visa']
                 }

--- a/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
@@ -1,5 +1,13 @@
+import { h } from 'preact';
 import { MetaConfiguration, StoryConfiguration } from '../../types';
 import { FastlaneInSinglePageApp } from './FastlaneInSinglePageApp';
+import { ComponentContainer } from '../../ComponentContainer';
+
+import Dropin from '../../../../src/components/Dropin/Dropin';
+import Card from '../../../../src/components/Card/Card';
+import PayPal from '../../../../src/components/PayPal/Paypal';
+import Fastlane from '../../../../src/components/PayPalFastlane';
+import { Checkout } from '../../Checkout';
 
 type FastlaneStory = StoryConfiguration<{}>;
 
@@ -9,8 +17,6 @@ const meta: MetaConfiguration<FastlaneStory> = {
 
 export const Default: FastlaneStory = {
     render: checkoutConfig => {
-        const allowedPaymentTypes = ['scheme', 'paypal', 'fastlane'];
-
         const paymentMethodsOverride = {
             paymentMethods: [
                 {
@@ -31,7 +37,49 @@ export const Default: FastlaneStory = {
             ]
         };
 
-        return <FastlaneInSinglePageApp checkoutConfig={{ allowedPaymentTypes, paymentMethodsOverride, ...checkoutConfig }} />;
+        return <FastlaneInSinglePageApp checkoutConfig={{ paymentMethodsOverride, ...checkoutConfig }} />;
+    }
+};
+
+export const WithMockedRecognizedFlow: FastlaneStory = {
+    render: checkoutConfig => {
+        const paymentMethodsOverride = {
+            paymentMethods: [
+                {
+                    type: 'scheme',
+                    name: 'Card',
+                    brands: ['mc', 'visa']
+                },
+                {
+                    configuration: { merchantId: 'QSXMR9W7GV8NY', intent: 'capture' },
+                    name: 'PayPal',
+                    type: 'paypal'
+                },
+                {
+                    name: 'Fastlane',
+                    type: 'fastlane',
+                    brands: ['mc', 'visa']
+                }
+            ]
+        };
+
+        return (
+            <Checkout checkoutConfig={{ ...checkoutConfig, paymentMethodsOverride }}>
+                {checkout => (
+                    <ComponentContainer
+                        element={
+                            new Dropin(checkout, {
+                                showStoredPaymentMethods: false,
+                                paymentMethodComponents: [Card, PayPal, Fastlane],
+                                paymentMethodsConfiguration: {
+                                    fastlane: { tokenId: 'xxx', customerId: 'sss', lastFour: '1111', brand: 'visa', email: 'email@adyen.com' }
+                                }
+                            })
+                        }
+                    />
+                )}
+            </Checkout>
+        );
     }
 };
 

--- a/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
@@ -72,7 +72,14 @@ export const WithMockedRecognizedFlow: FastlaneStory = {
                                 showStoredPaymentMethods: false,
                                 paymentMethodComponents: [Card, PayPal, Fastlane],
                                 paymentMethodsConfiguration: {
-                                    fastlane: { tokenId: 'xxx', customerId: 'sss', lastFour: '1111', brand: 'visa', email: 'email@adyen.com' }
+                                    fastlane: {
+                                        tokenId: 'xxx',
+                                        customerId: 'sss',
+                                        lastFour: '1111',
+                                        brand: 'visa',
+                                        email: 'email@adyen.com',
+                                        fastlaneSessionId: 'xxx'
+                                    }
                                 }
                             })
                         }

--- a/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
@@ -9,8 +9,29 @@ const meta: MetaConfiguration<FastlaneStory> = {
 
 export const Default: FastlaneStory = {
     render: checkoutConfig => {
-        const allowedPaymentTypes = ['scheme', 'paypal'];
-        return <FastlaneInSinglePageApp checkoutConfig={{ allowedPaymentTypes, ...checkoutConfig }} />;
+        const allowedPaymentTypes = ['scheme', 'paypal', 'fastlane'];
+
+        const paymentMethodsOverride = {
+            paymentMethods: [
+                {
+                    type: 'scheme',
+                    name: 'Card',
+                    brands: ['mc', 'visa']
+                },
+                {
+                    configuration: { merchantId: 'QSXMR9W7GV8NY', intent: 'capture' },
+                    name: 'PayPal',
+                    type: 'paypal'
+                },
+                {
+                    name: 'Fastlane',
+                    type: 'fastlane',
+                    brands: ['mc', 'visa']
+                }
+            ]
+        };
+
+        return <FastlaneInSinglePageApp checkoutConfig={{ allowedPaymentTypes, paymentMethodsOverride, ...checkoutConfig }} />;
     }
 };
 

--- a/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
@@ -10,13 +10,14 @@ import Fastlane from '../../../../src/components/PayPalFastlane';
 import { Checkout } from '../../Checkout';
 import { ComponentContainer } from '../../ComponentContainer';
 import { GuestShopperForm } from './components/GuestShopperForm';
+import type { FastlanePaymentMethodConfiguration } from '../../../../src/components/PayPalFastlane/types';
 
 interface Props {
     checkoutConfig: GlobalStoryProps;
 }
 
 export const FastlaneInSinglePageApp = ({ checkoutConfig }: Props) => {
-    const [componentConfig, setComponentConfig] = useState<any>(null);
+    const [componentConfig, setComponentConfig] = useState<FastlanePaymentMethodConfiguration>(null);
 
     const handleOnCheckoutStep = config => {
         console.log('Component config:', config);
@@ -36,14 +37,7 @@ export const FastlaneInSinglePageApp = ({ checkoutConfig }: Props) => {
                             showStoredPaymentMethods: false,
                             paymentMethodComponents: [Card, PayPal, Fastlane],
                             paymentMethodsConfiguration: {
-                                fastlane: {
-                                    tokenId: 'xxx',
-                                    customerId: 'sss',
-                                    lastFour: '1111',
-                                    brand: 'visa',
-                                    email: 'email@adyen.com',
-                                    fastlaneSessionId: 'zzz'
-                                }
+                                [componentConfig.paymentType]: componentConfig.configuration
                             }
                         })
                     }

--- a/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
@@ -16,16 +16,16 @@ interface Props {
 }
 
 export const FastlaneInSinglePageApp = ({ checkoutConfig }: Props) => {
-    // const [componentConfig, setComponentConfig] = useState<any>(null);
-    //
-    // const handleOnCheckoutStep = config => {
-    //     console.log('Component config:', config);
-    //     setComponentConfig(config);
-    // };
-    //
-    // if (!componentConfig) {
-    //     return <GuestShopperForm onCheckoutStep={handleOnCheckoutStep} />;
-    // }
+    const [componentConfig, setComponentConfig] = useState<any>(null);
+
+    const handleOnCheckoutStep = config => {
+        console.log('Component config:', config);
+        setComponentConfig(config);
+    };
+
+    if (!componentConfig) {
+        return <GuestShopperForm onCheckoutStep={handleOnCheckoutStep} />;
+    }
 
     return (
         <Checkout checkoutConfig={checkoutConfig}>

--- a/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
@@ -5,6 +5,7 @@ import { GlobalStoryProps } from '../../types';
 import Dropin from '../../../../src/components/Dropin';
 import Card from '../../../../src/components/Card';
 import PayPal from '../../../../src/components/PayPal';
+import Fastlane from '../../../../src/components/PayPalFastlane';
 
 import { Checkout } from '../../Checkout';
 import { ComponentContainer } from '../../ComponentContainer';
@@ -15,21 +16,31 @@ interface Props {
 }
 
 export const FastlaneInSinglePageApp = ({ checkoutConfig }: Props) => {
-    const [componentConfig, setComponentConfig] = useState<any>(null);
-
-    const handleOnCheckoutStep = config => {
-        console.log('Component config:', config);
-        setComponentConfig(config);
-    };
-
-    if (!componentConfig) {
-        return <GuestShopperForm onCheckoutStep={handleOnCheckoutStep} />;
-    }
+    // const [componentConfig, setComponentConfig] = useState<any>(null);
+    //
+    // const handleOnCheckoutStep = config => {
+    //     console.log('Component config:', config);
+    //     setComponentConfig(config);
+    // };
+    //
+    // if (!componentConfig) {
+    //     return <GuestShopperForm onCheckoutStep={handleOnCheckoutStep} />;
+    // }
 
     return (
         <Checkout checkoutConfig={checkoutConfig}>
             {checkout => (
-                <ComponentContainer element={new Dropin(checkout, { showStoredPaymentMethods: false, paymentMethodComponents: [Card, PayPal] })} />
+                <ComponentContainer
+                    element={
+                        new Dropin(checkout, {
+                            showStoredPaymentMethods: false,
+                            paymentMethodComponents: [Card, PayPal, Fastlane],
+                            paymentMethodsConfiguration: {
+                                fastlane: { tokenId: 'xxx', customerId: 'sss', lastFour: '1111', brand: 'visa', email: 'email@adyen.com' }
+                            }
+                        })
+                    }
+                />
             )}
         </Checkout>
     );

--- a/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/FastlaneInSinglePageApp.tsx
@@ -36,7 +36,14 @@ export const FastlaneInSinglePageApp = ({ checkoutConfig }: Props) => {
                             showStoredPaymentMethods: false,
                             paymentMethodComponents: [Card, PayPal, Fastlane],
                             paymentMethodsConfiguration: {
-                                fastlane: { tokenId: 'xxx', customerId: 'sss', lastFour: '1111', brand: 'visa', email: 'email@adyen.com' }
+                                fastlane: {
+                                    tokenId: 'xxx',
+                                    customerId: 'sss',
+                                    lastFour: '1111',
+                                    brand: 'visa',
+                                    email: 'email@adyen.com',
+                                    fastlaneSessionId: 'zzz'
+                                }
                             }
                         })
                     }

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/CollectEmail.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/CollectEmail.tsx
@@ -30,7 +30,6 @@ export const CollectEmail = ({ fastlaneSdk, onFastlaneLookup, onEditEmail }: Col
     const handleButtonClick = async () => {
         try {
             const authResult = await fastlaneSdk.authenticate(email);
-            console.log('triggerAuthenticationFlow result:', authResult);
             onFastlaneLookup(authResult);
             setViewOnly(true);
         } catch (error) {

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -36,7 +36,6 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
 
     const handleOnCheckoutClick = (shippingAddress?: any) => {
         console.log('Shipping address', shippingAddress);
-
         const componentConfig = fastlane.getComponentConfiguration(fastlaneAuthResult);
         onCheckoutStep(componentConfig);
     };

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -35,12 +35,14 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
     };
 
     const handleOnCheckoutClick = (shippingAddress?: any) => {
+        console.log('Shipping address', shippingAddress);
+
         const componentConfig = fastlane.getComponentConfiguration(fastlaneAuthResult);
         onCheckoutStep(componentConfig);
     };
 
     useEffect(() => {
-        void loadFastlane().catch(error => {
+        void loadFastlane().catch(() => {
             alert('Failed to initialize: Fetch the token using Postman');
         });
     }, []);

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -35,15 +35,13 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
     };
 
     const handleOnCheckoutClick = (shippingAddress?: any) => {
-        console.log('Shipping address', shippingAddress);
-
         const componentConfig = fastlane.getComponentConfiguration(fastlaneAuthResult);
         onCheckoutStep(componentConfig);
     };
 
     useEffect(() => {
         void loadFastlane().catch(error => {
-            console.log(error);
+            alert('Failed to initialize: Fetch the token using Postman');
         });
     }, []);
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Created Fastlane component for recognized shopper flow
- Adjusted Drop-in to render only Fastlane if available; and if button 'Other payment methods' gets clicked, render the default Drop-in without Fastlane
- Adjusted  the`Button` component to render as a link by passing `variant=link`
- Added a file `components/utilities.ts` where we can expose utility functions (Ex: `initializeFastlane` ), therefore we do not mix that with the `components/index.ts` where we expose the UI components (this leads to certain errors with auto bundle; so that is why I separated them)

It is possible to test/visualize the flow by going to the Fastlane story

## Tested scenarios
- Added test for Drop-in and Fastlane . It is not possible to perform /payments yet
