### PR TITLE
Upped SF version to fix issue with LastPass auto-filling expiryDate

### DIFF
--- a/.changeset/new-lies-doubt.md
+++ b/.changeset/new-lies-doubt.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Upped SF version to fix issue with LastPass & autofilling

--- a/packages/e2e-playwright/mocks/binLookup/binLookup.data.ts
+++ b/packages/e2e-playwright/mocks/binLookup/binLookup.data.ts
@@ -41,6 +41,20 @@ const hiddenDateAndCvcMock = {
     requestedId: null
 };
 
+const hiddenDateAndRequiredCvcMock = {
+    brands: [
+        {
+            brand: 'mc',
+            enableLuhnCheck: true,
+            supported: true,
+            cvcPolicy: 'required',
+            expiryDatePolicy: 'hidden'
+        }
+    ],
+    issuingCountryCode: 'US',
+    requestedId: null
+};
+
 const optionalDateWithPanLengthMock = {
     brands: [
         {
@@ -134,6 +148,7 @@ const socialSecurityNumberRequiredMock = {
 export {
     optionalDateAndCvcMock,
     hiddenDateAndCvcMock,
+    hiddenDateAndRequiredCvcMock,
     optionalDateWithPanLengthMock,
     hiddenDateWithPanLengthMock,
     optionalDateAndCvcWithPanLengthMock,

--- a/packages/e2e-playwright/tests/ui/card/binLookup/plcc/plcc.luhn.paste.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/plcc/plcc.luhn.paste.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../../../../fixtures/card.fixture';
 import { getStoryUrl } from '../../../../utils/getStoryUrl';
-import { PLCC_NO_LUHN_NO_DATE, PLCC_WITH_LUHN_NO_DATE_WOULD_FAIL_LUHN, TEST_CVC_VALUE, TEST_DATE_VALUE } from '../../../../utils/constants';
+import { PLCC_NO_LUHN_OPTIONAL_DATE, PLCC_WITH_LUHN_OPTIONAL_DATE_WOULD_FAIL_LUHN, TEST_CVC_VALUE } from '../../../../utils/constants';
 import { URL_MAP } from '../../../../../fixtures/URL_MAP';
 import LANG from '../../../../../../server/translations/en-US.json';
 
@@ -18,7 +18,7 @@ test.describe('Testing binLookup/plcc/pasting fny: test what happens when cards 
         /**
          * Type number that identifies as plcc, no date, with luhn required, but that fails luhn
          */
-        await card.fillCardNumber(PLCC_WITH_LUHN_NO_DATE_WOULD_FAIL_LUHN);
+        await card.fillCardNumber(PLCC_WITH_LUHN_OPTIONAL_DATE_WOULD_FAIL_LUHN);
         await page.waitForTimeout(100);
 
         await card.typeCvc(TEST_CVC_VALUE);
@@ -30,7 +30,7 @@ test.describe('Testing binLookup/plcc/pasting fny: test what happens when cards 
         await expect(card.cardNumberErrorElement).toHaveText(PAN_ERROR_NOT_VALID);
 
         // "Paste" number that identifies as plcc, no luhn required
-        await card.fillCardNumber(PLCC_NO_LUHN_NO_DATE);
+        await card.fillCardNumber(PLCC_NO_LUHN_OPTIONAL_DATE);
         await page.waitForTimeout(100);
 
         // If correct events have fired expect the card to be valid i.e. no error message when pressing pay

--- a/packages/e2e-playwright/tests/ui/card/binLookup/plcc/plcc.noluhn.nodate.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/plcc/plcc.noluhn.nodate.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from '../../../../../fixtures/card.fixture';
 import { getStoryUrl } from '../../../../utils/getStoryUrl';
-import { PLCC_NO_LUHN_NO_DATE_WOULD_FAIL_LUHN, TEST_CVC_VALUE } from '../../../../utils/constants';
+import { PLCC_NO_LUHN_OPTIONAL_DATE_WOULD_FAIL_LUHN, TEST_CVC_VALUE } from '../../../../utils/constants';
 import { URL_MAP } from '../../../../../fixtures/URL_MAP';
+import LANG from '../../../../../../server/translations/en-US.json';
+
+const DATE_LABEL = LANG['creditCard.expiryDate.label'];
+const DATE_LABEL_OPTIONAL = `${LANG['creditCard.expiryDate.label']} ${LANG['field.title.optional']}`;
 
 test.describe('Testing binLookup endpoint for a response that should indicate a luhn check is not required)', () => {
     test('Test a PLCC card, that does not require a date, becomes valid with a number that fails the luhn check', async ({ card, page }) => {
@@ -13,14 +17,17 @@ test.describe('Testing binLookup endpoint for a response that should indicate a 
         await card.isComponentVisible();
 
         // Number that identifies as plcc, with no luhn required, but that also fails luhn
-        await card.typeCardNumber(PLCC_NO_LUHN_NO_DATE_WOULD_FAIL_LUHN);
+        await card.typeCardNumber(PLCC_NO_LUHN_OPTIONAL_DATE_WOULD_FAIL_LUHN);
 
         // Confirm plcc brand
         let brandingIconSrc = await card.brandingIcon.getAttribute('src');
         expect(brandingIconSrc).toContain('synchrony_plcc.svg');
 
-        // Confirm date is hidden
-        await expect(card.expiryDateField).not.toBeVisible();
+        // Confirm date is optional
+        // ...with "optional" text
+        await expect(card.expiryDateLabelText).toHaveText(DATE_LABEL_OPTIONAL);
+        // ...and optional class
+        await expect(card.expiryDateField).toHaveClass(/adyen-checkout__field__exp-date--optional/);
 
         // Fill cvc
         await card.typeCvc(TEST_CVC_VALUE);
@@ -39,8 +46,8 @@ test.describe('Testing binLookup endpoint for a response that should indicate a 
         brandingIconSrc = await card.brandingIcon.getAttribute('src');
         expect(brandingIconSrc).toContain('nocard.svg');
 
-        // Confirm date is visible again
-        await expect(card.expiryDateField).toBeVisible();
+        // Confirm date is required again
+        await expect(card.expiryDateLabelText).toHaveText(DATE_LABEL);
 
         // PM is not valid
         cardValid = await page.evaluate('window.component.isValid');

--- a/packages/e2e-playwright/tests/ui/card/expiryDate/card.expiryDatePolicies.hidden.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/expiryDate/card.expiryDatePolicies.hidden.spec.ts
@@ -4,10 +4,13 @@ import {
     ENCRYPTED_CARD_NUMBER,
     ENCRYPTED_EXPIRY_DATE,
     ENCRYPTED_SECURITY_CODE,
-    PLCC_NO_LUHN_NO_DATE,
+    PLCC_NO_LUHN_OPTIONAL_DATE,
+    REGULAR_TEST_CARD,
     TEST_CVC_VALUE
 } from '../../../utils/constants';
 import { getStoryUrl } from '../../../utils/getStoryUrl';
+import { binLookupMock } from '../../../../mocks/binLookup/binLookup.mock';
+import { hiddenDateAndRequiredCvcMock } from '../../../../mocks/binLookup/binLookup.data';
 
 const PAN_ERROR = LANG['cc.num.900'];
 const DATE_INVALID_ERROR = LANG['cc.dat.912'];
@@ -19,10 +22,12 @@ const url = getStoryUrl({ baseUrl: urlNoAutoFocus, componentConfig: { brands: ['
 
 test.describe('Test how Card Component handles hidden expiryDate policy', () => {
     test('#1 how UI & state respond', async ({ page, card }) => {
+        await binLookupMock(page, hiddenDateAndRequiredCvcMock);
+
         await card.goto(url);
 
-        // Fill number to provoke binLookup response
-        await card.typeCardNumber(PLCC_NO_LUHN_NO_DATE);
+        // Fill number to provoke (mock) binLookup response
+        await card.typeCardNumber(REGULAR_TEST_CARD);
 
         // UI reflects that binLookup says expiryDate is hidden
         await expect(card.expiryDateField).not.toBeVisible();
@@ -66,7 +71,7 @@ test.describe('Test how Card Component handles hidden expiryDate policy', () => 
         await expect(cardErrors[ENCRYPTED_SECURITY_CODE]).not.toBe(undefined);
 
         // Fill number to provoke binLookup response
-        await card.typeCardNumber(PLCC_NO_LUHN_NO_DATE);
+        await card.typeCardNumber(PLCC_NO_LUHN_OPTIONAL_DATE);
 
         // Headless test seems to need time for UI reset to register on state
         await page.waitForTimeout(500);
@@ -82,6 +87,7 @@ test.describe('Test how Card Component handles hidden expiryDate policy', () => 
     });
 
     test('#3 Hidden date field in error does not stop card becoming valid', async ({ page, card }) => {
+        await binLookupMock(page, hiddenDateAndRequiredCvcMock);
         await card.goto(url);
         // Card out of date
         await card.typeExpiryDate('12/90');
@@ -95,7 +101,7 @@ test.describe('Test how Card Component handles hidden expiryDate policy', () => 
         await card.cardNumberLabelElement.click();
 
         // Fill number to provoke binLookup response
-        await card.typeCardNumber(PLCC_NO_LUHN_NO_DATE);
+        await card.typeCardNumber(REGULAR_TEST_CARD);
 
         // UI reflects that binLookup says expiryDate is hidden
         await expect(card.expiryDateField).not.toBeVisible();

--- a/packages/e2e-playwright/tests/utils/constants.ts
+++ b/packages/e2e-playwright/tests/utils/constants.ts
@@ -23,10 +23,10 @@ export const UNKNOWN_BIN_CARD = '135410014004955'; // card that is not in the te
 export const UNKNOWN_BIN_CARD_REGEX_VISA = '4354100140049554'; // card that is not in the test DBs but which our regEx will recognise as Visa
 export const UNKNOWN_VISA_CARD = '41111111'; // card is now in the test DBs (visa) - so keep it short to stop it firing binLookup
 
-export const PLCC_NO_LUHN_NO_DATE = '6044100018023838'; // binLookup gives luhn check and date not required
+export const PLCC_NO_LUHN_OPTIONAL_DATE = '6044100018023838'; // binLookup gives luhn check and date not required
 export const PLCC_WITH_LUHN_NO_DATE = '6044141000018769'; // binLookup gives luhn check required but date not required
-export const PLCC_WITH_LUHN_NO_DATE_WOULD_FAIL_LUHN = '6044141000018768'; // binLookup gives luhn check required, date not required, BUT that will fail the luhn check
-export const PLCC_NO_LUHN_NO_DATE_WOULD_FAIL_LUHN = '6044100033327222'; // A PAN that identifies as a plcc that doesn't require a luhn check BUT that would fail the luhn check if it was required
+export const PLCC_WITH_LUHN_OPTIONAL_DATE_WOULD_FAIL_LUHN = '6044141000018768'; // binLookup gives luhn check required, date not required, BUT that will fail the luhn check
+export const PLCC_NO_LUHN_OPTIONAL_DATE_WOULD_FAIL_LUHN = '6044100033327222'; // A PAN that identifies as a plcc that doesn't require a luhn check BUT that would fail the luhn check if it was required
 
 // intersolve (plastix)
 export const GIFTCARD_NUMBER = '4010100000000000000';

--- a/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '5.5.1';
+export const SF_VERSION = '5.5.2';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Upped SF version (to `v5.5.2`) to fix issue with LastPass & autofilling

There was an issue with LastPass password manager when it came to auto-filling the `expiryDate` in the Card component.

Their autofill process was bypassing any handlers we had for the autofill situation (because it wasn't firing the expected events on the input fields in securedFields) - and was managing to directly inject a 4 digit expiry year. This then got truncated into 2 digits (but unfortunately it was the first 2 digits, not the last 2 --> so **2030** was ending up set as **20** - which is an "expired" year)

This was not a situation we had prepared for (since our handlers were expected to be engaged, and would have caught this 4 digit year scenario).

A fix with securedFields detects a 4 digits expiry year and truncates it correctly **2030** --> **30**

## Tested scenarios
Manually tested against the LastPass Chrome extension


**Relates to issue**:  PF-1898
