### PR TITLE
Fastlane - Retrieving consent details and fastlane session id

### DIFF
--- a/packages/e2e-playwright/tests/e2e/card/fastlane.signup.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/fastlane.signup.spec.ts
@@ -142,11 +142,11 @@ test.describe('Card - Fastlane Sign up', () => {
                     componentConfig: {
                         fastlaneConfiguration: {
                             showConsent: false,
-                            defaultToggleState: false,
-                            termsAndConditionsLink: 'https://adyen.com',
-                            privacyPolicyLink: 'https://adyen.com',
-                            termsAndConditionsVersion: 'v1',
-                            fastlaneSessionId: 'ABC-123'
+                            fastlaneSessionId: 'ABC-123',
+                            defaultToggleState: undefined,
+                            termsAndConditionsLink: undefined,
+                            privacyPolicyLink: undefined,
+                            termsAndConditionsVersion: undefined
                         }
                     }
                 })
@@ -167,7 +167,6 @@ test.describe('Card - Fastlane Sign up', () => {
             expect(JSON.parse(atob(paymentMethod.fastlaneData))).toEqual({
                 consentShown: false,
                 consentGiven: false,
-                consentVersion: 'v1',
                 fastlaneSessionId: 'ABC-123'
             });
 

--- a/packages/lib/src/components/Card/components/Fastlane/FastlaneSignup.test.tsx
+++ b/packages/lib/src/components/Card/components/Fastlane/FastlaneSignup.test.tsx
@@ -13,14 +13,14 @@ const customRender = ui => {
     );
 };
 
-test('should trigger onChange even if the consent UI is not allowed to be shown', () => {
+test('should trigger onChange event if the consent UI is not allowed to be shown (showConsent: false)', () => {
     const fastlaneConfiguration: FastlaneSignupConfiguration = {
         showConsent: false,
-        defaultToggleState: false,
-        termsAndConditionsLink: 'https://adyen.com',
-        termsAndConditionsVersion: 'v1',
-        privacyPolicyLink: 'https://adyen.com',
-        fastlaneSessionId: 'xxx-bbb'
+        fastlaneSessionId: 'fastlane-session-id',
+        defaultToggleState: undefined,
+        termsAndConditionsLink: undefined,
+        termsAndConditionsVersion: undefined,
+        privacyPolicyLink: undefined
     };
 
     const onChangeMock = jest.fn();
@@ -32,8 +32,7 @@ test('should trigger onChange even if the consent UI is not allowed to be shown'
         fastlaneData: {
             consentGiven: false,
             consentShown: false,
-            consentVersion: 'v1',
-            fastlaneSessionId: 'xxx-bbb'
+            fastlaneSessionId: 'fastlane-session-id'
         }
     });
 });

--- a/packages/lib/src/components/Card/components/Fastlane/FastlaneSignup.tsx
+++ b/packages/lib/src/components/Card/components/Fastlane/FastlaneSignup.tsx
@@ -38,7 +38,6 @@ const FastlaneSignup = ({
     const { i18n } = useCoreContext();
 
     const isFastlaneConfigurationValid = useMemo(() => {
-        // TODO: Check with PayPal. If showConsent is false, do we get privacyLink, t&c link, version, etc?
         return isConfigurationValid({
             showConsent,
             defaultToggleState,
@@ -49,6 +48,9 @@ const FastlaneSignup = ({
         });
     }, [showConsent, defaultToggleState, termsAndConditionsLink, privacyPolicyLink, termsAndConditionsVersion, fastlaneSessionId]);
 
+    /**
+     * If the configuration is valid, the Component propagates fastlaneData to the Card component state
+     */
     useEffect(() => {
         if (!isFastlaneConfigurationValid) {
             return;
@@ -57,9 +59,9 @@ const FastlaneSignup = ({
         onChange({
             fastlaneData: {
                 consentShown,
-                consentGiven: displaySignup ? isChecked : false,
-                consentVersion: termsAndConditionsVersion,
                 fastlaneSessionId: fastlaneSessionId,
+                consentGiven: displaySignup ? isChecked : false,
+                ...(termsAndConditionsVersion && { consentVersion: termsAndConditionsVersion }),
                 ...(telephoneNumber && { telephoneNumber })
             }
         });
@@ -74,6 +76,9 @@ const FastlaneSignup = ({
         isFastlaneConfigurationValid
     ]);
 
+    /**
+     * If the sign-up has been displayed at least once, we set consentShown: true
+     */
     useEffect(() => {
         if (displaySignup) setConsentShown(true);
     }, [displaySignup]);

--- a/packages/lib/src/components/Card/components/Fastlane/FastlaneSignup.tsx
+++ b/packages/lib/src/components/Card/components/Fastlane/FastlaneSignup.tsx
@@ -50,6 +50,9 @@ const FastlaneSignup = ({
 
     /**
      * If the configuration is valid, the Component propagates fastlaneData to the Card component state
+     *
+     * 'telephoneNumber' is optional since the shopper can check out without passing it
+     * 'termsAndConditionsVersion' is optional since the signup flow may not be available for the shopper, although we still add fastlaneData to the /payments request for analytics purposes
      */
     useEffect(() => {
         if (!isFastlaneConfigurationValid) {

--- a/packages/lib/src/components/Card/components/Fastlane/utils/validate-configuration.ts
+++ b/packages/lib/src/components/Card/components/Fastlane/utils/validate-configuration.ts
@@ -15,7 +15,7 @@ const VALID_KEYS: ConfigurationKey[] = [
 /**
  * Verifies that Fastlane configuration for Card component is valid
  * - If the consent can be shown, then validate that all required fields are valid
- * - If the consent should not be shown, then validate that the fastlaneSessionId is valid
+ * - If the consent should not be shown, then validate the showConsent is valid boolean
  *
  * @param config
  */
@@ -25,7 +25,7 @@ const isConfigurationValid = (config: FastlaneSignupConfiguration): boolean => {
             !VALID_KEYS.includes(key) && console.warn(`Fastlane: '${key}' is not valid Fastlane config property`)
     );
 
-    const { showConsent, defaultToggleState, termsAndConditionsLink, privacyPolicyLink, termsAndConditionsVersion, fastlaneSessionId } = config;
+    const { showConsent, defaultToggleState, termsAndConditionsLink, privacyPolicyLink, termsAndConditionsVersion } = config;
 
     let isValid: boolean = false;
 
@@ -35,15 +35,15 @@ const isConfigurationValid = (config: FastlaneSignupConfiguration): boolean => {
             isValidHttpUrl(termsAndConditionsLink) &&
             typeof showConsent === 'boolean' &&
             typeof defaultToggleState === 'boolean' &&
-            !!termsAndConditionsVersion &&
-            !!fastlaneSessionId;
+            !!termsAndConditionsVersion;
     } else {
-        isValid = !!fastlaneSessionId && typeof showConsent === 'boolean';
+        isValid = typeof showConsent === 'boolean';
     }
 
     if (!isValid) {
         console.warn('Fastlane: Component configuration is not valid. Fastlane will not be displayed');
     }
+
     return isValid;
 };
 

--- a/packages/lib/src/components/Card/components/Fastlane/utils/validate-configuration.ts
+++ b/packages/lib/src/components/Card/components/Fastlane/utils/validate-configuration.ts
@@ -1,26 +1,49 @@
 import { isValidHttpUrl } from '../../../../../utils/isValidURL';
 import type { FastlaneSignupConfiguration } from '../../../../PayPalFastlane/types';
 
-const isConfigurationValid = ({
-    showConsent,
-    defaultToggleState,
-    termsAndConditionsLink,
-    privacyPolicyLink,
-    termsAndConditionsVersion,
-    fastlaneSessionId
-}: FastlaneSignupConfiguration) => {
-    const isValid =
-        isValidHttpUrl(privacyPolicyLink) &&
-        isValidHttpUrl(termsAndConditionsLink) &&
-        typeof showConsent === 'boolean' &&
-        typeof defaultToggleState === 'boolean' &&
-        !!termsAndConditionsVersion &&
-        !!fastlaneSessionId;
+type ConfigurationKey = keyof FastlaneSignupConfiguration;
+
+const VALID_KEYS: ConfigurationKey[] = [
+    'showConsent',
+    'defaultToggleState',
+    'termsAndConditionsLink',
+    'privacyPolicyLink',
+    'termsAndConditionsVersion',
+    'fastlaneSessionId'
+];
+
+/**
+ * Verifies that Fastlane configuration for Card component is valid
+ * - If the consent can be shown, then validate that all required fields are valid
+ * - If the consent should not be shown, then validate that the fastlaneSessionId is valid
+ *
+ * @param config
+ */
+const isConfigurationValid = (config: FastlaneSignupConfiguration): boolean => {
+    Object.keys(config).forEach(
+        (key: keyof FastlaneSignupConfiguration) =>
+            !VALID_KEYS.includes(key) && console.warn(`Fastlane: '${key}' is not valid Fastlane config property`)
+    );
+
+    const { showConsent, defaultToggleState, termsAndConditionsLink, privacyPolicyLink, termsAndConditionsVersion, fastlaneSessionId } = config;
+
+    let isValid: boolean = false;
+
+    if (showConsent) {
+        isValid =
+            isValidHttpUrl(privacyPolicyLink) &&
+            isValidHttpUrl(termsAndConditionsLink) &&
+            typeof showConsent === 'boolean' &&
+            typeof defaultToggleState === 'boolean' &&
+            !!termsAndConditionsVersion &&
+            !!fastlaneSessionId;
+    } else {
+        isValid = !!fastlaneSessionId && typeof showConsent === 'boolean';
+    }
 
     if (!isValid) {
         console.warn('Fastlane: Component configuration is not valid. Fastlane will not be displayed');
     }
-
     return isValid;
 };
 

--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -320,7 +320,6 @@ describe('Dropin', () => {
                 paymentMethodsConfiguration: {
                     fastlane: {
                         tokenId: 'xxx',
-                        customerId: 'sss',
                         lastFour: '1111',
                         brand: 'visa',
                         email: 'email@adyen.com',
@@ -386,7 +385,6 @@ describe('Dropin', () => {
                 paymentMethodsConfiguration: {
                     fastlane: {
                         tokenId: 'xxx',
-                        customerId: 'sss',
                         lastFour: '1111',
                         brand: 'visa',
                         email: 'email@adyen.com',

--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -321,6 +321,7 @@ describe('Dropin', () => {
                     fastlane: {
                         tokenId: 'xxx',
                         lastFour: '1111',
+                        customerId: 'customer-id',
                         brand: 'visa',
                         email: 'email@adyen.com',
                         fastlaneSessionId: 'session-id'
@@ -386,6 +387,7 @@ describe('Dropin', () => {
                     fastlane: {
                         tokenId: 'xxx',
                         lastFour: '1111',
+                        customerId: 'customer-id',
                         brand: 'visa',
                         email: 'email@adyen.com',
                         fastlaneSessionId: 'session-id'

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
@@ -22,14 +22,6 @@ describe('Fastlane', () => {
         // @ts-ignore Testing with incomplete config properties
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
-            customerId: 'zzz'
-        });
-        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
-
-        // @ts-ignore Testing with incomplete config properties
-        fastlane = new Fastlane(global.core, {
-            tokenId: 'xxx',
-            customerId: 'zzz',
             lastFour: '1111'
         });
         await expect(fastlane.isAvailable()).rejects.toBeUndefined();
@@ -37,7 +29,6 @@ describe('Fastlane', () => {
         // @ts-ignore Testing with incomplete config properties
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
-            customerId: 'zzz',
             lastFour: '1111',
             brand: 'visa'
         });
@@ -46,7 +37,6 @@ describe('Fastlane', () => {
         // @ts-ignore Testing with incomplete config properties
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
-            customerId: 'zzz',
             lastFour: '1111',
             brand: 'visa',
             email: 'shopper@adyen.com'
@@ -55,7 +45,6 @@ describe('Fastlane', () => {
 
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
-            customerId: 'zzz',
             lastFour: '1111',
             brand: 'visa',
             email: 'shopper@adyen.com',
@@ -72,7 +61,6 @@ describe('Fastlane', () => {
     test('should return encoded blob to process the payment', () => {
         const fastlane = new Fastlane(global.core, {
             tokenId: 'token-id',
-            customerId: 'customer-id',
             lastFour: '1111',
             brand: 'visa',
             email: 'shopper@adyen.com',
@@ -81,9 +69,8 @@ describe('Fastlane', () => {
 
         const encodedBlob = btoa(
             JSON.stringify({
-                sessionId: 'session-id',
-                tokenId: 'token-id',
-                customerId: 'customer-id'
+                fastlaneSessionId: 'session-id',
+                tokenId: 'token-id'
             })
         );
 
@@ -101,7 +88,6 @@ describe('Fastlane', () => {
             modules: { resources },
             i18n: global.i18n,
             tokenId: 'token-id',
-            customerId: 'customer-id',
             lastFour: '1111',
             brand: 'visa',
             email: 'shopper@adyen.com',

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
@@ -22,7 +22,8 @@ describe('Fastlane', () => {
         // @ts-ignore Testing with incomplete config properties
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
-            lastFour: '1111'
+            lastFour: '1111',
+            customerId: 'customer-id'
         });
         await expect(fastlane.isAvailable()).rejects.toBeUndefined();
 
@@ -30,6 +31,7 @@ describe('Fastlane', () => {
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
             lastFour: '1111',
+            customerId: 'customer-id',
             brand: 'visa'
         });
         await expect(fastlane.isAvailable()).rejects.toBeUndefined();
@@ -38,6 +40,7 @@ describe('Fastlane', () => {
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
             lastFour: '1111',
+            customerId: 'customer-id',
             brand: 'visa',
             email: 'shopper@adyen.com'
         });
@@ -46,6 +49,7 @@ describe('Fastlane', () => {
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
             lastFour: '1111',
+            customerId: 'customer-id',
             brand: 'visa',
             email: 'shopper@adyen.com',
             fastlaneSessionId: '1111'
@@ -63,6 +67,7 @@ describe('Fastlane', () => {
             tokenId: 'token-id',
             lastFour: '1111',
             brand: 'visa',
+            customerId: 'customer-id',
             email: 'shopper@adyen.com',
             fastlaneSessionId: 'session-id'
         });
@@ -70,7 +75,8 @@ describe('Fastlane', () => {
         const encodedBlob = btoa(
             JSON.stringify({
                 fastlaneSessionId: 'session-id',
-                tokenId: 'token-id'
+                tokenId: 'token-id',
+                customerId: 'customer-id'
             })
         );
 
@@ -89,6 +95,7 @@ describe('Fastlane', () => {
             i18n: global.i18n,
             tokenId: 'token-id',
             lastFour: '1111',
+            customerId: 'customer-id',
             brand: 'visa',
             email: 'shopper@adyen.com',
             fastlaneSessionId: 'session-id'

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.test.ts
@@ -36,6 +36,7 @@ describe('Fastlane', () => {
         });
         await expect(fastlane.isAvailable()).rejects.toBeUndefined();
 
+        // fastlaneSessionId is mandatory, although it can be that SDK fails to return it. It must not block the payment in this case
         // @ts-ignore Testing with incomplete config properties
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',
@@ -44,7 +45,7 @@ describe('Fastlane', () => {
             brand: 'visa',
             email: 'shopper@adyen.com'
         });
-        await expect(fastlane.isAvailable()).rejects.toBeUndefined();
+        await expect(fastlane.isAvailable()).resolves.toBeUndefined();
 
         fastlane = new Fastlane(global.core, {
             tokenId: 'xxx',

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -19,7 +19,8 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
                 fastlaneData: btoa(
                     JSON.stringify({
                         fastlaneSessionId: this.props.fastlaneSessionId,
-                        tokenId: this.props.tokenId
+                        tokenId: this.props.tokenId,
+                        customerId: this.props.customerId
                     })
                 )
             }
@@ -27,8 +28,8 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
     }
 
     public override async isAvailable(): Promise<void> {
-        const { tokenId, lastFour, brand, email, fastlaneSessionId } = this.props;
-        if (tokenId && lastFour && brand && email && fastlaneSessionId) {
+        const { tokenId, customerId, lastFour, brand, email, fastlaneSessionId } = this.props;
+        if (tokenId && customerId && lastFour && brand && email && fastlaneSessionId) {
             return Promise.resolve();
         }
         return Promise.reject();

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -45,7 +45,10 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
         return this.props.icon ?? this.resources.getImage()('card');
     }
 
-    public get(): { icon: string; name: string }[] {
+    /**
+     * Used to display the payment method supported brands within Drop-in
+     */
+    public get brands(): { icon: string; name: string }[] {
         const { brands } = this.props;
         return brands.map(brand => ({ icon: this.props.modules.resources.getImage()(brand), name: brand }));
     }

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -28,8 +28,8 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
     }
 
     public override async isAvailable(): Promise<void> {
-        const { tokenId, customerId, lastFour, brand, email, fastlaneSessionId } = this.props;
-        if (tokenId && customerId && lastFour && brand && email && fastlaneSessionId) {
+        const { tokenId, customerId, lastFour, brand, email } = this.props;
+        if (tokenId && customerId && lastFour && brand && email) {
             return Promise.resolve();
         }
         return Promise.reject();

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -18,9 +18,8 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
                 type: Fastlane.type,
                 fastlaneData: btoa(
                     JSON.stringify({
-                        sessionId: this.props.fastlaneSessionId,
-                        tokenId: this.props.tokenId,
-                        customerId: this.props.customerId
+                        fastlaneSessionId: this.props.fastlaneSessionId,
+                        tokenId: this.props.tokenId
                     })
                 )
             }
@@ -28,8 +27,8 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
     }
 
     public override async isAvailable(): Promise<void> {
-        const { tokenId, customerId, lastFour, brand, email, fastlaneSessionId } = this.props;
-        if (tokenId && customerId && lastFour && brand && email && fastlaneSessionId) {
+        const { tokenId, lastFour, brand, email, fastlaneSessionId } = this.props;
+        if (tokenId && lastFour && brand && email && fastlaneSessionId) {
             return Promise.resolve();
         }
         return Promise.reject();
@@ -39,11 +38,14 @@ class Fastlane extends UIElement<FastlaneConfiguration> {
         return true;
     }
 
+    /**
+     * Used to display payment method logo within Drop-in
+     */
     public override get icon(): string {
         return this.props.icon ?? this.resources.getImage()('card');
     }
 
-    public get brands(): { icon: string; name: string }[] {
+    public get(): { icon: string; name: string }[] {
         const { brands } = this.props;
         return brands.map(brand => ({ icon: this.props.modules.resources.getImage()(brand), name: brand }));
     }

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
@@ -187,7 +187,6 @@ describe('FastlaneSDK', () => {
             paymentType: 'fastlane',
             configuration: {
                 brand: 'visa',
-                customerId: 'customer-context-id',
                 email: 'test@adyen.com',
                 lastFour: '1111',
                 fastlaneSessionId: 'fastlane-session-id',

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
@@ -204,6 +204,7 @@ describe('FastlaneSDK', () => {
             paymentType: 'fastlane',
             configuration: {
                 brand: 'visa',
+                customerId: customerContextId,
                 email: 'test@adyen.com',
                 lastFour: '1111',
                 fastlaneSessionId: 'fastlane-session-id',

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
@@ -5,7 +5,7 @@ import Script from '../../utils/Script';
 import type { FastlaneWindowInstance, FastlaneProfile, FastlaneShipping } from './types';
 
 const fastlaneMock = mockDeep<FastlaneWindowInstance>();
-const fastlaneConstructorMock = jest.fn().mockResolvedValue(fastlaneMock);
+let fastlaneConstructorMock = null;
 
 const mockScriptLoaded = jest.fn().mockImplementation(() => {
     window.paypal = {};
@@ -32,8 +32,25 @@ describe('FastlaneSDK', () => {
     beforeEach(() => {
         mockReset(fastlaneMock);
 
+        fastlaneConstructorMock = jest.fn().mockResolvedValue(fastlaneMock);
         fastlaneMock.identity.getSession.mockResolvedValue({
             sessionId: 'fastlane-session-id'
+        });
+    });
+
+    test('should force consent details to be returned if "forceConsentDetails" is used', async () => {
+        await initializeFastlane({
+            clientKey: 'test_xxx',
+            environment: 'test',
+            forceConsentDetails: true
+        });
+
+        expect(fastlaneConstructorMock).toHaveBeenCalledTimes(1);
+        expect(fastlaneConstructorMock).toHaveBeenCalledWith({
+            intendedExperience: 'externalProcessorCustomConsent',
+            metadata: {
+                geoLocOverride: 'US'
+            }
         });
     });
 

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.test.ts
@@ -3,6 +3,7 @@ import initializeFastlane from './initializeFastlane';
 import { httpPost } from '../../core/Services/http';
 import Script from '../../utils/Script';
 import type { FastlaneWindowInstance, FastlaneProfile, FastlaneShipping } from './types';
+import FastlaneSDK from './FastlaneSDK';
 
 const fastlaneMock = mockDeep<FastlaneWindowInstance>();
 let fastlaneConstructorMock = null;
@@ -213,6 +214,32 @@ describe('FastlaneSDK', () => {
         });
     });
 
+    test('should throw an error if fastlane profile does not have a card assigned to it', async () => {
+        const customerContextId = 'customer-context-id';
+        fastlaneMock.identity.lookupCustomerByEmail.mockResolvedValue({
+            customerContextId
+        });
+        fastlaneMock.identity.triggerAuthenticationFlow.mockResolvedValue({
+            authenticationState: 'succeeded',
+            profileData: mock<FastlaneProfile>({
+                card: undefined
+            })
+        });
+        fastlaneMock.identity.getSession.mockResolvedValue({
+            sessionId: 'fastlane-session-id'
+        });
+
+        const fastlane = await initializeFastlane({
+            clientKey: 'test_xxx',
+            environment: 'test'
+        });
+        const authResult = await fastlane.authenticate('test@adyen.com');
+
+        await expect(fastlane.getComponentConfiguration(authResult)).rejects.toThrow(
+            'getComponentConfiguration(): There is no card associated with the authenticated profile'
+        );
+    });
+
     test('should return card component configuration if shopper does not have profile', async () => {
         const customerContextId = 'customer-context-id';
         fastlaneMock.identity.lookupCustomerByEmail.mockResolvedValue({
@@ -305,6 +332,32 @@ describe('FastlaneSDK', () => {
         });
     });
 
+    test('should throw an error if it fails to get the consent details for the unrecognized shopper', async () => {
+        const customerContextId = 'customer-context-id';
+        fastlaneMock.identity.lookupCustomerByEmail.mockResolvedValue({
+            customerContextId
+        });
+        fastlaneMock.identity.triggerAuthenticationFlow.mockResolvedValue({
+            authenticationState: 'not_found',
+            profileData: undefined
+        });
+        fastlaneMock.identity.getSession.mockResolvedValue({
+            sessionId: 'fastlane-session-id'
+        });
+        fastlaneMock.ConsentComponent.mockResolvedValue({
+            getRenderState: jest.fn().mockRejectedValue({})
+        });
+
+        const fastlane = await initializeFastlane({
+            clientKey: 'test_xxx',
+            environment: 'test'
+        });
+
+        const authResult = await fastlane.authenticate('test@adyen.com');
+
+        await expect(fastlane.getComponentConfiguration(authResult)).rejects.toThrow('fetchConsentDetails(): failed to fetch consent details');
+    });
+
     test('should thrown an error if there is no auth result to create the component configuration', async () => {
         const fastlane = await initializeFastlane({
             clientKey: 'test_xxx',
@@ -313,5 +366,48 @@ describe('FastlaneSDK', () => {
 
         // @ts-ignore It is expected to omit the parameter here
         await expect(fastlane.getComponentConfiguration()).rejects.toThrowError();
+    });
+
+    test('should throw error if environment and clientKey are not passed when initializing it', async () => {
+        // @ts-ignore Testing not passing the parameters
+        await expect(initializeFastlane()).rejects.toThrowError("FastlaneSDK: 'environment' property is required");
+
+        // @ts-ignore Testing not passing the parameters
+        await expect(initializeFastlane({ environment: 'test' })).rejects.toThrowError("FastlaneSDK: 'clientKey' property is required");
+    });
+
+    test('should warn if "forceConsentDetails" is set in a "live" environment', async () => {
+        const mock = jest.spyOn(console, 'warn').mockImplementation();
+        await initializeFastlane({
+            clientKey: 'test_xxx',
+            environment: 'live',
+            forceConsentDetails: true
+        });
+
+        expect(mock).toHaveBeenLastCalledWith("Fastlane SDK: 'forceConsentDetails' should not be used on 'live' environment");
+    });
+
+    test('should warn if fetching the Fastlane session ID fails', async () => {
+        const mock = jest.spyOn(console, 'warn').mockImplementation();
+        fastlaneMock.identity.getSession.mockRejectedValue({});
+
+        await initializeFastlane({
+            clientKey: 'test_xxx',
+            environment: 'test'
+        });
+
+        expect(mock).toHaveBeenLastCalledWith('Fastlane SDK: Failed to fetch session ID', {});
+    });
+
+    test('should throw error if Fastlane does not get created', async () => {
+        fastlaneConstructorMock = jest.fn().mockRejectedValue({});
+        await expect(initializeFastlane({ clientKey: 'test_xxx', environment: 'test' })).rejects.toThrowError(
+            'Fastlane SDK: Failed to initialize fastlane using the window.paypal.Fastlane constructor'
+        );
+    });
+
+    test('should throw error if authentication is triggered without Fastlane being available', async () => {
+        const fastlaneSdk = new FastlaneSDK({ environment: 'test', clientKey: 'test' });
+        await expect(fastlaneSdk.authenticate('test@adyen.com')).rejects.toThrowError('authenticate(): Fastlane SDK is not initialized');
     });
 });

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
@@ -20,7 +20,7 @@ class FastlaneSDK {
     private readonly forceConsentDetails: boolean;
 
     private fastlaneSdk: FastlaneWindowInstance;
-    private authenticatedShopper: { email: string; customerContextId: string };
+    private authenticatedShopper: { email: string; customerId: string };
     private fastlaneSessionId?: string;
 
     constructor(configuration: FastlaneSDKConfiguration) {
@@ -62,7 +62,7 @@ class FastlaneSDK {
         const { customerContextId } = await this.fastlaneSdk.identity.lookupCustomerByEmail(email);
 
         if (customerContextId) {
-            this.authenticatedShopper = { email, customerContextId };
+            this.authenticatedShopper = { email, customerId: customerContextId };
             return this.fastlaneSdk.identity.triggerAuthenticationFlow(customerContextId);
         } else {
             return {
@@ -93,6 +93,7 @@ class FastlaneSDK {
                 paymentType: 'fastlane',
                 configuration: {
                     fastlaneSessionId: this.fastlaneSessionId,
+                    customerId: this.authenticatedShopper.customerId,
                     email: this.authenticatedShopper.email,
                     tokenId: authResult.profileData.card.id,
                     lastFour: authResult.profileData.card.paymentSource.card.lastDigits,

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
@@ -19,9 +19,8 @@ class FastlaneSDK {
     private readonly locale: string;
 
     private fastlaneSdk: FastlaneWindowInstance;
-    private authenticatedShopper: { email: string; customerId: string };
-    private fastlaneSessionId: string | undefined;
-    private consentComponentDetails: FastlaneConsentRenderState | undefined;
+    private authenticatedShopper: { email: string; customerContextId: string };
+    private fastlaneSessionId?: string;
 
     constructor(configuration: FastlaneSDKConfiguration) {
         if (!configuration.environment) throw new AdyenCheckoutError('IMPLEMENTATION_ERROR', "FastlaneSDK: 'environment' property is required");
@@ -58,7 +57,7 @@ class FastlaneSDK {
         const { customerContextId } = await this.fastlaneSdk.identity.lookupCustomerByEmail(email);
 
         if (customerContextId) {
-            this.authenticatedShopper = { email, customerId: customerContextId };
+            this.authenticatedShopper = { email, customerContextId };
             return this.fastlaneSdk.identity.triggerAuthenticationFlow(customerContextId);
         } else {
             return {
@@ -89,7 +88,6 @@ class FastlaneSDK {
                 paymentType: 'fastlane',
                 configuration: {
                     fastlaneSessionId: this.fastlaneSessionId,
-                    customerId: this.authenticatedShopper.customerId,
                     email: this.authenticatedShopper.email,
                     tokenId: authResult.profileData.card.id,
                     lastFour: authResult.profileData.card.paymentSource.card.lastDigits,

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -29,10 +29,10 @@ export interface FastlaneWindowInstance {
 
 export interface FastlaneConsentRenderState {
     showConsent: boolean;
-    defaultToggleState: boolean | undefined;
-    termsAndConditionsLink: string | undefined;
-    termsAndConditionsVersion: string | undefined;
-    privacyPolicyLink: string | undefined;
+    defaultToggleState?: boolean;
+    termsAndConditionsLink?: string;
+    termsAndConditionsVersion?: string;
+    privacyPolicyLink?: string;
 }
 
 export interface FastlaneOptions {
@@ -108,7 +108,6 @@ type FastlaneComponentConfiguration = {
     paymentType: 'fastlane';
     configuration: {
         fastlaneSessionId: string;
-        customerId: string;
         email: string;
         tokenId: string;
         lastFour: string;
@@ -136,27 +135,34 @@ export interface FastlaneSDKConfiguration {
 }
 
 export interface FastlaneConfiguration extends UIElementProps {
+    /**
+     * Card token ID, used to process the payment
+     */
     tokenId: string;
-    customerId: string;
-    lastFour: string;
-    brand: string;
-    email: string;
+    /**
+     * Fastlane session ID, used to process the payment
+     */
     fastlaneSessionId: string;
     /**
-     * Display the brand images inside the Drop-in payment method header
+     * Initial last four digits displayed once the Component is rendered
+     */
+    lastFour: string;
+    /**
+     * Initial brand displayed once the Component is rendered
+     */
+    brand: string;
+    /**
+     * Shopper's email (it will be used in the future to re-authenticate using Fastlane SDK within the Component)
+     */
+    email: string;
+    /**
+     * Used internally by Drop-in. Displays the brand images inside the Drop-in payment method header
      * @internal
      */
     keepBrandsVisible?: boolean;
     /**
-     * List of brands accepted by the component
+     * Property returned by the backend. Contains the list of brands supported by Fastlane component
      * @internal
      */
     brands?: string[];
-    /**
-     * Configuration returned by the backend
-     * @internal
-     */
-    configuration?: {
-        brands: string[];
-    };
 }

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -37,6 +37,9 @@ export interface FastlaneConsentRenderState {
 
 export interface FastlaneOptions {
     intendedExperience: 'externalProcessorCustomConsent';
+    metadata?: {
+        geoLocOverride?: string;
+    };
 }
 
 // TODO: TBD if this is needed
@@ -132,6 +135,13 @@ export interface FastlaneSDKConfiguration {
     clientKey: string;
     environment: CoreConfiguration['environment'];
     locale?: 'en-US' | 'es-US' | 'fr-RS' | 'zh-US';
+    /**
+     * Used to force the Fastlane SDK to return the consent details in case the shopper is not recognized.
+     * Use-case: Developer is testing the flow in another country outside US, which would not get consent details.
+     *
+     * This configuration should not be used for 'live' environment
+     */
+    forceConsentDetails?: boolean;
 }
 
 export interface FastlaneConfiguration extends UIElementProps {

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -111,6 +111,7 @@ type FastlaneComponentConfiguration = {
     paymentType: 'fastlane';
     configuration: {
         fastlaneSessionId: string;
+        customerId: string;
         email: string;
         tokenId: string;
         lastFour: string;
@@ -153,6 +154,10 @@ export interface FastlaneConfiguration extends UIElementProps {
      * Fastlane session ID, used to process the payment
      */
     fastlaneSessionId: string;
+    /**
+     * Customer ID used to process the payment
+     */
+    customerId: string;
     /**
      * Initial last four digits displayed once the Component is rendered
      */

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -61,10 +61,17 @@ export interface FastlaneShippingAddressSelectorResult {
     selectedAddress: FastlaneShipping;
 }
 
-export interface FastlaneAuthenticatedCustomerResult {
-    authenticationState: 'succeeded' | 'failed' | 'canceled' | 'not_found';
+interface FastlaneAuthenticatedCustomerSucceeded {
+    authenticationState: 'succeeded';
     profileData: FastlaneProfile;
 }
+
+interface FastlaneAuthenticatedCustomerFailed {
+    authenticationState: 'failed' | 'canceled' | 'not_found';
+    profileData?: undefined;
+}
+
+export type FastlaneAuthenticatedCustomerResult = FastlaneAuthenticatedCustomerSucceeded | FastlaneAuthenticatedCustomerFailed;
 
 export interface FastlaneAddress {
     addressLine1: string;
@@ -99,7 +106,7 @@ export interface FastlaneProfile {
         fullName: string;
     };
     shippingAddress: FastlaneShipping;
-    card: {
+    card?: {
         id: string;
         paymentSource: {
             card: CardPaymentSource;
@@ -151,7 +158,7 @@ export interface FastlaneConfiguration extends UIElementProps {
      */
     tokenId: string;
     /**
-     * Fastlane session ID, used to process the payment
+     * Fastlane session ID
      */
     fastlaneSessionId: string;
     /**

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -13,18 +13,31 @@ export interface FastlaneWindowInstance {
     identity: {
         lookupCustomerByEmail: (email: string) => Promise<{ customerContextId: string }>;
         triggerAuthenticationFlow: (customerContextId: string, options?: AuthenticationFlowOptions) => Promise<FastlaneAuthenticatedCustomerResult>;
+        getSession: () => Promise<{ sessionId: string }>;
     };
     profile: {
         showShippingAddressSelector: () => Promise<FastlaneShippingAddressSelectorResult>;
     };
     setLocale: (locale: string) => void;
+    ConsentComponent: () => Promise<{
+        getRenderState: () => Promise<FastlaneConsentRenderState>;
+    }>;
     FastlaneWatermarkComponent: (options: { includeAdditionalInfo: boolean }) => Promise<{
         render: (container) => null;
     }>;
 }
 
-// TODO: TBD if this is needed
-export interface FastlaneOptions {}
+export interface FastlaneConsentRenderState {
+    showConsent: boolean;
+    defaultToggleState: boolean | undefined;
+    termsAndConditionsLink: string | undefined;
+    termsAndConditionsVersion: string | undefined;
+    privacyPolicyLink: string | undefined;
+}
+
+export interface FastlaneOptions {
+    intendedExperience: 'externalProcessorCustomConsent';
+}
 
 // TODO: TBD if this is needed
 interface AuthenticationFlowOptions {}
@@ -110,12 +123,7 @@ type FastlaneCardComponentConfiguration = {
     };
 };
 
-export type FastlaneSignupConfiguration = {
-    showConsent: boolean;
-    defaultToggleState: boolean;
-    termsAndConditionsLink: string;
-    privacyPolicyLink: string;
-    termsAndConditionsVersion: string;
+export type FastlaneSignupConfiguration = FastlaneConsentRenderState & {
     fastlaneSessionId: string;
 };
 

--- a/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
@@ -125,6 +125,7 @@ export const MockedRecognizedFlowDropin: FastlaneStory = {
                                     fastlane: {
                                         tokenId: 'xxx',
                                         lastFour: '1111',
+                                        customerId: 'customer-id',
                                         brand: 'visa',
                                         email: 'email@adyen.com',
                                         fastlaneSessionId: 'xxx'
@@ -167,6 +168,7 @@ export const MockedRecognizedFlowStandalone: FastlaneStory = {
                                         resultCode: 'Authorised'
                                     });
                                 },
+                                customerId: 'customer-id',
                                 tokenId: 'xxx',
                                 lastFour: '1111',
                                 brand: 'visa',

--- a/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/Fastlane.stories.tsx
@@ -124,7 +124,6 @@ export const MockedRecognizedFlowDropin: FastlaneStory = {
                                 paymentMethodsConfiguration: {
                                     fastlane: {
                                         tokenId: 'xxx',
-                                        customerId: 'sss',
                                         lastFour: '1111',
                                         brand: 'visa',
                                         email: 'email@adyen.com',
@@ -169,7 +168,6 @@ export const MockedRecognizedFlowStandalone: FastlaneStory = {
                                     });
                                 },
                                 tokenId: 'xxx',
-                                customerId: 'sss',
                                 lastFour: '1111',
                                 brand: 'visa',
                                 email: 'email@adyen.com',

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/CollectEmail.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/CollectEmail.tsx
@@ -31,7 +31,10 @@ export const CollectEmail = ({ fastlaneSdk, onFastlaneLookup, onEditEmail }: Col
         try {
             const authResult = await fastlaneSdk.authenticate(email);
             onFastlaneLookup(authResult);
-            setViewOnly(true);
+
+            if (authResult.authenticationState === 'succeeded') {
+                setViewOnly(true);
+            }
         } catch (error) {
             console.log(error);
         }

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -21,7 +21,8 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
     const loadFastlane = async () => {
         const sdk = await initializeFastlane({
             clientKey: 'test_JC3ZFTA6WFCCRN454MVDEYOWEI5D3LT2', // Joost clientkey
-            environment: 'test'
+            environment: 'test',
+            forceConsentDetails: true
         });
         setFastlane(sdk);
     };

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -38,8 +38,13 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
 
     const handleOnCheckoutClick = async (shippingAddress?: any) => {
         console.log('Shipping address', shippingAddress);
-        const componentConfig = await fastlane.getComponentConfiguration(fastlaneAuthResult);
-        onCheckoutStep(componentConfig);
+        try {
+            const componentConfig = await fastlane.getComponentConfiguration(fastlaneAuthResult);
+            onCheckoutStep(componentConfig);
+        } catch (error) {
+            console.warn(error);
+            onCheckoutStep({});
+        }
     };
 
     useEffect(() => {

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -20,7 +20,8 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
 
     const loadFastlane = async () => {
         const sdk = await initializeFastlane({
-            clientKey: 'test_JC3ZFTA6WFCCRN454MVDEYOWEI5D3LT2', // Joost clientkey
+            // clientKey: 'test_JC3ZFTA6WFCCRN454MVDEYOWEI5D3LT2', // Joost clientkey
+            clientKey: process.env.CLIENT_KEY,
             environment: 'test',
             forceConsentDetails: true
         });

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -20,7 +20,7 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
 
     const loadFastlane = async () => {
         const sdk = await initializeFastlane({
-            clientKey: 'test_JC3ZFTA6WFCCRN454MVDEYOWEI5D3LT2', // Joost clientkey
+            clientKey: 'test_L6HTEOAXQBCZJHKNU4NLN6EI7IE6VRRW', // Joost clientkey
             environment: 'test'
         });
         setFastlane(sdk);
@@ -41,9 +41,7 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
     };
 
     useEffect(() => {
-        void loadFastlane().catch(() => {
-            alert('Failed to initialize: Fetch the token using Postman');
-        });
+        void loadFastlane();
     }, []);
 
     if (!fastlane) {

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -20,7 +20,7 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
 
     const loadFastlane = async () => {
         const sdk = await initializeFastlane({
-            clientKey: 'test_L6HTEOAXQBCZJHKNU4NLN6EI7IE6VRRW', // Joost clientkey
+            clientKey: 'test_JC3ZFTA6WFCCRN454MVDEYOWEI5D3LT2', // Joost clientkey
             environment: 'test'
         });
         setFastlane(sdk);

--- a/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
+++ b/packages/lib/storybook/stories/wallets/Fastlane/components/GuestShopperForm.tsx
@@ -34,9 +34,9 @@ export const GuestShopperForm = ({ onCheckoutStep }: GuestShopperFormProps) => {
         setFastlaneAuthResult(data);
     };
 
-    const handleOnCheckoutClick = (shippingAddress?: any) => {
+    const handleOnCheckoutClick = async (shippingAddress?: any) => {
         console.log('Shipping address', shippingAddress);
-        const componentConfig = fastlane.getComponentConfiguration(fastlaneAuthResult);
+        const componentConfig = await fastlane.getComponentConfiguration(fastlaneAuthResult);
         onCheckoutStep(componentConfig);
     };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added the functionality to retrieve the consent UI details using Fastlane SDK (The consent UI details is used to display the sign-up component within Card)
- Added the functionality to retrieve the Fastlane session ID once the SDK is initialized (The session ID is used to PayPal internal analytics)
- Added the functionality to force the consent details to be returned (They are not returned if PayPal detects that you are not in US): `forceConsentDetails` property
- Added code comments for the majority of interfaces/configurations
- Added/fixed tests