### PR TITLE
fix missing props in PaymentData

### DIFF
--- a/.changeset/silver-ideas-care.md
+++ b/.changeset/silver-ideas-care.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+fix: add billing address and shopper details to PaymentData interface

--- a/packages/lib/src/types/global-types.ts
+++ b/packages/lib/src/types/global-types.ts
@@ -300,8 +300,6 @@ export interface PaymentData extends PaymentMethodData {
     storePaymentMethod?: boolean;
     billingAddress?: AddressData;
     deliveryAddress?: AddressData;
-    shopperEmail?: string;
-    shopperName?: string;
 }
 
 export type ResultCode =

--- a/packages/lib/src/types/global-types.ts
+++ b/packages/lib/src/types/global-types.ts
@@ -298,6 +298,10 @@ export interface PaymentData extends PaymentMethodData {
     clientStateDataIndicator: boolean;
     sessionData?: string;
     storePaymentMethod?: boolean;
+    billingAddress?: AddressData;
+    deliveryAddress?: AddressData;
+    shopperEmail?: string;
+    shopperName?: string;
 }
 
 export type ResultCode =


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Add missing properties to the `PaymentData` interface to align with the data structure expected in payment submission flows.
This aligns with what is right now on `BeforeSubmitActions`.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
#3419 