### PR TITLE
Update clipboard.ts

### DIFF
--- a/packages/lib/src/utils/clipboard.ts
+++ b/packages/lib/src/utils/clipboard.ts
@@ -8,17 +8,8 @@ export function copyToClipboard(value) {
     }
 
     const copyInput = createInput(value);
-
-    if (window.navigator.userAgent.match(/ipad|iphone/i)) {
-        const range = document.createRange();
-        range.selectNodeContents(copyInput);
-        const selection = window.getSelection();
-        selection.removeAllRanges();
-        selection.addRange(range);
-        copyInput.setSelectionRange(0, 999999);
-    } else {
-        copyInput.select();
-    }
+    
+    copyInput.select();
 
     document.execCommand('copy');
 


### PR DESCRIPTION
Removed iOS conditional for specific clipboard logic

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Clipboard copy method does not work on some iOS browsers. Code has a conditional that checks if user agent is iPhone/iPad. Logic present on this conditional block is not working on said browsers. The conditional is useless, as the default `select()` method is present on Safari/Webview iOS since version 1. For that reason, all customers using iOS paying by QR Code on websites that uses Adyen components can't proceed with payment. 

The fix is to basically remove the useless conditional and use the default `select()` method, [widely available on all browsers](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select).

## Tested scenarios
I've copied the clipboard.ts and made a tool for testing in multiple browsers. What should be a fallback is the default and only option on iOS user agents. 

Also, we have an app with an webview that changes useragent name. Users using Safari Webview with this changed user agent can copy using the mentioned method.


**Fixed issue**:  #3313
