### PR TITLE
GooglePay - Handling challengeWindowSize when using GooglePay as Drop-in Instant payment method

### DIFF
--- a/.changeset/afraid-roses-cheer.md
+++ b/.changeset/afraid-roses-cheer.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+GooglePay - Fixed challengeWindowSize property when using Google Pay as Instant payment type inside Drop-in

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/InstantPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/InstantPaymentMethods.tsx
@@ -1,20 +1,22 @@
-import { Fragment, h } from 'preact';
+import { h } from 'preact';
 import UIElement from '../../../internal/UIElement/UIElement';
 import './InstantPaymentMethods.scss';
 
 interface InstantPaymentMethodsProps {
     paymentMethods: UIElement[];
+    onSelect: (paymentMethod: UIElement) => void;
 }
 
-function InstantPaymentMethods({ paymentMethods }: InstantPaymentMethodsProps) {
+function InstantPaymentMethods({ paymentMethods, onSelect }: InstantPaymentMethodsProps) {
     return (
-        <Fragment>
-            <ul className="adyen-checkout__instant-payment-methods-list">
-                {paymentMethods.map(pm => (
-                    <li key={pm.type}>{pm.render()}</li>
-                ))}
-            </ul>
-        </Fragment>
+        <ul className="adyen-checkout__instant-payment-methods-list">
+            {paymentMethods.map(pm => (
+                // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+                <li key={pm._id} data-testid={pm.type} onClick={() => onSelect(pm)}>
+                    {pm.render()}
+                </li>
+            ))}
+        </ul>
     );
 }
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -80,7 +80,7 @@ const PaymentMethodList = ({
                 />
             )}
 
-            {hasInstantPaymentMethods && <InstantPaymentMethods paymentMethods={instantPaymentMethods} />}
+            {hasInstantPaymentMethods && <InstantPaymentMethods paymentMethods={instantPaymentMethods} onSelect={onSelect} />}
 
             {hasStoredPaymentMethods && (
                 <PaymentMethodsContainer

--- a/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
+++ b/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
@@ -26,11 +26,12 @@ const meta: MetaConfiguration<DropinConfiguration> = {
     args: {
         componentConfiguration: getComponentConfigFromUrl() ?? {
             showRadioButton: false,
-            instantPaymentTypes: ['googlepay'],
+            instantPaymentTypes: ['googlepay', 'applepay'],
             showRemovePaymentMethodButton: false,
             paymentMethodsConfiguration: {
                 googlepay: {
-                    buttonType: 'plain'
+                    buttonType: 'plain',
+                    challengeWindowSize: '05'
                 }
             }
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Instant payment methods were never set as 'active payment method' within Drop-in.

When handling actions inside Drop-in (E.g. 3DS2 for GooglePay), its code relies on the 'activePaymentMethod' , and in this case the active payment method was being another payment method instead of the one being clicked.

In this PR, an event listener is added to the markup wrapping the payment method ([same approach as we have here](https://github.com/Adyen/adyen-web/blob/main/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx#L88)). Once the payment method is clicked, it is set as the active payment method. 

There is a UI effect though: If there is one payment method active and open (e.g. card) , and shopper clicks in an instant payment method button, the current active payment method will be collapsed since it is not the active payment method anymore. 

## Tested scenario

Drop-in on Storybook, having the googlepay configured as instant payment type and setting its challengeWindowSize to a different value than the default.

