### PR TITLE
chore: increase timeout for e2e job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-then-e2e:
     if: ${{ github.actor != 'renovate[bot]' && github.actor != 'lgtm-com[bot]' }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Increases the timeout for the e2e pipeline from 60 to 120 mins. I could have increase more but I think we should discuss again if we need to increase this number further.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
