### PR TITLE
Fix: remove Klarna type from global Window object

### DIFF
--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -4,7 +4,6 @@ import { AdditionalDetailsData } from '../../core/types';
 
 declare global {
     interface Window {
-        Klarna: any;
         klarnaAsyncCallback: any;
     }
 }


### PR DESCRIPTION
## Summary
There is a conflict between Adyen Klarna type and custom Klarna type that any merchant can add for TS Klarna support.

Adyen Klarna types:
`
declare global {
    interface Window {
        Klarna: any;
        klarnaAsyncCallback: any;
    }
}
`

A merchant may also add Klarna types to benefit from TS support:
`
declare global {
    interface Window {
        Klarna: IKlarna;
        klarnaAsyncCallback: IKlarnaAsyncCallback;
    }
}
`
In this case, a type conflict will prevent pushing the changes. So, to fix the issue, the suggested solution is to remove Adyen Klarna types, as it doesn't provide a useful type for Klarna.

