### PR TITLE
BrowserInfo no longer calls obsolete navigator.javaEnabled function

### DIFF
--- a/.changeset/pretty-apricots-fetch.md
+++ b/.changeset/pretty-apricots-fetch.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+BrowserInfo no longer calls obsolete `navigator.javaEnabled` function

--- a/packages/lib/src/utils/browserInfo.ts
+++ b/packages/lib/src/utils/browserInfo.ts
@@ -14,7 +14,7 @@ import { BrowserInfo } from '../types/global-types';
  */
 export default function collectBrowserInfo(): BrowserInfo {
     const colorDepth = getProp(window, 'screen.colorDepth') || '';
-    const javaEnabled = getProp(window, 'navigator.javaEnabled') ? window.navigator.javaEnabled() : false;
+    const javaEnabled = false;
     const screenHeight = getProp(window, 'screen.height') || ''; // TODO: Shall we set this to null instead?
     const screenWidth = getProp(window, 'screen.width') || ''; // TODO: Shall we set this to null instead?
     const userAgent = getProp(window, 'navigator.userAgent') || '';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
`browserInfo.ts` no longer calls deprecated `navigator.javaEnabled` function

As described in the docs, this function is now deprecated and will always return `false`
(ref: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/javaEnabled)

So we keep the property for backward compatibility but always directly set it to equal `false`
