### PR TITLE
Update error message for single branded card

### DIFF
--- a/.changeset/cool-teachers-tease.md
+++ b/.changeset/cool-teachers-tease.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+update error message for single branded card

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/isConfigured.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/isConfigured.ts
@@ -21,7 +21,9 @@ export function isConfigured({ csfState, csfConfig, csfProps, csfCallbacks }: CS
     // If a recurring card
     if (csfState.numIframes === 1 && csfConfig.isCreditCardType) {
         if (csfState.type === 'card') {
-            logger.error("ERROR: Payment method with a single secured field - but 'type' has not been set to a specific card brand");
+            logger.error(
+                "ERROR: Payment method with a single secured field - but 'brands' has not been set to an array containing the specific card brand"
+            );
             return false;
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When a Card component is instantiated to be single branded (most commonly as a stored card), the error message, for when this setup is configured incorrectly, still reflected how it used to be done in v5, not how it should be done in v6


**Fixed issue**:  This confusion around the error message was raised recently in a Q&A thread
