### PR TITLE
v5 - Fixing clipboard copy-paste mechanism

### DIFF
--- a/.changeset/cuddly-peaches-sort.md
+++ b/.changeset/cuddly-peaches-sort.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": patch
+---
+
+Fixed issue where clipboard copy-paste functionality wasn't working for mobile Safari 18.4 browsers

--- a/packages/lib/src/utils/clipboard.ts
+++ b/packages/lib/src/utils/clipboard.ts
@@ -8,20 +8,9 @@ export function copyToClipboard(value) {
     }
 
     const copyInput = createInput(value);
-
-    if (window.navigator.userAgent.match(/ipad|iphone/i)) {
-        const range = document.createRange();
-        range.selectNodeContents(copyInput);
-        const selection = window.getSelection();
-        selection.removeAllRanges();
-        selection.addRange(range);
-        copyInput.setSelectionRange(0, 999999);
-    } else {
-        copyInput.select();
-    }
+    copyInput.select();
 
     document.execCommand('copy');
-
     document.body.removeChild(copyInput);
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Copy-paste mechanism stopped working on mobile Safari 18.4.1.

We had certain logic to make copy-paste work on old iOS versions ( <= 13 ) which for now seems to be legacy. This logic seems to break mobile Safari 18.4.1 . 

For reference, our way of copy-pasting seems that was based on these reasonings: [here](https://stackoverflow.com/questions/40147676/javascript-copy-to-clipboard-on-safari) and [here](https://stackoverflow.com/questions/34045777/copy-to-clipboard-using-javascript-in-ios)

## Tested scenarios
- Tested the change on v6 using the testing playground


**Fixed issue**:  #3313 
