### PR TITLE
Fix `GooglePayButton` `buttonRadius` being 0 issue

### DIFF
--- a/.changeset/empty-files-cough.md
+++ b/.changeset/empty-files-cough.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Resolve the issue where `GooglePayButton` fails to pass `buttonRadius` to the `createButton` function when the value is 0.

--- a/packages/lib/src/components/GooglePay/components/GooglePayButton.tsx
+++ b/packages/lib/src/components/GooglePay/components/GooglePayButton.tsx
@@ -28,7 +28,7 @@ const GooglePayButton = (props: GooglePayButtonProps) => {
                     buttonLocale,
                     buttonSizeMode,
                     buttonRootNode,
-                    ...(buttonRadius && { buttonRadius })
+                    ...(buttonRadius !== undefined && { buttonRadius })
                 })
             )
             .then(googlePayButton => {

--- a/packages/lib/storybook/stories/wallets/GooglePayExpress.stories.tsx
+++ b/packages/lib/storybook/stories/wallets/GooglePayExpress.stories.tsx
@@ -251,7 +251,13 @@ export const Express: GooglePayStory = {
             },
 
             // Shipping Options config
-            shippingOptionRequired: true
+            shippingOptionRequired: true,
+
+            // Button UI config
+            buttonColor: 'black',
+            buttonType: 'buy',
+            buttonSizeMode: 'fill',
+            buttonRadius: 0
         }
     }
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Resolve the issue where `GooglePayButton` fails to pass `buttonRadius` to the `createButton` function when the value is 0.

## Tested scenarios
Tested in storybook


**Fixed issue**:  #3022
