### PR TITLE
Klarna - Fix for handling multiple instances of the widget

### DIFF
--- a/.changeset/wet-forks-invite.md
+++ b/.changeset/wet-forks-invite.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Klarna - Fixed issue where PayLater/PayOverTime payments were not authorized accordingly depending on how the shopper interacted with the Drop-in/Component

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -58,7 +58,11 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         this.setState({ status: { type: status, props } });
     };
 
-    private setActivePaymentMethod = (paymentMethod: UIElement) => {
+    private setActivePaymentMethod = (paymentMethod: UIElement): void => {
+        if (paymentMethod === this.state.activePaymentMethod) {
+            return;
+        }
+
         this.setState(prevState => ({
             activePaymentMethod: paymentMethod,
             cachedPaymentMethods: { ...prevState.cachedPaymentMethods, [paymentMethod._id]: true }

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -9,6 +9,7 @@ import { sanitizeOrder } from '../../internal/UIElement/utils';
 import { PaymentAmount } from '../../../types/global-types';
 import { ANALYTICS_RENDERED_STR } from '../../../core/Analytics/constants';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
+import UIElement from '../../internal/UIElement';
 
 export class DropinComponent extends Component<DropinComponentProps, DropinComponentState> {
     public state: DropinComponentState = {
@@ -57,11 +58,15 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         this.setState({ status: { type: status, props } });
     };
 
-    private setActivePaymentMethod = paymentMethod => {
+    private setActivePaymentMethod = (paymentMethod: UIElement) => {
         this.setState(prevState => ({
             activePaymentMethod: paymentMethod,
             cachedPaymentMethods: { ...prevState.cachedPaymentMethods, [paymentMethod._id]: true }
         }));
+
+        if (this.state.cachedPaymentMethods[paymentMethod._id]) {
+            paymentMethod.activate();
+        }
     };
 
     componentDidUpdate(prevProps, prevState) {

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -22,40 +22,35 @@ describe('KlarnaPayments', () => {
         expect(screen.queryByRole('button', { name: 'Continue to Pay By Bank' })).toBeFalsy();
     });
 
-    test.skip('should call setStatus if elementRef is a drop-in', async () => {
-        const KlarnaPaymentsEle = new KlarnaPayments(global.core, {
-            ...coreProps,
-            ...{ paymentData: '', paymentMethodType: '', sdkData: undefined, useKlarnaWidget: false, showPayButton: false }
+    test('should call setStatus if elementRef is a drop-in', async () => {
+        const klarna = new KlarnaPayments(global.core, {
+            ...coreProps
         });
-        KlarnaPaymentsEle.elementRef = new Dropin(global.core);
-        render(KlarnaPaymentsEle.render());
-        const spy = jest.spyOn(KlarnaPaymentsEle.elementRef, 'setStatus');
+        klarna.elementRef = new Dropin(global.core);
+        render(klarna.render());
+
+        const spy = jest.spyOn(klarna.elementRef, 'setStatus');
+        await waitFor(() => klarna.componentRef);
+
         // @ts-ignore to test
-        await waitFor(() => KlarnaPaymentsEle.componentRef);
-        // @ts-ignore to test
-        KlarnaPaymentsEle.componentRef.props.onLoaded();
+        klarna.onLoaded();
+
         expect(spy).toHaveBeenCalled();
     });
 
-    test.skip('should call handleAdditionalDetails onComplete', async () => {
+    test('should call handleAdditionalDetails onComplete', async () => {
         const onAdditionalDetailsMock = jest.fn(() => {});
-
-        const KlarnaPaymentsEle = new KlarnaPayments(global.core, {
+        const klarna = new KlarnaPayments(global.core, {
             ...coreProps,
-            ...{
-                paymentData: '',
-                paymentMethodType: '',
-                sdkData: undefined,
-                useKlarnaWidget: false,
-                showPayButton: false,
-                onAdditionalDetails: onAdditionalDetailsMock
-            }
+            onAdditionalDetails: onAdditionalDetailsMock
         });
-        render(KlarnaPaymentsEle.render());
+
+        render(klarna.render());
+        await waitFor(() => klarna.componentRef);
+
         // @ts-ignore to test
-        await waitFor(() => KlarnaPaymentsEle.componentRef);
-        // @ts-ignore to test
-        KlarnaPaymentsEle.componentRef.props.onComplete();
+        klarna.onComplete();
+
         expect(onAdditionalDetailsMock).toHaveBeenCalled();
     });
 });

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -22,7 +22,7 @@ describe('KlarnaPayments', () => {
         expect(screen.queryByRole('button', { name: 'Continue to Pay By Bank' })).toBeFalsy();
     });
 
-    test('should call setStatus if elementRef is a drop-in', async () => {
+    test.skip('should call setStatus if elementRef is a drop-in', async () => {
         const KlarnaPaymentsEle = new KlarnaPayments(global.core, {
             ...coreProps,
             ...{ paymentData: '', paymentMethodType: '', sdkData: undefined, useKlarnaWidget: false, showPayButton: false }
@@ -37,7 +37,7 @@ describe('KlarnaPayments', () => {
         expect(spy).toHaveBeenCalled();
     });
 
-    test('should call handleAdditionalDetails onComplete', async () => {
+    test.skip('should call handleAdditionalDetails onComplete', async () => {
         const onAdditionalDetailsMock = jest.fn(() => {});
 
         const KlarnaPaymentsEle = new KlarnaPayments(global.core, {

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -4,7 +4,7 @@ import { CoreProvider } from '../../core/Context/CoreProvider';
 import PayButton from '../internal/PayButton';
 import { KlarnaContainer } from './components/KlarnaContainer/KlarnaContainer';
 import { TxVariants } from '../tx-variants';
-import type { KlarnaAction, KlarnaComponentRef, KlarnaConfiguration } from './types';
+import type { KlarnaAction, KlarnaAdditionalDetailsData, KlarnaComponentRef, KlarnaConfiguration } from './types';
 import type { ICore } from '../../core/types';
 
 class KlarnaPayments extends UIElement<KlarnaConfiguration> {
@@ -47,13 +47,17 @@ class KlarnaPayments extends UIElement<KlarnaConfiguration> {
         this.componentRef.setAction(action);
     }
 
-    onLoaded() {
+    private onLoaded() {
         // When action/widget is loaded, set the 'drop-in' back to ready
         this.setElementStatus('ready');
     }
 
     public override activate() {
         this.componentRef.reinitializeWidget();
+    }
+
+    protected onComplete(details: KlarnaAdditionalDetailsData): void {
+        this.handleAdditionalDetails(details);
     }
 
     render() {
@@ -63,7 +67,7 @@ class KlarnaPayments extends UIElement<KlarnaConfiguration> {
                     {...this.props}
                     setComponentRef={this.setComponentRef}
                     displayName={this.displayName}
-                    onComplete={state => this.handleAdditionalDetails(state)}
+                    onComplete={this.onComplete}
                     onError={this.props.onError}
                     payButton={this.payButton}
                     onLoaded={this.onLoaded}

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -1,22 +1,23 @@
 import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import { CoreProvider } from '../../core/Context/CoreProvider';
-import { KlarnConfiguration } from './types';
 import PayButton from '../internal/PayButton';
 import { KlarnaContainer } from './components/KlarnaContainer/KlarnaContainer';
-import { PaymentAction } from '../../types/global-types';
 import { TxVariants } from '../tx-variants';
+import type { KlarnaAction, KlarnaComponentRef, KlarnaConfiguration } from './types';
 import type { ICore } from '../../core/types';
 
-class KlarnaPayments extends UIElement<KlarnConfiguration> {
+class KlarnaPayments extends UIElement<KlarnaConfiguration> {
     public static type = TxVariants.klarna;
     public static txVariants = [TxVariants.klarna, TxVariants.klarna_account, TxVariants.klarna_paynow, TxVariants.klarna_b2b];
+
+    public componentRef: KlarnaComponentRef;
 
     protected static defaultProps = {
         useKlarnaWidget: false
     };
 
-    constructor(checkout: ICore, props?: KlarnConfiguration) {
+    constructor(checkout: ICore, props?: KlarnaConfiguration) {
         super(checkout, props);
 
         this.onComplete = this.onComplete.bind(this);
@@ -41,7 +42,7 @@ class KlarnaPayments extends UIElement<KlarnConfiguration> {
         return <PayButton amount={this.props.amount} onClick={this.submit} {...props} />;
     };
 
-    updateWithAction(action: PaymentAction): void {
+    updateWithAction(action: KlarnaAction): void {
         if (action.paymentMethodType !== this.type) throw new Error('Invalid Action');
         this.componentRef.setAction(action);
     }
@@ -51,20 +52,24 @@ class KlarnaPayments extends UIElement<KlarnConfiguration> {
         this.setElementStatus('ready');
     }
 
+    public override activate() {
+        this.componentRef.reinitializeWidget();
+    }
+
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
                 <KlarnaContainer
                     {...this.props}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                     displayName={this.displayName}
                     onComplete={state => this.handleAdditionalDetails(state)}
                     onError={this.props.onError}
                     payButton={this.payButton}
                     onLoaded={this.onLoaded}
+                    showPayButton={this.props.showPayButton}
                     onActionHandled={this.onActionHandled}
+                    type={this.props.type}
                 />
             </CoreProvider>
         );

--- a/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx
@@ -3,14 +3,14 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import { KlarnaWidget } from '../KlarnaWidget/KlarnaWidget';
 import type { ComponentMethodsRef, PayButtonFunctionProps, UIElementStatus } from '../../../internal/UIElement/types';
 import type { ActionHandledReturnObject } from '../../../../types/global-types';
-import type { AdyenCheckoutError, KlarnaAction, KlarnaComponentRef } from '../../../../types';
+import type { AdyenCheckoutError, KlarnaAction, KlarnaAdditionalDetailsData, KlarnaComponentRef } from '../../../../types';
 
 interface KlarnaContainerProps {
     setComponentRef: (ref: ComponentMethodsRef) => void;
     displayName: string;
     showPayButton: boolean;
     type: string;
-    onComplete(state: any): void;
+    onComplete(state: KlarnaAdditionalDetailsData): void;
     onError(error: AdyenCheckoutError): void;
     payButton(props?: PayButtonFunctionProps): h.JSX.Element;
     onLoaded(): void;

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
@@ -41,7 +41,8 @@ describe('KlarnaWidget', () => {
         paymentData,
         paymentMethodType,
         sdkData,
-        payButton
+        payButton,
+        widgetInitializationTime: new Date().getTime()
     };
 
     beforeAll(() => {

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -1,5 +1,6 @@
 import { type ComponentMethodsRef, UIElementProps } from '../internal/UIElement/types';
 import { PaymentAction } from '../../types/global-types';
+import { AdditionalDetailsData } from '../../core/types';
 
 declare global {
     interface Window {
@@ -38,7 +39,7 @@ export interface KlarnaWidgetProps extends KlarnaPaymentsShared {
 
     widgetInitializationTime: number;
 
-    onComplete: (detailsData) => void;
+    onComplete: (detailsData: KlarnaAdditionalDetailsData) => void;
     onError: (error) => void;
 }
 
@@ -63,5 +64,14 @@ export interface KlarnaAction extends PaymentAction {
     sdkData: {
         client_token: string;
         payment_method_category: string;
+    };
+}
+
+export interface KlarnaAdditionalDetailsData extends AdditionalDetailsData {
+    data: {
+        paymentData: string;
+        details: {
+            authorization_token?: string;
+        };
     };
 }

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -1,4 +1,5 @@
-import { UIElementProps } from '../internal/UIElement/types';
+import { type ComponentMethodsRef, UIElementProps } from '../internal/UIElement/types';
+import { PaymentAction } from '../../types/global-types';
 
 declare global {
     interface Window {
@@ -35,11 +36,13 @@ export interface KlarnaWidgetProps extends KlarnaPaymentsShared {
     /** @internal */
     onLoaded: () => void;
 
+    widgetInitializationTime: number;
+
     onComplete: (detailsData) => void;
     onError: (error) => void;
 }
 
-export type KlarnConfiguration = UIElementProps &
+export type KlarnaConfiguration = UIElementProps &
     KlarnaPaymentsShared & {
         useKlarnaWidget?: boolean;
     };
@@ -49,4 +52,16 @@ export interface KlarnaWidgetAuthorizeResponse {
     show_form: boolean;
     authorization_token: string;
     error?: any;
+}
+
+export interface KlarnaComponentRef extends ComponentMethodsRef {
+    setAction(action: KlarnaAction): void;
+    reinitializeWidget(): void;
+}
+
+export interface KlarnaAction extends PaymentAction {
+    sdkData: {
+        client_token: string;
+        payment_method_category: string;
+    };
 }

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -118,6 +118,14 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
         };
     }
 
+    /**
+     * Method used to make the payment method active
+     * (Useful when there are different payment methods available and activating one PM must trigger a specific task)
+     */
+    public activate(): void {
+        return;
+    }
+
     public render(): ComponentChild | Error {
         // render() not implemented in the element
         throw new Error('Payment method cannot be rendered.');

--- a/packages/lib/src/components/internal/BaseElement/types.ts
+++ b/packages/lib/src/components/internal/BaseElement/types.ts
@@ -27,4 +27,5 @@ export interface IBaseElement {
     update(props): IBaseElement;
     unmount(): IBaseElement;
     remove(): void;
+    activate(): void;
 }

--- a/packages/lib/storybook/stories/components/Klarna.stories.tsx
+++ b/packages/lib/storybook/stories/components/Klarna.stories.tsx
@@ -1,12 +1,12 @@
 import { MetaConfiguration, StoryConfiguration } from '../types';
 import { ComponentContainer } from '../ComponentContainer';
-import { KlarnConfiguration } from '../../../src/components/Klarna/types';
+import { KlarnaConfiguration } from '../../../src/components/Klarna/types';
 import Klarna from '../../../src/components/Klarna/KlarnaPayments';
 import { Checkout } from '../Checkout';
 
-type KlarnaStory = StoryConfiguration<KlarnConfiguration>;
+type KlarnaStory = StoryConfiguration<KlarnaConfiguration>;
 
-const meta: MetaConfiguration<KlarnConfiguration> = {
+const meta: MetaConfiguration<KlarnaConfiguration> = {
     title: 'Components/Klarna'
 };
 

--- a/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
+++ b/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
@@ -46,23 +46,7 @@ export const Auto: DropinStory = {
 
         return (
             <Checkout checkoutConfig={checkoutConfig}>
-                {checkout => (
-                    <ComponentContainer
-                        element={
-                            new DropinComponent(checkout, {
-                                ...componentConfiguration,
-                                paymentMethodsConfiguration: {
-                                    klarna: {
-                                        useKlarnaWidget: true
-                                    },
-                                    klarna_account: {
-                                        useKlarnaWidget: true
-                                    }
-                                }
-                            })
-                        }
-                    />
-                )}
+                {checkout => <ComponentContainer element={new DropinComponent(checkout, componentConfiguration)} />}
             </Checkout>
         );
     }

--- a/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
+++ b/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
@@ -46,7 +46,23 @@ export const Auto: DropinStory = {
 
         return (
             <Checkout checkoutConfig={checkoutConfig}>
-                {checkout => <ComponentContainer element={new DropinComponent(checkout, componentConfiguration)} />}
+                {checkout => (
+                    <ComponentContainer
+                        element={
+                            new DropinComponent(checkout, {
+                                ...componentConfiguration,
+                                paymentMethodsConfiguration: {
+                                    klarna: {
+                                        useKlarnaWidget: true
+                                    },
+                                    klarna_account: {
+                                        useKlarnaWidget: true
+                                    }
+                                }
+                            })
+                        }
+                    />
+                )}
             </Checkout>
         );
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
PR to handle the issue with multiple instances of the Klarna widget being present in the PM list

There are 2 issues:
1. When we initialise the `KlarnaWidget` it loads the KlarnaSDK, which in turn calls the callback we create (`window.klarnaAsyncCallback`), which initialises the KlarnaSDK.
- _However_, if there is a second `KlarnaWidget` in the PM list, initialising that _will not_ see the KlarnaSDK calling our callback for a second time, and so the KlarnaSDK is not re-initialised with the right `sdkData.client_token` to make the correct payment.
- This means that if you pay with the second widget, the payment from the first widget gets authorised.
2. Having solved the first problem there is now the (edge) use case that, if the shopper opens the first widget, opens the second widget, and then _returns to the first widget_ - the first widget (which is cached and never re-initialised) will, once again, not re-initialise the KlarnaSDK with the right `sdkData.client_token`
- This means that if you pay with the first widget, the payment from the second widget gets authorised.

So..
- When we initialise a second `KlarnaWidget` component it checks if it "manually" needs to initialise the KlarnaSDK widget _(fixes issue 1)_
- We now detect when a (cached) component is made active for a second (and subsequent) time, and we call a function it inherits from `UIElement` to allow it to run some custom logic (`onPaymentMethodActive`). 
This allows the `KlarnaWidget` to "manually" re-initialise the KlarnaSDK.  _(fixes issue 2)_

## Proposed changes:
- Added method `component.activate()` which can be used when the Component is active 
  - This name aligns with our current public API (ex: `.submit()`, .`mount()`, etc)
  - This method can be leveraged by merchants that are integrating standalone Components and might be using different Klarna payment methods
- When the payment method in Drop-in is set to active, the `component.activate()` is called in case the Component was previously created
  - For Klarna, that will imply that the 'widget initialization time' gets refreshed, forcing the Widget to be reinitialized
- Fix typescript typo for `KlarnaConfiguration` 

**Fixes issue**:  COWEB-1468
