### PR TITLE
Google Pay - Adding support for 'paywithgoogle' when using standalone component  

### DIFF
--- a/.changeset/young-cougars-knock.md
+++ b/.changeset/young-cougars-knock.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Google Pay - Fixed issue where Google Pay standalone component wasn't recognizing 'paywithgoogle' payment method

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -3,6 +3,9 @@ import GooglePayService from './GooglePayService';
 
 import Analytics from '../../core/Analytics';
 import { ANALYTICS_EVENT, ANALYTICS_SELECTED_STR, NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
+import PaymentMethods from '../../core/ProcessResponse/PaymentMethods';
+import { mock } from 'jest-mock-extended';
+import { ICore } from '../../types';
 
 const analyticsModule = Analytics({ analytics: {}, loadingContext: '', locale: '', clientKey: '', bundleType: 'umd' });
 
@@ -55,6 +58,23 @@ beforeEach(() => {
 });
 
 describe('GooglePay', () => {
+    describe('Supporting "paywithgoogle" type as standalone Component', () => {
+        test('should load the configuration from payment methods response', () => {
+            const core = mock<ICore>({});
+            core.paymentMethodsResponse = new PaymentMethods({
+                paymentMethods: [
+                    { name: 'Google Pay', type: 'paywithgoogle', configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } }
+                ]
+            });
+
+            const googlepay = new GooglePay(core);
+
+            expect(googlepay.type).toBe('paywithgoogle');
+            expect(googlepay.props.configuration.merchantId).toBe('merchant-id');
+            expect(googlepay.props.configuration.gatewayMerchantId).toBe('gateway-id');
+        });
+    });
+
     describe('onClick()', () => {
         test('should not call "initiatePayment" if the onClick reject() is called', async () => {
             const googlepay = new GooglePay(global.core, {

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -11,7 +11,7 @@ import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement
 import { ANALYTICS_INSTANT_PAYMENT_BUTTON, ANALYTICS_SELECTED_STR } from '../../core/Analytics/constants';
 import { SendAnalyticsObject } from '../../core/Analytics/types';
 
-import type { AddressData, BrowserInfo, PaymentResponseData, RawPaymentResponse } from '../../types/global-types';
+import type { AddressData, BrowserInfo, PaymentMethod, PaymentResponseData, RawPaymentResponse } from '../../types/global-types';
 import type { GooglePayConfiguration } from './types';
 import type { ICore } from '../../core/types';
 
@@ -47,6 +47,19 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
             ...(isExpress && paymentDataCallbacks?.onPaymentDataChanged && { onPaymentDataChanged: paymentDataCallbacks.onPaymentDataChanged }),
             onPaymentAuthorized: this.onPaymentAuthorized
         });
+    }
+
+    /**
+     * Google Pay requires custom logic due to supporting two Tx variants that lead to the same payment method.
+     * If the merchant creates a standalone Google Pay component, we need to verify if the payment method is available using both tx variants
+     *
+     * @param type
+     * @returns
+     */
+    protected override getPaymentMethodFromPaymentMethodsResponse(type?: string): PaymentMethod {
+        return (
+            this.core.paymentMethodsResponse.find(type || this.constructor['type']) || this.core.paymentMethodsResponse.find(TxVariants.paywithgoogle)
+        );
     }
 
     protected override formatProps(props): GooglePayConfiguration {

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -18,6 +18,7 @@ import type {
     PaymentAction,
     PaymentAmount,
     PaymentData,
+    PaymentMethod,
     PaymentMethodsResponse,
     PaymentResponseData
 } from '../../../types/global-types';
@@ -71,14 +72,13 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     protected override buildElementProps(componentProps?: P) {
         const globalCoreProps = this.core.getCorePropsForComponent();
         const isStoredPaymentMethod = !!componentProps?.isStoredPaymentMethod;
-        const paymentMethodsResponseProps = isStoredPaymentMethod
-            ? {}
-            : this.core.paymentMethodsResponse.find(componentProps?.type || this.constructor['type']);
+
+        const paymentMethodFromResponse = isStoredPaymentMethod ? {} : this.getPaymentMethodFromPaymentMethodsResponse(componentProps?.type);
 
         const finalProps = {
             showPayButton: true,
             ...globalCoreProps,
-            ...paymentMethodsResponseProps,
+            ...paymentMethodFromResponse,
             ...componentProps
         };
 
@@ -89,6 +89,15 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
             ...getRegulatoryDefaults(this.core.options.countryCode, isDropin), // regulatory defaults
             ...finalProps // the rest (inc. merchant defined config)
         });
+    }
+
+    /**
+     *  Get the payment method from the paymentMethodsResponse
+     *
+     * @param type - The type of the payment method to get. (This prop is passed by Drop-in OR Standalone components containing the property 'type' as part of their configuration)
+     */
+    protected getPaymentMethodFromPaymentMethodsResponse(type?: string): PaymentMethod {
+        return this.core.paymentMethodsResponse.find(type || this.constructor['type']);
     }
 
     protected storeElementRefOnCore(props?: P) {

--- a/packages/lib/storybook/stories/components/Klarna.stories.tsx
+++ b/packages/lib/storybook/stories/components/Klarna.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { MetaConfiguration, StoryConfiguration } from '../types';
 import { ComponentContainer } from '../ComponentContainer';
 import { KlarnaConfiguration } from '../../../src/components/Klarna/types';
@@ -20,6 +21,19 @@ export const Widget: KlarnaStory = {
     args: {
         countryCode: 'NL',
         componentConfiguration: { useKlarnaWidget: true }
+    }
+};
+
+export const B2b: KlarnaStory = {
+    render: ({ componentConfiguration, ...checkoutConfig }) => (
+        <Checkout checkoutConfig={checkoutConfig}>
+            {checkout => <ComponentContainer element={new Klarna(checkout, { ...componentConfiguration, type: 'klarna_b2b' })} />}
+        </Checkout>
+    ),
+
+    args: {
+        countryCode: 'NL',
+        componentConfiguration: {}
     }
 };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed issue where Google Pay standalone component wasn't recognizing 'paywithgoogle' payment method.

To fix that, Google Pay had to override the new method 'getPaymentMethodFromPaymentMethodsResponse()' and also inspect the payment methods response for its varirant 'paywithgoogle'

## Tested scenarios
- Added tests
- Tested Google Pay component with 'paywithgoogle' tx type


**Fixed issue**:  #3191 
