### PR TITLE
Fixes small a11y problems

### DIFF
--- a/.changeset/quiet-berries-wonder.md
+++ b/.changeset/quiet-berries-wonder.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+A11y improvements: contrast, aria-expands and svg alt text

--- a/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVC.tsx
@@ -47,6 +47,8 @@ export default function CVC(props: CVCProps) {
 
     const fieldLabel = cvcPolicy !== CVC_POLICY_OPTIONAL ? label : i18n.get('creditCard.securityCode.label.optional');
 
+    const imageDescription = `${fieldLabel} ${contextualText}`;
+
     return (
         <Field
             label={fieldLabel}
@@ -68,7 +70,7 @@ export default function CVC(props: CVCProps) {
         >
             <DataSfSpan encryptedFieldType={ENCRYPTED_SECURITY_CODE} className={cvcClassnames} />
 
-            <CVCHint frontCVC={frontCVC} fieldLabel={fieldLabel} />
+            <CVCHint frontCVC={frontCVC} fieldLabel={imageDescription} />
         </Field>
     );
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CVCHint.tsx
@@ -19,7 +19,6 @@ export default function CVCHint({ frontCVC = false, fieldLabel }: CVCHintProps) 
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
                 aria-hidden={!frontCVC}
-                aria-describedby={'adyen-checkout__cvc__front-hint-img'}
                 role={'img'}
             >
                 <title id={'adyen-checkout__cvc__front-hint-img'}>{fieldLabel}</title>
@@ -40,7 +39,6 @@ export default function CVCHint({ frontCVC = false, fieldLabel }: CVCHintProps) 
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
                 aria-hidden={!!frontCVC}
-                aria-describedby={'adyen-checkout__cvc__back-hint-img'}
                 role={'img'}
             >
                 <title id={'adyen-checkout__cvc__back-hint-img'}>{fieldLabel}</title>

--- a/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/ExpirationDate.tsx
@@ -38,6 +38,8 @@ export default function ExpirationDate(props: ExpirationDateProps) {
 
     const fieldLabel = expiryDatePolicy !== DATE_POLICY_OPTIONAL ? label : `${label} ${i18n.get('field.title.optional')}`;
 
+    const imageDescription = `${fieldLabel} ${contextualText}`;
+
     return (
         <Field
             label={fieldLabel}
@@ -73,7 +75,7 @@ export default function ExpirationDate(props: ExpirationDateProps) {
                 <img
                     src={getImage({ imageFolder: 'components/' })('expiry_date_hint')}
                     className="adyen-checkout__field__exp-date_hint"
-                    alt={fieldLabel}
+                    alt={imageDescription}
                 />
             </span>
         </Field>

--- a/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/StoredCardFields.test.tsx
@@ -36,7 +36,7 @@ describe('StoredCard', () => {
 
         // Look for cvc field elements
         expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
-        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code 3 digits on back of card' })).toBeTruthy();
     });
 
     test('Renders a StoredCard field, without expiryDate (relevant data is null); and with cvc field', () => {
@@ -49,7 +49,7 @@ describe('StoredCard', () => {
         expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
 
         expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
-        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code 3 digits on back of card' })).toBeTruthy();
     });
 
     test('Renders a StoredCard field, without expiryDate (relevant data is empty string); and with cvc field', () => {
@@ -62,7 +62,7 @@ describe('StoredCard', () => {
         expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
 
         expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
-        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code 3 digits on back of card' })).toBeTruthy();
     });
 
     test('Renders a StoredCard field, without expiryDate (relevant data is missing); and with cvc field', () => {
@@ -75,6 +75,6 @@ describe('StoredCard', () => {
         expect(screen.queryByText('Expiry date', { exact: false })).toBeNull(); // non-presence
 
         expect(screen.getAllByText('Security code', { exact: true })).toBeTruthy();
-        expect(screen.getByRole('img', { name: 'Security code' })).toBeTruthy();
+        expect(screen.getByRole('img', { name: 'Security code 3 digits on back of card' })).toBeTruthy();
     });
 });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.scss
@@ -76,7 +76,7 @@
 }
 
 .adyen-checkout__payment-method__surcharge {
-    color: token(color-outline-tertiary);
+    color: token(color-label-secondary);
     margin-left: token(spacer-020);
 }
 
@@ -133,7 +133,7 @@
     overflow: hidden;
 
     & .adyen-checkout__payment-method__brand-number {
-        color: token(color-outline-tertiary);
+        color: token(color-label-secondary);
         font-size: token(text-body-font-size);
     }
 }

--- a/packages/lib/src/components/Giftcard/components/GiftcardResult.scss
+++ b/packages/lib/src/components/Giftcard/components/GiftcardResult.scss
@@ -32,7 +32,7 @@
     margin-bottom: token(spacer-040);
 
     .adyen-checkout__giftcard-result__balance__title--transactionLimit {
-        color: token(color-outline-tertiary);
+        color: token(color-label-secondary);
     }
 
     &:last-child {

--- a/packages/lib/src/components/internal/Await/Await.scss
+++ b/packages/lib/src/components/internal/Await/Await.scss
@@ -68,7 +68,7 @@
 }
 
 .adyen-checkout__await__countdown {
-    color: token(color-outline-tertiary);
+    color: token(color-label-secondary);
     font-size: token(text-body-font-size);
 }
 

--- a/packages/lib/src/components/internal/ExpandButton/ExpandButton.tsx
+++ b/packages/lib/src/components/internal/ExpandButton/ExpandButton.tsx
@@ -14,7 +14,8 @@ interface ExpandButton {
 function ExpandButton({ buttonId, showRadioButton, isSelected, expandContentId, children, classNameModifiers = [] }: Readonly<ExpandButton>) {
     return (
         // See discussion: https://github.com/w3c/aria/issues/1404
-        // eslint-disable-next-line jsx-a11y/role-supports-aria-props
+        // this has been disabled as we got quite a few complains
+        // mainly from merchants running automated systems
         <button
             className={classNames(
                 'adyen-checkout__payment-method__header__title',
@@ -23,7 +24,7 @@ function ExpandButton({ buttonId, showRadioButton, isSelected, expandContentId, 
             id={buttonId}
             role={'radio'}
             aria-checked={isSelected}
-            aria-expanded={isSelected}
+            //aria-expanded={isSelected} - disabled for now
             aria-controls={expandContentId}
             type="button"
         >

--- a/packages/lib/src/styles/variable-generator.scss
+++ b/packages/lib/src/styles/variable-generator.scss
@@ -3,6 +3,13 @@
 @import '~@adyen/bento-design-tokens/dist/scss-map/bento/components';
 @import 'overrides';
 
+// simple re-mapping
+$color: map-merge($color, (
+        // this color has been remapped for a11y reasons
+        color-label-critical: map-get($color, color-label-on-background-critical-weak),
+        color-label-tertiary: map-get($color, color-label-secondary), // label tertiary doesn't have enough contrast
+));
+
 @function adyen-sdk-generate-css-variables($maps...) {
     $adyen-output-map: ();
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Small fixes long description to document this changes for the future.

### Constrast changes

These are documented in COWEB-1484. However to summarise the issue is that the `color-label-tertiary` never has enough contrast, even against a white background, so here I just override it via our scss token loader. The same happens for the red color used for the error messages. 

### Aria expands attribute on radio buttons

Basically this change keeps being requested by merchants who have automated tools. Currently `aria-expands` on radio elements is still not part of the official aria spec. See the proposal here: https://github.com/w3c/aria/issues/1404

So for now we are going to disable this feature. The objective is to enable it soon as the proposal get's approved.

### SVG alt description

This is a 2 in 1, we remove `aria-describedby` from the SVG and also add additional information to both the CVC hint image and the expiry date hint image.

To start with, I could not find anywhere any documentation supporting the use of `aria-describedby` for this use case. The alternatives found in documentation for alt text on SVGs are `aria-label` / `aria-labelledby` or svg `<title>`.  We are going with `title`. 

Further more, there's been a discussion between us and merchants where some auditors are marking these images alt text as not meaningful (enough). So we are also adding the context text to the image, which will hopefully be enough information for the user. This information might turn out to be to much but we will iterate on this.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
