### PR TITLE
Add size limit to main push

### DIFF
--- a/.github/workflows/.size-limit.yml
+++ b/.github/workflows/.size-limit.yml
@@ -1,7 +1,12 @@
 name: Size limit
 
-on: [pull_request]
-
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+    
 jobs:
   size:
     runs-on: ubuntu-latest

--- a/packages/lib/.size-limit.cjs
+++ b/packages/lib/.size-limit.cjs
@@ -2,10 +2,37 @@ module.exports = [
     /**
      * UMD
      */
+
+    /**
+     * These are the results as of 2025-08-08
+     * 
+     *  [
+            {
+                "name": "UMD",
+                "size": 114365,
+            },
+            {
+                "name": "Auto",
+                "size": 121065,
+            },
+            {
+                "name": "ESM - Core",
+                "size": 24270,
+            },
+            {
+                "name": "ESM - Core + Card",
+                "size": 65042,
+            },
+            {
+                "name": "ESM - Core + Dropin with Card",
+                "size": 69819,
+            }
+        ]
+     */
     {
         name: 'UMD',
         path: 'dist/umd/adyen.js',
-        limit: '120 KB',
+        limit: '116 KB',
         running: false
     },
     /**
@@ -15,7 +42,7 @@ module.exports = [
         name: 'Auto',
         path: 'auto/auto.js',
         import: '{ AdyenCheckout, Dropin }',
-        limit: '125 KB',
+        limit: '123 KB',
         running: false
     },
     /**
@@ -25,21 +52,21 @@ module.exports = [
         name: 'ESM - Core',
         path: 'dist/es/index.js',
         import: '{ AdyenCheckout }',
-        limit: '30 KB',
+        limit: '26 KB',
         running: false
     },
     {
         name: 'ESM - Core + Card',
         path: 'dist/es/index.js',
         import: '{ AdyenCheckout, Card }',
-        limit: '65 KB',
+        limit: '67 KB',
         running: false
     },
     {
         name: 'ESM - Core + Dropin with Card',
         path: 'dist/es/index.js',
         import: '{ AdyenCheckout, Dropin, Card }',
-        limit: '70 KB',
+        limit: '72 KB',
         running: false
     }
 ];


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Right now we don't know if `size-limit` is failing only for a specfic PR or failing in the main branch. This is useful to track down were the size-limit was exceeded and if we should worry about the change or not.

I also added todays values and also changed all the limits to be with 3(+/-1)KB of current value.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
