### PR TITLE
Fixes Click to Pay link looking buttons into proper buttons

### DIFF
--- a/.changeset/nice-bats-exist.md
+++ b/.changeset/nice-bats-exist.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixes Click to Pay link looking buttons into proper buttons

--- a/packages/lib/src/components/internal/Button/types.ts
+++ b/packages/lib/src/components/internal/Button/types.ts
@@ -1,11 +1,11 @@
 import { h } from 'preact';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'action';
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'action' | 'link';
 
 export interface ButtonProps {
     status?: string;
     /**
-     * Class name modifiers will be used as: `adyen-checkout__image--${modifier}`
+     * Class name modifiers will be used as: `adyen-checkout__button--${modifier}`
      */
     classNameModifiers?: string[];
     variant?: ButtonVariant;

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.scss
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.scss
@@ -1,13 +1,7 @@
 @import 'styles/variable-generator';
 
-.adyen-checkout-ctp__otp-resend-code {
-    font-size: 13px;
-    font-weight: token(text-body-font-weight);
-    color: token(color-label-primary);
+.adyen-checkout__button--otp-resend-code {
     margin-left: auto;
-    cursor: pointer;
-    text-decoration: underline;
-
 }
 
 .adyen-checkout-ctp__otp-resend-code--disabled,

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.scss
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.scss
@@ -1,7 +1,11 @@
 @import 'styles/variable-generator';
 
-.adyen-checkout__button--otp-resend-code {
+.adyen-checkout-ctp__otp-resend-code-wrapper {
     margin-left: auto;
+    top: 0;
+    right: 0;
+    position: absolute;
+    line-height: token(text-body-line-height);
 }
 
 .adyen-checkout-ctp__otp-resend-code--disabled,
@@ -35,4 +39,8 @@
 
 .adyen-checkout-ctp__section > .adyen-checkout__field.adyen-checkout__field--otp {
     margin-bottom: token(spacer-060);
+}
+
+.adyen-checkout-ctp__otp-field-wrapper {
+    position: relative;
 }

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.test.tsx
@@ -45,7 +45,7 @@ describe('Click to Pay - CtPOneTimePasswordInput', () => {
             { clickToPayService: ctpServiceMock }
         );
 
-        const resendOtpLink = await screen.findByRole('link', { name: 'Resend code' });
+        const resendOtpLink = await screen.findByRole('button', { name: 'Resend code' });
         const otpInput = screen.getByLabelText('One time code', { exact: false });
 
         await user.click(resendOtpLink);
@@ -78,7 +78,7 @@ describe('Click to Pay - CtPOneTimePasswordInput', () => {
             { clickToPayService: ctpServiceMock, configuration }
         );
 
-        const resendOtpLink = await screen.findByRole('link', { name: 'Resend code' });
+        const resendOtpLink = await screen.findByRole('button', { name: 'Resend code' });
         const otpInput = screen.getByLabelText('One time code', { exact: false });
 
         await user.click(resendOtpLink);

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
@@ -100,31 +100,31 @@ const CtPOneTimePasswordInput = (props: CtPOneTimePasswordInputProps): h.JSX.Ele
     }, [data, valid, errors]);
 
     return (
-        <Field
-            name="oneTimePassword"
-            label={i18n.get('ctp.otp.fieldLabel')}
-            labelEndAdornment={
-                !props.hideResendOtpButton && (
-                    <CtPResendOtpLink disabled={props.isValidatingOtp} onError={handleOnResendOtpError} onResendCode={handleOnResendOtp} />
-                )
-            }
-            errorMessage={isOtpFielDirty ? resendOtpError || props.errorMessage || !!errors.otp : null}
-            classNameModifiers={['otp']}
-        >
-            <InputText
-                name={'otp'}
-                autocorrect={'off'}
-                spellcheck={false}
-                value={data.otp}
-                disabled={props.disabled}
-                onInput={handleChangeFor('otp', 'input')}
-                onBlur={handleChangeFor('otp', 'blur')}
-                onKeyPress={handleOnKeyPress}
-                setRef={(ref: HTMLInputElement) => {
-                    inputRef.current = ref;
-                }}
-            />
-        </Field>
+        <div className={'adyen-checkout-ctp__otp-field-wrapper'}>
+            <Field
+                name="oneTimePassword"
+                label={i18n.get('ctp.otp.fieldLabel')}
+                errorMessage={isOtpFielDirty ? resendOtpError || props.errorMessage || !!errors.otp : null}
+                classNameModifiers={['otp']}
+            >
+                <InputText
+                    name={'otp'}
+                    autocorrect={'off'}
+                    spellcheck={false}
+                    value={data.otp}
+                    disabled={props.disabled}
+                    onInput={handleChangeFor('otp', 'input')}
+                    onBlur={handleChangeFor('otp', 'blur')}
+                    onKeyPress={handleOnKeyPress}
+                    setRef={(ref: HTMLInputElement) => {
+                        inputRef.current = ref;
+                    }}
+                />
+            </Field>
+            <div className={'adyen-checkout-ctp__otp-resend-code-wrapper'}>
+                <CtPResendOtpLink disabled={props.isValidatingOtp} onError={handleOnResendOtpError} onResendCode={handleOnResendOtp} />
+            </div>
+        </div>
     );
 };
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
@@ -6,6 +6,7 @@ import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
 import Icon from '../../../../Icon';
 import { isSrciError } from '../../../services/utils';
 import { PREFIX } from '../../../../Icon/constants';
+import Button from '../../../../Button';
 
 const CONFIRMATION_SHOWING_TIME = 2000;
 
@@ -83,15 +84,15 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: CtPResendOtpLinkP
     }
 
     return (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-        <div
-            role="link"
-            tabIndex={0}
-            className={classnames('adyen-checkout-ctp__otp-resend-code', { 'adyen-checkout-ctp__otp-resend-code--disabled': disabled })}
+        <Button
+            classNameModifiers={[classnames('otp-resend-code', { 'otp-resend-code--disabled': disabled })]}
             onClick={handleResendCodeClick}
+            variant="link"
+            inline={true}
+            disabled={disabled}
         >
             {i18n.get('ctp.otp.resendCode')}
-        </div>
+        </Button>
     );
 };
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.scss
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.scss
@@ -1,16 +1,10 @@
 @import 'styles/variable-generator';
 
