### PR TITLE
Fix/stored card selection in storybook

### DIFF
--- a/.changeset/breezy-fans-make.md
+++ b/.changeset/breezy-fans-make.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Change how Dropin story selects a storedCard, and how we set the alt attr on a storedCard image, after changes to the API response.

--- a/packages/e2e-playwright/models/dropin.ts
+++ b/packages/e2e-playwright/models/dropin.ts
@@ -32,6 +32,7 @@ class Dropin extends Base {
     readonly payButton: Locator;
 
     protected _paymentMethods: Array<{ name: string; type: string }>;
+    protected _storedPaymentMethods: Array<{ name: string; type: string; brand: string }>;
 
     constructor(
         public readonly page: Page,
@@ -55,7 +56,17 @@ class Dropin extends Base {
         // Wait for payment methods from the payments call
         const responsePromise = this.page.waitForResponse(response => response.url().includes('paymentMethods') && response.status() === 200);
         const response = await responsePromise;
-        this._paymentMethods = (await response.json()).paymentMethods.map(({ name, type }: { name: string; type: string }) => ({ name, type }));
+        this._paymentMethods = (await response.json()).paymentMethods.map(({ name, type }: { name: string; type: string }) => ({
+            name,
+            type
+        }));
+        this._storedPaymentMethods = (await response.json()).storedPaymentMethods.map(
+            ({ name, type, brand }: { name: string; type: string; brand: string }) => ({
+                name,
+                type,
+                brand
+            })
+        );
         await this.isComponentVisible();
     }
 
@@ -96,7 +107,7 @@ class Dropin extends Base {
 
     // Stored payment methods
     async selectFirstStoredPaymentMethod(pmType: string, lastFour?: string): Promise<{ paymentMethodDetailsLocator: Locator }> {
-        const pmLabel = this.paymentMethods.find((pm: { type: string }) => pm.type === pmType)?.name;
+        const pmLabel = this.storedPaymentMethods.find((pm: { brand: string }) => pm.brand === pmType)?.name;
 
         const paymentMethodHeaderLocator = await this.page
             .locator('.adyen-checkout__payment-method')
@@ -120,6 +131,10 @@ class Dropin extends Base {
 
     get paymentMethods() {
         return this._paymentMethods;
+    }
+
+    get storedPaymentMethods() {
+        return this._storedPaymentMethods;
     }
 
     get paymentResult() {

--- a/packages/e2e-playwright/models/dropinWithSession.ts
+++ b/packages/e2e-playwright/models/dropinWithSession.ts
@@ -7,10 +7,19 @@ class DropinWithSession extends Dropin {
         const regex = /\/checkoutshopper\/.*\/sessions/;
         const responsePromise = this.page.waitForResponse(response => regex.test(response.url()) && response.status() === 200);
         const response = await responsePromise;
+
         this._paymentMethods = (await response.json()).paymentMethods.paymentMethods.map(({ name, type }: { name: string; type: string }) => ({
             name,
             type
         }));
+
+        this._storedPaymentMethods = (await response.json()).paymentMethods.storedPaymentMethods.map(
+            ({ name, type, brand }: { name: string; type: string; brand: string }) => ({
+                name,
+                type,
+                brand
+            })
+        );
 
         await this.isComponentVisible();
     }

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -96,7 +96,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
                     >
                         <PaymentMethodIcon
                             // Only add alt attribute to storedPaymentMethods (to avoid SR reading the PM name twice)
-                            {...(paymentMethod.props.oneClick && { altDescription: paymentMethod.props.name })}
+                            {...(paymentMethod.props.oneClick && { altDescription: paymentMethod.props.brand })}
                             type={paymentMethod.type}
                             src={paymentMethod.icon}
                         />


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
After API changes from the Cards team, the `name` property on a storedCard can vary depending on the `countryCode`.
Example:
`countryCode:"US"`
```
{
    "brand": "maestro",
    ...
    "name": "MasterCard",
    ...
    "type": "scheme"
}
```
`countryCode:"BE"`
```
{
    "brand": "maestro",
    ...
    "name": "Maestro",
    ...
    "type": "scheme"
}
```
This variation in the value of the `name` property was affecting how a storedPM is selected in the Dropin story.
This meant that whether Playwright tests were passing, or failing, was dependent on the `countryCode` value.

We were also using the `name` property to set the `alt` attribute on a storedPM's image. This mean that this could have an incorrect value depending on the `countryCode`.

This PR changes the storedPM selection mechanism in the Dropin story and how we set the `alt` attr. 
Now both mechanisms use the `brand` property, which aligns with the _txvariant_

## Tested scenarios
All related e2e tests pass


