### PR TITLE
fix: adds missing onAddressSelected callback type to CardConfiguration

### DIFF
--- a/.changeset/fine-hoops-talk.md
+++ b/.changeset/fine-hoops-talk.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+adds onAddressSelected callback type to CardConfiguration

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -14,7 +14,7 @@ import { ClickToPayProps } from '../internal/ClickToPay/types';
 import { InstallmentOptions } from './components/CardInput/components/types';
 import { DisclaimerMsgObject } from '../internal/DisclaimerMessage/DisclaimerMessage';
 import { UIElementProps } from '../internal/UIElement/types';
-import type { OnAddressLookupType } from '../internal/Address/components/AddressSearch';
+import type { OnAddressLookupType, OnAddressSelectedType } from '../internal/Address/components/AddressSearch';
 import type { FastlaneSignupConfiguration } from '../PayPalFastlane/types';
 
 type PlaceholderKeys =
@@ -286,6 +286,12 @@ export interface CardConfiguration extends UIElementProps {
      * - merchant set config option
      */
     onAddressLookup?: OnAddressLookupType;
+
+    /**
+     * Function used to handle the selected address from 3rd party Address lookup
+     * - merchant set config option
+     */
+    onAddressSelected?: OnAddressSelectedType;
 
     /**
      * After binLookup call - provides the brand(s) we detect the user is entering, and if we support the brand(s)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary


## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
