### PR TITLE
Allow typing to continue in cardNumber field after panLength result

### DIFF
--- a/.changeset/funny-tables-film.md
+++ b/.changeset/funny-tables-film.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Allow typing to continue in cardNumber field after panLength result from binLookup

--- a/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.regular.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/panLength/panLength.focus.regular.spec.ts
@@ -29,7 +29,7 @@ test.describe('Test Card, & binLookup w/o panLength property', () => {
 });
 
 test.describe('Test Card, & binLookup w. panLength property', () => {
-    test('#1 Fill out PAN and see maxLength is set on cardNumber SF, and that focus moves to expiryDate', async ({ card }) => {
+    test('#1 Fill out PAN and see maxLength is not set on cardNumber SF, and that focus moves to expiryDate', async ({ card }) => {
         await card.goto(URL_MAP.card);
 
         await card.isComponentVisible();
@@ -40,11 +40,11 @@ test.describe('Test Card, & binLookup w. panLength property', () => {
         await expect(card.cardNumberInput).not.toBeFocused();
         await expect(card.expiryDateInput).toBeFocused();
 
-        // Expect iframe to exist in number field with maxlength attr set to 19
+        // Expect iframe to exist in number field with maxlength attr kept to 24, since we know mitigate against binLookup having incorrect panLength values
         let panInputMaxLength = await card.cardNumberInput.getAttribute('maxlength');
-        expect(panInputMaxLength).toEqual('19');
+        expect(panInputMaxLength).toEqual('24');
 
-        // Delete number and see that the maxlength is reset on the iframe
+        // Delete number and see that the maxlength is kept on the iframe
         await card.deleteCardNumber();
         panInputMaxLength = await card.cardNumberInput.getAttribute('maxlength');
 
@@ -180,7 +180,7 @@ test.describe('Test Card, & binLookup w. panLength property', () => {
         }
     );
 
-    test('#8 Fill out PAN with Visa num that binLookup says has a panLength of 16 - you should not then be able to type more digits in the card number field', async ({
+    test('#8 Fill out PAN with Visa num that binLookup says has a panLength of 16 - you should then be able to type more digits in the card number field', async ({
         card
     }) => {
         await card.goto(URL_MAP.card);
@@ -189,12 +189,12 @@ test.describe('Test Card, & binLookup w. panLength property', () => {
 
         await card.typeCardNumber(CARD_WITH_PAN_LENGTH);
 
-        // Should not be able to add more digits to the PAN
+        // Should be able to add more digits to the PAN
         await card.cardNumberInput.press('End'); /** NOTE: how to add text at end */
         await card.typeCardNumber('6');
 
-        // Confirm PAN value has not had chars added
+        // Confirm PAN value has had chars added
         let val = await card.cardNumberInput.inputValue();
-        expect(val).toEqual('4000 6200 0000 0007');
+        expect(val).toEqual('4000 6200 0000 0007 6');
     });
 });

--- a/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
@@ -17,7 +17,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '5.5.0';
+export const SF_VERSION = '5.5.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Allow the shopper to input more digits into the `cardNumber` field even after the `/binLookup` call returns a `panLength`.
Previously we were freezing the field based on the `panLength` result - but a recent case where the BIN table contained an incorrect `panLength` value means we will now allow the shopper to add more digits if they want to.

**Note:** relies on update to securedFields `5.5.1`

## Tested scenarios
Existing e2e test corrected to allow for new scenario
All other e2e tests pass


**Fixed issue**:  COWEB-1485
