### PR TITLE
fix: remove if clause to allow E2E on renovate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build-then-e2e:
-    if: ${{ github.actor != 'renovate[bot]' && github.actor != 'lgtm-com[bot]' }}
     timeout-minutes: 120
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
It seems like this line is the culprit of E2E not running on renovate. However, I don't understand how on the same day a renovate PR has been merged successfully: #3534 

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
