### PR TITLE
fix(click-to-pay-ShopperCard): treat 'ACTIVE' and 'PENDING' cards as active

### DIFF
--- a/.changeset/brown-papers-cross.md
+++ b/.changeset/brown-papers-cross.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Click to Pay: treat cards with Status Active and Pending as non expired.

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPSingleCard/CtPSingleCard.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPSingleCard/CtPSingleCard.test.tsx
@@ -3,8 +3,9 @@ import { render, screen } from '@testing-library/preact';
 import CtPSingleCard from './CtPSingleCard';
 import ShopperCard from '../../../models/ShopperCard';
 import { CoreProvider } from '../../../../../../core/Context/CoreProvider';
+import { DigitalCardStatus } from '../../../services/sdks/types';
 
-function createShopperCard({ panExpirationYear = '2030', panExpirationMonth = '09' }): ShopperCard {
+function createShopperCard({ panExpirationYear = '2030', panExpirationMonth = '09', status = 'ACTIVE' as DigitalCardStatus }): ShopperCard {
     return new ShopperCard(
         {
             srcDigitalCardId: 'xxxx-yyyy',
@@ -17,7 +18,7 @@ function createShopperCard({ panExpirationYear = '2030', panExpirationMonth = '0
             digitalCardData: {
                 descriptorName: 'Visa',
                 artUri: 'http://image.com',
-                status: 'ACTIVE'
+                status
             },
             tokenId: 'xxxx-wwww'
         },
@@ -44,4 +45,22 @@ test('should display Expired card label', () => {
     customRender(<CtPSingleCard card={createShopperCard({ panExpirationYear: '2022', panExpirationMonth: '09' })} />);
     expect(screen.getByText('Visa •••• 2024')).toBeTruthy();
     expect(screen.getByText('Expired')).toBeTruthy();
+});
+
+test('should display Expired card label for SUSPENDED card', () => {
+    customRender(<CtPSingleCard card={createShopperCard({ status: 'SUSPENDED' })} />);
+    expect(screen.getByText('Visa •••• 2024')).toBeTruthy();
+    expect(screen.getByText('Expired')).toBeTruthy();
+});
+
+test('should display Expired card label for EXPIRED card', () => {
+    customRender(<CtPSingleCard card={createShopperCard({ status: 'EXPIRED' })} />);
+    expect(screen.getByText('Visa •••• 2024')).toBeTruthy();
+    expect(screen.getByText('Expired')).toBeTruthy();
+});
+
+test('should not display Expired card label for PENDING card', () => {
+    customRender(<CtPSingleCard card={createShopperCard({ status: 'PENDING' })} />);
+    expect(screen.getByText('Visa •••• 2024')).toBeTruthy();
+    expect(screen.queryByText('Expired')).not.toBeInTheDocument();
 });

--- a/packages/lib/src/components/internal/ClickToPay/models/ShopperCard.ts
+++ b/packages/lib/src/components/internal/ClickToPay/models/ShopperCard.ts
@@ -44,7 +44,8 @@ class ShopperCard {
     }
 
     private confirmCardIsExpired(): boolean {
-        if (this.status !== 'ACTIVE') return true;
+        if (!['ACTIVE', 'PENDING'].includes(this.status)) return true;
+
         if (!this.panExpirationYear && !this.panExpirationMonth) return false;
 
         const [currentMonth, currentYear] = [new Date().getMonth() + 1, new Date().getFullYear()];


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We need to treat cards with Status Active and Pending as active (non expired).

## Tested scenarios
All unit tests pass


**Fixed issue**:  DSP-2728