### PR TITLE
Add missing type (onAutoComplete) in CustomCardConfiguration

### DIFF
--- a/.changeset/small-otters-rule.md
+++ b/.changeset/small-otters-rule.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Added missing type (onAutoComplete) in CustomCardConfiguration

--- a/packages/lib/src/components/CustomCard/types.ts
+++ b/packages/lib/src/components/CustomCard/types.ts
@@ -3,6 +3,7 @@ import { Placeholders, SFError } from '../Card/components/CardInput/types';
 import UIElement from '../internal/UIElement';
 import {
     CardAllValidData,
+    CardAutoCompleteData,
     CardBinLookupData,
     CardBinValueData,
     CardBrandData,
@@ -96,6 +97,11 @@ export type CustomCardConfiguration = {
      * - merchant set config option
      */
     minimumExpiryDate?: string;
+
+    /**
+     * Called when the holderName field is autofilled
+     */
+    onAutoComplete?: (event: CardAutoCompleteData) => void;
 
     /**
      * After binLookup call - provides the brand(s) we detect the user is entering, and if we support the brand(s)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added missing type (`onAutoComplete`) in `CustomCardConfiguration`


**Fixed issue**:  #3137 
