### PR TITLE
Updated types in the onChangeData type

### DIFF
--- a/.changeset/popular-ads-join.md
+++ b/.changeset/popular-ads-join.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Updated types in the onChangeData type

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -86,9 +86,11 @@ export type OnChangeData = {
         [fieldKey: string]: {
             isValid: boolean;
             errorMessage: string;
-            errorI18n: string;
-            error: string;
-            rootNode: HTMLElement;
+            error?: string;
+            // These are only ever populated for the Card component
+            errorI18n?: string;
+            rootNode?: HTMLElement;
+            detectedBrands?: string[];
         };
     };
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The `onChangeData` type describes the `state` object sent to the merchant defined `onChange` callback.
This PR adds a type for the optional `detectedBrands` property which can exist on securedFields related errors.

**Fixed issue**:  #3034 
