### PR TITLE
Google Pay -  Parsing brands from paymentMethods API

### DIFF
--- a/.changeset/smooth-cloths-relax.md
+++ b/.changeset/smooth-cloths-relax.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+GooglePay - Parsing brands from Backoffice if available

--- a/packages/lib/.size-limit.cjs
+++ b/packages/lib/.size-limit.cjs
@@ -42,7 +42,7 @@ module.exports = [
         name: 'Auto',
         path: 'auto/auto.js',
         import: '{ AdyenCheckout, Dropin }',
-        limit: '123 KB',
+        limit: '125 KB',
         running: false
     },
     /**

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -488,6 +488,41 @@ describe('GooglePay', () => {
     });
 
     describe('Process CA based configuration data', () => {
+        describe('brands', () => {
+            test('should parse "brands" from configuration if available', () => {
+                const gpay = new GooglePay(global.core, {
+                    configuration: {
+                        merchantId: 'adyen',
+                        gatewayMerchantId: 'adyen'
+                    },
+                    brands: ['mc', 'visa']
+                });
+                expect(gpay.props.allowedCardNetworks).toEqual(['MASTERCARD', 'VISA']);
+            });
+
+            test('should ignore "brands" from configuration if "allowedCardNetworks" is set', () => {
+                const gpay = new GooglePay(global.core, {
+                    configuration: {
+                        merchantId: 'adyen',
+                        gatewayMerchantId: 'adyen'
+                    },
+                    brands: ['mc', 'visa', 'discover', 'elo'],
+                    allowedCardNetworks: ['AMEX', 'MASTERCARD']
+                });
+                expect(gpay.props.allowedCardNetworks).toEqual(['AMEX', 'MASTERCARD']);
+            });
+
+            test('should set default "allowedCardNetworks" values if "brands" and "allowedCardNetworks" props are not set', () => {
+                const gpay = new GooglePay(global.core, {
+                    configuration: {
+                        merchantId: 'adyen',
+                        gatewayMerchantId: 'adyen'
+                    }
+                });
+                expect(gpay.props.allowedCardNetworks).toEqual(['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA']);
+            });
+        });
+
         test('Retrieves merchantId from configuration', () => {
             const gpay = new GooglePay(global.core, { configuration: { merchantId: 'abcdef', gatewayMerchantId: 'TestMerchant' } });
             expect(gpay.props.configuration.merchantId).toEqual('abcdef');

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -120,19 +120,20 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
      * to use the 'brands' returned by the backoffice. It can be that 'brands' is not returned, which in this case we
      * set default values
      *
-     * @param allowedCardNetworks
-     * @param brandsFromBackoffice
+     * @param {object} brandsConfig
+     * @param brandsConfig.allowedCardNetworks - Brands set in the component config
+     * @param brandsConfig.brands - Brands returned by backend
      * @private
      */
     private createAllowedCardNetworksValues({
         allowedCardNetworks,
-        brands: brandsFromBackoffice
+        brands
     }: {
         allowedCardNetworks?: google.payments.api.CardNetwork[];
         brands?: string[];
     }): google.payments.api.CardNetwork[] {
         if (allowedCardNetworks?.length > 0) return allowedCardNetworks;
-        if (brandsFromBackoffice?.length > 0) return mapGooglePayBrands(brandsFromBackoffice);
+        if (brands?.length > 0) return mapGooglePayBrands(brands);
 
         return DEFAULT_ALLOWED_CARD_NETWORKS;
     }

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -74,6 +74,10 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
 
         const callbackIntents: google.payments.api.CallbackIntent[] = [...props.callbackIntents, 'PAYMENT_AUTHORIZATION'];
 
