### PR TITLE
fix(ach): hide the holder name contextual text

### DIFF
--- a/.changeset/young-dragons-thank.md
+++ b/.changeset/young-dragons-thank.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Hide the default ACH holder name contextual text.

--- a/packages/lib/src/components/Ach/components/AchInput/defaultProps.ts
+++ b/packages/lib/src/components/Ach/components/AchInput/defaultProps.ts
@@ -6,7 +6,7 @@ export default {
     holderNameRequired: true,
     billingAddressRequired: true,
     billingAddressAllowedCountries: ['US', 'PR'],
-    showContextualElement: true,
+    showContextualElement: false,
 
     // Events
     onLoad: () => {},


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Hide the ACH holder name contextual text

## Tested scenarios
Unit tests passed


**Fixed issue**:  COWEB-1469
