### PR TITLE
Apple Pay - Https check before calling  ApplePaySession.supportsVersion API

### DIFF
--- a/packages/lib/src/components/ApplePay/ApplePay.test.ts
+++ b/packages/lib/src/components/ApplePay/ApplePay.test.ts
@@ -64,6 +64,13 @@ const configurationMock = {
 describe('ApplePay', () => {
     describe('constructor()', () => {
         test('should load the SDK and define the apple pay version/applepay web options', async () => {
+            Object.defineProperty(window, 'location', {
+                writable: true,
+                value: {
+                    protocol: 'https:'
+                }
+            });
+
             const onApplePayCodeCloseMock = jest.fn();
             new ApplePay(global.core, {
                 onApplePayCodeClose: onApplePayCodeCloseMock

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -160,6 +160,7 @@ class ApplePayElement extends UIElement<ApplePayConfiguration> {
      * @private
      */
     private defineApplePayVersionNumber() {
+        if (window.location.protocol !== 'https:') return;
         this.applePayVersionNumber = this.props.version || resolveSupportedVersion(LATEST_APPLE_PAY_VERSION);
     }
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/isConfigured.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/partials/isConfigured.test.ts
@@ -58,7 +58,9 @@ describe('Testing CSFs isConfigured functionality', () => {
         expect(validateForm).not.toHaveBeenCalled();
 
         expect(res).toEqual(false);
-        expect(consoleError).toEqual("ERROR: Payment method with a single secured field - but 'type' has not been set to a specific card brand");
+        expect(consoleError).toEqual(
+            "ERROR: Payment method with a single secured field - but 'brands' has not been set to an array containing the specific card brand"
+        );
     });
 
     test('validateForm should not be called since we are dealing with a recurring card that has a cvcPolicy that equals "reguired"', () => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

- Adding a check for HTTPS before calling ApplePaySession.supportsVersion. (If we avoid this check, the browser console gets a warning message from Apple Pay SDK which is not needed)
