### PR TITLE
[V5] fix(pay-button): alignment and font size for the secondary amount label

### DIFF
--- a/.changeset/eager-lands-cough.md
+++ b/.changeset/eager-lands-cough.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed alignment and font size for the Pay button's secondary amount label.

--- a/packages/lib/src/components/internal/Button/Button.scss
+++ b/packages/lib/src/components/internal/Button/Button.scss
@@ -59,6 +59,8 @@
 
         display: flex;
         justify-content: center;
+        align-items: center;
+        gap: 4px;
     }
 
     &.adyen-checkout__button--standalone {

--- a/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.scss
+++ b/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.scss
@@ -1,5 +1,0 @@
-.checkout-secondary-button__text {
-    font-size: 0.85em;
-    margin-left: 5px;
-    margin-top: 1px;
-}

--- a/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.tsx
+++ b/packages/lib/src/components/internal/PayButton/components/SecondaryButtonLabel.tsx
@@ -1,5 +1,4 @@
 import { h } from 'preact';
-import './SecondaryButtonLabel.scss';
 
 const SecondaryButtonLabel = ({ label }) => {
     return <span className={'checkout-secondary-button__text'}>{label}</span>;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fixed alignment and font size for the Pay button's secondary amount label.

**Fixed issue**:  COSDK-150
