### PR TITLE
[ci] Release v5

### DIFF
--- a/.changeset/cuddly-peaches-sort.md
+++ b/.changeset/cuddly-peaches-sort.md
@@ -1,5 +1,0 @@
----
-"@adyen/adyen-web": patch
----
-
-Fixed issue where clipboard copy-paste functionality wasn't working for mobile Safari 18.4 browsers

--- a/packages/e2e-playwright/package.json
+++ b/packages/e2e-playwright/package.json
@@ -26,6 +26,6 @@
     "webpack-dev-server": "4.15.1"
   },
   "dependencies": {
-    "@adyen/adyen-web": "5.71.2"
+    "@adyen/adyen-web": "5.71.3"
   }
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -41,6 +41,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "5.71.2"
+        "@adyen/adyen-web": "5.71.3"
     }
 }

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @adyen/adyen-web
 
+## 5.71.3
+
+### Patch Changes
+
+-   Fixed issue where clipboard copy-paste functionality wasn't working for mobile Safari 18.4 browsers ([#3319](https://github.com/Adyen/adyen-web/pull/3319))
+
 ## 5.71.2
 
 ### Patch Changes

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -25,7 +25,7 @@
         "./dist/es/adyen.css": "./dist/es/adyen.css",
         "./package.json": "./package.json"
     },
-    "version": "5.71.2",
+    "version": "5.71.3",
     "license": "MIT",
     "homepage": "https://docs.adyen.com/checkout",
     "repository": "github:Adyen/adyen-web",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -41,6 +41,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-        "@adyen/adyen-web": "5.71.2"
+        "@adyen/adyen-web": "5.71.3"
     }
 }


### PR DESCRIPTION
## 5.71.3

### Patch Changes

-   Fixed issue where clipboard copy-paste functionality wasn't working for mobile Safari 18.4 browsers ([#3319](https://github.com/Adyen/adyen-web/pull/3319))