### PR TITLE
Partial feature: Payto Await

### DIFF
--- a/packages/lib/.size-limit.cjs
+++ b/packages/lib/.size-limit.cjs
@@ -5,8 +5,8 @@ module.exports = [
     {
         name: 'UMD',
         path: 'dist/umd/adyen.js',
-        limit: '110 KB',
-        running: false,
+        limit: '120 KB',
+        running: false
     },
     /**
      * 'auto' bundle with all Components included, excluding Languages
@@ -14,9 +14,9 @@ module.exports = [
     {
         name: 'Auto',
         path: 'auto/auto.js',
-        import: "{ AdyenCheckout, Dropin }",
-        limit: '110 KB',
-        running: false,
+        import: '{ AdyenCheckout, Dropin }',
+        limit: '120 KB',
+        running: false
     },
     /**
      * ES modules (tree-shake)
@@ -24,22 +24,22 @@ module.exports = [
     {
         name: 'ESM - Core',
         path: 'dist/es/index.js',
-        import: "{ AdyenCheckout }",
+        import: '{ AdyenCheckout }',
         limit: '30 KB',
-        running: false,
+        running: false
     },
     {
         name: 'ESM - Core + Card',
         path: 'dist/es/index.js',
-        import: "{ AdyenCheckout, Card }",
+        import: '{ AdyenCheckout, Card }',
         limit: '65 KB',
-        running: false,
+        running: false
     },
     {
         name: 'ESM - Core + Dropin with Card',
         path: 'dist/es/index.js',
-        import: "{ AdyenCheckout, Dropin, Card }",
+        import: '{ AdyenCheckout, Dropin, Card }',
         limit: '70 KB',
-        running: false,
-    },
-]
+        running: false
+    }
+];

--- a/packages/lib/.storybook/main.ts
+++ b/packages/lib/.storybook/main.ts
@@ -26,7 +26,8 @@ const config: StorybookConfig = {
         options: {}
     },
 
-    staticDirs: ['../storybook/assets'],
+    // public added for msw: https://github.com/mswjs/msw-storybook-addon?tab=readme-ov-file#start-storybook
+    staticDirs: ['../storybook/assets', '../storybook/public'],
 
     viteFinal(config) {
         return mergeConfig(config, {

--- a/packages/lib/.storybook/preview.tsx
+++ b/packages/lib/.storybook/preview.tsx
@@ -1,6 +1,12 @@
 import './main.css';
 import { Preview } from '@storybook/preact';
 import { DEFAULT_COUNTRY_CODE, DEFAULT_SHOPPER_LOCALE, DEFAULT_AMOUNT_VALUE, SHOPPER_LOCALES } from '../storybook/config/commonConfig';
+import { initialize as initializeMSW, mswLoader } from 'msw-storybook-addon';
+
+// from the docs: https://github.com/mswjs/msw-storybook-addon
+initializeMSW({
+    onUnhandledRequest: 'bypass'
+});
 
 const preview: Preview = {
     argTypes: {
@@ -27,7 +33,8 @@ const preview: Preview = {
         shopperLocale: DEFAULT_SHOPPER_LOCALE,
         amount: DEFAULT_AMOUNT_VALUE,
         showPayButton: true
-    }
+    },
+    loaders: [mswLoader]
 };
 
 export default preview;

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -123,6 +123,7 @@
     "jest-mock-extended": "3.0.7",
     "lint-staged": "15.2.11",
     "msw": "^2.6.4",
+    "msw-storybook-addon": "^2.0.4",
     "postcss": "8.4.49",
     "rollup": "4.22.4",
     "rollup-plugin-dts": "6.1.1",
@@ -154,5 +155,10 @@
     "*.{js,jsx,ts,tsx}": "eslint",
     "*.{scss,css}": "stylelint",
     "*.{js,jsx,ts,tsx,html,md}": "prettier --write"
+  },
+  "msw": {
+    "workerDirectory": [
+      "storybook/public"
+    ]
   }
 }

--- a/packages/lib/src/components/PayTo/PayTo.test.ts
+++ b/packages/lib/src/components/PayTo/PayTo.test.ts
@@ -10,6 +10,16 @@ jest.mock('../../core/Services/get-dataset');
     })
 );
 
+const MOCK_MANDATE = {
+    amount: '4001', // [Mandatory] for PayTo - Mandate Amount field
+    amountRule: 'exact', // [Mandatory] for PayTo - Needs to be Localised
+    endsAt: '2024-12-31', // [Mandatory] for PayTo - Date format
+    frequency: 'adhoc', // [Mandatory] for PayTo - Needs to be Localised
+    remarks: 'testThroughFlow1', // [Mandatory] for PayTo - Needs to be Localised as "Description"
+    count: '3', // [Optional] will be returned only if the merchant sends it
+    startsAt: '2024-11-13' // [Optional] will be returned only if the merchant sends it
+};
+
 describe('PayTo', () => {
     let onSubmitMock;
     let user;
@@ -22,6 +32,7 @@ describe('PayTo', () => {
     test('should render payment and show PayID page', async () => {
         const payTo = new PayTo(global.core, {
             i18n: global.i18n,
+            mandate: MOCK_MANDATE,
             loadingContext: 'test',
             modules: { resources: global.resources }
         });
@@ -37,6 +48,7 @@ describe('PayTo', () => {
     test('should render continue button', async () => {
         const payTo = new PayTo(global.core, {
             onSubmit: onSubmitMock,
+            mandate: MOCK_MANDATE,
             i18n: global.i18n,
             loadingContext: 'test',
             modules: { resources: global.resources }
@@ -55,6 +67,7 @@ describe('PayTo', () => {
     test('should change to different identifier when selected', async () => {
         const payTo = new PayTo(global.core, {
             onSubmit: onSubmitMock,
+            mandate: MOCK_MANDATE,
             i18n: global.i18n,
             loadingContext: 'test',
             modules: { resources: global.resources },

--- a/packages/lib/src/components/PayTo/PayTo.test.ts
+++ b/packages/lib/src/components/PayTo/PayTo.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/preact';
 import PayTo from './PayTo';
 import userEvent from '@testing-library/user-event';
 import getDataset from '../../core/Services/get-dataset';
+import { MandateType } from './types';
 
 jest.mock('../../core/Services/get-dataset');
 (getDataset as jest.Mock).mockImplementation(
@@ -10,7 +11,7 @@ jest.mock('../../core/Services/get-dataset');
     })
 );
 
-const MOCK_MANDATE = {
+const MOCK_MANDATE: MandateType = {
     amount: '4001', // [Mandatory] for PayTo - Mandate Amount field
     amountRule: 'exact', // [Mandatory] for PayTo - Needs to be Localised
     endsAt: '2024-12-31', // [Mandatory] for PayTo - Date format

--- a/packages/lib/src/components/PayTo/PayTo.tsx
+++ b/packages/lib/src/components/PayTo/PayTo.tsx
@@ -7,38 +7,12 @@ import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 /*
 Types (previously in their own file)
  */
-import { UIElementProps } from '../internal/UIElement/types';
 import { TxVariants } from '../tx-variants';
-import { PayIdFormData } from './components/PayIDInput';
 import { PayToIdentifierEnum } from './components/IdentifierSelector';
-import PayToComponent, { PayToComponentData } from './components/PayToComponent';
-import { BSBFormData } from './components/BSBInput';
+import PayToComponent from './components/PayToComponent';
 import { PayToInstructions } from './components/PayToInstructions';
 import MandateSummary from './components/MandateSummary';
-
-//TODO export type MandateFrequencyType = 'adhoc' | 'daily' | 'weekly' | 'biWeekly' | 'monthly' | 'quarterly' | 'halfYearly' | 'yearly';
-
-export interface MandateType {
-    amount: string;
-    amountRule: string;
-    frequency: string;
-    startsAt?: string;
-    endsAt: string;
-    remarks: string;
-    count?: string;
-}
-
-export interface PayToConfiguration extends UIElementProps {
-    paymentData?: any;
-    data?: PayToData;
-    placeholders?: any; //TODO
-    mandate: MandateType;
-    instructions?: any; //TODO this probably should not be here
-}
-
-export interface PayToData extends PayIdFormData, BSBFormData, PayToComponentData {
-    shopperAccountIdentifier: string;
-}
+import { PayToConfiguration, PayToData } from './types';
 
 /*
 Await Config (previously in its own file)

--- a/packages/lib/src/components/PayTo/PayTo.tsx
+++ b/packages/lib/src/components/PayTo/PayTo.tsx
@@ -13,11 +13,27 @@ import { PayIdFormData } from './components/PayIDInput';
 import { PayToIdentifierEnum } from './components/IdentifierSelector';
 import PayToComponent, { PayToComponentData } from './components/PayToComponent';
 import { BSBFormData } from './components/BSBInput';
+import { PayToInstructions } from './components/PayToInstructions';
+import MandateSummary from './components/MandateSummary';
+
+//TODO export type MandateFrequencyType = 'adhoc' | 'daily' | 'weekly' | 'biWeekly' | 'monthly' | 'quarterly' | 'halfYearly' | 'yearly';
+
+export interface MandateType {
+    amount: string;
+    amountRule: string;
+    frequency: string;
+    startsAt?: string;
+    endsAt: string;
+    remarks: string;
+    count?: string;
+}
 
 export interface PayToConfiguration extends UIElementProps {
     paymentData?: any;
     data?: PayToData;
     placeholders?: any; //TODO
+    mandate: MandateType;
+    instructions?: any; //TODO this probably should not be here
 }
 
 export interface PayToData extends PayIdFormData, BSBFormData, PayToComponentData {
@@ -85,7 +101,12 @@ export class PayToElement extends UIElement<PayToConfiguration> {
             paymentMethod: {
                 type: PayToElement.type,
                 shopperAccountIdentifier: getAccountIdentifier(this.state.data)
-            }
+            },
+            shopperName: {
+                firstName: this.state.data.firstName,
+                lastName: this.state.data.lastName
+            },
+            mandate: this.props.mandate
         };
     }
 
@@ -106,18 +127,22 @@ export class PayToElement extends UIElement<PayToConfiguration> {
                             ref={ref => {
                                 this.componentRef = ref;
                             }}
+                            amount={this.props.amount}
+                            showAmount={true}
+                            instructions={PayToInstructions}
                             clientKey={this.props.clientKey}
                             paymentData={this.props.paymentData}
                             onError={this.props.onError}
                             onComplete={this.onComplete}
                             brandLogo={this.icon}
                             type={this.constructor['type']}
-                            messageText={this.props.i18n.get('ancv.confirmPayment')}
+                            messageText={this.props.i18n.get('payto.confirmPayment')}
                             awaitText={this.props.i18n.get('await.waitForConfirmation')}
                             showCountdownTimer={config.showCountdownTimer}
                             throttleTime={config.THROTTLE_TIME}
                             throttleInterval={config.THROTTLE_INTERVAL}
                             onActionHandled={this.onActionHandled}
+                            endSlot={() => <MandateSummary mandate={this.props.mandate} currencyCode={this.props.amount.currency} />}
                         />
                     </SRPanelProvider>
                 </CoreProvider>

--- a/packages/lib/src/components/PayTo/components/MandateSummary.scss
+++ b/packages/lib/src/components/PayTo/components/MandateSummary.scss
@@ -1,0 +1,12 @@
+@import 'styles/variable-generator';
+
+.adyen-checkout__await--payto {
+  .adyen-checkout__details-table {
+    margin-top: token(spacer-070);
+    padding-top: token(spacer-060);
+  }
+
+  .adyen-checkout__details-table__item:first-child {
+    border-top: none;
+  }
+}

--- a/packages/lib/src/components/PayTo/components/MandateSummary.tsx
+++ b/packages/lib/src/components/PayTo/components/MandateSummary.tsx
@@ -1,0 +1,67 @@
+import DetailsTable from '../../internal/DetailsTable';
+import { h } from 'preact';
+import { MandateType } from '../PayTo';
+import { useCoreContext } from '../../../core/Context/CoreProvider';
+import { DetailsTableData } from '../../internal/DetailsTable/DetailsTable';
+import './MandateSummary.scss';
+
+export default function MandateSummary({ mandate, currencyCode }: { mandate: MandateType; currencyCode: string }) {
+    const { i18n } = useCoreContext();
+    console.log(mandate);
+    const tableFields: DetailsTableData = Object.keys(mandate).map((key: keyof MandateType) => {
+        // get the label for the key, like payto.mandate.amount.label, payto.mandate.frequency.label
+        const labelText = i18n.get(`payto.mandate.${key}.label`);
+        const amountValue = Number(mandate['amount']);
+        switch (key) {
+            case 'amount': {
+                // it can be either show "amount" OR "amount up to (max amount)"
+                const formatedAmount = i18n.amount(amountValue, currencyCode);
+                if (mandate.amountRule === 'max') {
+                    return {
+                        label: labelText,
+                        value: i18n.get('payto.mandate.amount.max', { values: { amount: formatedAmount } })
+                    };
+                } else {
+                    return {
+                        label: labelText,
+                        value: i18n.amount(amountValue, currencyCode)
+                    };
+                }
+            }
+            case 'frequency': {
+                if (!mandate.count) {
+                    // if there's no count we just say 'adhoc'
+                    return {
+                        label: labelText,
+                        value: i18n.get(`payto.mandate.frequency.adhoc-no-count`)
+                    };
+                } else {
+                    // frequency can be: adhoc, daily, weekly, biWeekly, monthly, quarterly, halfYearly, yearly
+                    return {
+                        label: labelText,
+                        value: i18n.get(`payto.mandate.frequency.${mandate.frequency}`, { values: { count: mandate.count } })
+                    };
+                }
+            }
+            // TODO test this for XSS
+            case 'remarks':
+                return {
+                    label: labelText,
+                    value: mandate.remarks
+                };
+            case 'startsAt':
+                return {
+                    label: labelText,
+                    value: i18n.date(mandate.startsAt)
+                };
+
+            case 'endsAt':
+                return {
+                    label: labelText,
+                    value: i18n.date(mandate.endsAt)
+                };
+        }
+    });
+
+    return <DetailsTable tableFields={tableFields}></DetailsTable>;
+}

--- a/packages/lib/src/components/PayTo/components/MandateSummary.tsx
+++ b/packages/lib/src/components/PayTo/components/MandateSummary.tsx
@@ -1,13 +1,12 @@
 import DetailsTable from '../../internal/DetailsTable';
 import { h } from 'preact';
-import { MandateType } from '../PayTo';
+import { MandateType } from '../types';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import { DetailsTableData } from '../../internal/DetailsTable/DetailsTable';
 import './MandateSummary.scss';
 
 export default function MandateSummary({ mandate, currencyCode }: { mandate: MandateType; currencyCode: string }) {
     const { i18n } = useCoreContext();
-    console.log(mandate);
     const tableFields: DetailsTableData = Object.keys(mandate).map((key: keyof MandateType) => {
         // get the label for the key, like payto.mandate.amount.label, payto.mandate.frequency.label
         const labelText = i18n.get(`payto.mandate.${key}.label`);

--- a/packages/lib/src/components/PayTo/components/PayToInstructions.tsx
+++ b/packages/lib/src/components/PayTo/components/PayToInstructions.tsx
@@ -1,0 +1,15 @@
+import { useCoreContext } from '../../../core/Context/CoreProvider';
+import { Timeline, TimelineWrapper } from '../../internal/Timeline';
+import { h } from 'preact';
+
+export const PayToInstructions = () => {
+    const { i18n } = useCoreContext();
+
+    const instructions = i18n.get('payto.instructions.steps').split('@');
+
+    return (
+        <TimelineWrapper>
+            <Timeline instructions={instructions} />
+        </TimelineWrapper>
+    );
+};

--- a/packages/lib/src/components/PayTo/types.ts
+++ b/packages/lib/src/components/PayTo/types.ts
@@ -1,0 +1,27 @@
+import { UIElementProps } from '../internal/UIElement/types';
+import { PayIdFormData } from './components/PayIDInput';
+import { BSBFormData } from './components/BSBInput';
+import { PayToComponentData } from './components/PayToComponent';
+
+export type MandateFrequencyType = 'adhoc' | 'daily' | 'weekly' | 'biWeekly' | 'monthly' | 'quarterly' | 'halfYearly' | 'yearly';
+
+export interface MandateType {
+    amount: string;
+    amountRule: string;
+    frequency: MandateFrequencyType;
+    startsAt?: string;
+    endsAt: string;
+    remarks: string;
+    count?: string;
+}
+
+export interface PayToConfiguration extends UIElementProps {
+    paymentData?: any;
+    data?: PayToData;
+    placeholders?: any; //TODO
+    mandate: MandateType;
+}
+
+export interface PayToData extends PayIdFormData, BSBFormData, PayToComponentData {
+    shopperAccountIdentifier: string;
+}

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -85,6 +85,7 @@ export { default as Blik } from './Blik';
 export { default as MBWay } from './MBWay';
 export { default as UPI } from './UPI';
 export { default as ANCV } from './ANCV';
+export { default as PayTo } from './PayTo';
 
 /** Giftcard */
 export { default as Giftcard } from './Giftcard';

--- a/packages/lib/src/components/internal/Await/Await.scss
+++ b/packages/lib/src/components/internal/Await/Await.scss
@@ -81,6 +81,13 @@
     display: none;
 }
 
