### PR TITLE
feat(dropin): added `filterStoredPaymentMethods` callback

### DIFF
--- a/.changeset/six-jeans-teach.md
+++ b/.changeset/six-jeans-teach.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Added `filterStoredPaymentMethods` callback to the Drop-in. This callback lets you choose which saved payment methods appear in the Drop-in.

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -128,7 +128,12 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
         const elements = showPaymentMethods ? createElements(paymentMethods, paymentMethodsConfiguration, commonProps, this.core) : [];
         const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, paymentMethodsConfiguration, commonProps, this.core);
         const storedElements = showStoredPaymentMethods
-            ? createStoredElements(storedPaymentMethods, paymentMethodsConfiguration, commonProps, this.core)
+            ? createStoredElements(
+                  this.props.filterStoredPaymentMethods?.(storedPaymentMethods) ?? storedPaymentMethods,
+                  paymentMethodsConfiguration,
+                  commonProps,
+                  this.core
+              )
             : [];
         const fastlanePaymentElement = fastlanePaymentMethod
             ? createElements([fastlanePaymentMethod], paymentMethodsConfiguration, commonProps, this.core)

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -1,4 +1,4 @@
-import type { Order, OrderStatus, PaymentActionsType, PaymentAmount } from '../../types/global-types';
+import type { Order, OrderStatus, PaymentActionsType, PaymentAmount, StoredPaymentMethod } from '../../types/global-types';
 import { StatusFromAction, UIElementProps, UIElementStatus } from '../internal/UIElement/types';
 import type { NewableComponent } from '../../core/core.registry';
 import type { ICore } from '../../core/types';
@@ -101,6 +101,12 @@ export interface DropinConfiguration extends UIElementProps {
      * Callback triggered once the Drop-in is ready to be used
      */
     onReady?(): void;
+
+    /**
+     * Callback triggered before Drop-in creates the stored payment method UIElements.
+     * This callback lets you choose which saved payment methods appear in the Drop-in.
+     */
+    filterStoredPaymentMethods?(storedPaymentMethods: StoredPaymentMethod[]): StoredPaymentMethod[];
 
     /**
      * Callback triggered once the shopper selects a different payment method in the Drop-in

--- a/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
+++ b/packages/lib/storybook/stories/dropin/Dropin.stories.tsx
@@ -5,6 +5,7 @@ import { DropinConfiguration } from '../../../src/components/Dropin/types';
 import './customization.scss';
 import { Checkout } from '../Checkout';
 import { getComponentConfigFromUrl } from '../../utils/get-configuration-from-url';
+import { StoredPaymentMethod } from '../../../src/types/global-types';
 
 type DropinStory = StoryConfiguration<DropinConfiguration>;
 
@@ -66,6 +67,32 @@ export const StyleCustomization: DropinStory = {
                     {checkout => <ComponentContainer element={new DropinComponent(checkout, componentConfiguration)} />}
                 </Checkout>
             </div>
+        );
+    }
+};
+
+export const OnlySavedACH: DropinStory = {
+    render: ({ componentConfiguration, ...checkoutConfig }: PaymentMethodStoryProps<DropinConfiguration>) => {
+        // Register all Components
+        const { Dropin, ...Components } = components;
+        const Classes = Object.keys(Components).map(key => Components[key]);
+        AdyenCheckout.register(...Classes);
+
+        return (
+            <Checkout checkoutConfig={checkoutConfig}>
+                {checkout => (
+                    <ComponentContainer
+                        element={
+                            new DropinComponent(checkout, {
+                                ...componentConfiguration,
+                                showPaymentMethods: false,
+                                filterStoredPaymentMethods: (storedPaymentMethods: StoredPaymentMethod[]) =>
+                                    storedPaymentMethods.filter(pm => pm.type === 'ach')
+                            })
+                        }
+                    />
+                )}
+            </Checkout>
         );
     }
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Added `filterStoredPaymentMethods` callback to the Drop-in. This callback lets you choose which saved payment methods appear in the Drop-in.
- It will be first used by hosted checkout for pay by bank pix to present only one stored pm in the drop-in

## Tested scenarios
It's difficult to unit test, i created a story to show only ach save pms https://localhost:3020/?path=/story/dropin-default--only-saved-ach
