### PR TITLE
Klarna fix - Handling SDK action as standalone component

### DIFF
--- a/.changeset/fresh-terms-love.md
+++ b/.changeset/fresh-terms-love.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Klarna - Fix issue where Klarna as standalone component didn't initialize the Klarna Widget SDK accordingly

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -82,7 +82,7 @@ describe('KlarnaPayments', () => {
                     });
                 }
             });
-            const spy = jest.spyOn(klarna, 'handleAction');
+            const spy = jest.spyOn(klarna, 'updateWithAction');
 
             render(klarna.render());
             klarna.submit();
@@ -90,7 +90,7 @@ describe('KlarnaPayments', () => {
             await waitFor(() => expect(spy).toHaveBeenCalledWith(widgetAction), { interval: 100 });
         });
 
-        test('should NOT use updateWithAction when action type is NOT "sdk"', async () => {
+        test('should NOT use updateWithAction when action type is NOT "sdk"', done => {
             const action: PaymentAction = {
                 paymentMethodType: 'klarna_paynow',
                 type: 'redirect',
@@ -108,12 +108,15 @@ describe('KlarnaPayments', () => {
                     });
                 }
             });
-            const spy = jest.spyOn(klarna, 'handleAction');
+            const spy = jest.spyOn(klarna, 'updateWithAction');
 
             render(klarna.render());
             klarna.submit();
 
-            await waitFor(() => expect(spy).not.toHaveBeenCalled(), { interval: 100 });
+            setTimeout(() => {
+                expect(spy).not.toHaveBeenCalled();
+                done();
+            }, 500);
         });
     });
 });

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen, waitFor } from '@testing-library/preact';
 import KlarnaPayments from './KlarnaPayments';
 import Dropin from '../Dropin';
+import { PaymentAction } from '../../types/global-types';
 
 describe('KlarnaPayments', () => {
-    const coreProps = { name: 'Klarna', i18n: global.i18n, loadingContext: 'test', modules: { resources: global.resources } };
+    const coreProps = {
+        name: 'Klarna',
+        i18n: global.i18n,
+        loadingContext: 'test',
+        modules: { resources: global.resources, analytics: global.analytics }
+    };
     const renderKlarna = props => {
         const KlarnaPaymentsEle = new KlarnaPayments(global.core, {
             ...coreProps,
@@ -52,5 +58,62 @@ describe('KlarnaPayments', () => {
         klarna.onComplete();
 
         expect(onAdditionalDetailsMock).toHaveBeenCalled();
+    });
+
+    describe('when handling action', () => {
+        test('should use updateWithAction when action type is "sdk"', async () => {
+            const widgetAction: PaymentAction = {
+                paymentData: 'Ab02b4c0!...',
+                paymentMethodType: 'klarna_paynow',
+                type: 'sdk',
+                sdkData: {
+                    client_token: 'eyJhbGciOiJ...',
+                    payment_method_category: 'pay_over_time'
+                }
+            };
+
+            const klarna = new KlarnaPayments(global.core, {
+                ...coreProps,
+                type: 'klarna_paynow',
+                onSubmit(state, component, actions) {
+                    actions.resolve({
+                        resultCode: 'Pending',
+                        action: widgetAction
+                    });
+                }
+            });
+            const spy = jest.spyOn(klarna, 'handleAction');
+
+            render(klarna.render());
+            klarna.submit();
+
+            await waitFor(() => expect(spy).toHaveBeenCalledWith(widgetAction), { interval: 100 });
+        });
+
+        test('should NOT use updateWithAction when action type is NOT "sdk"', async () => {
+            const action: PaymentAction = {
+                paymentMethodType: 'klarna_paynow',
+                type: 'redirect',
+                url: 'https://checkoutshopper-test.adyen.com/checkoutshopper/checkoutPaymentRedirect?redirectData=X3XtfGC9%21H4s...',
+                method: 'GET'
+            };
+
+            const klarna = new KlarnaPayments(global.core, {
+                ...coreProps,
+                type: 'klarna_paynow',
+                onSubmit(state, component, actions) {
+                    actions.resolve({
+                        resultCode: 'Pending',
+                        action
+                    });
+                }
+            });
+            const spy = jest.spyOn(klarna, 'handleAction');
+
+            render(klarna.render());
+            klarna.submit();
+
+            await waitFor(() => expect(spy).not.toHaveBeenCalled(), { interval: 100 });
+        });
     });
 });

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -42,6 +42,14 @@ class KlarnaPayments extends UIElement<KlarnaConfiguration> {
         return <PayButton amount={this.props.amount} onClick={this.submit} {...props} />;
     };
 
+    public override handleAction(action: KlarnaAction, props = {}): UIElement | null {
+        if (action.type === 'sdk') {
+            this.updateWithAction(action);
+            return;
+        }
+        return super.handleAction(action, props);
+    }
+
     updateWithAction(action: KlarnaAction): void {
         if (action.paymentMethodType !== this.type) throw new Error('Invalid Action');
         this.componentRef.setAction(action);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Before v6.6.0, Klarna component was handling the action through 2 different ways:
- When using it inside Drop-in, the  Drop-in `handleAction` [was directly calling Klarna `updateWithAction`](https://github.com/Adyen/adyen-web/blob/v6.6.0/packages/lib/src/components/Dropin/Dropin.tsx#L149)  passing the action and therefore triggering the **re-render** of the Component. 
- When using it as standalone component, the UIElement `handleAction` was creating a **new**  Klarna component and passing the action as props  (as it can [be seen here](https://github.com/Adyen/adyen-web/blob/v6.5.1/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx#L7))

With the changes introduced by v6.6.0,  the `KlarnaContainer`  stopped receiving the `action` as `props`  (which caused the standalone Component integration to break). The action started being supported by setting it explicitly by calling the [setAction](https://github.com/Adyen/adyen-web/blob/v6.6.0/packages/lib/src/components/Klarna/components/KlarnaContainer/KlarnaContainer.tsx#L25) from the [parent](https://github.com/Adyen/adyen-web/blob/v6.6.0/packages/lib/src/components/Klarna/KlarnaPayments.tsx#L47), and props weren't used anymore.

To fix this issue and keep supporting the standalone integration, the following change was added:
- Added `handleAction` on `Klarna` element, overriding the default one from `UIElement`.  Its `handleAction` will handle in case the widget needs to be loaded, otherwise it will fallback to the UIElement `handleAction`. 
  -  If the action is 'sdk', it sets the action in the child component. If it is a redirect, the default `handleAction` from UIElement will handle it
- By doing this way, we keep a single way of setting the `action` for the Klarna component as opposed to how it was before

## Tests
- Manual test checking standalone component works, and drop-in version works
