### PR TITLE
allow-custom-billing-address-specifications

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -92,7 +92,7 @@ const CardInput: FunctionalComponent<CardInputProps> = props => {
 
     const showBillingAddress = props.billingAddressMode !== AddressModeOptions.none && props.billingAddressRequired;
 
-    const partialAddressSchema = handlePartialAddressMode(props.billingAddressMode);
+    const partialAddressSchema = handlePartialAddressMode(props.billingAddressMode, specifications.getSpecifications());
     // Keeps the value of the country set initially by the merchant, before the Address Component mutates it
     const partialAddressCountry = useRef<string>(partialAddressSchema && props.data?.billingAddress?.country);
 

--- a/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
+++ b/packages/lib/src/components/Card/components/CardInput/defaultProps.ts
@@ -11,6 +11,7 @@ export default {
     billingAddressAllowedCountries: [],
     billingAddressMode: AddressModeOptions.full,
     billingAddressRequired: false,
+    specifications: {},
     billingAddressRequiredFields: ['street', 'houseNumberOrName', 'postalCode', 'city', 'stateOrProvince', 'country'],
 
     configuration: { koreanAuthenticationRequired: false, socialSecurityNumberMode: 'auto' as SocialSecurityMode },

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -4,8 +4,7 @@ import { AddressData, PaymentAmount } from '../../../../types';
 import { InstallmentOptions } from './components/types';
 import { ValidationResult } from '../../../internal/PersonalDetails/types';
 import { CVCPolicyType, DatePolicyType, CbObjOnError, StylesObject } from '../../../internal/SecuredFields/lib/types';
-import Specifications from '../../../internal/Address/Specifications';
-import { AddressSchema } from '../../../internal/Address/types';
+import { AddressSchema, AddressSpecifications } from '../../../internal/Address/types';
 import { Resources } from '../../../../core/Context/Resources';
 import { SRPanel } from '../../../../core/Errors/SRPanel';
 import RiskElement from '../../../../core/RiskModule';
@@ -122,7 +121,7 @@ export interface CardInputProps {
     showPayButton?: boolean;
     showStoreDetailsCheckbox?: boolean;
     showWarnings?: boolean;
-    specifications?: Specifications;
+    specifications?: AddressSpecifications;
     storedPaymentMethodId?: string;
     styles?: StylesObject;
     trimTrailingSeparator?: boolean;

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -166,7 +166,10 @@ export const extractPropsForSFP = (props: CardInputProps) => {
     } as SFPProps; // Can't set as return type on fn or it will complain about missing, mandatory, props
 };
 
-export const handlePartialAddressMode = (addressMode: AddressModeOptions): AddressSpecifications | null => {
+export const handlePartialAddressMode = (addressMode: AddressModeOptions, specifications: AddressSpecifications): AddressSpecifications | null => {
+    if (specifications) {
+        return specifications;
+    }
     return addressMode == AddressModeOptions.partial ? PARTIAL_ADDRESS_SCHEMA : null;
 };
 

--- a/packages/lib/src/components/internal/Address/Specifications.ts
+++ b/packages/lib/src/components/internal/Address/Specifications.ts
@@ -5,10 +5,14 @@ import { AddressField } from '../../../types';
 const SCHEMA_MAX_DEPTH = 2;
 
 class Specifications {
-    private specifications: AddressSpecifications;
+    private readonly specifications: AddressSpecifications;
 
-    constructor(specifications?) {
-        this.specifications = { ...ADDRESS_SPECIFICATIONS, ...specifications };
+    constructor(specifications?: AddressSpecifications) {
+        if (specifications && typeof specifications === 'object') {
+            this.specifications = { ...ADDRESS_SPECIFICATIONS, ...specifications };
+        } else {
+            this.specifications = { ...ADDRESS_SPECIFICATIONS };
+        }
     }
 
     /**
@@ -85,6 +89,14 @@ class Specifications {
         return this.getAddressSchemaForCountry(country)
             .flat(SCHEMA_MAX_DEPTH)
             .filter((element): element is AddressField => typeof element === 'string');
+    }
+
+    /**
+     * Returns the specifications object.
+     * @returns specifications - returns combines specifications
+     */
+    getSpecifications(): AddressSpecifications {
+        return this.specifications;
     }
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adyen-web drop-in can get `specifications` which can provide address specifications. This can be used to specifically determine for each country, which bill address fields are needed, and what are specific details needed (label/placeholder/optional/etc).

However, in the code, the `specifications` is not actively used, and finally, when renderingthe  Credit Card Address component, the main criteria depend on `billingAddressMode` only. And the specifications is ignored.

Here is a summary of data flow:

1. In the Credit Card components in `CardInput.tsx`  ([github](https://github.com/Adyen/adyen-web/blob/main/packages/lib/src/components/Card/components/CardInput/CardInput.tsx#L469)). While the specifications is used it is not passed to `FieldsToRendered`

```
<FieldsToRender
   {...restOfProps}
    partialAddressSchema={partialAddressSchema}
/>
```


2. in case `FieldsToRender` uses `CardFieldsWrapper`
3. `CardFieldsWrapper` will use the `partialAddressSchema` as `specifications` and completely ignores specifications you pass in ([github](https://github.com/Adyen/adyen-web/blob/main/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx#L171))

```
            {billingAddressRequired && (
                <Address
                    ...rest
                    specifications={partialAddressSchema}
                />
            )}
```

so it either uses the hardcoded partial form (meaning only postal code) or `null`.


This MR will make sure that if specifications are passed, it is preferred over default specifications.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