+.adyen-checkout__await__amount {
+    margin-top: token(spacer-070);
+    font-size: token(text-title-l-font-size);
+    font-weight: token(text-title-font-weight);
+    text-align: center;
+}
+
 @media only screen and (max-device-width: 1200px) {
     .adyen-checkout__await__app-link {
         display: block;

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -192,7 +192,9 @@ function Await(props: AwaitComponentProps) {
         >
             {props.brandLogo && <img src={props.brandLogo} alt={props.type} className="adyen-checkout__await__brand-logo" />}
 
-            {props.showAmount && amount && amount.value && amount.currency && (
+            {/* Everything is wrapped in !! so we evaluate the result as boolean,
+             otherwise we might just print the value or object as mistake */}
+            {!!(props.showAmount && amount && amount.value && amount.currency) && (
                 <div className="adyen-checkout__await__amount">{i18n.amount(amount.value, amount.currency)}</div>
             )}
 

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -26,6 +26,7 @@ function Await(props: AwaitComponentProps) {
     const [timePassed, setTimePassed] = useState(0);
     const [hasAdjustedTime, setHasAdjustedTime] = useState(false);
     const [storedTimeout, setStoredTimeout] = useState(null);
+    const { amount } = props;
 
     const onTimeUp = (): void => {
         setExpired(true);
@@ -191,7 +192,9 @@ function Await(props: AwaitComponentProps) {
         >
             {props.brandLogo && <img src={props.brandLogo} alt={props.type} className="adyen-checkout__await__brand-logo" />}
 
-            {props.showAmount && <div className="adyen-checkout__await__amount">{i18n.amount(props.amount.value, props.amount.currency)}</div>}
+            {props.showAmount && amount && amount.value && amount.currency && (
+                <div className="adyen-checkout__await__amount">{i18n.amount(amount.value, amount.currency)}</div>
+            )}
 
             <div className="adyen-checkout__await__subtitle">{props.messageText}</div>
 

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -191,6 +191,8 @@ function Await(props: AwaitComponentProps) {
         >
             {props.brandLogo && <img src={props.brandLogo} alt={props.type} className="adyen-checkout__await__brand-logo" />}
 
+            {props.showAmount && <div className="adyen-checkout__await__amount">{i18n.amount(props.amount.value, props.amount.currency)}</div>}
+
             <div className="adyen-checkout__await__subtitle">{props.messageText}</div>
 
             <div className="adyen-checkout__await__indicator-holder">
@@ -220,6 +222,14 @@ function Await(props: AwaitComponentProps) {
                     <Button classNameModifiers={['await']} onClick={() => redirectToApp(props.url)} label={i18n.get('openApp')} />
                 </div>
             )}
+
+            {props.instructions && (
+                <div className="adyen-checkout__await__instructions">
+                    {typeof props.instructions === 'string' ? i18n.get(props.instructions) : props.instructions?.()}
+                </div>
+            )}
+
+            {props.endSlot && <div className="adyen-checkout__await__end-slot">{props.endSlot()}</div>}
         </div>
     );
 }

--- a/packages/lib/src/components/internal/Await/types.ts
+++ b/packages/lib/src/components/internal/Await/types.ts
@@ -1,5 +1,6 @@
 import { UIElementProps } from '../UIElement/types';
-import { ActionHandledReturnObject } from '../../../types/global-types';
+import { ActionHandledReturnObject, PaymentAmount } from '../../../types/global-types';
+import { h } from 'preact';
 
 interface StatusObjectProps {
     payload: string;
@@ -31,6 +32,10 @@ export interface AwaitComponentProps {
     awaitText: string;
     ref: any;
     onActionHandled?: (rtnObj: ActionHandledReturnObject) => void;
+    instructions?: string | (() => h.JSX.Element);
+    endSlot?: () => h.JSX.Element;
+    amount?: PaymentAmount;
+    showAmount?: boolean;
 }
 
 export interface AwaitConfiguration extends UIElementProps {

--- a/packages/lib/src/components/internal/DetailsTable/DetailsTable.scss
+++ b/packages/lib/src/components/internal/DetailsTable/DetailsTable.scss
@@ -1,0 +1,33 @@
+@import 'styles/variable-generator';
+
+.adyen-checkout__details-table {
+  list-style: none;
+  padding: 0;
+  margin: -1px auto 0;
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    font-size: token(text-body-font-size);
+    color: token(color-label-primary);
+    padding: token(spacer-070) token(spacer-090);
+    border-top: 1px solid token(color-separator-primary);
+    word-break: break-word;
+  }
+
+  &__item:last-child {
+    margin-bottom: 0;
+  }
+
+  &__label {
+    max-width: 50%;
+    text-align: left;
+  }
+
+  &__value {
+    max-width: 50%;
+    text-align: right;
+    font-weight: bold;
+  }
+}
+

--- a/packages/lib/src/components/internal/DetailsTable/DetailsTable.tsx
+++ b/packages/lib/src/components/internal/DetailsTable/DetailsTable.tsx
@@ -16,18 +16,18 @@ export default function DetailsTable({ tableFields }: DetailsTableProps) {
     // This was originally part of the voucher component and ported out
     // We can remove the voucher class names at point
     return (
-        <ul className="adyen-checkout__voucher-result__details adyen-checkout__details-table">
+        <dl className="adyen-checkout__voucher-result__details adyen-checkout__details-table">
             {tableFields
                 // first remove empty values
                 .filter(item => !!item)
                 // or objects without label and value
                 .filter(({ label, value }) => !!label && !!value)
                 .map(({ label, value }, index) => (
-                    <li key={index} className="adyen-checkout__voucher-result__details__item adyen-checkout__details-table__item">
-                        <span className="adyen-checkout__voucher-result__details__label adyen-checkout__details-table__label">{label}</span>
-                        <span className="adyen-checkout__voucher-result__details__value adyen-checkout__details-table__value">{value}</span>
-                    </li>
+                    <div key={index} className="adyen-checkout__voucher-result__details__item adyen-checkout__details-table__item">
+                        <dt className="adyen-checkout__voucher-result__details__label adyen-checkout__details-table__label">{label}</dt>
+                        <dd className="adyen-checkout__voucher-result__details__value adyen-checkout__details-table__value">{value}</dd>
+                    </div>
                 ))}
-        </ul>
+        </dl>
     );
 }

--- a/packages/lib/src/components/internal/DetailsTable/DetailsTable.tsx
+++ b/packages/lib/src/components/internal/DetailsTable/DetailsTable.tsx
@@ -1,0 +1,33 @@
+import { h } from 'preact';
+import './DetailsTable.scss';
+
+export interface DetailsTableData
+    extends Array<{
+        label: string;
+        value: string;
+    }> {}
+
+export interface DetailsTableProps {
+    tableFields: DetailsTableData;
+}
+
+export default function DetailsTable({ tableFields }: DetailsTableProps) {
+    // For context, this markup uses 2 classes for backwards compatibility
+    // This was originally part of the voucher component and ported out
+    // We can remove the voucher class names at point
+    return (
+        <ul className="adyen-checkout__voucher-result__details adyen-checkout__details-table">
+            {tableFields
+                // first remove empty values
+                .filter(item => !!item)
+                // or objects without label and value
+                .filter(({ label, value }) => !!label && !!value)
+                .map(({ label, value }, index) => (
+                    <li key={index} className="adyen-checkout__voucher-result__details__item adyen-checkout__details-table__item">
+                        <span className="adyen-checkout__voucher-result__details__label adyen-checkout__details-table__label">{label}</span>
+                        <span className="adyen-checkout__voucher-result__details__value adyen-checkout__details-table__value">{value}</span>
+                    </li>
+                ))}
+        </ul>
+    );
+}

--- a/packages/lib/src/components/internal/DetailsTable/index.ts
+++ b/packages/lib/src/components/internal/DetailsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DetailsTable';

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.scss
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.scss
@@ -110,6 +110,11 @@
     margin-top: token(spacer-100);
 }
 
+.adyen-checkout__await__instructions {
+    display: flex;
+    justify-content: center;
+}
+
 @media (max-width: 1024px) {
     .adyen-checkout__qr-loader__app-link {
         display: block;

--- a/packages/lib/src/components/internal/Voucher/Voucher.scss
+++ b/packages/lib/src/components/internal/Voucher/Voucher.scss
@@ -153,37 +153,6 @@
     line-height: 1.2;
 }
 
-.adyen-checkout__voucher-result__details {
-    list-style: none;
-    padding: 0;
-    margin: -1px auto 0;
-}
-
-.adyen-checkout__voucher-result__details__item {
-    display: flex;
-    justify-content: space-between;
-    font-size: token(text-body-font-size);
-    color: token(color-label-primary);
-    padding: token(spacer-070) token(spacer-090);
-    border-top: 1px solid token(color-separator-primary);
-    word-break: break-word;
-}
-
-.adyen-checkout__voucher-result__details__item:last-child {
-    margin-bottom: 0;
-}
-
-.adyen-checkout__voucher-result__details__label {
-    max-width: 50%;
-    text-align: left;
-}
-
-.adyen-checkout__voucher-result__details__value {
-    max-width: 50%;
-    text-align: right;
-    font-weight: bold;
-}
-
 .adyen-checkout__voucher-result__actions {
     margin: 0 auto token(spacer-100);
     max-width: 100%;

--- a/packages/lib/src/components/internal/Voucher/Voucher.tsx
+++ b/packages/lib/src/components/internal/Voucher/Voucher.tsx
@@ -8,6 +8,7 @@ import './Voucher.scss';
 import { VoucherProps } from './types';
 import useImage from '../../../core/Context/useImage';
 import { PREFIX } from '../Icon/constants';
+import DetailsTable from '../DetailsTable';
 
 export default function Voucher({ voucherDetails = [], className = '', ...props }: VoucherProps) {
     const { i18n } = useCoreContext();
@@ -115,16 +116,7 @@ export default function Voucher({ voucherDetails = [], className = '', ...props 
                     </ul>
                 )}
 
-                <ul className="adyen-checkout__voucher-result__details">
-                    {voucherDetails
-                        .filter(({ label, value }) => !!label && !!value)
-                        .map(({ label, value }, index) => (
-                            <li key={index} className="adyen-checkout__voucher-result__details__item">
-                                <span className="adyen-checkout__voucher-result__details__label">{label}</span>
-                                <span className="adyen-checkout__voucher-result__details__value">{value}</span>
-                            </li>
-                        ))}
-                </ul>
+                <DetailsTable tableFields={voucherDetails} />
             </div>
         </div>
     );

--- a/packages/lib/src/components/types.ts
+++ b/packages/lib/src/components/types.ts
@@ -27,6 +27,7 @@ export * from './Redirect/types';
 export * from './Sepa/types';
 export * from './ThreeDS2/types';
 export * from './UPI/types';
+export * from './PayTo/types';
 
 /**
  * Helpers

--- a/packages/lib/storybook/public/mockServiceWorker.js
+++ b/packages/lib/storybook/public/mockServiceWorker.js
@@ -1,0 +1,302 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.7.0';
+const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f';
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
+const activeClientIds = new Set();
+
+self.addEventListener('install', function () {
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', async function (event) {
+    const clientId = event.source.id;
+
+    if (!clientId || !self.clients) {
+        return;
+    }
+
+    const client = await self.clients.get(clientId);
+
+    if (!client) {
+        return;
+    }
+
+    const allClients = await self.clients.matchAll({
+        type: 'window'
+    });
+
+    switch (event.data) {
+        case 'KEEPALIVE_REQUEST': {
+            sendToClient(client, {
+                type: 'KEEPALIVE_RESPONSE'
+            });
+            break;
+        }
+
+        case 'INTEGRITY_CHECK_REQUEST': {
+            sendToClient(client, {
+                type: 'INTEGRITY_CHECK_RESPONSE',
+                payload: {
+                    packageVersion: PACKAGE_VERSION,
+                    checksum: INTEGRITY_CHECKSUM
+                }
+            });
+            break;
+        }
+
+        case 'MOCK_ACTIVATE': {
+            activeClientIds.add(clientId);
+
+            sendToClient(client, {
+                type: 'MOCKING_ENABLED',
+                payload: {
+                    client: {
+                        id: client.id,
+                        frameType: client.frameType
+                    }
+                }
+            });
+            break;
+        }
+
+        case 'MOCK_DEACTIVATE': {
+            activeClientIds.delete(clientId);
+            break;
+        }
+
+        case 'CLIENT_CLOSED': {
+            activeClientIds.delete(clientId);
+
+            const remainingClients = allClients.filter(client => {
+                return client.id !== clientId;
+            });
+
+            // Unregister itself when there are no more clients
+            if (remainingClients.length === 0) {
+                self.registration.unregister();
+            }
+
+            break;
+        }
+    }
+});
+
+self.addEventListener('fetch', function (event) {
+    const { request } = event;
+
+    // Bypass navigation requests.
+    if (request.mode === 'navigate') {
+        return;
+    }
+
+    // Opening the DevTools triggers the "only-if-cached" request
+    // that cannot be handled by the worker. Bypass such requests.
+    if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+        return;
+    }
+
+    // Bypass all requests when there are no active clients.
+    // Prevents the self-unregistered worked from handling requests
+    // after it's been deleted (still remains active until the next reload).
+    if (activeClientIds.size === 0) {
+        return;
+    }
+
+    // Generate unique request ID.
+    const requestId = crypto.randomUUID();
+    event.respondWith(handleRequest(event, requestId));
+});
+
+async function handleRequest(event, requestId) {
+    const client = await resolveMainClient(event);
+    const response = await getResponse(event, client, requestId);
+
+    // Send back the response clone for the "response:*" life-cycle events.
+    // Ensure MSW is active and ready to handle the message, otherwise
+    // this message will pend indefinitely.
+    if (client && activeClientIds.has(client.id)) {
+        (async function () {
+            const responseClone = response.clone();
+
+            sendToClient(
+                client,
+                {
+                    type: 'RESPONSE',
+                    payload: {
+                        requestId,
+                        isMockedResponse: IS_MOCKED_RESPONSE in response,
+                        type: responseClone.type,
+                        status: responseClone.status,
+                        statusText: responseClone.statusText,
+                        body: responseClone.body,
+                        headers: Object.fromEntries(responseClone.headers.entries())
+                    }
+                },
+                [responseClone.body]
+            );
+        })();
+    }
+
+    return response;
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+    const client = await self.clients.get(event.clientId);
+
+    if (activeClientIds.has(event.clientId)) {
+        return client;
+    }
+
+    if (client?.frameType === 'top-level') {
+        return client;
+    }
+
+    const allClients = await self.clients.matchAll({
+        type: 'window'
+    });
+
+    return allClients
+        .filter(client => {
+            // Get only those clients that are currently visible.
+            return client.visibilityState === 'visible';
+        })
+        .find(client => {
+            // Find the client ID that's recorded in the
+            // set of clients that have registered the worker.
+            return activeClientIds.has(client.id);
+        });
+}
+
+async function getResponse(event, client, requestId) {
+    const { request } = event;
+
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the client).
+    const requestClone = request.clone();
+
+    function passthrough() {
+        // Cast the request headers to a new Headers instance
+        // so the headers can be manipulated with.
+        const headers = new Headers(requestClone.headers);
+
+        // Remove the "accept" header value that marked this request as passthrough.
+        // This prevents request alteration and also keeps it compliant with the
+        // user-defined CORS policies.
+        const acceptHeader = headers.get('accept');
+        if (acceptHeader) {
+            const values = acceptHeader.split(',').map(value => value.trim());
+            const filteredValues = values.filter(value => value !== 'msw/passthrough');
+
+            if (filteredValues.length > 0) {
+                headers.set('accept', filteredValues.join(', '));
+            } else {
+                headers.delete('accept');
+            }
+        }
+
+        return fetch(requestClone, { headers });
+    }
+
+    // Bypass mocking when the client is not active.
+    if (!client) {
+        return passthrough();
+    }
+
+    // Bypass initial page load requests (i.e. static assets).
+    // The absence of the immediate/parent client in the map of the active clients
+    // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+    // and is not ready to handle requests.
+    if (!activeClientIds.has(client.id)) {
+        return passthrough();
+    }
+
+    // Notify the client that a request has been intercepted.
+    const requestBuffer = await request.arrayBuffer();
+    const clientMessage = await sendToClient(
+        client,
+        {
+            type: 'REQUEST',
+            payload: {
+                id: requestId,
+                url: request.url,
+                mode: request.mode,
+                method: request.method,
+                headers: Object.fromEntries(request.headers.entries()),
+                cache: request.cache,
+                credentials: request.credentials,
+                destination: request.destination,
+                integrity: request.integrity,
+                redirect: request.redirect,
+                referrer: request.referrer,
+                referrerPolicy: request.referrerPolicy,
+                body: requestBuffer,
+                keepalive: request.keepalive
+            }
+        },
+        [requestBuffer]
+    );
+
+    switch (clientMessage.type) {
+        case 'MOCK_RESPONSE': {
+            return respondWithMock(clientMessage.data);
+        }
+
+        case 'PASSTHROUGH': {
+            return passthrough();
+        }
+    }
+
+    return passthrough();
+}
+
+function sendToClient(client, message, transferrables = []) {
+    return new Promise((resolve, reject) => {
+        const channel = new MessageChannel();
+
+        channel.port1.onmessage = event => {
+            if (event.data && event.data.error) {
+                return reject(event.data.error);
+            }
+
+            resolve(event.data);
+        };
+
+        client.postMessage(message, [channel.port2].concat(transferrables.filter(Boolean)));
+    });
+}
+
+async function respondWithMock(response) {
+    // Setting response status code to 0 is a no-op.
+    // However, when responding with a "Response.error()", the produced Response
+    // instance will have status code set to 0. Since it's not possible to create
+    // a Response instance with status code 0, handle that use-case separately.
+    if (response.status === 0) {
+        return Response.error();
+    }
+
+    const mockedResponse = new Response(response.body, response);
+
+    Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+        value: true,
+        enumerable: true
+    });
+
+    return mockedResponse;
+}

--- a/packages/lib/storybook/stories/components/PayTo.stories.tsx
+++ b/packages/lib/storybook/stories/components/PayTo.stories.tsx
@@ -2,8 +2,9 @@ import { Meta, StoryObj } from '@storybook/preact';
 import { PaymentMethodStoryProps } from '../types';
 import { ComponentContainer } from '../ComponentContainer';
 import { Checkout } from '../Checkout';
-import PayTo, { MandateType, PayToConfiguration } from '../../../src/components/PayTo/PayTo';
+import PayTo from '../../../src/components/PayTo/PayTo';
 import { http, HttpResponse } from 'msw';
+import { MandateType, PayToConfiguration } from '../../../src/components/PayTo/types';
 
 // extend the default story args so we can change mandate top level
 interface ExtendedStoryArgs extends PaymentMethodStoryProps<PayToConfiguration> {
@@ -11,11 +12,11 @@ interface ExtendedStoryArgs extends PaymentMethodStoryProps<PayToConfiguration> 
 }
 type PayToStory = StoryObj<ExtendedStoryArgs>;
 
-const MANDATE_EXAMPLE = {
+const MANDATE_EXAMPLE: MandateType = {
     amount: '25900', // [Mandatory] for PayTo - Mandate Amount field
     amountRule: 'exact', // [Mandatory] for PayTo - Needs to be Localised
     endsAt: '2025-12-31', // [Mandatory] for PayTo - Date format
-    frequency: 'adhoc', // [Mandatory] for PayTo - Needs to be Localised
+    frequency: 'monthly', // [Mandatory] for PayTo - Needs to be Localised
     remarks: 'testThroughFlow1', // [Mandatory] for PayTo - Needs to be Localised as "Description"
     count: '3' // [Optional] will be returned only if the merchant sends it
     //startsAt: '2025-02-01' // [Optional] will be returned only if the merchant sends it

--- a/packages/lib/storybook/stories/components/PayTo.stories.tsx
+++ b/packages/lib/storybook/stories/components/PayTo.stories.tsx
@@ -10,10 +10,61 @@ const meta: Meta<PaymentMethodStoryProps<PayToStory>> = {
     title: 'Components/PayTo'
 };
 
+// const payToPaymentObject = {
+//     amount: {
+//         currency: 'AUD', // [Mandatory] only supported value: "AUD"
+//         value: 4200 // [Mandatory] { int: 1 to 1000000000 }
+//     },
+//     paymentMethod: {
+//         type: 'payto', // [Mandatory]
+//         shopperAccountIdentifier: '123456-98765432' // [Mandatory]
+//     },
+//     countryCode: 'AU', // [Mandatory]
+//     merchantAccount: 'YOUR_MERCHANT_ACCOUNT', // [Mandatory]
+//     reference: 'YOUR_ORDER_NUMBER', // [Mandatory]
+//     mandate: {
+//         amount: '42000', // [Mandatory] { int: 1 to 1000000000 }
+//         amountRule: 'exact', // [Mandatory]
+//         frequency: 'monthly', // [Mandatory] need to update docs to add "adhoc"
+//         startsAt: '2024-10-01', // [Optional]
+//         endsAt: '2027-10-01', // [Mandatory]
+//         remarks: 'Remark on mandate', // [Mandatory]
+//         count: '1' // [Conditional] new field
+//     },
+//     shopperName: { firstName: 'John', lastName: 'Doe' }, // [Mandatory]
+//     shopperEmail: 's.hopper@example.com', // [Mandatory]
+//     storePaymentMethod: true, // [Mandatory]
+//     shopperInteraction: 'Ecommerce', // [Mandatory]
+//     recurringProcessingModel: 'Subscription', // [Mandatory]
+//     shopperReference: 'YOUR_SHOPPER_REFERENCE' // [Mandatory]
+// };
+
+const payToConfigurationObject = {
+    mandate: {
+        amount: '25900', // [Mandatory] { int: 1 to 1000000000 }
+        amountRule: 'exact', // [Mandatory]
+        frequency: 'monthly', // [Mandatory] need to update docs to add "adhoc"
+        //startsAt: '2024-10-01', // [Optional]
+        endsAt: '2027-10-01', // [Mandatory]
+        remarks: 'Remark on mandate', // [Mandatory]
+        count: '1' // [Conditional] new field
+    },
+    shopperEmail: 's.hopper@example.com' // [Mandatory]
+};
+
 export const Default: PayToStory = {
     render: ({ componentConfiguration, ...checkoutConfig }) => (
         <Checkout checkoutConfig={checkoutConfig}>
-            {checkout => <ComponentContainer element={new PayTo(checkout, componentConfiguration)} />}
+            {checkout => (
+                <ComponentContainer
+                    element={
+                        new PayTo(checkout, {
+                            ...payToConfigurationObject,
+                            ...componentConfiguration
+                        })
+                    }
+                />
+            )}
         </Checkout>
     ),
     args: {
@@ -22,3 +73,55 @@ export const Default: PayToStory = {
     }
 };
 export default meta;
+
+// const paymentResponse = {
+//     resultCode: 'Pending',
+//     action: {
+//         paymentData: 'Ab02b4c0....J86s=',
+//         paymentMethodType: 'payto',
+//         expiresAt: '2024-11-13T00:01:37Z',
+//         mandate: {
+//             amount: '4001', // [Mandatory] for PayTo - Mandate Amount field
+//             amountRule: 'exact', // [Mandatory] for PayTo - Needs to be Localised
+//             endsAt: '2024-12-31', // [Mandatory] for PayTo - Date format
+//             frequency: 'adhoc', // [Mandatory] for PayTo - Needs to be Localised
+//             remarks: 'testThroughFlow1', // [Mandatory] for PayTo - Needs to be Localised as "Description"
+//             count: '3', // [Optional] will be returned only if the merchant sends it
+//             startsAt: '2024-11-13' // [Optional] will be returned only if the merchant sends it
+//         },
+//         name: 'John Smitty', // Echo back the field passed in the request
+//         shopperAccountIdentifier: 'test_again@test.com', // Echo back the field passed in the request
+//         payee: '[MERCHANT_NAME]', // Merchant name displayed in the agreement
+//         type: 'await'
+//     }
+// };
+
+export const PayToAwaitScreen: PayToStory = {
+    args: {
+        countryCode: 'AU',
+        shopperLocale: 'en-US'
+    },
+    render: ({ componentConfiguration, ...checkoutConfig }) => (
+        <Checkout checkoutConfig={checkoutConfig}>
+            {checkout => (
+                <ComponentContainer
+                    element={
+                        new PayTo(checkout, {
+                            paymentData: 'Ab02b4c0....J86s=',
+                            mandate: {
+                                amount: '25900', // [Mandatory] for PayTo - Mandate Amount field
+                                amountRule: 'exact', // [Mandatory] for PayTo - Needs to be Localised
+                                endsAt: '2024-12-31', // [Mandatory] for PayTo - Date format
+                                frequency: 'adhoc', // [Mandatory] for PayTo - Needs to be Localised
+                                remarks: 'testThroughFlow1', // [Mandatory] for PayTo - Needs to be Localised as "Description"
+                                count: '3', // [Optional] will be returned only if the merchant sends it
+                                startsAt: '2024-11-13' // [Optional] will be returned only if the merchant sends it
+                            },
+                            ...componentConfiguration
+                        })
+                    }
+                />
+            )}
+        </Checkout>
+    )
+};

--- a/packages/server/translations/en-US.json
+++ b/packages/server/translations/en-US.json
@@ -337,5 +337,22 @@
     "payto.bsb.header": "BSB",
     "payto.bsb.description" : "Enter the bank account number and the Bank State Branch that is connected to your account to continue",
     "payto.bsb.label.bankAccountNumber": "Bank account number",
-    "payto.bsb.label.bsb": "Bank State Branch"
+    "payto.bsb.label.bsb": "Bank State Branch",
+    "payto.instructions.steps": "Log into your PayTo banking app@Authorize the PayTo agreement@Approve the payment terms@Complete the transaction",
+    "payto.confirmPayment": "Thank you for your purchase, complete your payment by following the instructions below.",
+    "payto.mandate.amount.label": "Amount",
+    "payto.mandate.frequency.label": "Frequency",
+    "payto.mandate.remarks.label": "Description",
+    "payto.mandate.startsAt.label": "Start Date",
+    "payto.mandate.endsAt.label": "Ends Date",
+    "payto.mandate.amount.max": "Up to %{amount} per transaction",
+    "payto.mandate.frequency.adhoc-no-count": "Ad Hoc",
+    "payto.mandate.frequency.adhoc": "%{count} time(s)",
+    "payto.mandate.frquency.daily": "%{count} payment(s) Daily",
+    "payto.mandate.frquency.weekly": "%{count} payment(s) Weekly",
+    "payto.mandate.frquency.biWeekly": "%{count} payment(s) Fortnightly",
+    "payto.mandate.frquency.monthly": "%{count} payment(s) Monthly",
+    "payto.mandate.frquency.quarterly": "%{count} payment(s) Quarterly",
+    "payto.mandate.frquency.halfYearly": "%{count} payment(s) Bi-Annual",
+    "payto.mandate.frquency.yearly": "%{count} payment(s) Yearly"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6661,7 +6661,7 @@ is-negative-zero@^2.0.3:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
 
-is-node-process@^1.2.0:
+is-node-process@^1.0.1, is-node-process@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
   integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
@@ -7992,6 +7992,13 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+msw-storybook-addon@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/msw-storybook-addon/-/msw-storybook-addon-2.0.4.tgz#ff1f583c95aef5f8c2014299f235e13cdd34dc1b"
+  integrity sha512-rstO8+r01sRMg6PPP7OxM8LG5/6r4+wmp2uapHeHvm9TQQRHvpPXOU/Y9/Somysz8Oi4Ea1aummXH3JlnP2LIA==
+  dependencies:
+    is-node-process "^1.0.1"
 
 msw@^2.6.4:
   version "2.7.0"
@@ -10347,16 +10354,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10483,14 +10481,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11676,7 +11667,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11689,15 +11680,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

A few changes for this part of the component.

* Await can now display the amount via `showAmount` flag
* Await now has instructions like QRLoader
* Await has one final element, I just called it endSlot so it could be generic, this open to discussion.
* Moved the voucher details / list / table into a new component
* The new component DetailsTable uses a `dl` element (definition list), see docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl#metadata
* Mandate Summary handles all the i18n logic to display the table, this could have been a function but seems more clean in separate component
* There's a discussion point on the length of the Mandate Summary logic block as it seems quite big, however I want to retain all the logic in one place for ease of editing, feel free to discuss this too

## Tested scenarios
<!-- Description of tested scenarios -->

* There's been a few manual testing steps however more it's coming


**Fixed issue**:  <!-- #-prefixed issue number -->
