### PR TITLE
Feature: Add srpanel for gift card

### DIFF
--- a/.changeset/loose-ducks-appear.md
+++ b/.changeset/loose-ducks-appear.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+a11y: improve giftcard screen reader errors

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.test.tsx
@@ -169,6 +169,7 @@ describe('Gift card', () => {
 
     beforeEach(() => {
         const props = {
+            ...global.commonCoreProps,
             id: '3',
             type: 'giftcard',
             brand: 'givex',

--- a/packages/lib/src/components/Giftcard/Giftcard.test.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { AnalyticsModule } from '../../types/global-types';
 import { mockDeep } from 'jest-mock-extended';
+import { ANALYTICS_ERROR_TYPE } from '../../core/Analytics/constants';
 
 const flushPromises = () => new Promise(process.nextTick);
 

--- a/packages/lib/src/components/Giftcard/Giftcard.test.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.test.tsx
@@ -4,21 +4,16 @@ import userEvent from '@testing-library/user-event';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { AnalyticsModule } from '../../types/global-types';
 import { mockDeep } from 'jest-mock-extended';
-import { ANALYTICS_ERROR_TYPE } from '../../core/Analytics/constants';
 
 const flushPromises = () => new Promise(process.nextTick);
 
 describe('Giftcard', () => {
-    const resources = global.resources;
     const i18n = global.i18n;
     const user = userEvent.setup();
 
     const baseProps = {
+        ...global.commonCoreProps,
         clientKey: 'mock',
-        modules: {
-            resources,
-            analytics: global.analytics
-        },
         amount: { value: 1000, currency: 'EUR' },
         name: 'My Test Gift Card',
         type: 'giftcard',
@@ -152,7 +147,7 @@ describe('Giftcard', () => {
             const giftcard = new Giftcard(global.core, {
                 ...baseProps,
                 modules: {
-                    resources,
+                    ...baseProps.modules,
                     analytics
                 },
                 onError: () => {},

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -73,6 +73,11 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     }
 
     private onBalanceCheck = (): void => {
+        if (!this.isValid) {
+            this.showValidation();
+            return;
+        }
+
         // skip balance check if no onBalanceCheck event has been defined
         const hasBalanceCheck = this.props.session || this.props.onBalanceCheck;
         if (!hasBalanceCheck) return super.submit();
@@ -140,11 +145,6 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     public submit() {
         // for simplicity of the merchant we always only expose .submit()
         // however to make the actual payment call we call makeSubmitCall
-        if (!this.isValid) {
-            this.showValidation();
-            return false;
-        }
-
         this.balanceCheck();
     }
 

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -7,6 +7,7 @@ import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { PaymentAmount } from '../../types/global-types';
 import { GiftCardElementData, GiftCardConfiguration, balanceCheckResponseType } from './types';
 import { TxVariants } from '../tx-variants';
+import SRPanelProvider from '../../core/Errors/SRPanelProvider';
 
 export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     public static type = TxVariants.giftcard;
@@ -160,18 +161,20 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     render() {
         return (
             <CoreProvider i18n={this.props.i18n} loadingContext={this.props.loadingContext} resources={this.resources}>
-                <GiftcardComponent
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
-                    {...this.props}
-                    handleKeyPress={this.handleKeyPress}
-                    showPayButton={this.props.showPayButton}
-                    onChange={this.setState}
-                    makeBalanceCheck={() => this.onBalanceCheck()}
-                    makePayment={() => this.makeSubmitCall()}
-                    payButton={this.payButton}
-                />
+                <SRPanelProvider srPanel={this.props.modules.srPanel}>
+                    <GiftcardComponent
+                        ref={ref => {
+                            this.componentRef = ref;
+                        }}
+                        {...this.props}
+                        handleKeyPress={this.handleKeyPress}
+                        showPayButton={this.props.showPayButton}
+                        onChange={this.setState}
+                        makeBalanceCheck={() => this.onBalanceCheck()}
+                        makePayment={() => this.makeSubmitCall()}
+                        payButton={this.payButton}
+                    />
+                </SRPanelProvider>
             </CoreProvider>
         );
     }

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -7,6 +7,7 @@ import { PaymentAmount } from '../../../types/global-types';
 import { GIFT_CARD } from '../../internal/SecuredFields/lib/constants';
 import { GiftCardFields } from './GiftcardFields';
 import { GiftcardFieldsProps, Placeholders } from './types';
+import { useSRPanelForGiftcardErrors } from './useSRPanelForGiftcardErrors';
 
 interface GiftcardComponentProps {
     onChange: (state) => void;
@@ -34,7 +35,9 @@ class Giftcard extends Component<GiftcardComponentProps> {
         balance: null,
         transactionLimit: null,
         focusedElement: false,
-        isValid: false
+        isValid: false,
+        sfpState: {},
+        transformedErrors: {}
     };
 
     public static defaultProps = {
@@ -48,20 +51,29 @@ class Giftcard extends Component<GiftcardComponentProps> {
 
     public sfp;
 
+    /**
+     * Maps string error codes from SecuredFields to validation rule objects
+     */
+    public mapErrorsToValidationObjects = () => {
+        // Use the sfp reference to call mapErrorsToValidationRuleResult
+        if (!this.sfp) return {};
+        return this.sfp.mapErrorsToValidationRuleResult();
+    };
+
     public onChange = sfpState => {
+        // Add transformed errors to the state
+        const transformedErrors = this.mapErrorsToValidationObjects();
+
+        this.setState({
+            sfpState,
+            transformedErrors
+        });
+
         this.props.onChange({
             data: sfpState.data,
             isValid: sfpState.isSfpValid
         });
     };
-
-    public showValidation = () => {
-        this.sfp.showValidation();
-    };
-
-    setStatus(status) {
-        this.setState({ status });
-    }
 
     public handleFocus = e => {
         this.setState({ focusedElement: e.currentFocusObject });
@@ -78,8 +90,14 @@ class Giftcard extends Component<GiftcardComponentProps> {
         this.setState({ balance, transactionLimit });
     };
 
-    render(props, { focusedElement, balance, transactionLimit }) {
+    render(props, { focusedElement, balance, transactionLimit, sfpState, transformedErrors }) {
         const { i18n } = useCoreContext();
+
+        // Handle SRPanel errors in render with transformed error objects
+        useSRPanelForGiftcardErrors({
+            errors: transformedErrors,
+            isValidating: sfpState?.isValidating || { current: false }
+        });
 
         const transactionAmount = transactionLimit?.value < balance?.value ? transactionLimit : balance;
         const hasEnoughBalance = transactionAmount?.value >= this.props.amount?.value;
@@ -92,6 +110,7 @@ class Giftcard extends Component<GiftcardComponentProps> {
                     transactionLimit={transactionLimit}
                     makePayment={props.makePayment}
                     status={this.state.status}
+                    makeBalanceCheck={props.makeBalanceCheck}
                     showPayButton={this.props.showPayButton}
                     payButton={this.props.payButton}
                 />

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -104,7 +104,8 @@ class Giftcard extends Component<GiftcardComponentProps> {
         // Handle SRPanel errors in render with transformed error objects
         useSRPanelForGiftcardErrors({
             errors: transformedErrors,
-            isValidating
+            isValidating,
+            sfp: this.sfp
         });
 
         const transactionAmount = transactionLimit?.value < balance?.value ? transactionLimit : balance;

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -92,13 +92,7 @@ class Giftcard extends Component<GiftcardComponentProps> {
     };
 
     public showValidation = () => {
-        // TODO check if this is actually needed
-        this.setState({
-            sfpState: {
-                ...this.state.sfpState
-            },
-            isValidating: true
-        });
+        this.setState({ isValidating: true });
 
         // Validate SecuredFields
         this.sfp?.showValidation();

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -90,6 +90,19 @@ class Giftcard extends Component<GiftcardComponentProps> {
         this.setState({ balance, transactionLimit });
     };
 
+    public showValidation = () => {
+        // TODO check if this is actually needed
+        this.setState({
+            sfpState: {
+                ...this.state.sfpState,
+                isValidating: true
+            }
+        });
+
+        // Validate SecuredFields
+        this.sfp?.showValidation();
+    };
+
     render(props, { focusedElement, balance, transactionLimit, sfpState, transformedErrors }) {
         const { i18n } = useCoreContext();
 

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -37,6 +37,7 @@ class Giftcard extends Component<GiftcardComponentProps> {
         focusedElement: false,
         isValid: false,
         sfpState: {},
+        isValidating: false,
         transformedErrors: {}
     };
 
@@ -94,22 +95,22 @@ class Giftcard extends Component<GiftcardComponentProps> {
         // TODO check if this is actually needed
         this.setState({
             sfpState: {
-                ...this.state.sfpState,
-                isValidating: true
-            }
+                ...this.state.sfpState
+            },
+            isValidating: true
         });
 
         // Validate SecuredFields
         this.sfp?.showValidation();
     };
 
-    render(props, { focusedElement, balance, transactionLimit, sfpState, transformedErrors }) {
+    render(props, { focusedElement, balance, transactionLimit, isValidating, transformedErrors }) {
         const { i18n } = useCoreContext();
 
         // Handle SRPanel errors in render with transformed error objects
         useSRPanelForGiftcardErrors({
             errors: transformedErrors,
-            isValidating: sfpState?.isValidating || { current: false }
+            isValidating
         });
 
         const transactionAmount = transactionLimit?.value < balance?.value ? transactionLimit : balance;

--- a/packages/lib/src/components/Giftcard/components/GiftcardResult.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardResult.tsx
@@ -10,12 +10,14 @@ interface GiftcardResultProps {
     transactionLimit: PaymentAmount;
     status: string;
     makePayment: () => void;
+    makeBalanceCheck: () => void;
     showPayButton: boolean;
     payButton(props?: PayButtonProps): h.JSX.Element;
 }
 
 function GiftcardResult({ amount, balance, transactionLimit, status, makePayment, showPayButton, payButton }: GiftcardResultProps) {
     const { i18n } = useCoreContext();
+    // Calculate the transaction amount based on balance and transaction limit
     const transactionAmount = amount.value > transactionLimit?.value ? transactionLimit : amount;
     const remainingBalance = balance?.value - transactionAmount?.value;
 

--- a/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
+++ b/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'preact/hooks';
+import { SetSRMessagesReturnObject } from '../../../core/Errors/types';
+import useSRPanelContext from '../../../core/Errors/useSRPanelContext';
+import { usePrevious } from '../../../utils/hookUtils';
+import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../core/Errors/constants';
+import { getArrayDifferences } from '../../../utils/arrayUtils';
+import { ValidationRuleResult } from '../../../utils/Validator/ValidationRuleResult';
+import { setFocusOnField } from '../../../utils/setFocus';
+import { SetSRMessagesReturnFn } from '../../../core/Errors/SRPanelProvider';
+
+/**
+ * Interface for gift card field errors, matching the encrypted field types
+ */
+export interface GiftcardStateErrors {
+    encryptedCardNumber: ValidationRuleResult;
+    encryptedSecurityCode: ValidationRuleResult;
+}
+
+/**
+ * Interface for transformed error objects returned from mapErrorsToValidationRuleResult
+ */
+export interface TransformedError {
+    isValid: boolean;
+    errorMessage: string;
+    errorI18n: string;
+    error: string;
+    rootNode: HTMLElement;
+}
+
+/**
+ * Interface for errors object with transformed error entries
+ */
+export interface TransformedErrorsObj {
+    [key: string]: TransformedError | null;
+}
+
+/**
+ * Props interface for the error handling hook
+ */
+interface UseSRPanelForGiftcardErrorsProps {
+    errors: TransformedErrorsObj;
+    isValidating: { current: boolean } | boolean;
+}
+
+/**
+ * Interface for sorted error objects used for comparison
+ */
+interface SortedErrorObject {
+    field: string;
+    errorMessage: string;
+}
+
+/**
+ * Custom hook for handling gift card component errors and screen reader announcements
+ *
+ * This hook manages both visual and screen reader error announcements for the gift card component,
+ * handling both blur-based validation errors and form-wide validation errors.
+ */
+export const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGiftcardErrorsProps) => {
+    console.log('useSRPanelForGiftcardErrors errors', errors);
+    // Track sorted list of errors for comparison with previous state
+    const [sortedErrorList, setSortedErrorList] = useState<SortedErrorObject[]>(null);
+    // Track previous error list for detecting changes
+    const previousSortedErrors = usePrevious(sortedErrorList);
+
+    // Get SRPanel context for managing screen reader messages
+    const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
+
+    // Fixed layout array defining the order of fields for error sorting
+    const layout = ['encryptedCardNumber', 'encryptedSecurityCode'];
+
+    useEffect(() => {
+        try {
+            // Create a partial function for setting SR messages with fixed configuration
+            const setMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({});
+            // Set messages with current errors and layout
+            // Handle isValidating being either an object with current property or a boolean
+            const isValidatingValue = typeof isValidating === 'boolean' ? isValidating : isValidating?.current || false;
+
+            const srPanelResp: SetSRMessagesReturnObject = setMessages?.({
+                errors,
+                isValidating: isValidatingValue,
+                layout
+            });
+
+            // Store the sorted list of errors for comparison
+            const currentErrorsSortedByLayout = srPanelResp?.currentErrorsSortedByLayout;
+            setSortedErrorList(currentErrorsSortedByLayout);
+
+            // Handle different error scenarios based on the action type
+            switch (srPanelResp?.action) {
+                case ERROR_ACTION_FOCUS_FIELD:
+                    // When a field needs to be focused due to validation error
+                    if (shouldMoveFocusSR) {
+                        setFocusOnField('.adyen-checkout__giftcard', srPanelResp.fieldToFocus);
+                    }
+                    // Reset validation state after 300ms to allow for error collection
+                    setTimeout(() => {
+                        if (typeof isValidating === 'boolean') {
+                            isValidating = false;
+                        } else if (isValidating?.current !== undefined) {
+                            isValidating.current = false;
+                        }
+                    }, 300);
+                    break;
+
+                case ERROR_ACTION_BLUR_SCENARIO: {
+                    // Handle blur-based validation errors
+                    const difference = getArrayDifferences(currentErrorsSortedByLayout, previousSortedErrors, 'field');
+                    const latestErrorMsg = difference?.[0];
+
+                    if (latestErrorMsg) {
+                        // Only announce blur-based errors to screen reader
+                        const isBlurBasedError = true;
+                        const latestSRError = isBlurBasedError ? latestErrorMsg.errorMessage : null;
+                        setSRMessagesFromStrings(latestSRError);
+                    } else {
+                        // Clear SR panel if there are no more errors
+                        clearSRPanel();
+                    }
+                    break;
+                }
+            }
+        } catch (_) {
+            // Fail silently - we don't want to break the component if SRPanel fails
+            console.error('Error in useSRPanelForGiftcardErrors', _);
+        }
+    }, [errors]);
+};

--- a/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
+++ b/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
@@ -11,7 +11,7 @@ import { SetSRMessagesReturnFn } from '../../../core/Errors/SRPanelProvider';
 /**
  * Interface for gift card field errors, matching the encrypted field types
  */
-export interface GiftcardStateErrors {
+interface GiftcardStateErrors {
     encryptedCardNumber: ValidationRuleResult;
     encryptedSecurityCode: ValidationRuleResult;
 }
@@ -19,7 +19,7 @@ export interface GiftcardStateErrors {
 /**
  * Interface for transformed error objects returned from mapErrorsToValidationRuleResult
  */
-export interface TransformedError {
+interface TransformedError {
     isValid: boolean;
     errorMessage: string;
     errorI18n: string;
@@ -30,7 +30,7 @@ export interface TransformedError {
 /**
  * Interface for errors object with transformed error entries
  */
-export interface TransformedErrorsObj {
+interface TransformedErrorsObj {
     [key: string]: TransformedError | null;
 }
 
@@ -56,8 +56,7 @@ interface SortedErrorObject {
  * This hook manages both visual and screen reader error announcements for the gift card component,
  * handling both blur-based validation errors and form-wide validation errors.
  */
-export const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGiftcardErrorsProps) => {
-    console.log('useSRPanelForGiftcardErrors errors', errors);
+const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGiftcardErrorsProps) => {
     // Track sorted list of errors for comparison with previous state
     const [sortedErrorList, setSortedErrorList] = useState<SortedErrorObject[]>(null);
     // Track previous error list for detecting changes
@@ -123,7 +122,11 @@ export const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanel
             }
         } catch (_) {
             // Fail silently - we don't want to break the component if SRPanel fails
-            console.error('Error in useSRPanelForGiftcardErrors', _);
         }
     }, [errors]);
 };
+
+// Export all interfaces and the hook
+export type { GiftcardStateErrors, TransformedError, TransformedErrorsObj };
+
+export { useSRPanelForGiftcardErrors };

--- a/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
+++ b/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
@@ -39,7 +39,7 @@ interface TransformedErrorsObj {
  */
 interface UseSRPanelForGiftcardErrorsProps {
     errors: TransformedErrorsObj;
-    isValidating: { current: boolean } | boolean;
+    isValidating: boolean;
 }
 
 /**
@@ -73,12 +73,11 @@ const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGift
             // Create a partial function for setting SR messages with fixed configuration
             const setMessages: SetSRMessagesReturnFn = setSRMessagesFromObjects?.({});
             // Set messages with current errors and layout
-            // Handle isValidating being either an object with current property or a boolean
-            const isValidatingValue = typeof isValidating === 'boolean' ? isValidating : isValidating?.current || false;
 
+            // Unlike Card SR Panel, isValidating is a boolean
             const srPanelResp: SetSRMessagesReturnObject = setMessages?.({
                 errors,
-                isValidating: isValidatingValue,
+                isValidating,
                 layout
             });
 
@@ -93,12 +92,10 @@ const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGift
                     if (shouldMoveFocusSR) {
                         setFocusOnField('.adyen-checkout__giftcard', srPanelResp.fieldToFocus);
                     }
-                    // Reset validation state after 300ms to allow for error collection
+                    // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
                     setTimeout(() => {
                         if (typeof isValidating === 'boolean') {
                             isValidating = false;
-                        } else if (isValidating?.current !== undefined) {
-                            isValidating.current = false;
                         }
                     }, 300);
                     break;

--- a/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
+++ b/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
@@ -4,17 +4,8 @@ import useSRPanelContext from '../../../core/Errors/useSRPanelContext';
 import { usePrevious } from '../../../utils/hookUtils';
 import { ERROR_ACTION_BLUR_SCENARIO, ERROR_ACTION_FOCUS_FIELD } from '../../../core/Errors/constants';
 import { getArrayDifferences } from '../../../utils/arrayUtils';
-import { ValidationRuleResult } from '../../../utils/Validator/ValidationRuleResult';
-import { setFocusOnField } from '../../../utils/setFocus';
 import { SetSRMessagesReturnFn } from '../../../core/Errors/SRPanelProvider';
-
-/**
- * Interface for gift card field errors, matching the encrypted field types
- */
-interface GiftcardStateErrors {
-    encryptedCardNumber: ValidationRuleResult;
-    encryptedSecurityCode: ValidationRuleResult;
-}
+import SecuredFieldsProvider from '../../internal/SecuredFields/SFP/SecuredFieldsProvider';
 
 /**
  * Interface for transformed error objects returned from mapErrorsToValidationRuleResult
@@ -40,6 +31,7 @@ interface TransformedErrorsObj {
 interface UseSRPanelForGiftcardErrorsProps {
     errors: TransformedErrorsObj;
     isValidating: boolean;
+    sfp: SecuredFieldsProvider;
 }
 
 /**
@@ -56,7 +48,7 @@ interface SortedErrorObject {
  * This hook manages both visual and screen reader error announcements for the gift card component,
  * handling both blur-based validation errors and form-wide validation errors.
  */
-const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGiftcardErrorsProps) => {
+const useSRPanelForGiftcardErrors = ({ errors, isValidating, sfp }: UseSRPanelForGiftcardErrorsProps) => {
     // Track sorted list of errors for comparison with previous state
     const [sortedErrorList, setSortedErrorList] = useState<SortedErrorObject[]>(null);
     // Track previous error list for detecting changes
@@ -91,7 +83,7 @@ const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGift
                 case ERROR_ACTION_FOCUS_FIELD:
                     // When a field needs to be focused due to validation error
                     if (shouldMoveFocusSR) {
-                        setFocusOnField('.adyen-checkout__giftcard', srPanelResp.fieldToFocus);
+                        sfp?.setFocusOn(srPanelResp?.fieldToFocus);
                     }
                     // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
                     setTimeout(() => {
@@ -125,6 +117,6 @@ const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGift
 };
 
 // Export all interfaces and the hook
-export type { GiftcardStateErrors, TransformedError, TransformedErrorsObj };
+export type { TransformedError, TransformedErrorsObj };
 
 export { useSRPanelForGiftcardErrors };

--- a/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
+++ b/packages/lib/src/components/Giftcard/components/useSRPanelForGiftcardErrors.ts
@@ -66,7 +66,8 @@ const useSRPanelForGiftcardErrors = ({ errors, isValidating }: UseSRPanelForGift
     const { setSRMessagesFromObjects, setSRMessagesFromStrings, clearSRPanel, shouldMoveFocusSR } = useSRPanelContext();
 
     // Fixed layout array defining the order of fields for error sorting
-    const layout = ['encryptedCardNumber', 'encryptedSecurityCode'];
+    // Assume fields in this order, and adds encryptedExpiryDate for MealVoucher, this is ignored in giftcard
+    const layout = ['encryptedCardNumber', 'encryptedExpiryDate', 'encryptedSecurityCode'];
 
     useEffect(() => {
         try {

--- a/packages/lib/src/components/MealVoucherFR/MealVoucherFR.test.tsx
+++ b/packages/lib/src/components/MealVoucherFR/MealVoucherFR.test.tsx
@@ -3,15 +3,11 @@ import MealVoucherFR from './MealVoucherFR';
 import { render, screen } from '@testing-library/preact';
 
 describe('MealVoucherFR', () => {
-    const resources = global.resources;
     const i18n = global.i18n;
     const user = userEvent.setup();
 
     const baseProps = {
-        modules: {
-            resources,
-            analytics: global.analytics
-        },
+        ...global.commonCoreProps,
         amount: { value: 1000, currency: 'EUR' },
         name: 'MealVoucher',
         i18n,

--- a/packages/lib/src/core/Errors/utils.ts
+++ b/packages/lib/src/core/Errors/utils.ts
@@ -189,7 +189,7 @@ export const setSRMessagesFromErrors = (
         layout
     });
 
-    const doLog = false;
+    const doLog = true;
 
     if (doLog) console.log('### setSRMessagesFromErrors::currentErrorsSortedByLayout:: ', currentErrorsSortedByLayout);
 

--- a/packages/lib/storybook/stories/giftcards/Gifcards.stories.tsx
+++ b/packages/lib/storybook/stories/giftcards/Gifcards.stories.tsx
@@ -16,6 +16,7 @@ export const withCard: GifcardStory = {
     args: {
         countryCode: 'NL',
         useSessions: true,
+        srConfig: { showPanel: false, moveFocus: true },
         componentConfiguration: {
             brand: 'givex'
         }
@@ -29,6 +30,7 @@ export const withGiftCard: GifcardStory = {
     args: {
         countryCode: 'NL',
         useSessions: true,
+        srConfig: { showPanel: false, moveFocus: true },
         componentConfiguration: {
             brand: 'givex'
         }

--- a/packages/lib/storybook/stories/giftcards/GiftcardExample.tsx
+++ b/packages/lib/storybook/stories/giftcards/GiftcardExample.tsx
@@ -20,15 +20,16 @@ export const GiftcardExample = ({ contextArgs, renderCard = true }: GiftcardExam
     const [remainingAmount, setRemainingAmount] = useState('');
 
     const createCheckout = async () => {
-        const { useSessions, showPayButton, countryCode, shopperLocale, amount } = contextArgs;
+        const { useSessions, showPayButton, countryCode, shopperLocale, amount, srConfig } = contextArgs;
 
         checkout.current = useSessions
-            ? await createSessionsCheckout({ showPayButton, countryCode, shopperLocale, amount })
+            ? await createSessionsCheckout({ showPayButton, countryCode, shopperLocale, amount, srConfig })
             : await createAdvancedFlowCheckout({
                   showPayButton,
                   countryCode,
                   shopperLocale,
-                  amount
+                  amount,
+                  srConfig
               });
 
         const onOrderUpdated = data => {

--- a/packages/lib/storybook/stories/types.ts
+++ b/packages/lib/storybook/stories/types.ts
@@ -46,4 +46,5 @@ export type AdyenCheckoutProps = {
     paymentMethodsOverride?: PaymentMethodsResponse;
     paymentsOptions?: {}; // TODO we don't have proper type for this right now
     onPaymentCompleted?: (data: any, element?: UIElement) => void;
+    srConfig: { showPanel: boolean; moveFocus: boolean };
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Adds error panel to Giftcard.

There's a few tricks however, the `useSRPanelForGiftcardErrors` hook is passed to render function because Giftcard component is a Class component. 

Also we had to use `mapErrorsToValidationRuleResult` to conver SF errors into `useForm` like errors. 


## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
