### PR TITLE
ACH - Fixing pay button label

### DIFF
--- a/.changeset/social-banks-pay.md
+++ b/.changeset/social-banks-pay.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+ACH - Component pay button now displays "Pay {value}" instead of "Continue purchase"

--- a/packages/lib/src/components/Ach/Ach.test.ts
+++ b/packages/lib/src/components/Ach/Ach.test.ts
@@ -31,7 +31,7 @@ describe('ACH', () => {
             await user.type(screen.getByLabelText(/Account number/), '1234567890');
             await user.type(screen.getByLabelText(/Verify account number/i), '1234567890');
 
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
 
             expect(onSubmitMock).toHaveBeenCalledTimes(1);
             expect(onSubmitMock).toHaveBeenCalledWith(
@@ -74,7 +74,7 @@ describe('ACH', () => {
 
             await user.click(screen.getByLabelText(/Save for my next payment/i));
 
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
 
             expect(onSubmitMock).toHaveBeenCalledTimes(1);
             expect(onSubmitMock).toHaveBeenCalledWith(
@@ -114,7 +114,7 @@ describe('ACH', () => {
             await user.type(screen.getByLabelText(/Account number/), '12345');
             await user.type(screen.getByLabelText(/Verify account number/i), '4321');
 
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
 
             expect(await screen.findByText('Account number does not match')).toBeVisible();
             expect(onSubmitMock).not.toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('ACH', () => {
             await user.type(screen.getByLabelText(/Account number/), '123');
             await user.type(screen.getByLabelText(/Verify account number/i), '123');
 
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
 
             expect(await screen.findByText('Enter the complete bank account number')).toBeVisible();
             expect(onSubmitMock).not.toHaveBeenCalled();
@@ -159,18 +159,18 @@ describe('ACH', () => {
             await user.type(screen.getByLabelText(/Account number/), '1234567890');
             await user.type(screen.getByLabelText(/Verify account number/i), '1234567890');
 
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
 
             expect(await screen.findByText('Enter the bank routing number')).toBeVisible();
             expect(onSubmitMock).not.toHaveBeenCalled();
 
             await user.type(screen.getByLabelText(/Routing number/i), '12345');
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
             expect(await screen.findByText('Enter the complete bank routing number')).toBeVisible();
             expect(onSubmitMock).not.toHaveBeenCalled();
 
             await user.type(screen.getByLabelText(/Routing number/i), '123456789');
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
             expect(onSubmitMock).toHaveBeenCalledTimes(1);
         });
 
@@ -194,7 +194,7 @@ describe('ACH', () => {
             await user.type(screen.getByLabelText(/Account number/), '1234567890');
             await user.type(screen.getByLabelText(/Verify account number/i), '1234567890');
 
-            await user.click(screen.queryByRole('button', { name: 'Confirm purchase' }));
+            await user.click(screen.queryByRole('button', { name: /Pay/i }));
 
             expect(onSubmitMock).toHaveBeenCalledTimes(1);
             expect(onSubmitMock).toHaveBeenCalledWith(

--- a/packages/lib/src/components/Ach/components/AchComponent.tsx
+++ b/packages/lib/src/components/Ach/components/AchComponent.tsx
@@ -11,6 +11,7 @@ import { achValidationRules, achFormatters } from './validate';
 import StoreDetails from '../../internal/StoreDetails';
 import useSRPanelForAchErrors from './useSRPanelForACHErrors';
 import useImage from '../../../core/Context/useImage';
+import { PREFIX } from '../../internal/Icon/constants';
 
 import type { PayButtonProps } from '../../internal/PayButton/PayButton';
 import type { ComponentMethodsRef } from '../../internal/UIElement/types';
@@ -190,7 +191,7 @@ function AchComponent({ onChange, payButton, showPayButton, placeholders, hasHol
 
             {enableStoreDetails && <StoreDetails disabled={isFormDisabled} onChange={setStorePaymentMethod} />}
 
-            {showPayButton && payButton({ status, icon: getImage({ imageFolder: 'components/' })('bento_lock') })}
+            {showPayButton && payButton({ status, icon: getImage({ imageFolder: 'components/' })(`${PREFIX}lock`) })}
         </div>
     );
 }

--- a/packages/lib/src/components/Ach/components/AchComponent.tsx
+++ b/packages/lib/src/components/Ach/components/AchComponent.tsx
@@ -9,12 +9,13 @@ import Field from '../../internal/FormFields/Field';
 import InputText from '../../internal/FormFields/InputText';
 import { achValidationRules, achFormatters } from './validate';
 import StoreDetails from '../../internal/StoreDetails';
+import useSRPanelForAchErrors from './useSRPanelForACHErrors';
+import useImage from '../../../core/Context/useImage';
 
 import type { PayButtonProps } from '../../internal/PayButton/PayButton';
 import type { ComponentMethodsRef } from '../../internal/UIElement/types';
 import type { AchPlaceholders } from '../types';
 import type { AchStateErrors } from './useSRPanelForACHErrors';
-import useSRPanelForAchErrors from './useSRPanelForACHErrors';
 
 type AchForm = {
     selectedAccountType: string;
@@ -47,6 +48,7 @@ interface AchComponentProps {
 }
 
 function AchComponent({ onChange, payButton, showPayButton, placeholders, hasHolderName, setComponentRef, enableStoreDetails }: AchComponentProps) {
+    const getImage = useImage();
     const schema = useMemo(
         () => ['selectedAccountType', 'routingNumber', 'accountNumber', 'accountNumberVerification', ...(hasHolderName ? ['ownerName'] : [])],
         [hasHolderName]
@@ -188,7 +190,7 @@ function AchComponent({ onChange, payButton, showPayButton, placeholders, hasHol
 
             {enableStoreDetails && <StoreDetails disabled={isFormDisabled} onChange={setStorePaymentMethod} />}
 
-            {showPayButton && payButton({ status, label: i18n.get('confirmPurchase') })}
+            {showPayButton && payButton({ status, icon: getImage({ imageFolder: 'components/' })('bento_lock') })}
         </div>
     );
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Component pay button now displays "Pay {value}" instead of "Continue purchase"