### PR TITLE
fix(installments): correct missing border and background styles

### DIFF
--- a/.changeset/pretty-adults-peel.md
+++ b/.changeset/pretty-adults-peel.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed a styling issue where the installments dropdown was missing its border and background color.

--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.scss
@@ -1,9 +1,9 @@
 @use 'styles/index';
 
-.adyen-checkout__installments {
-  .adyen-checkout__input-wrapper {
-    @include index.adyen-checkout-input-wrapper-reset;
-  }
+.adyen-checkout__installments--revolving-plan {
+    .adyen-checkout__input-wrapper {
+      @include index.adyen-checkout-input-wrapper-reset;
+    }
 
   .adyen-checkout__fieldset--revolving-plan{
     margin-top: -5px;

--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.tsx
@@ -81,7 +81,7 @@ function Installments(props: InstallmentsProps) {
     // Alternate interface for installments with the possibility of a "revolving" plan
     if (hasRadioButtonUI) {
         return (
-            <div className="adyen-checkout__installments">
+            <div className="adyen-checkout__installments adyen-checkout__installments--revolving-plan">
                 <Field
                     label={i18n.get('installments')}
                     classNameModifiers={['installments']}

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -90,7 +90,7 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
     public displayFinalAnimation(type: 'success' | 'error') {
         if (this.props.disableFinalAnimation) return;
 
-        this.dropinRef.setStatus(type);
+        this.dropinRef?.setStatus(type);
     }
 
     /**

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -100,7 +100,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
      * @param type - The type of the payment method to get. (This prop is passed by Drop-in OR Standalone components containing the property 'type' as part of their configuration)
      */
     protected getPaymentMethodFromPaymentMethodsResponse(type?: string): PaymentMethod {
-        return this.core.paymentMethodsResponse.find(type || this.constructor['type']);
+        return this.core.paymentMethodsResponse?.find(type || this.constructor['type']);
     }
 
     protected storeElementRefOnCore(props?: P) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The installments dropdown was missing its border and background color, making it appear transparent against the page background. This change applies the correct styling to fix the visual defect.

## Tested scenarios
Both mc card and visa card should have correct styles for the installments dropdown.
https://localhost:3020/?path=/story/cards-card--with-installments

**Fixed issue**:  COSDK-573