### PR TITLE
All bcmc tests first make call to go to a URL

### DIFF
--- a/packages/e2e-playwright/fixtures/card.fixture.ts
+++ b/packages/e2e-playwright/fixtures/card.fixture.ts
@@ -33,7 +33,6 @@ const test = base.extend<Fixture>({
     },
     bcmc: async ({ page }, use) => {
         const bcmc = new BCMC(page);
-        await bcmc.goto(URL_MAP.bcmc);
         await use(bcmc);
     }
 });

--- a/packages/e2e-playwright/models/bcmc.ts
+++ b/packages/e2e-playwright/models/bcmc.ts
@@ -5,10 +5,10 @@ class BCMC extends Card {
         return this.cardNumberField.locator('.adyen-checkout__card__cardNumber__brandIcon').all();
     }
 
-    async waitForVisibleDualBrands() {
+    async waitForVisibleBrands(expectedNumber = 2) {
         return await this.page.waitForFunction(
             expectedLength => [...document.querySelectorAll('.adyen-checkout__card__cardNumber__brandIcon')].length === expectedLength,
-            2
+            expectedNumber
         );
     }
 

--- a/packages/e2e-playwright/tests/a11y/bcmc/bancontact.visa.a11y.spec.ts
+++ b/packages/e2e-playwright/tests/a11y/bcmc/bancontact.visa.a11y.spec.ts
@@ -3,11 +3,13 @@ import { BCMC_DUAL_BRANDED_VISA, DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VA
 import { URL_MAP } from '../../../fixtures/URL_MAP';
 
 test('BCMC logo should have correct alt text', async ({ bcmc }) => {
+    await bcmc.goto(URL_MAP.bcmc);
     await bcmc.typeCardNumber('41');
     expect(bcmc.rootElement.getByAltText(/bancontact card/i)).toBeTruthy();
 });
 
 test('Visa logo should have correct alt text', async ({ bcmc }) => {
+    await bcmc.goto(URL_MAP.bcmc);
     await bcmc.typeCardNumber(VISA_CARD);
     expect(bcmc.rootElement.getByAltText(/visa/i)).toBeTruthy();
 });

--- a/packages/e2e-playwright/tests/a11y/bcmc/bancontact.visa.a11y.spec.ts
+++ b/packages/e2e-playwright/tests/a11y/bcmc/bancontact.visa.a11y.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../../fixtures/card.fixture';
 import { BCMC_DUAL_BRANDED_VISA, DUAL_BRANDED_CARD, TEST_CVC_VALUE, TEST_DATE_VALUE, VISA_CARD } from '../../utils/constants';
+import { URL_MAP } from '../../../fixtures/URL_MAP';
 
 test('BCMC logo should have correct alt text', async ({ bcmc }) => {
     await bcmc.typeCardNumber('41');
@@ -17,6 +18,7 @@ test(
         'then click Visa logo and expect comp to not be valid' +
         'then click BCMC logo and expect comp to be valid again',
     async ({ page, bcmc }) => {
+        await bcmc.goto(URL_MAP.bcmc);
         await bcmc.typeCardNumber(BCMC_DUAL_BRANDED_VISA);
         await bcmc.typeExpiryDate(TEST_DATE_VALUE);
         expect(bcmc.cvcField).toBeHidden();
@@ -42,6 +44,7 @@ test(
         'then click Visa logo and expect comp to not be valid' +
         'then enter CVC and expect comp to be valid',
     async ({ bcmc, page }) => {
+        await bcmc.goto(URL_MAP.bcmc);
         await bcmc.typeCardNumber(BCMC_DUAL_BRANDED_VISA);
         await bcmc.typeExpiryDate(TEST_DATE_VALUE);
         await page.waitForFunction(() => globalThis.component.isValid === true);
@@ -60,6 +63,7 @@ test(
         'then re-add it' +
         'and expect Visa logo to be shown a second time (showing CSF has reset state)',
     async ({ bcmc }) => {
+        await bcmc.goto(URL_MAP.bcmc);
         await bcmc.typeCardNumber(DUAL_BRANDED_CARD);
         expect(bcmc.rootElement.getByAltText(/visa/i)).toBeTruthy();
         await bcmc.deleteCardNumber();

--- a/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
@@ -20,7 +20,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_CARD);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 const [firstBrand, secondBrand] = await bcmc.brands;
                 expect(firstBrand).toHaveAttribute('data-value', 'bcmc');
@@ -37,7 +37,7 @@ test.describe('Bcmc payments with dual branding', () => {
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_CARD);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
                 await bcmc.selectBrand('Bancontact card');
                 await bcmc.pay();
 
@@ -61,7 +61,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_CARD);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 const [firstBrand, secondBrand] = await bcmc.brands;
                 expect(firstBrand).toHaveAttribute('data-value', 'bcmc');
@@ -77,7 +77,7 @@ test.describe('Bcmc payments with dual branding', () => {
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_CARD);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
                 await bcmc.selectBrand('Maestro');
                 await bcmc.pay();
 
@@ -103,7 +103,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 const [firstBrand, secondBrand] = await bcmc.brands;
                 expect(firstBrand).toHaveAttribute('data-value', 'bcmc');
@@ -120,7 +120,7 @@ test.describe('Bcmc payments with dual branding', () => {
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
                 await bcmc.selectBrand('Bancontact card');
                 await bcmc.pay();
 
@@ -144,7 +144,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 const [firstBrand, secondBrand] = await bcmc.brands;
                 expect(firstBrand).toHaveAttribute('data-value', 'bcmc');
@@ -165,7 +165,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 await bcmc.selectBrand(/visa/i);
                 await bcmc.pay();
@@ -192,7 +192,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 const [firstBrand, secondBrand] = await bcmc.brands;
                 expect(firstBrand).toHaveAttribute('data-value', 'bcmc');
@@ -208,7 +208,7 @@ test.describe('Bcmc payments with dual branding', () => {
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
                 await bcmc.selectBrand('Bancontact card');
                 await bcmc.pay();
 
@@ -232,7 +232,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 const [firstBrand, secondBrand] = await bcmc.brands;
                 expect(firstBrand).toHaveAttribute('data-value', 'bcmc');
@@ -251,7 +251,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
                 await bcmc.fillExpiryDate(TEST_DATE_VALUE);
-                await bcmc.waitForVisibleDualBrands();
+                await bcmc.waitForVisibleBrands();
 
                 await bcmc.selectBrand('MasterCard');
                 await bcmc.pay();

--- a/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
@@ -8,11 +8,14 @@ import {
     TEST_DATE_VALUE,
     THREEDS2_CHALLENGE_PASSWORD
 } from '../../../utils/constants';
+import { URL_MAP } from '../../../../fixtures/URL_MAP';
 
 test.describe('Bcmc payments with dual branding', () => {
     test.describe('Bancontact (BCMC) / Maestro brands', () => {
         test.describe('Selecting the Bancontact brand', () => {
             test('should submit the bcmc payment', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
+
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_CARD);
@@ -31,6 +34,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the bcmc payment with incomplete form data', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_CARD);
                 await bcmc.waitForVisibleDualBrands();
@@ -41,6 +45,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the bcmc payment with invalid bcmc card number', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(`${BCMC_CARD}111`);
                 await bcmc.pay();
@@ -51,6 +56,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
         test.describe('Selecting the maestro brand', () => {
             test('should submit the maestro payment', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_CARD);
@@ -68,6 +74,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the maestro payment with incomplete form data', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_CARD);
                 await bcmc.waitForVisibleDualBrands();
@@ -78,6 +85,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the maestro payment with invalid maestro card number', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(`${BCMC_CARD}111`);
                 await bcmc.pay();
@@ -90,6 +98,7 @@ test.describe('Bcmc payments with dual branding', () => {
     test.describe('Bancontact (BCMC) / Visa Debit brands', () => {
         test.describe('Selecting the Bancontact brand', () => {
             test('should submit the bcmc payment', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
@@ -108,6 +117,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the bcmc payment with incomplete form data', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
                 await bcmc.waitForVisibleDualBrands();
@@ -118,6 +128,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the bcmc payment with invalid bcmc card number', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(`${BCMC_DUAL_BRANDED_VISA}111`);
                 await bcmc.pay();
@@ -128,6 +139,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
         test.describe('Selecting the visa brand', () => {
             test('should submit the visa payment', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
@@ -148,6 +160,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the visa payment with incomplete form data', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_VISA);
@@ -161,6 +174,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the visa payment with invalid visa card number', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(`${BCMC_DUAL_BRANDED_VISA}111`);
                 await bcmc.pay();
@@ -173,6 +187,7 @@ test.describe('Bcmc payments with dual branding', () => {
     test.describe('Bancontact (BCMC) / MC brands', () => {
         test.describe('Selecting the Bancontact brand', () => {
             test('should submit the bcmc payment', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
@@ -190,6 +205,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the bcmc payment with incomplete form data', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
                 await bcmc.waitForVisibleDualBrands();
@@ -200,6 +216,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the bcmc payment with invalid bcmc card number', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(`${BCMC_DUAL_BRANDED_MC}111`);
                 await bcmc.pay();
@@ -210,6 +227,7 @@ test.describe('Bcmc payments with dual branding', () => {
 
         test.describe('Selecting the mc brand', () => {
             test('should submit the mc payment', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
@@ -228,6 +246,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the mc payment with incomplete form data', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
 
                 await bcmc.fillCardNumber(BCMC_DUAL_BRANDED_MC);
@@ -241,6 +260,7 @@ test.describe('Bcmc payments with dual branding', () => {
             });
 
             test('should not submit the mc payment with invalid mc card number', async ({ bcmc }) => {
+                await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.fillCardNumber(`${BCMC_DUAL_BRANDED_MC}111`);
                 await bcmc.pay();

--- a/packages/e2e-playwright/tests/e2e/card/threeDS2/card.threeDS2.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/threeDS2/card.threeDS2.spec.ts
@@ -31,7 +31,7 @@ test.describe('Card with 3DS2', () => {
         });
 
         test('should handle full flow (fingerprint & challenge)', async ({ page, card }) => {
-            const submitFingerprintResponsePromise = page.waitForResponse(response => response.url().includes('/submitThreeDS2Fingerprint'));
+            const makeDetailsCallResponsePromise = page.waitForResponse(response => response.url().includes('/paymentDetails')); // Check for sessions' /paymentDetails call
 
             await card.goto(URL_MAP.card);
 
@@ -43,10 +43,10 @@ test.describe('Card with 3DS2', () => {
             await card.threeDs2Challenge.fillInPassword(THREEDS2_CHALLENGE_PASSWORD);
             await card.threeDs2Challenge.submit();
 
-            const fingerPrintResponse = await submitFingerprintResponsePromise;
+            const detailsCallResponse = await makeDetailsCallResponsePromise;
 
             await expect(card.paymentResult).toContainText(PAYMENT_RESULT.authorised);
-            expect(fingerPrintResponse.status()).toBe(200);
+            expect(detailsCallResponse.status()).toBe(200);
         });
 
         test('should handle challenge-only flow', async ({ page, card }) => {

--- a/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.regular.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.regular.spec.ts
@@ -108,7 +108,7 @@ test.describe('Test Card, & binLookup w. panLength property', () => {
         // Card out of date
         await card.fillExpiryDate('12/90');
 
-        await card.typeCardNumber(CARD_WITH_PAN_LENGTH, 300);
+        await card.typeCardNumber(CARD_WITH_PAN_LENGTH);
 
         // Expect UI change - expiryDate field has focus
         await expect(card.cardNumberInput).not.toBeFocused();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
All bcmc tests first make call to go to a URL. This is consistent with how other tests work

Plus: added fix so 3DS2 test checks correct endpoint before assessing final result
