### PR TITLE
chore: Add script that marks old releases as deprecated

### DIFF
--- a/.github/scripts/deprecate-releases.js
+++ b/.github/scripts/deprecate-releases.js
@@ -1,5 +1,16 @@
 // A script to mark all GitHub releases in a repository as [DEPRECATED].
 // Uses the GitHub REST API and supports a dry run mode.
+// 
+// To get your API token go to Your profile, and create a Fine-grained PAT:
+// Resource owner: Adyen
+// Repository access: adyen-web
+// Give permission for: Contents R/W
+//
+// Then you can export the token temporarily in your console (before runnning):
+// export GITHUB_TOKEN=github_pat_xxx
+//
+// You can run this script by doing:
+// DRY_RUN=false MAJOR_VERSION=X node .github/scripts/deprecate-releases.js
 
 const fetch = require('node-fetch');
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Creates a script that can be used by running:

`DRY_RUN=false MAJOR_VERSION=X node .github/scripts/deprecate-releases.js`

The script fetchs all available version via the Github API. Loops thru them, and if they match the major version then it changes the release name/title to include `[DEPRECATED]`. 

To get your API token go to Your profile, and create a PAT with `Contents` R/W with the scope for this project.

## Tested scenarios
<!-- Description of tested scenarios -->
- Changes already made 🙃 

**Fixed issue**:  <!-- #-prefixed issue number -->