+        console.log(props);
+
+        // const allowedCardNetworks =
+
         return {
             ...props,
             configuration: props.configuration,

--- a/packages/lib/src/components/GooglePay/defaultProps.ts
+++ b/packages/lib/src/components/GooglePay/defaultProps.ts
@@ -36,7 +36,6 @@ const defaultProps: GooglePayConfiguration = {
     // CardParameters
     // https://developers.google.com/pay/api/web/reference/object#CardParameters
     allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'] as google.payments.api.CardAuthMethod[],
-    allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'] as google.payments.api.CardNetwork[],
     allowCreditCards: true, // Set to false if you don't support credit cards.
     allowPrepaidCards: true, // Set to false if you don't support prepaid cards.
     billingAddressRequired: false, // A billing address should only be requested if it's required to process the transaction.

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -5,6 +5,12 @@ export interface GooglePayConfiguration extends UIElementProps {
     type?: 'googlepay' | 'paywithgoogle';
 
     /**
+     * List of brands accepted by the component. Values are configured on the Backoffice and returned in the /paymentMethodsResponse data
+     * @internal
+     */
+    brands?: string[];
+
+    /**
      * Used for analytics
      */
     expressPage?: 'cart' | 'minicart' | 'pdp' | 'checkout';

--- a/packages/lib/src/components/GooglePay/utils/map-adyen-brands-to-googlepay-brands.test.ts
+++ b/packages/lib/src/components/GooglePay/utils/map-adyen-brands-to-googlepay-brands.test.ts
@@ -1,0 +1,63 @@
+import { mapGooglePayBrands } from './map-adyen-brands-to-googlepay-brands';
+
+describe('mapGooglePayBrands()', () => {
+    it('should correctly map a list of known Adyen brand codes', () => {
+        const adyenBrands = ['mc', 'visa', 'amex'];
+        const expected = ['MASTERCARD', 'VISA', 'AMEX'];
+        const result = mapGooglePayBrands(adyenBrands);
+
+        expect(result).toEqual(expected);
+    });
+
+    it('should ignore any unknown or unsupported brand codes in the list', () => {
+        const adyenBrands = ['mc', 'unsupported_brand', 'visa'];
+        const expected = ['MASTERCARD', 'VISA'];
+        const result = mapGooglePayBrands(adyenBrands);
+
+        expect(result).toEqual(expected);
+    });
+
+    it('should return a unique list of brands even if the input contains duplicates', () => {
+        const adyenBrands = ['mc', 'visa', 'mc'];
+        const expected = ['MASTERCARD', 'VISA'];
+        const result = mapGooglePayBrands(adyenBrands);
+
+        expect(result.length).toBe(2);
+        expect(result).toEqual(expected);
+    });
+
+    it('should return an empty array when given an empty array', () => {
+        const adyenBrands: string[] = [];
+        const result = mapGooglePayBrands(adyenBrands);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if all provided brands are unknown', () => {
+        const adyenBrands = ['unknown1', 'unknown2'];
+        const result = mapGooglePayBrands(adyenBrands);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should correctly map all supported Adyen brands', () => {
+        const allAdyenBrands = ['mc', 'amex', 'visa', 'elodebit', 'elo', 'interac', 'discover', 'jcb', 'electron', 'maestro'];
+        const allExpectedGooglePayBrands: google.payments.api.CardNetwork[] = [
+            'MASTERCARD',
+            'AMEX',
+            'VISA',
+            'ELO_DEBIT',
+            'ELO',
+            'INTERAC',
+            'DISCOVER',
+            'JCB',
+            'ELECTRON',
+            'MAESTRO'
+        ];
+
+        const result = mapGooglePayBrands(allAdyenBrands);
+
+        expect(result.length).toBe(allExpectedGooglePayBrands.length);
+        expect(result).toEqual(allExpectedGooglePayBrands);
+    });
+});

--- a/packages/lib/src/components/GooglePay/utils/map-adyen-brands-to-googlepay-brands.ts
+++ b/packages/lib/src/components/GooglePay/utils/map-adyen-brands-to-googlepay-brands.ts
@@ -1,4 +1,4 @@
-const brandMapping: Record<string, google.payments.api.CardNetwork> = {
+const brandMapping: Record<string, google.payments.api.CardNetwork> = Object.freeze({
     mc: 'MASTERCARD',
     amex: 'AMEX',
     visa: 'VISA',
@@ -9,7 +9,7 @@ const brandMapping: Record<string, google.payments.api.CardNetwork> = {
     jcb: 'JCB',
     electron: 'ELECTRON',
     maestro: 'MAESTRO'
-};
+});
 
 export function mapGooglePayBrands(brands: string[]): google.payments.api.CardNetwork[] {
     const mappedBrands = brands.map(brand => brandMapping[brand]).filter((brand): brand is google.payments.api.CardNetwork => !!brand);

--- a/packages/lib/src/components/GooglePay/utils/map-adyen-brands-to-googlepay-brands.ts
+++ b/packages/lib/src/components/GooglePay/utils/map-adyen-brands-to-googlepay-brands.ts
@@ -1,0 +1,17 @@
+const brandMapping: Record<string, google.payments.api.CardNetwork> = {
+    mc: 'MASTERCARD',
+    amex: 'AMEX',
+    visa: 'VISA',
+    elodebit: 'ELO_DEBIT',
+    elo: 'ELO',
+    interac: 'INTERAC',
+    discover: 'DISCOVER',
+    jcb: 'JCB',
+    electron: 'ELECTRON',
+    maestro: 'MAESTRO'
+};
+
+export function mapGooglePayBrands(brands: string[]): google.payments.api.CardNetwork[] {
+    const mappedBrands = brands.map(brand => brandMapping[brand]).filter((brand): brand is google.payments.api.CardNetwork => !!brand);
+    return [...new Set(mappedBrands)];
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR adds capability for Google Pay to parse `brands` returned from `paymentMethods` response:
- Merchant can still override this on the frontend by setting `allowedCardNetworks` config. By doing that, the `brands` returned by backend are ignored
- For legacy integrations (e.g. using `paywithgoogle` tx variant) , `brands` are not returned in the API. There is a fallback value that is set in case nor `brands` nor `allowedCardNetworks` are set

## Tested scenarios
- Added tests
<!-- Description of tested scenarios -->


**Fixed issue**:  #3506 