-.adyen-checkout-ctp__section-logout-button {
-    font-size: 13px;
-    line-height: token(text-caption-line-height);
-    font-weight: token(text-body-font-weight);
-    color: token(color-label-primary);
+.adyen-checkout__button--section-logout-button {
     margin-left: auto;
-    cursor: pointer;
-    text-decoration: underline;
 }
 
-.adyen-checkout-ctp__section-logout-button--disabled {
+.adyen-checkout__button--section-logout-button--disabled {
     pointer-events: none;
     color: token(color-label-disabled);
 }

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPLogoutLink.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 import './CtPLogoutLink.scss';
+import Button from '../../../Button';
 
 const CtPLogoutLink = () => {
     const { ctpState, logoutShopper, status, cards } = useClickToPayContext();
@@ -22,17 +23,19 @@ const CtPLogoutLink = () => {
     }, [i18n, ctpState]);
 
     return (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-        <span
-            role="button"
-            tabIndex={0}
-            className={classnames('adyen-checkout-ctp__section-logout-button', {
-                'adyen-checkout-ctp__section-logout-button--disabled': status === 'loading'
-            })}
+        <Button
+            classNameModifiers={[
+                classnames('section-logout-button', {
+                    'section-logout-button--disabled': status === 'loading'
+                })
+            ]}
+            disabled={status === 'loading'}
             onClick={logoutShopper}
+            variant="link"
+            inline={true}
         >
             {label}
-        </span>
+        </Button>
     );
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We had some elements that should have been buttons but weren't. This prevented behind activated with the keyboard. 

This PR makes them proper buttons, but also adds the `variant` link to the button types. 

To keep things consistent with the rest of the SDK the style of this buttons has also been changed from primary color (black) with underline to link color (blue) with no underline.

We also changed some markup so this might be a breaking change (UI wise), since both CSS classes and the overall markup.

## Tested scenarios
<!-- Description of tested scenarios -->
All tests pass and it was manually tested with my CTP both buttons work and also the states of the OTP request message.

![Screenshot 2024-12-17 at 17 10 02](https://github.com/user-attachments/assets/de6f2f57-29a5-47f0-883d-5a4738d0028c)


**Fixed issue**:  <!-- #-prefixed issue number -->
#3009
