### PR TITLE
Stop stories setting the onChange callback

### DIFF
--- a/packages/lib/storybook/helpers/create-advanced-checkout.ts
+++ b/packages/lib/storybook/helpers/create-advanced-checkout.ts
@@ -1,6 +1,6 @@
 import { AdyenCheckout } from '../../src/core/AdyenCheckout';
 import { cancelOrder, checkBalance, createOrder, getPaymentMethods, makeDetailsCall, makePayment } from './checkout-api-calls';
-import { handleChange, handleError, handleFinalState } from './checkout-handlers';
+import { handleError, handleFinalState } from './checkout-handlers';
 import getCurrency from '../utils/get-currency';
 import { AdyenCheckoutProps } from '../stories/types';
 import Checkout from '../../src/core/core';
@@ -98,10 +98,6 @@ async function createAdvancedFlowCheckout({
         onPaymentFailed(result, element) {
             console.log('onPaymentFailed', result, element);
             handleFinalState(result, element);
-        },
-
-        onChange: (state, component) => {
-            handleChange(state, component);
         },
 
         onBalanceCheck: async (resolve, reject, data) => {

--- a/packages/lib/storybook/helpers/create-sessions-checkout.ts
+++ b/packages/lib/storybook/helpers/create-sessions-checkout.ts
@@ -1,6 +1,6 @@
 import { createSession } from './checkout-api-calls';
 import { RETURN_URL, SHOPPER_REFERENCE } from '../config/commonConfig';
-import { handleChange, handleError, handleFinalState } from './checkout-handlers';
+import { handleError, handleFinalState } from './checkout-handlers';
 import getCurrency from '../utils/get-currency';
 import { AdyenCheckoutProps } from '../stories/types';
 import Checkout from '../../src/core/core';
@@ -51,10 +51,6 @@ async function createSessionsCheckout({
 
         onError: (error, component) => {
             handleError(error, component);
-        },
-
-        onChange: (state, component) => {
-            handleChange(state, component);
         },
 
         ...restCheckoutProps


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
As agreed, stories no longer set the `onChange` callback, which was cluttering the console
