### PR TITLE
fix(translation): changed the translation for `wechatpay.timetopay`

### DIFF
--- a/.changeset/wicked-laws-hang.md
+++ b/.changeset/wicked-laws-hang.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Change WeChat Pay QR countdown translation.

--- a/packages/server/translations/zh-CN.json
+++ b/packages/server/translations/zh-CN.json
@@ -31,7 +31,7 @@
     "loading": "正在加载...",
     "continue": "继续",
     "continueTo": "继续至",
-    "wechatpay.timetopay": "您需要支付 %@",
+    "wechatpay.timetopay": "您有 %@ 可以支付",
     "sr.wechatpay.timetopay": "您有 %#分%# %#秒%# 可以支付",
     "wechatpay.scanqrcode": "扫描二维码",
     "personalDetails": "个人详细信息",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Changed the translation for `wechatpay.timetopay` for `zh-CN.json`, to be the same as the `zh-TW.json`.


**Fixed issue**:  #2995
