### PR TITLE
Extra logic to only show dual brand switching UI if certain brands ar…

### DIFF
--- a/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardFieldsWrapper.tsx
@@ -92,6 +92,11 @@ export const CardFieldsWrapper = ({
         />
     );
 
+    // Only if these brands are present in the binLookup response shguld we show the UI to choose between brands
+    const dualBrandsThatNeedSelectionMechanism = ['cartebancaire', 'bcmc', 'dankort'];
+    // If the filter array contains anything - then we need to show the choice UI
+    const showDualBrandSelectElements = !!dualBrandSelectElements.filter(item => dualBrandsThatNeedSelectionMechanism.includes(item.id)).length;
+
     return (
         <LoadingWrapper status={sfpState.status}>
             {hasHolderName && positionHolderNameOnTop && cardHolderField}
@@ -114,7 +119,7 @@ export const CardFieldsWrapper = ({
 
             {hasHolderName && !positionHolderNameOnTop && cardHolderField}
 
-            {dualBrandSelectElements.length > 0 && dualBrandSelectElements && (
+            {showDualBrandSelectElements && dualBrandSelectElements.length > 0 && dualBrandSelectElements && (
                 <Fieldset classNameModifiers={['dual-brand-switcher']} label={i18n.get('creditCard.dualBrand.title')}>
                     <p className={'adyen-checkout-form-instruction'}>{i18n.get('creditCard.dualBrand.description')}</p>
                     <RadioGroupExtended


### PR DESCRIPTION
…e present in the binLookup response

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The new dual brand switching UI should _only_ be shown if the `/binLookup` response contains `cartebancaire`, `bcmc`, or `dankort`.
This PR performs the necessary check

## Tested scenarios
Manually tested with dual brands that are present in the "inclusion" list and those that aren't


