### PR TITLE
TS : argument `options` in ICore:createFromAction is optional

### DIFF
--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -31,7 +31,7 @@ export interface ICore {
     submitDetails(details: AdditionalDetailsData['data']): void;
     getCorePropsForComponent(): any;
     getComponent(txVariant: string): NewableComponent | undefined;
-    createFromAction(action: PaymentAction, options: any): UIElement;
+    createFromAction(action: PaymentAction, options?: any): UIElement;
     storeElementReference(element: UIElement): void;
     options: CoreConfiguration;
     paymentMethodsResponse: PaymentMethods;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This PR fix typescript for `ICore::createFromAction()` : 

- The argument `options` is optional.

Here is an example where the argument `options` is (probably) considered optional

https://github.com/Adyen/adyen-web/blob/46d6f27b81628d3785e10c58f7491eb77b9dc0df/packages/lib/src/core/core.ts#L226-L228

https://github.com/Adyen/adyen-web/blob/46d6f27b81628d3785e10c58f7491eb77b9dc0df/packages/lib/src/core/core.test.ts#L103-L109