### PR TITLE
Update securedFields version to 5.5.0 (supports font size set in rem)

### DIFF
--- a/.changeset/silver-poets-happen.md
+++ b/.changeset/silver-poets-happen.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Update securedFields version to 5.5.0 (supports font size set in rem)

--- a/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
@@ -17,7 +17,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '5.4.0';
+export const SF_VERSION = '5.5.0';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Updated securedFields version to 5.5.0 (supports font size set in rem)

## Tested scenarios
All existing tests pass


**Relates to issue**:  COWEB-1472