### PR TITLE
revert size limit triggers

### DIFF
--- a/.github/workflows/.size-limit.yml
+++ b/.github/workflows/.size-limit.yml
@@ -1,12 +1,7 @@
 name: Size limit
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
-    
+on: [pull_request]
+
 jobs:
   size:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

Reverts the modifications of sizelimit job back to be only on Pull request as size-limit action does not support push flow.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
