### PR TITLE
test(stored-card-ach.spec): skip on api v69

### DIFF
--- a/packages/e2e-playwright/tests/e2e/dropin/storedCard/stored-card-ach.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/dropin/storedCard/stored-card-ach.spec.ts
@@ -1,13 +1,17 @@
+import dotenv from 'dotenv';
 import { mergeTests, expect } from '@playwright/test';
 import { test as dropin } from '../../../../fixtures/dropin.fixture';
 import { test as ach } from '../../../../fixtures/ach.fixture';
 import { URL_MAP } from '../../../../fixtures/URL_MAP';
 import { PAYMENT_RESULT } from '../../../utils/constants';
-
+dotenv.config();
+const apiVersion = Number(process.env.API_VERSION.substring(1));
 const test = mergeTests(dropin, ach);
 
 test.describe('Stored ach card', () => {
     test('should make a successful payment', async ({ dropinWithSession, ach }) => {
+        test.skip(apiVersion === 69, 'Skipping test for api version 69');
+
         const lastFourDigits = '3123';
         await dropinWithSession.goto(URL_MAP.dropinWithSession);
         await dropinWithSession.selectFirstStoredPaymentMethod('ach', lastFourDigits);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Skip the `e2e/dropin/storedCard/stored-card-ach.spec.ts` test for api version 69.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
