### PR TITLE
feat: expose `core`

### DIFF
--- a/.changeset/happy-numbers-bow.md
+++ b/.changeset/happy-numbers-bow.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Export `Core` class.

--- a/packages/lib/src/core/AdyenCheckout.ts
+++ b/packages/lib/src/core/AdyenCheckout.ts
@@ -19,4 +19,4 @@ AdyenCheckout.setBundleType = (type: string) => {
     Core.setBundleType(type);
 };
 
-export { AdyenCheckout };
+export { AdyenCheckout, Core };

--- a/packages/lib/src/core/Services/sessions/submit-details.ts
+++ b/packages/lib/src/core/Services/sessions/submit-details.ts
@@ -8,7 +8,7 @@ import { CheckoutSessionDetailsResponse } from '../../CheckoutSession/types';
 function submitDetails(details, session: Session): Promise<CheckoutSessionDetailsResponse> {
     const path = `${API_VERSION}/sessions/${session.id}/paymentDetails?clientKey=${session.clientKey}`;
     const data = {
-        sessionData: session.data,
+        ...(session.data && { sessionData: session.data }),
         ...details
     };
 

--- a/packages/lib/src/index.umd.ts
+++ b/packages/lib/src/index.umd.ts
@@ -1,4 +1,4 @@
-import { AdyenCheckout } from './core/AdyenCheckout';
+import { AdyenCheckout, Core } from './core/AdyenCheckout';
 import { NewableComponent } from './core/core.registry';
 import * as components from './components';
 import createComponent from './create-component.umd';
@@ -10,6 +10,7 @@ const Classes: NewableComponent[] = Object.keys(Components).map(key => Component
 AdyenCheckout.register(...Classes);
 
 const AdyenWeb = {
+    Core,
     AdyenCheckout,
     createComponent,
     ...components


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
**Context**

With redirect-based payment methods like iDEAL, shoppers may return back to the site using a different browser after completing the payment on an external site or application. This behavior makes it unreliable to depend on locally stored `sessionData`, as it may not be available upon return.

Currently, when initializing `AdyenCheckout` after redirection, the sdk always triggers a setup call. This call fails if `sessionData` is missing (e.g., due to localStorage missing the `sessionData` in the new browser context).

To address this, we’re now exposing the `Core` class. This provides more flexibility for PBL/merchants: in redirection to a different browser scenarios, instead of instantiating a new `AdyenCheckout`, they can directly instantiate `Core`. This approach bypasses the setup call, avoiding failure due to missing `sessionData`.
