### PR TITLE
Analytics: track api errors

### DIFF
--- a/.changeset/fresh-lamps-raise.md
+++ b/.changeset/fresh-lamps-raise.md
@@ -1,0 +1,9 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Start tracking API errors for the following endpoints for analytics purposes:
+- `/sessions/${session.id}/payments`
+- `/sessions/${session.id}/orders`
+- `/sessions/${session.id}/paymentDetails`
+- `v1/submitThreeDS2Fingerprint`

--- a/packages/lib/src/components/ANCV/ANCV.test.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/preact';
+import { mockDeep } from 'jest-mock-extended';
+import { AnalyticsModule } from '../../types/global-types';
+import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
+import { ANALYTICS_ERROR_TYPE, ANALYTICS_EVENT } from '../../core/Analytics/constants';
+import ANCV from './ANCV';
+
+const flushPromises = () => new Promise(process.nextTick);
+
+describe('ANCV', () => {
+    const resources = global.resources;
+    const i18n = global.i18n;
+
+    const baseProps = {
+        amount: { value: 1000, currency: 'EUR' },
+        i18n,
+        loadingContext: 'mock'
+    };
+
+    describe('createOrder', () => {
+        test('should send an error event to the analytics if the createOrder call fails for the session flow', async () => {
+            const code = 'mockErrorCode';
+            const analytics = mockDeep<AnalyticsModule>();
+            const mockedSendAnalytics = analytics.sendAnalytics as jest.Mock;
+
+            const ancv = new ANCV(global.core, {
+                ...baseProps,
+                modules: {
+                    resources,
+                    analytics
+                },
+                onError: () => {},
+                // @ts-ignore test only
+                session: {
+                    createOrder: () => {
+                        return Promise.reject(new AdyenCheckoutError('NETWORK_ERROR', '', { code }));
+                    }
+                }
+            });
+            render(ancv.render());
+            await ancv.createOrder();
+            await flushPromises();
+            expect(mockedSendAnalytics).toHaveBeenCalledWith(
+                'ancv',
+                { code, errorType: ANALYTICS_ERROR_TYPE.apiError, type: ANALYTICS_EVENT.error },
+                undefined
+            );
+        });
+    });
+});

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -56,7 +56,13 @@ export class ANCVElement extends UIElement<ANCVConfiguration> {
             })
             .catch(error => {
                 this.setStatus(error?.message || 'error');
-                if (this.props.onError) this.handleError(new AdyenCheckoutError('ERROR', error));
+                if (this.props.onError) {
+                    if (error instanceof AdyenCheckoutError) {
+                        this.handleError(error);
+                    } else {
+                        this.handleError(new AdyenCheckoutError('ERROR', error));
+                    }
+                }
             });
     };
 

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -62,7 +62,6 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
             return new Promise((resolve, reject) => {
                 void this.props.onOrderRequest(resolve, reject, data);
             });
-
         if (this.props.session) {
             return this.props.session.createOrder();
         }

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -102,7 +102,13 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
             })
             .catch(error => {
                 this.setStatus(error?.message || 'error');
-                if (this.props.onError) this.handleError(new AdyenCheckoutError('ERROR', error));
+                if (this.props.onError) {
+                    if (error instanceof AdyenCheckoutError) {
+                        this.handleError(error);
+                    } else {
+                        this.handleError(new AdyenCheckoutError('ERROR', error));
+                    }
+                }
             });
     };
 

--- a/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
+++ b/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
@@ -5,6 +5,7 @@ import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { THREEDS2_ERROR, THREEDS2_FINGERPRINT_SUBMIT } from './constants';
 import { ANALYTICS_ERROR_TYPE, Analytics3DS2Errors } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
