### PR TITLE
fixing typo in error message for the Google Pay merchantId check

### DIFF
--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -39,7 +39,7 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
         if (!this.props.configuration.merchantId) {
             throw new AdyenCheckoutError(
                 'IMPLEMENTATION_ERROR',
-                'GooglePay - Missing merchantId. Please ensure the it is correctly configured in your customer area.'
+                'GooglePay - Missing merchantId. Please ensure that it is correctly configured in your customer area.'
             );
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This change fixes a typo for the error message when the Google Pay merchantId is missing in the configuration:
Before: `Please ensure the it is correctly configured in your customer area.`
After: `Please ensure that it is correctly configured in your customer area.`

## Tested scenarios
N/A


**Fixed issue**:  N/A
