### PR TITLE
Fixed issue where card inputs weren't respecting background color styles

### DIFF
--- a/.changeset/calm-foxes-chew.md
+++ b/.changeset/calm-foxes-chew.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed issue where card inputs weren't respecting background color styles if the merchant set a meta tag to describe the color scheme

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.scss
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.scss
@@ -3,4 +3,5 @@
     height: 100%;
     width: 100%;
     overflow: hidden;
+    color-scheme: auto;
 }


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed issue where card inputs weren't respecting background color styles if the merchant set a meta tag to describe the color scheme e.g. `<meta name="color-scheme" content="dark">`

Because the color scheme of the iframe was seen as different to that of the parent, embedding, document - the iframe was getting an opaque background (a fuller explanation can be found in [the issue](https://github.com/Adyen/adyen-web/issues/3259) and the links contained within)

## Tested scenarios
Manually tested with both Card and Custom Card components


**Fixed issue**:  #3259 
