### PR TITLE
Fix typo in PaymentMethodBrands property

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.test.tsx
@@ -61,7 +61,7 @@ describe('PaymentMethodBrands', () => {
             { name: 'maestro', icon: 'maestro.png' }
         ];
 
-        renderWrapper(<PaymentMethodBrands brands={brands} isPaymentMethodSelected={false} showOtherInsteafOfNumber={true} />);
+        renderWrapper(<PaymentMethodBrands brands={brands} isPaymentMethodSelected={false} showOtherInsteadOfNumber={true} />);
 
         screen.getByAltText('VISA');
         screen.getByAltText('MasterCard');

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
@@ -17,7 +17,7 @@ interface PaymentMethodBrandsProps {
     excludedUIBrands?: Array<string>;
     isPaymentMethodSelected: boolean;
     keepBrandsVisible?: boolean;
-    showOtherInsteafOfNumber?: boolean;
+    showOtherInsteadOfNumber?: boolean;
 }
 
 const PaymentMethodBrands = ({
@@ -25,7 +25,7 @@ const PaymentMethodBrands = ({
     excludedUIBrands = [],
     isPaymentMethodSelected,
     keepBrandsVisible = false,
-    showOtherInsteafOfNumber = false
+    showOtherInsteadOfNumber = false
 }: PaymentMethodBrandsProps) => {
     const { i18n } = useCoreContext();
 
@@ -41,7 +41,7 @@ const PaymentMethodBrands = ({
             {visibleBrands.map(brand => (
                 <PaymentMethodIcon key={brand.name} altDescription={getFullBrandName(brand.name)} type={brand.name} src={brand.icon} />
             ))}
-            {showOtherInsteafOfNumber ? (
+            {showOtherInsteadOfNumber ? (
                 <span className="adyen-checkout__payment-method__brand-number">+ {i18n.get('paymentMethodBrand.other')}</span>
             ) : (
                 leftBrandsAmount !== 0 && <span className="adyen-checkout__payment-method__brand-number">+{leftBrandsAmount}</span>

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -123,7 +123,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
 
                     {showBrands && (
                         <PaymentMethodBrands
-                            showOtherInsteafOfNumber={paymentMethod.props.showOtherInsteafOfNumber}
+                            showOtherInsteadOfNumber={paymentMethod.props.showOtherInsteadOfNumber}
                             keepBrandsVisible={paymentMethod.props.keepBrandsVisible}
                             brands={paymentMethod.brands}
                             excludedUIBrands={BRAND_ICON_UI_EXCLUSION_LIST}

--- a/packages/lib/src/components/PayByBankUS/PayByBankUS.tsx
+++ b/packages/lib/src/components/PayByBankUS/PayByBankUS.tsx
@@ -14,7 +14,7 @@ export default class PayByBankUS extends RedirectElement {
         return {
             // paymentMethodBrands configuration
             keepBrandsVisible: true,
-            showOtherInsteafOfNumber: true,
+            showOtherInsteadOfNumber: true,
             ...props
         };
     }


### PR DESCRIPTION
Greetings,

I noticed a typo in the `PaymentMethodBrands` component. `showOtherInsteafOfNumber` should be likely `showOtherInsteadOfNumber`.

Since this is my first PR in the project, please let me know if you need anything from me.
Best,
Christoph