### PR TITLE
feat(applepay): add support for `shippingContactEditingMode`

### DIFF
--- a/.changeset/orange-lights-occur.md
+++ b/.changeset/orange-lights-occur.md
@@ -1,0 +1,9 @@
+---
+'@adyen/adyen-web': minor
+---
+
+[Apple Pay] Add support for shippingContactEditingMode configuration value
+
+This configuration value is used to prevent a user from editing the shipping address. This is useful for store pickup checkout options.
+
+https://developer.apple.com/documentation/applepayontheweb/applepaypaymentrequest/shippingcontacteditingmode

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -90,6 +90,12 @@ export interface ApplePayConfiguration extends UIElementProps {
     merchantCapabilities?: ApplePayJS.ApplePayMerchantCapability[];
 
     /**
+     * A value that indicates whether the shipping mode prevents the user from editing the shipping address.
+     * {@link https://developer.apple.com/documentation/applepayontheweb/applepaypaymentrequest/shippingcontacteditingmode}
+     */
+    shippingContactEditingMode?: ApplePayJS.ApplePayShippingContactEditingMode;
+
+    /**
      * A set of shipping method objects that describe the available shipping methods.
      */
     shippingMethods?: ApplePayJS.ApplePayShippingMethod[];

--- a/packages/lib/src/components/ApplePay/utils/payment-request.test.ts
+++ b/packages/lib/src/components/ApplePay/utils/payment-request.test.ts
@@ -23,6 +23,7 @@ describe('preparePaymentRequest', () => {
             countryCode: 'NL',
             companyName: 'Company Name',
             amount: { value: 115800, currency: 'EUR' },
+            shippingContactEditingMode: 'storePickup',
             supportedNetworks: ['amex', 'discover', 'masterCard', 'visa'],
             totalPriceLabel: 'Amount'
         });
@@ -30,6 +31,7 @@ describe('preparePaymentRequest', () => {
         expect(paymentRequest.total.amount).toBe('1158');
         expect(paymentRequest.total.label).toBe('Amount');
         expect(paymentRequest.countryCode).toBe('NL');
+        expect(paymentRequest.shippingContactEditingMode).toBe('storePickup');
         expect(paymentRequest.supportedNetworks.includes('visa')).toBe(true);
         expect(paymentRequest.currencyCode).toBe('EUR');
     });

--- a/packages/lib/src/components/ApplePay/utils/payment-request.ts
+++ b/packages/lib/src/components/ApplePay/utils/payment-request.ts
@@ -22,6 +22,7 @@ export const preparePaymentRequest = (paymentRequest): ApplePayJS.ApplePayPaymen
         },
 
         lineItems: props.lineItems,
+        shippingContactEditingMode: props.shippingContactEditingMode,
         shippingMethods: props.shippingMethods,
         shippingType: props.shippingType,
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This PR adds support for the `shippingContactEditingMode` Apple Pay configuration value which can be used to prevent a user from editing the shipping address. This is useful for store pickup checkout options. Relevant documentation:

https://developer.apple.com/documentation/applepayontheweb/applepaypaymentrequest/shippingcontacteditingmode

## Tested scenarios
<!-- Description of tested scenarios -->
A test has been added to `payment-request-test.ts` for `shippingContactEditingMode`.

**Fixed issue**:  <!-- #-prefixed issue number -->
N/A