### PR TITLE
feat: allow domainName to be overrided for iframe apply pay session

### DIFF
--- a/.changeset/curvy-bats-worry.md
+++ b/.changeset/curvy-bats-worry.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Adds ApplePay domain name override for iframe usage

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -342,13 +342,13 @@ class ApplePayElement extends UIElement<ApplePayConfiguration> {
 
     private async validateMerchant(resolve, reject) {
         const { hostname: domainName } = window.location;
-        const { clientKey, configuration, loadingContext, initiative } = this.props;
+        const { clientKey, configuration, loadingContext, initiative, domainNameOverride } = this.props;
         const { merchantName, merchantId } = configuration;
         const path = `v1/applePay/sessions?clientKey=${clientKey}`;
         const options = { loadingContext, path };
         const request: ApplePaySessionRequest = {
             displayName: merchantName,
-            domainName,
+            domainName: domainNameOverride || domainName,
             initiative,
             merchantIdentifier: merchantId
         };

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -341,14 +341,14 @@ class ApplePayElement extends UIElement<ApplePayConfiguration> {
     }
 
     private async validateMerchant(resolve, reject) {
-        const { hostname: domainName } = window.location;
-        const { clientKey, configuration, loadingContext, initiative, domainNameOverride } = this.props;
+        const { hostname } = window.location;
+        const { clientKey, configuration, loadingContext, initiative, domainName } = this.props;
         const { merchantName, merchantId } = configuration;
         const path = `v1/applePay/sessions?clientKey=${clientKey}`;
         const options = { loadingContext, path };
         const request: ApplePaySessionRequest = {
             displayName: merchantName,
-            domainName: domainNameOverride || domainName,
+            domainName: domainName || hostname,
             initiative,
             merchantIdentifier: merchantId
         };

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -231,7 +231,7 @@ export interface ApplePayConfiguration extends UIElementProps {
     /**
      * Used to override the domain name for the Apple Pay button.
      */
-    domainNameOverride?: string;
+    domainName?: string;
 }
 
 export interface ApplePayElementData {

--- a/packages/lib/src/components/ApplePay/types.ts
+++ b/packages/lib/src/components/ApplePay/types.ts
@@ -227,6 +227,11 @@ export interface ApplePayConfiguration extends UIElementProps {
      * Used to tweak the text of the button types that contain text ('Continue with', 'Book with', etc)
      */
     buttonLocale?: string;
+
+    /**
+     * Used to override the domain name for the Apple Pay button.
+     */
+    domainNameOverride?: string;
 }
 
 export interface ApplePayElementData {


### PR DESCRIPTION
## Summary
- iframe ApplePay sessions do not work as the parent frame URL is not being sent down to the ApplePaySession instantiation. It uses `window.location.hostname` so it will always be the iframe URL instead of the parent URL.

Some basic principles on why this approach:
- Cross-origin domains is a choice, not a norm.
- window.location.hostname works for most cases if not cross-origin
- In the case of cross-origin domains, the parent domain will be passed to the child by whatever mechanism desired, it is not the responsibility of the adyen-web package. It only accepts the override in the conditions that the app has decided it to be for security reasons.
- It is still subject to the apple pay domains that are added.

## Tested scenarios
- Having a page load an iframe which contains adyen-web with ApplePay loaded. Payment method has both domains white listed but Apple Pay only works when loading the iframe URL standalone, but when loaded from the parent site, it shows an error and closes the payment sheet.

## Does it work?
- Yes, I have built the package and used it locally in my own application and tested that iframe apple pay works and payment was successful.

