### PR TITLE
Use built-in mechanism to disable OpenInvoice when Pay pressed

### DIFF
--- a/.changeset/many-clouds-try.md
+++ b/.changeset/many-clouds-try.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Use built-in mechanism to disable OpenInvoice (and ACH) components when Pay pressed

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.scss
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.scss
@@ -1,3 +1,4 @@
+@use 'styles/index';
 @import 'styles/variable-generator';
 
 .adyen-checkout__loading-input__form {
@@ -29,6 +30,12 @@
 .sf-input {
     &__wrapper {
         position: relative;
+    }
+}
+
+.adyen-checkout__ach{
+    &--loading{
+        @include index.adyen-checkout-component-loading;
     }
 }
 

--- a/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
+++ b/packages/lib/src/components/Ach/components/AchInput/AchInput.tsx
@@ -129,7 +129,12 @@ function AchInput(props: ACHInputProps) {
     }, [data, valid, errors, storePaymentMethod]);
 
     return (
-        <div className="adyen-checkout__ach">
+        <div
+            className={classNames({
+                'adyen-checkout__ach': true,
+                'adyen-checkout__ach--loading': status === 'loading'
+            })}
+        >
             <FormInstruction />
 
             <SecuredFieldsProvider

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.scss
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.scss
@@ -27,3 +27,10 @@
 .adyen-checkout__open-invoice .adyen-checkout__field--consentCheckbox {
     margin-top: token(spacer-070);
 }
+
+.adyen-checkout__open-invoice{
+    &--loading{
+        @include index.adyen-checkout__component--loading;
+    }
+}
+

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.scss
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.scss
@@ -30,7 +30,7 @@
 
 .adyen-checkout__open-invoice{
     &--loading{
-        @include index.adyen-checkout__component--loading;
+        @include index.adyen-checkout-component-loading;
     }
 }
 

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -22,6 +22,7 @@ import Field from '../FormFields/Field';
 import FormInstruction from '../FormInstruction';
 import { ComponentMethodsRef } from '../UIElement/types';
 import useSRPanelForOpenInvoiceErrors from './useSRPanelForOpenInvoiceErrors';
+import classNames from 'classnames';
 
 const consentCBErrorObj: GenericError = {
     isValid: false,
@@ -111,7 +112,12 @@ export default function OpenInvoice(props: OpenInvoiceProps) {
         setErrors(prevErrors => ({ ...prevErrors, ...{ consentCheckbox: !checked ? consentCBErrorObj : null } }));
     };
     return (
-        <div className="adyen-checkout__open-invoice">
+        <div
+            className={classNames({
+                'adyen-checkout__open-invoice': true,
+                'adyen-checkout__open-invoice--loading': status === 'loading'
+            })}
+        >
             <FormInstruction />
 
             {activeFieldsets.companyDetails && (

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -111,11 +111,17 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         return this;
     }
 
+    /**
+     * elementRef is a ref to the subclass that extends UIElement e.g. Card.tsx
+     */
     public setElementStatus(status: UIElementStatus, props?: any): this {
         this.elementRef?.setStatus(status, props);
         return this;
     }
 
+    /**
+     * componentRef is a ref to the primary component inside that subclass e.g. CardInput.tsx
+     */
     public setStatus(status: UIElementStatus, props?): this {
         if (this.componentRef?.setStatus) {
             this.componentRef.setStatus(status, props);

--- a/packages/lib/src/styles/mixins.scss
+++ b/packages/lib/src/styles/mixins.scss
@@ -140,3 +140,7 @@ $adyen-checkout-media-query-l-min: 1024px;
     padding: 0;
     position: absolute;
 }
+
+@mixin adyen-checkout__component--loading {
+    pointer-events: none;
+}

--- a/packages/lib/src/styles/mixins.scss
+++ b/packages/lib/src/styles/mixins.scss
@@ -141,6 +141,6 @@ $adyen-checkout-media-query-l-min: 1024px;
     position: absolute;
 }
 
-@mixin adyen-checkout__component--loading {
+@mixin adyen-checkout-component-loading {
     pointer-events: none;
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Apply the built-in mechanism initiated via the `UIElement.setElementStatus` method to disable an `OpenInvoice` when the "Pay' button is pressed.

***Open questions:***
- Do we agree this mechanism is the best way to do this?
- If we do, then should the component specific `.scss` file (`OpenInvoice.scss`), which always needs to set a new class anyway, use a mixin the way we have done here:
```
.adyen-checkout__open-invoice{
    &--loading{
        @include index.adyen-checkout__component--loading;
    }
}
```
_or_
each time just set it's own component specific class, and not use a mixin at all:
```
.adyen-checkout__open-invoice.adyen-checkout__open-invoice--loading {
    pointer-events: none;
}
```

## Tested scenarios
An `OpenInvoice` component is now disbaled when "pay" is pressed


