### PR TITLE
Card: Fix SF loading state not hiding pay button

### DIFF
--- a/.changeset/rude-lizards-buy.md
+++ b/.changeset/rude-lizards-buy.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Card: Pay button now loads at the same time as other UI elements

--- a/packages/e2e-playwright/models/card.ts
+++ b/packages/e2e-playwright/models/card.ts
@@ -52,6 +52,8 @@ class Card extends Base {
     readonly selectorList: Locator;
     readonly threeDs2Challenge: ThreeDs2Challenge;
 
+    readonly payButton: Locator;
+
     constructor(
         public readonly page: Page,
         public readonly rootElementSelector?: Locator | string
@@ -121,6 +123,9 @@ class Card extends Base {
         this.selectorList = this.rootElement.getByRole('listbox');
 
         this.threeDs2Challenge = new ThreeDs2Challenge(page);
+
+        // Regex needs to be this complex other wise it matches Google Pay in the Dropin
+        this.payButton = this.page.getByRole('button', { name: /(Pay .*)|(Save details)/ });
     }
 
     // The brands as displayed under the CardNumber field
@@ -164,9 +169,7 @@ class Card extends Base {
     }
 
     async isComponentVisible() {
-        await this.cardNumberInput.waitFor({ state: 'visible' });
-        await this.expiryDateInput.waitFor({ state: 'visible' });
-        await this.cvcInput.waitFor({ state: 'visible' });
+        await this.payButton.waitFor({state: 'visible'})
     }
 
     /**

--- a/packages/e2e-playwright/models/card.ts
+++ b/packages/e2e-playwright/models/card.ts
@@ -169,7 +169,15 @@ class Card extends Base {
     }
 
     async isComponentVisible() {
-        await this.payButton.waitFor({state: 'visible'})
+        await this.payButton.waitFor({ state: 'visible' });
+        // for some reason on webkit this line needs to be here
+        // removing this waitFor makes that the focus state is never returned to the Card Number Input in case of error handling
+        // it's unclear why is that the case and why only happens in Webkit, but also doesn't seem to be a race condition as adding
+        // a really long timeout also doesn't fix the issue
+        // in the the future to test this change pay attention to tests for the auto focus feature
+        await this.cardNumberInput.waitFor({ state: 'visible'});
+        await this.cvcInput.waitFor({ state: 'visible'});
+        await this.expiryDateInput.waitFor({ state: 'visible'});
     }
 
     /**

--- a/packages/e2e-playwright/models/giftcard.ts
+++ b/packages/e2e-playwright/models/giftcard.ts
@@ -17,6 +17,8 @@ export class Giftcard extends Base {
 
     readonly cvcInput: Locator;
 
+    readonly payButton: Locator;
+
     constructor(
         public readonly page: Page,
         rootElementSelector = '.adyen-checkout__giftcard'
@@ -30,6 +32,8 @@ export class Giftcard extends Base {
 
         const cvcIframe = this.rootElement.frameLocator(`[title="${CVC_IFRAME_TITLE}"]`);
         this.cvcInput = cvcIframe.locator(`input[aria-label="${CVC_IFRAME_LABEL}"]`);
+
+        this.payButton = this.rootElement.getByRole('button', { name: 'Redeem' });
     }
 
     async goto(url: string = URL_MAP.giftcard_with_card) {
@@ -43,8 +47,7 @@ export class Giftcard extends Base {
     }
 
     async isComponentVisible() {
-        await this.cardNumberInput.waitFor({ state: 'visible' });
-        await this.cvcInput.waitFor({ state: 'visible' });
+        await this.payButton.waitFor({ state: 'visible' });
     }
 
     async hasCorrectRemainingAmount(amount: string) {

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -154,7 +154,7 @@ describe('CardInput > holderName', () => {
         /* eslint-disable testing-library/no-node-access */
         const children = select.children;
 
-        const positionDiv = children.item(1);
+        const positionDiv = children.item(0); // the instrucitions will be hidden while loading
 
         const positionDivChildren = positionDiv.children;
 
@@ -190,7 +190,7 @@ describe('CardInput > holderName', () => {
         /* eslint-disable testing-library/no-node-access */
         const children = select.children;
 
-        const positionDiv = children.item(1);
+        const positionDiv = children.item(0); // the instrucitions will be hidden while loading
 
         const positionDivChildren = positionDiv.children;
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -448,72 +448,68 @@ const CardInput = (props: CardInputProps) => {
                 onStateUpdate={handleSFPStateUpdate}
                 type={props.brand}
                 disableIOSArrowKeys={props.disableIOSArrowKeys ? handleTouchstartIOS : null}
-                render={({ setRootNode, setFocusOn }, sfpState) =>
-                    showCardUIElements && (
-                        <div
-                            ref={setRootNode}
-                            className={classNames({
-                                'adyen-checkout__card-input': true,
-                                'adyen-checkout-card-input__wrapper': true,
-                                [`adyen-checkout__card-input--${props.fundingSource ?? 'credit'}`]: true,
-                                'adyen-checkout__card-input--loading': status === 'loading'
-                            })}
-                            role={'form'}
-                        >
-                            <FormInstruction />
+                render={({ setRootNode, setFocusOn }, sfpState) => (
+                    <div
+                        ref={setRootNode}
+                        className={classNames({
+                            'adyen-checkout__card-input': true,
+                            'adyen-checkout-card-input__wrapper': true,
+                            [`adyen-checkout__card-input--${props.fundingSource ?? 'credit'}`]: true,
+                            'adyen-checkout__card-input--loading': status === 'loading'
+                        })}
+                        role={'form'}
+                    >
+                        {showCardUIElements && <FormInstruction />}
 
-                            <FieldToRender
-                                // Extract exact props that we need to pass down
-                                {...extractPropsForCardFields(props)}
-                                // Pass on vars created in CardInput:
-                                // Base (shared w. StoredCard)
-                                data={data}
-                                valid={valid}
-                                errors={errors}
-                                handleChangeFor={handleChangeFor}
-                                focusedElement={focusedElement}
-                                setFocusOn={setFocusOn}
-                                sfpState={sfpState}
-                                cvcPolicy={cvcPolicy}
-                                hasInstallments={hasInstallments}
-                                showAmountsInInstallments={showAmountsInInstallments}
-                                handleInstallments={setInstallments}
-                                // For Card
-                                brandsIcons={props.brandsIcons}
-                                formData={formData}
-                                formErrors={formErrors}
-                                formValid={formValid}
-                                expiryDatePolicy={expiryDatePolicy}
-                                dualBrandSelectElements={dualBrandSelectElements}
-                                extensions={extensions}
-                                selectedBrandValue={selectedBrandValue}
-                                // For KCP
-                                showKCP={showKCP}
-                                // For SSN
-                                showBrazilianSSN={showBrazilianSSN}
-                                socialSecurityNumber={socialSecurityNumber}
-                                // For Store details
-                                handleOnStoreDetails={setStorePaymentMethod}
-                                // For Address
-                                setAddressRef={setAddressRef}
-                                billingAddress={billingAddress}
-                                billingAddressValidationRules={
-                                    partialAddressSchema && getPartialAddressValidationRules(partialAddressCountry.current)
-                                }
-                                partialAddressSchema={partialAddressSchema}
-                                handleAddress={handleAddress}
-                                onAddressLookup={props.onAddressLookup}
-                                onAddressSelected={props.onAddressSelected}
-                                addressSearchDebounceMs={props.addressSearchDebounceMs}
-                                //
-                                iOSFocusedField={iOSFocusedField}
-                                //
-                                onFieldFocusAnalytics={onFieldFocusAnalytics}
-                                onFieldBlurAnalytics={onFieldBlurAnalytics}
-                            />
-                        </div>
-                    )
-                }
+                        <FieldToRender
+                            // Extract exact props that we need to pass down
+                            {...extractPropsForCardFields(props)}
+                            // Pass on vars created in CardInput:
+                            // Base (shared w. StoredCard)
+                            data={data}
+                            valid={valid}
+                            errors={errors}
+                            handleChangeFor={handleChangeFor}
+                            focusedElement={focusedElement}
+                            setFocusOn={setFocusOn}
+                            sfpState={sfpState}
+                            cvcPolicy={cvcPolicy}
+                            hasInstallments={hasInstallments}
+                            showAmountsInInstallments={showAmountsInInstallments}
+                            handleInstallments={setInstallments}
+                            // For Card
+                            brandsIcons={props.brandsIcons}
+                            formData={formData}
+                            formErrors={formErrors}
+                            formValid={formValid}
+                            expiryDatePolicy={expiryDatePolicy}
+                            dualBrandSelectElements={dualBrandSelectElements}
+                            extensions={extensions}
+                            selectedBrandValue={selectedBrandValue}
+                            // For KCP
+                            showKCP={showKCP}
+                            // For SSN
+                            showBrazilianSSN={showBrazilianSSN}
+                            socialSecurityNumber={socialSecurityNumber}
+                            // For Store details
+                            handleOnStoreDetails={setStorePaymentMethod}
+                            // For Address
+                            setAddressRef={setAddressRef}
+                            billingAddress={billingAddress}
+                            billingAddressValidationRules={partialAddressSchema && getPartialAddressValidationRules(partialAddressCountry.current)}
+                            partialAddressSchema={partialAddressSchema}
+                            handleAddress={handleAddress}
+                            onAddressLookup={props.onAddressLookup}
+                            onAddressSelected={props.onAddressSelected}
+                            addressSearchDebounceMs={props.addressSearchDebounceMs}
+                            //
+                            iOSFocusedField={iOSFocusedField}
+                            //
+                            onFieldFocusAnalytics={onFieldFocusAnalytics}
+                            onFieldBlurAnalytics={onFieldBlurAnalytics}
+                        />
+                    </div>
+                )}
             />
 
             {props.fastlaneConfiguration && (

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -105,7 +105,7 @@ const CardInput = (props: CardInputProps) => {
      * Used tho show and hide the pay button and instructions text
      * Should mimick the same logic as CardInput loading wrapper
      */
-    const [showCardUIElements, setShowCardUIElements] = useState('loading');
+    const [showCardUIElements, setShowCardUIElements] = useState(false);
 
     /**
      * LOCAL VARS
@@ -241,9 +241,12 @@ const CardInput = (props: CardInputProps) => {
      * Used right now to mimick the loading status changes, this can only be done this way
      * Trying to do it via onConfiguSuccess or onChange has side effects
      */
-    const handleSFPStateUpdate = useCallback(sfpState => {
-        mimickLoadingStatusChange(sfpState);
-    }, []);
+    const handleSFPStateUpdate = useCallback(
+        sfpState => {
+            mimickLoadingStatusChange(sfpState);
+        },
+        [showCardUIElements, setShowCardUIElements]
+    );
 
     /**
      * This function implements the same logic that LoadingProvider uses to show and hide elements
@@ -254,9 +257,9 @@ const CardInput = (props: CardInputProps) => {
     const mimickLoadingStatusChange = sfpState => {
         if (!sfpState.status) return;
         if (sfpState.status == 'loading') {
-            setShowCardUIElements('false');
+            setShowCardUIElements(false);
         } else {
-            setShowCardUIElements('false');
+            setShowCardUIElements(true);
         }
     };
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -103,7 +103,7 @@ const CardInput = (props: CardInputProps) => {
 
     /**
      * Used tho show and hide the pay button and instructions text
-     * Should mimick the same logic as CardInput loading wrapper
+     * Should mimic the same logic as CardInput loading wrapper
      */
     const [showCardUIElements, setShowCardUIElements] = useState(false);
 
@@ -238,23 +238,23 @@ const CardInput = (props: CardInputProps) => {
 
     /**
      * Listen to the full SecureFieldsProvider state and handle actions
-     * Used right now to mimick the loading status changes, this can only be done this way
+     * Used right now to mimic the loading status changes, this can only be done this way
      * Trying to do it via onConfiguSuccess or onChange has side effects
      */
     const handleSFPStateUpdate = useCallback(
         sfpState => {
-            mimickLoadingStatusChange(sfpState);
+            mimicLoadingStatusChange(sfpState);
         },
         [showCardUIElements, setShowCardUIElements]
     );
 
     /**
      * This function implements the same logic that LoadingProvider uses to show and hide elements
-     * We want to mimick this behavior so we can hide and show the pay button or the instructions text
+     * We want to mimic this behavior so we can hide and show the pay button or the instructions text
      * Deciding to do it this way since we garante there's no DOM changes to merchants
      * We can break this in the next major version (v7)
      */
-    const mimickLoadingStatusChange = sfpState => {
+    const mimicLoadingStatusChange = sfpState => {
         if (!sfpState.status) return;
         if (sfpState.status == 'loading') {
             setShowCardUIElements(false);

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -102,6 +102,12 @@ const CardInput = (props: CardInputProps) => {
     const [internallyDetectedBrand, setInternallyDetectedBrand] = useState('card');
 
     /**
+     * Used tho show and hide the pay button and instructions text
+     * Should mimick the same logic as CardInput loading wrapper
+     */
+    const [showCardUIElements, setShowCardUIElements] = useState('loading');
+
+    /**
      * LOCAL VARS
      */
     const {
@@ -228,6 +234,30 @@ const CardInput = (props: CardInputProps) => {
         setCvcPolicy(sfState.cvcPolicy);
         setShowSocialSecurityNumber(sfState.showSocialSecurityNumber);
         setExpiryDatePolicy(sfState.expiryDatePolicy);
+    };
+
+    /**
+     * Listen to the full SecureFieldsProvider state and handle actions
+     * Used right now to mimick the loading status changes, this can only be done this way
+     * Trying to do it via onConfiguSuccess or onChange has side effects
+     */
+    const handleSFPStateUpdate = useCallback(sfpState => {
+        mimickLoadingStatusChange(sfpState);
+    }, []);
+
+    /**
+     * This function implements the same logic that LoadingProvider uses to show and hide elements
+     * We want to mimick this behavior so we can hide and show the pay button or the instructions text
+     * Deciding to do it this way since we garante there's no DOM changes to merchants
+     * We can break this in the next major version (v7)
+     */
+    const mimickLoadingStatusChange = sfpState => {
+        if (!sfpState.status) return;
+        if (sfpState.status == 'loading') {
+            setShowCardUIElements('false');
+        } else {
+            setShowCardUIElements('false');
+        }
     };
 
     // Farm the handlers for binLookup related functionality out to another 'extensions' file
@@ -415,70 +445,75 @@ const CardInput = (props: CardInputProps) => {
                 onChange={handleSecuredFieldsChange}
                 onBrand={onBrand}
                 onFocus={handleFocus}
+                onStateUpdate={handleSFPStateUpdate}
                 type={props.brand}
                 disableIOSArrowKeys={props.disableIOSArrowKeys ? handleTouchstartIOS : null}
-                render={({ setRootNode, setFocusOn }, sfpState) => (
-                    <div
-                        ref={setRootNode}
-                        className={classNames({
-                            'adyen-checkout__card-input': true,
-                            'adyen-checkout-card-input__wrapper': true,
-                            [`adyen-checkout__card-input--${props.fundingSource ?? 'credit'}`]: true,
-                            'adyen-checkout__card-input--loading': status === 'loading'
-                        })}
-                        role={'form'}
-                    >
-                        <FormInstruction />
+                render={({ setRootNode, setFocusOn }, sfpState) =>
+                    showCardUIElements && (
+                        <div
+                            ref={setRootNode}
+                            className={classNames({
+                                'adyen-checkout__card-input': true,
+                                'adyen-checkout-card-input__wrapper': true,
+                                [`adyen-checkout__card-input--${props.fundingSource ?? 'credit'}`]: true,
+                                'adyen-checkout__card-input--loading': status === 'loading'
+                            })}
+                            role={'form'}
+                        >
+                            <FormInstruction />
 
-                        <FieldToRender
-                            // Extract exact props that we need to pass down
-                            {...extractPropsForCardFields(props)}
-                            // Pass on vars created in CardInput:
-                            // Base (shared w. StoredCard)
-                            data={data}
-                            valid={valid}
-                            errors={errors}
-                            handleChangeFor={handleChangeFor}
-                            focusedElement={focusedElement}
-                            setFocusOn={setFocusOn}
-                            sfpState={sfpState}
-                            cvcPolicy={cvcPolicy}
-                            hasInstallments={hasInstallments}
-                            showAmountsInInstallments={showAmountsInInstallments}
-                            handleInstallments={setInstallments}
-                            // For Card
-                            brandsIcons={props.brandsIcons}
-                            formData={formData}
-                            formErrors={formErrors}
-                            formValid={formValid}
-                            expiryDatePolicy={expiryDatePolicy}
-                            dualBrandSelectElements={dualBrandSelectElements}
-                            extensions={extensions}
-                            selectedBrandValue={selectedBrandValue}
-                            // For KCP
-                            showKCP={showKCP}
-                            // For SSN
-                            showBrazilianSSN={showBrazilianSSN}
-                            socialSecurityNumber={socialSecurityNumber}
-                            // For Store details
-                            handleOnStoreDetails={setStorePaymentMethod}
-                            // For Address
-                            setAddressRef={setAddressRef}
-                            billingAddress={billingAddress}
-                            billingAddressValidationRules={partialAddressSchema && getPartialAddressValidationRules(partialAddressCountry.current)}
-                            partialAddressSchema={partialAddressSchema}
-                            handleAddress={handleAddress}
-                            onAddressLookup={props.onAddressLookup}
-                            onAddressSelected={props.onAddressSelected}
-                            addressSearchDebounceMs={props.addressSearchDebounceMs}
-                            //
-                            iOSFocusedField={iOSFocusedField}
-                            //
-                            onFieldFocusAnalytics={onFieldFocusAnalytics}
-                            onFieldBlurAnalytics={onFieldBlurAnalytics}
-                        />
-                    </div>
-                )}
+                            <FieldToRender
+                                // Extract exact props that we need to pass down
+                                {...extractPropsForCardFields(props)}
+                                // Pass on vars created in CardInput:
+                                // Base (shared w. StoredCard)
+                                data={data}
+                                valid={valid}
+                                errors={errors}
+                                handleChangeFor={handleChangeFor}
+                                focusedElement={focusedElement}
+                                setFocusOn={setFocusOn}
+                                sfpState={sfpState}
+                                cvcPolicy={cvcPolicy}
+                                hasInstallments={hasInstallments}
+                                showAmountsInInstallments={showAmountsInInstallments}
+                                handleInstallments={setInstallments}
+                                // For Card
+                                brandsIcons={props.brandsIcons}
+                                formData={formData}
+                                formErrors={formErrors}
+                                formValid={formValid}
+                                expiryDatePolicy={expiryDatePolicy}
+                                dualBrandSelectElements={dualBrandSelectElements}
+                                extensions={extensions}
+                                selectedBrandValue={selectedBrandValue}
+                                // For KCP
+                                showKCP={showKCP}
+                                // For SSN
+                                showBrazilianSSN={showBrazilianSSN}
+                                socialSecurityNumber={socialSecurityNumber}
+                                // For Store details
+                                handleOnStoreDetails={setStorePaymentMethod}
+                                // For Address
+                                setAddressRef={setAddressRef}
+                                billingAddress={billingAddress}
+                                billingAddressValidationRules={
+                                    partialAddressSchema && getPartialAddressValidationRules(partialAddressCountry.current)
+                                }
+                                partialAddressSchema={partialAddressSchema}
+                                handleAddress={handleAddress}
+                                onAddressLookup={props.onAddressLookup}
+                                onAddressSelected={props.onAddressSelected}
+                                addressSearchDebounceMs={props.addressSearchDebounceMs}
+                                //
+                                iOSFocusedField={iOSFocusedField}
+                                //
+                                onFieldFocusAnalytics={onFieldFocusAnalytics}
+                                onFieldBlurAnalytics={onFieldBlurAnalytics}
+                            />
+                        </div>
+                    )
+                }
             />
 
             {props.fastlaneConfiguration && (
@@ -490,7 +525,8 @@ const CardInput = (props: CardInputProps) => {
                 />
             )}
 
-            {props.showPayButton &&
+            {showCardUIElements &&
+                props.showPayButton &&
                 props.payButton({
                     status,
                     variant: props.isPayButtonPrimaryVariant ? 'primary' : 'secondary',

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -131,6 +131,8 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
 
     public componentDidUpdate() {
         this.checkForKCPFields();
+        // Pass all the state data up - Used right now for loading status
+        this.props.onStateUpdate?.(this.state);
     }
 
     public componentWillUnmount(): void {

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -38,6 +38,7 @@ export interface SFPProps {
     onFieldValid?: () => {};
     onFocus?: () => {};
     onLoad?: () => {};
+    onStateUpdate: (obj: SFPState) => void;
     handleKeyPress?: (obj: KeyboardEvent) => void;
     rootNode: HTMLElement; // Specific to SecuredFieldsInput
     showWarnings?: boolean;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

I have rewritten this PR. The objective is to achieve the same behaviour as LoadingWrapper, but at CardInput level, without changing any of the DOM, or the the existing callbacks.

I believe this is the best way of achieving this, however it has to introduce a new callback that passes the full state up from SecureFieldsProvider to CardInput.

Other possibilities would be to use onConfigSuccess callback but this would not copy `status` and would in the end require additional steps and logic. For example, there's no clean way to handle the 'failed' to load status.

Another way could have been to listen to `onChange` and catch this changes in `handleSecuredFieldsChange` since the state is available here. Problem is that we don't call `onChange` when secure fields gets configure, so it doesn't serve as a true way of reliably getting the SecureFieldsProvider state. 

Another way could have been tapping in the `render` function passed on the SecureFieldsProvider. However I think it wouldn't be very obvious for future changes.

## Tested scenarios
<!-- Description of tested scenarios -->
- [x] Check if the following components can be "waited for" in E2E by just using the payButton in the UI
  - [x] Card
  - [x] Giftcard
- [x] Check what is the changes in Markup
- [x] Check for style regressions

**Fixed issue**:  <!-- #-prefixed issue number -->
