### PR TITLE
UPI: Fix checkmark styles for upi app selector

### DIFF
--- a/.changeset/tall-groups-speak.md
+++ b/.changeset/tall-groups-speak.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fix checkmark style for UPI app selector

--- a/packages/lib/src/components/UPI/components/UPIIntentAppList/UPIIntentAppItem/UPIIntentAppItem.scss
+++ b/packages/lib/src/components/UPI/components/UPIIntentAppList/UPIIntentAppItem/UPIIntentAppItem.scss
@@ -2,6 +2,11 @@
 
 $expand-btn: '.adyen-checkout-expand-button--upi-app-item';
 
+@mixin set-checkmark-color($color: token(color-label-primary)) {
+    border-bottom: 1.5px solid $color;
+    border-right: 1.5px solid $color;
+}
+
 .adyen-checkout-upi-app-item {
     background: token(color-background-primary);
     display: flex;
@@ -44,5 +49,13 @@ $expand-btn: '.adyen-checkout-expand-button--upi-app-item';
 
     #{$expand-btn} {
         margin-right: 0;
+    }
+
+    &__checkmark {
+        @include set-checkmark-color;
+
+        transform: rotate(45deg);
+        height: token(spacer-060);
+        width: token(spacer-030);
     }
 }

--- a/packages/lib/src/components/UPI/components/UPIIntentAppList/UPIIntentAppItem/UPIIntentAppItem.tsx
+++ b/packages/lib/src/components/UPI/components/UPIIntentAppList/UPIIntentAppItem/UPIIntentAppItem.tsx
@@ -36,7 +36,7 @@ const UPIIntentAppItem = ({ app, imgSrc, isSelected, onSelect = () => {} }: UPII
                     </label>
                 </ExpandButton>
             </div>
-            {isSelected && <span className="adyen-checkout-checkmark" />}
+            {isSelected && <span className="adyen-checkout-upi-app-item__checkmark" />}
         </li>
     );
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

As part of the [changes](https://github.com/Adyen/adyen-web/pull/3509/files#diff-56d114899088d200a29b44f490114d7e5fd66f84f3f769ed063baa76819c3b31) for improving the Pix UI, we removed the checkmark from the segmented control component. This however broke the styles for the checkmark on the UPI app selector component as it was depending on styles from the segmented control component. This change add specific styles for the checkmark on the `UPIIntentAppItem`

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