+import { API_ERROR_CODE } from '../../core/Services/sessions/constants';
 
 /**
  * ThreeDS2DeviceFingerprint, onComplete, calls a new, internal, endpoint which
@@ -15,7 +16,8 @@ export default function callSubmit3DS2Fingerprint({ data }): void {
         {
             path: `v1/submitThreeDS2Fingerprint?token=${this.props.clientKey}`,
             loadingContext: this.props.loadingContext,
-            errorLevel: 'fatal'
+            errorLevel: 'fatal',
+            errorCode: API_ERROR_CODE.submitThreeDS2Fingerprint
         },
         {
             ...data

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -177,7 +177,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         if (this.constructor['type'] === 'scheme' || this.constructor['type'] === 'bcmc') {
             return this.constructor['type'];
         }
-        return this.props.type;
+        return this.type;
     }
 
     public submit(): void {

--- a/packages/lib/src/core/Errors/AdyenCheckoutError.ts
+++ b/packages/lib/src/core/Errors/AdyenCheckoutError.ts
@@ -1,5 +1,6 @@
 interface CheckoutErrorOptions {
     cause?: any;
+    code?: string;
 }
 
 export const NETWORK_ERROR = 'NETWORK_ERROR';
@@ -35,13 +36,14 @@ class AdyenCheckoutError extends Error {
     };
 
     public cause: unknown;
+    public options: CheckoutErrorOptions;
 
     constructor(type: keyof typeof AdyenCheckoutError.errorTypes, message?: string, options?: CheckoutErrorOptions) {
         super(message);
 
         this.name = AdyenCheckoutError.errorTypes[type];
-
-        this.cause = options?.cause;
+        this.options = options || {};
+        this.cause = this.options.cause;
     }
 }
 

--- a/packages/lib/src/core/Services/sessions/constants.ts
+++ b/packages/lib/src/core/Services/sessions/constants.ts
@@ -1,1 +1,9 @@
 export const API_VERSION = 'v1';
+
+// Same error code will be sent to the analytics
+export const API_ERROR_CODE = {
+    makePayments: '620',
+    submitPaymentDetails: '621',
+    submitThreeDS2Fingerprint: '622',
+    createOrder: '623'
+};

--- a/packages/lib/src/core/Services/sessions/create-order.ts
+++ b/packages/lib/src/core/Services/sessions/create-order.ts
@@ -1,7 +1,7 @@
 import { httpPost } from '../http';
 import Session from '../../CheckoutSession';
 import { CheckoutSessionOrdersResponse } from '../../CheckoutSession/types';
-import { API_VERSION } from './constants';
+import { API_ERROR_CODE, API_VERSION } from './constants';
 
 /**
  */
@@ -11,7 +11,7 @@ function createOrder(session: Session): Promise<CheckoutSessionOrdersResponse> {
         sessionData: session.data
     };
 
-    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal' }, data);
+    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal', errorCode: API_ERROR_CODE.createOrder }, data);
 }
 
 export default createOrder;

--- a/packages/lib/src/core/Services/sessions/make-payment.ts
+++ b/packages/lib/src/core/Services/sessions/make-payment.ts
@@ -1,7 +1,7 @@
 import { httpPost } from '../http';
 import Session from '../../CheckoutSession';
 import { CheckoutSessionPaymentResponse } from '../../CheckoutSession/types';
-import { API_VERSION } from './constants';
+import { API_ERROR_CODE, API_VERSION } from './constants';
 
 /**
  */
@@ -12,7 +12,7 @@ function makePayment(paymentRequest, session: Session): Promise<CheckoutSessionP
         ...paymentRequest
     };
 
-    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal' }, data);
+    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal', errorCode: API_ERROR_CODE.makePayments }, data);
 }
 
 export default makePayment;

--- a/packages/lib/src/core/Services/sessions/submit-details.ts
+++ b/packages/lib/src/core/Services/sessions/submit-details.ts
@@ -1,6 +1,6 @@
 import { httpPost } from '../http';
 import Session from '../../CheckoutSession';
-import { API_VERSION } from './constants';
+import { API_ERROR_CODE, API_VERSION } from './constants';
 import { CheckoutSessionDetailsResponse } from '../../CheckoutSession/types';
 
 /**
@@ -12,7 +12,7 @@ function submitDetails(details, session: Session): Promise<CheckoutSessionDetail
         ...details
     };
 
-    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal' }, data);
+    return httpPost({ loadingContext: session.loadingContext, path, errorLevel: 'fatal', errorCode: API_ERROR_CODE.submitPaymentDetails }, data);
 }
 
 export default submitDetails;

--- a/packages/lib/src/styles/variable-generator.scss
+++ b/packages/lib/src/styles/variable-generator.scss
@@ -13,14 +13,13 @@
     @return $adyen-output-map;
 }
 
-
 @function token($token, $generate-css-var: true) {
     $adyen-tokens-map: ();
 
     @if $generate-css-var {
         $adyen-tokens-map: adyen-sdk-generate-css-variables($color, $text, $focus-ring, $border, $spacer, $shadow);
     } @else {
-        $adyen-tokens-map: map-merge($color, $text, $focus-ring, $border, $spacer, $shadow)
+        $adyen-tokens-map: map-merge($color, $text, $focus-ring, $border, $spacer, $shadow);
     }
 
     @return map-get($adyen-tokens-map, '#{$token}');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Started tracking API errors for the following endpoints for analytics purposes:
  `/sessions/${session.id}/payments`
  `/sessions/${session.id}/orders`
  `/sessions/${session.id}/paymentDetails`
  `v1/submitThreeDS2Fingerprint`
- Added error codes to the above API calls. When errors occur, the same codes are sent to analytics, eliminating the need for the analytics module to map each API call to different error codes
- Improved error handling for gift card and ANCV components to differentiate `NETWORK_ERROR` and send this specific error to the analytics.

## Tested scenarios
Added unit tests and manually tested sending error event for the `v1/submitThreeDS2Fingerprint` endpoint.

**Fixed issue**:  COWEB-1471
