### PR TITLE
fix(PayTo): SegmentedController aria-controls IDs

### DIFF
--- a/.changeset/slimy-waves-smoke.md
+++ b/.changeset/slimy-waves-smoke.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix PayTo aria-controls poiting to wrong IDs

--- a/packages/lib/src/components/PayTo/components/BSBInput.tsx
+++ b/packages/lib/src/components/PayTo/components/BSBInput.tsx
@@ -27,11 +27,12 @@ export interface BSBInputProps {
     placeholders: PayToPlaceholdersType;
     onChange: (e) => void;
     setComponentRef: (ref: ComponentMethodsRef) => void;
+    id?: string;
 }
 
 const BASE_SCHEMA = ['bankAccountNumber', 'bsb', 'firstName', 'lastName'];
 
-export default function BSBInput({ setComponentRef, defaultData, placeholders, onChange, setStatus }: BSBInputProps) {
+export default function BSBInput({ setComponentRef, defaultData, placeholders, onChange, setStatus, id }: BSBInputProps) {
     const { i18n } = useCoreContext();
 
     const form = useForm<BSBFormData>({
@@ -57,7 +58,7 @@ export default function BSBInput({ setComponentRef, defaultData, placeholders, o
     }, [setComponentRef]);
 
     return (
-        <Fieldset classNameModifiers={['payto__bsb_input']} label={'BSB'} description={'payto.bsb.description'}>
+        <Fieldset id={id} classNameModifiers={['payto__bsb_input']} label={'BSB'} description={'payto.bsb.description'}>
             <Field
                 label={i18n.get('payto.bsb.label.bankAccountNumber')}
                 classNameModifiers={['col-60', 'bankAccountNumber']}

--- a/packages/lib/src/components/PayTo/components/PayIDInput.tsx
+++ b/packages/lib/src/components/PayTo/components/PayIDInput.tsx
@@ -35,6 +35,7 @@ export interface PayIDInputProps {
     placeholders: PayToPlaceholdersType;
     onChange: (e) => void;
     setComponentRef: (ref: ComponentMethodsRef) => void;
+    id?: string;
 }
 
 const BASE_SCHEMA = ['selectedIdentifier', 'firstName', 'lastName'];
@@ -46,7 +47,7 @@ const IDENTIFIER_SCHEMA = {
     [PayToIdentifierEnum.orgid]: ['orgid']
 };
 
-export default function PayIDInput({ setComponentRef, defaultData, placeholders, onChange, setStatus }: PayIDInputProps) {
+export default function PayIDInput({ setComponentRef, defaultData, placeholders, onChange, setStatus, id }: PayIDInputProps) {
     const { i18n } = useCoreContext();
 
     const form = useForm<PayIdFormData>({
@@ -78,7 +79,7 @@ export default function PayIDInput({ setComponentRef, defaultData, placeholders,
     }, [setComponentRef]);
 
     return (
-        <Fieldset classNameModifiers={['payto__payid_input']} label={'PayID'} description={'payto.payid.description'}>
+        <Fieldset id={id} classNameModifiers={['payto__payid_input']} label={'PayID'} description={'payto.payid.description'}>
             <IdentifierSelector
                 classNameModifiers={['col-40']}
                 onSelectedIdentifier={handleChangeFor('selectedIdentifier')}

--- a/packages/lib/src/components/PayTo/components/PayToComponent.tsx
+++ b/packages/lib/src/components/PayTo/components/PayToComponent.tsx
@@ -9,6 +9,7 @@ import { ComponentMethodsRef, UIElementStatus } from '../../internal/UIElement/t
 import { PayToData, PayToPlaceholdersType } from '../types';
 import { PayButtonProps } from '../../internal/PayButton/PayButton';
 import classNames from 'classnames';
+import { getUniqueId } from '../../../utils/idGenerator';
 import './PayToComponent.scss';
 
 export type PayToInputOption = 'payid-option' | 'bsb-option';
@@ -29,22 +30,26 @@ export default function PayToComponent(props: PayToComponentProps) {
 
     const [status, setStatus] = useState<UIElementStatus>('ready');
 
+    // Generate unique IDs for the input sections
+    const payidInputId = useMemo(() => getUniqueId('payid-input'), []);
+    const bsbInputId = useMemo(() => getUniqueId('bsb-input'), []);
+
     const inputOptions: SegmentedControlOptions<PayToInputOption> = useMemo(
         () => [
             {
                 value: 'payid-option',
                 label: 'PayID',
                 id: 'payid-option',
-                controls: 'payid-input'
+                controls: payidInputId
             },
             {
                 value: 'bsb-option',
                 label: i18n.get('payto.bsb.option.label'),
                 id: 'bsb-option',
-                controls: 'bsb-input'
+                controls: bsbInputId
             }
         ],
-        [i18n]
+        [i18n, payidInputId, bsbInputId]
     );
 
     const defaultOption = inputOptions[0].value;
@@ -65,6 +70,7 @@ export default function PayToComponent(props: PayToComponentProps) {
             <SegmentedControl selectedValue={selectedInput} options={inputOptions} onChange={setSelectedInput} />
             {selectedInput === 'payid-option' && (
                 <PayIDInput
+                    id={payidInputId}
                     status={status}
                     setStatus={setStatus}
                     setComponentRef={props.setComponentRef}
@@ -75,6 +81,7 @@ export default function PayToComponent(props: PayToComponentProps) {
             )}
             {selectedInput === 'bsb-option' && (
                 <BSBInput
+                    id={bsbInputId}
                     status={status}
                     setStatus={setStatus}
                     setComponentRef={props.setComponentRef}

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
@@ -16,7 +16,7 @@ interface FieldsetProps {
 export default function Fieldset({ children, classNameModifiers = [], label, readonly = false, description, id }: FieldsetProps) {
     const { i18n } = useCoreContext();
 
-    const describedById = getUniqueId('fieldset-description');
+    const describedById = useMemo(() => getUniqueId('fieldset-description'), []);
 
     return (
         <fieldset

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
@@ -10,15 +10,17 @@ interface FieldsetProps {
     label?: string;
     description?: string;
     readonly?: boolean;
+    id?: string;
 }
 
-export default function Fieldset({ children, classNameModifiers = [], label, readonly = false, description }: FieldsetProps) {
+export default function Fieldset({ children, classNameModifiers = [], label, readonly = false, description, id }: FieldsetProps) {
     const { i18n } = useCoreContext();
 
-    const describedById = getUniqueId('payid-input-description');
+    const describedById = getUniqueId('fieldset-description');
 
     return (
         <fieldset
+            id={id}
             className={cx([
                 'adyen-checkout__fieldset',
                 ...classNameModifiers.map(m => `adyen-checkout__fieldset--${m}`),

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import './Fieldset.scss';
 import { getUniqueId } from '../../../../utils/idGenerator';
+import { useMemo } from 'preact/hooks';
 
 interface FieldsetProps {
     children: ComponentChildren;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

There was an error caught by our a11y tool that PayTo SegmentedController wasn't using IDs that were pointing properly to the Fieldset. 
This PR makes that change. 
Fieldset now supports optional IDs.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
