### PR TITLE
Add e2e tests for kcpAuthentication, stored-card-amex, stored-card-mc and stored-card-visa

### DIFF
--- a/packages/e2e-playwright/models/base.ts
+++ b/packages/e2e-playwright/models/base.ts
@@ -14,6 +14,10 @@ export abstract class Base {
         await this.isComponentVisible();
     }
 
+    async isPayable() {
+        await this.page.waitForFunction(() => globalThis.component.isValid === true);
+    }
+
     async pay(options: { name?: RegExp | string } = { name: /pay/i }): Promise<void> {
         if (this.payButton) {
             await this.payButton.click();

--- a/packages/e2e-playwright/models/card-kcp.ts
+++ b/packages/e2e-playwright/models/card-kcp.ts
@@ -7,6 +7,10 @@ class CardWithKCP extends Card {
         super(page);
     }
 
+    get cardNumberKoreanBrand() {
+        return this.rootElement.getByAltText('korean_local_card');
+    }
+
     get taxNumberInput() {
         return this.rootElement.getByRole('textbox', { name: /Cardholder birthdate/i });
     }

--- a/packages/e2e-playwright/tests/e2e/card/avs.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/avs.spec.ts
@@ -24,8 +24,7 @@ test.describe('Card payments with partial avs', () => {
             await cardWithAvs.typeExpiryDate(TEST_DATE_VALUE);
             await cardWithAvs.typeCvc(TEST_CVC_VALUE);
             await cardWithAvs.billingAddress.fillInPostCode(TEST_POSTCODE);
-            // wait for the form is valid
-            await page.waitForFunction(() => globalThis.component.isValid === true);
+            await cardWithAvs.isPayable();
             await cardWithAvs.pay();
             await cardWithAvs.paymentResult.waitFor({ state: 'visible' });
             await expect(cardWithAvs.paymentResult).toContainText(PAYMENT_RESULT.authorised);

--- a/packages/e2e-playwright/tests/e2e/card/kcpAuthentication.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/kcpAuthentication.spec.ts
@@ -1,27 +1,46 @@
-import { test } from '../../../fixtures/card.fixture';
+import { expect, test } from '../../../fixtures/card.fixture';
+import { URL_MAP } from '../../../fixtures/URL_MAP';
+import {
+    KOREAN_TEST_CARD,
+    PAYMENT_RESULT,
+    REGULAR_TEST_CARD,
+    TEST_CVC_VALUE,
+    TEST_DATE_VALUE,
+    TEST_PWD_VALUE,
+    TEST_TAX_NUMBER_VALUE
+} from '../../utils/constants';
 
 test.describe('Card payments with KCP enabled feature', () => {
-    test('should submit the korea issue card payment', async () => {
-        // fill in KOREAN_TEST_CARD
-        // expect to see the non-branded logo
-        // fill in the required fields
-        // click pay btn
-        // expect to see success msg
+    test('should submit the korea issue card payment', async ({ cardWithKCP }) => {
+        await cardWithKCP.goto(URL_MAP.cardWithKcp);
+        await cardWithKCP.fillCardNumber(KOREAN_TEST_CARD);
+        await cardWithKCP.cardNumberKoreanBrand.waitFor({ state: 'visible' });
+        await cardWithKCP.fillCvc(TEST_CVC_VALUE);
+        await cardWithKCP.fillExpiryDate(TEST_DATE_VALUE);
+        await cardWithKCP.taxNumberInput.fill(TEST_TAX_NUMBER_VALUE);
+        await cardWithKCP.passwordInput.fill(TEST_PWD_VALUE);
+        await cardWithKCP.pay();
+        await expect(cardWithKCP.paymentResult).toContainText(PAYMENT_RESULT.authorised);
     });
 
-    test('should not submit the korea issue card payment', async () => {
-        // fill in KOREAN_TEST_CARD
-        // expect to see the non-branded logo
-        // fill in partial fields
-        // click pay btn
-        // expect to see error msg
+    test('should not submit the korea issue card payment', async ({ cardWithKCP }) => {
+        await cardWithKCP.goto(URL_MAP.cardWithKcp);
+        await cardWithKCP.fillCardNumber(KOREAN_TEST_CARD);
+        await cardWithKCP.cardNumberKoreanBrand.waitFor({ state: 'visible' });
+        await cardWithKCP.fillCvc(TEST_CVC_VALUE);
+        await cardWithKCP.fillExpiryDate(TEST_DATE_VALUE);
+        await cardWithKCP.pay();
+        await expect(cardWithKCP.taxNumberErrorLocator).toContainText('Invalid Cardholder birthdate or Corporate registration number');
+        await expect(cardWithKCP.passwordErrorLocator).toContainText('Enter the password');
     });
 
-    test('should submit the regular non-korean card payment', async () => {
-        // fill in NON_KOREAN_TEST_CARD
-        // expect to see the brand logo
-        // fill in required fields
-        // click pay btn
-        // expect to see success msg
+    test('should submit the regular non-korean card payment', async ({ cardWithKCP, page }) => {
+        await cardWithKCP.goto(URL_MAP.cardWithKcp);
+        await cardWithKCP.fillCardNumber(REGULAR_TEST_CARD);
+        await cardWithKCP.fillCvc(TEST_CVC_VALUE);
+        await cardWithKCP.fillExpiryDate(TEST_DATE_VALUE);
+        await cardWithKCP.isPayable();
+        await cardWithKCP.pay();
+        await expect(cardWithKCP.paymentResult).toContainText(PAYMENT_RESULT.authorised);
     });
 });

--- a/packages/e2e-playwright/tests/e2e/dropin/storedCard/stored-card-amex.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/dropin/storedCard/stored-card-amex.spec.ts
@@ -1,61 +1,40 @@
-import { test } from '@playwright/test';
+import { cardInDropin as test, expect } from '../../../../fixtures/dropin.fixture';
+import { URL_MAP } from '../../../../fixtures/URL_MAP';
+import { PAYMENT_RESULT } from '../../../utils/constants';
+import { getStoryUrl } from '../../../utils/getStoryUrl';
 
 test.describe('Stored Amex card - cvc required', () => {
-    test('#1 Can fill out the cvc fields in the stored card and make a successful payment', async () => {
-        // Wait for field to appear in DOM
-        // await cardPage.cvcHolder();
-        //
-        // // handler for alert that's triggered on successful payment
-        // await t.setNativeDialogHandler(() => true);
-        //
-        // // expiry date field is readonly
-        // await t.expect(cardPage.storedCardExpiryDate.withAttribute('disabled').exists).ok();
-        //
-        // await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
-        //
-        // // click pay
-        // await t.click(cardPage.payButton).expect(cardPage.cvcLabelTextError.exists).notOk().wait(3000);
-        //
-        // // Check the value of the alert text
-        // const history = await t.getNativeDialogHistory();
-        // await t.expect(history[0].text).eql('Authorised', { timeout: 5000 });
+    test('#1 Can fill out the cvc fields in the stored card and make a successful payment', async ({ dropinWithSession, card }) => {
+        await dropinWithSession.goto(URL_MAP.dropinWithSession);
+        await dropinWithSession.selectFirstStoredPaymentMethod('American Express', '0002');
+        await card.cvcInput.waitFor({ state: 'visible' });
+        await card.fillCvc('7373');
+        await card.pay({ name: /pay \$259\.00/i });
+        await expect(card.paymentResult).toContainText(PAYMENT_RESULT.success);
     });
 
-    test('#2 Pressing pay without filling the cvc should generate a translated error ("empty")', async () => {
-        // Wait for field to appear in DOM
-        // await cardPage.cvcHolder();
-        //
-        // // click pay
-        // await t
-        //   .click(cardPage.payButton)
-        //   .expect(cardPage.cvcLabelTextError.exists)
-        //   .ok()
-        //   // with text
-        //   .expect(cardPage.cvcErrorText.withExactText(EMPTY_FIELD).exists)
-        //   .ok();
+    test('#2 Pressing pay without filling the cvc should generate a translated error ("empty")', async ({ dropinWithSession, card }) => {
+        await dropinWithSession.goto(URL_MAP.dropinWithSession);
+        await dropinWithSession.selectFirstStoredPaymentMethod('American Express', '0002');
+        await card.cvcInput.waitFor({ state: 'visible' });
+        await card.pay({ name: /pay \$259\.00/i });
+        await expect(card.cvcErrorElement).toContainText('Enter the security code');
     });
 
-    test('#3 A storedCard with no expiry date field still can be used for a successful payment', async () => {
-        // use window.cardConfig = {
-        //     expiryMonth: null,
-        //     expiryYear: null
-        // };
-        // Wait for field to appear in DOM
-        // await cardPage.cvcHolder();
-        //
-        // // handler for alert that's triggered on successful payment
-        // await t.setNativeDialogHandler(() => true);
-        //
-        // // expiry date field is not visible
-        // await t.expect(cardPage.storedCardExpiryDate.exists).notOk();
-        //
-        // await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
-        //
-        // // click pay
-        // await t.click(cardPage.payButton).expect(cardPage.cvcLabelTextError.exists).notOk().wait(3000);
-        //
-        // // Check the value of the alert text
-        // const history = await t.getNativeDialogHistory();
-        // await t.expect(history[0].text).eql('Authorised', { timeout: 5000 });
+    test('#3 A storedCard with no expiry date field still can be used for a successful payment', async ({ dropinWithSession, card }) => {
+        const url = getStoryUrl({
+            baseUrl: URL_MAP.dropinWithSession,
+            componentConfig: {
+                paymentMethodsConfiguration: {
+                    storedCard: { expiryMonth: null, expiryYear: null }
+                }
+            }
+        });
+        await dropinWithSession.goto(url);
+        await dropinWithSession.selectFirstStoredPaymentMethod('American Express', '0002');
+        await card.cvcInput.waitFor({ state: 'visible' });
+        await card.fillCvc('7373');
+        await card.pay({ name: /pay \$259\.00/i });
+        await expect(card.paymentResult).toContainText(PAYMENT_RESULT.success);
     });
 });

--- a/packages/e2e-playwright/tests/e2e/dropin/storedCard/stored-card-mc.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/dropin/storedCard/stored-card-mc.spec.ts
@@ -1,61 +1,40 @@
-import { test } from '@playwright/test';
+import { cardInDropin as test, expect } from '../../../../fixtures/dropin.fixture';
+import { URL_MAP } from '../../../../fixtures/URL_MAP';
+import { PAYMENT_RESULT, TEST_CVC_VALUE } from '../../../utils/constants';
+import { getStoryUrl } from '../../../utils/getStoryUrl';
 
 test.describe('Stored master card - cvc required', () => {
-    test('#1 Can fill out the cvc fields in the stored card and make a successful payment', async () => {
-        // Wait for field to appear in DOM
-        // await cardPage.cvcHolder();
-        //
-        // // handler for alert that's triggered on successful payment
-        // await t.setNativeDialogHandler(() => true);
-        //
-        // // expiry date field is readonly
-        // await t.expect(cardPage.storedCardExpiryDate.withAttribute('disabled').exists).ok();
-        //
-        // await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
-        //
-        // // click pay
-        // await t.click(cardPage.payButton).expect(cardPage.cvcLabelTextError.exists).notOk().wait(3000);
-        //
-        // // Check the value of the alert text
-        // const history = await t.getNativeDialogHistory();
-        // await t.expect(history[0].text).eql('Authorised', { timeout: 5000 });
+    test('#1 Can fill out the cvc fields in the stored card and make a successful payment', async ({ dropinWithSession, card }) => {
+        await dropinWithSession.goto(URL_MAP.dropinWithSession);
+        await dropinWithSession.selectFirstStoredPaymentMethod('MasterCard', '4444');
+        await card.cvcInput.waitFor({ state: 'visible' });
+        await card.fillCvc(TEST_CVC_VALUE);
+        await card.pay({ name: /pay \$259\.00/i });
+        await expect(card.paymentResult).toContainText(PAYMENT_RESULT.success);
     });
 
-    test('#2 Pressing pay without filling the cvc should generate a translated error ("empty")', async () => {
-        // Wait for field to appear in DOM
-        // await cardPage.cvcHolder();
-        //
-        // // click pay
-        // await t
-        //   .click(cardPage.payButton)
-        //   .expect(cardPage.cvcLabelTextError.exists)
-        //   .ok()
-        //   // with text
-        //   .expect(cardPage.cvcErrorText.withExactText(EMPTY_FIELD).exists)
-        //   .ok();
+    test('#2 Pressing pay without filling the cvc should generate a translated error ("empty")', async ({ dropinWithSession, card }) => {
+        await dropinWithSession.goto(URL_MAP.dropinWithSession);
+        await dropinWithSession.selectFirstStoredPaymentMethod('MasterCard', '4444');
+        await card.cvcInput.waitFor({ state: 'visible' });
+        await card.pay({ name: /pay \$259\.00/i });
+        await expect(card.cvcErrorElement).toContainText('Enter the security code');
     });
 
-    test('#3 A storedCard with no expiry date field still can be used for a successful payment', async () => {
-        // use window.cardConfig = {
-        //     expiryMonth: null,
-        //     expiryYear: null
-        // };
-        // Wait for field to appear in DOM
-        // await cardPage.cvcHolder();
-        //
-        // // handler for alert that's triggered on successful payment
-        // await t.setNativeDialogHandler(() => true);
-        //
-        // // expiry date field is not visible
-        // await t.expect(cardPage.storedCardExpiryDate.exists).notOk();
-        //
-        // await cardPage.cardUtils.fillCVC(t, TEST_CVC_VALUE, 'add', 0);
-        //
-        // // click pay
-        // await t.click(cardPage.payButton).expect(cardPage.cvcLabelTextError.exists).notOk().wait(3000);
-        //
-        // // Check the value of the alert text
-        // const history = await t.getNativeDialogHistory();
-        // await t.expect(history[0].text).eql('Authorised', { timeout: 5000 });
+    test('#3 A storedCard with no expiry date field still can be used for a successful payment', async ({ dropinWithSession, card }) => {
+        const url = getStoryUrl({
+            baseUrl: URL_MAP.dropinWithSession,
+            componentConfig: {
+                paymentMethodsConfiguration: {
+                    storedCard: { expiryMonth: null, expiryYear: null }
+                }
+            }
+        });
+        await dropinWithSession.goto(url);
+        await dropinWithSession.selectFirstStoredPaymentMethod('MasterCard', '4444');
+        await card.cvcInput.waitFor({ state: 'visible' });
+        await card.fillCvc(TEST_CVC_VALUE);
+        await card.pay({ name: /pay \$259\.00/i });
+        await expect(card.paymentResult).toContainText(PAYMENT_RESULT.success);
     });
 });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Add e2e tests for kcpAuthentication, stored-card-amex, stored-card-mc and stored-card-visa

