### PR TITLE
Allow all brands to be shown for payment method

### DIFF
--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
@@ -4,8 +4,8 @@ import PaymentMethodIcon from '../PaymentMethodIcon';
 import { getFullBrandName } from '../../../../Card/components/CardInput/utils';
 import { useCoreContext } from '../../../../../core/Context/CoreProvider';
 
-const prepareVisibleBrands = (allowedBrands: Array<BrandConfiguration>) => {
-    const visibleBrands = allowedBrands.length <= 4 ? allowedBrands : allowedBrands.slice(0, 3);
+const prepareVisibleBrands = (allowedBrands: Array<BrandConfiguration>, showAllBrands: boolean) => {
+    const visibleBrands = showAllBrands || allowedBrands.length <= 4 ? allowedBrands : allowedBrands.slice(0, 3);
     return {
         visibleBrands,
         leftBrandsAmount: allowedBrands.length - visibleBrands.length
@@ -18,6 +18,7 @@ interface PaymentMethodBrandsProps {
     isPaymentMethodSelected: boolean;
     keepBrandsVisible?: boolean;
     showOtherInsteadOfNumber?: boolean;
+    showAllBrands?: boolean;
 }
 
 const PaymentMethodBrands = ({
@@ -25,7 +26,8 @@ const PaymentMethodBrands = ({
     excludedUIBrands = [],
     isPaymentMethodSelected,
     keepBrandsVisible = false,
-    showOtherInsteadOfNumber = false
+    showOtherInsteadOfNumber = false,
+    showAllBrands = false
 }: PaymentMethodBrandsProps) => {
     const { i18n } = useCoreContext();
 
@@ -34,7 +36,7 @@ const PaymentMethodBrands = ({
     }
 
     const allowedBrands = brands.filter(brand => !excludedUIBrands?.includes(brand.name));
-    const { visibleBrands, leftBrandsAmount } = prepareVisibleBrands(allowedBrands);
+    const { visibleBrands, leftBrandsAmount } = prepareVisibleBrands(allowedBrands, showAllBrands);
 
     return (
         <span className="adyen-checkout__payment-method__brands">

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
@@ -38,6 +38,9 @@ const PaymentMethodBrands = ({
     const allowedBrands = brands.filter(brand => !excludedUIBrands?.includes(brand.name));
     const { visibleBrands, leftBrandsAmount } = prepareVisibleBrands(allowedBrands, showAllBrands);
 
+    // Force showOtherInsteadOfNumber to false if showAllBrands is given
+    showOtherInsteadOfNumber = showAllBrands ? false : showOtherInsteadOfNumber;
+
     return (
         <span className="adyen-checkout__payment-method__brands">
             {visibleBrands.map(brand => (

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -125,6 +125,7 @@ class PaymentMethodItem extends Component<PaymentMethodItemProps> {
                         <PaymentMethodBrands
                             showOtherInsteadOfNumber={paymentMethod.props.showOtherInsteadOfNumber}
                             keepBrandsVisible={paymentMethod.props.keepBrandsVisible}
+                            showAllBrands={paymentMethod.props.showAllBrands}
                             brands={paymentMethod.brands}
                             excludedUIBrands={BRAND_ICON_UI_EXCLUSION_LIST}
                             isPaymentMethodSelected={isSelected}


### PR DESCRIPTION
## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed.

---

## 📝 Summary

Hi,

we're using the Drop-In components and noticed an unfortunate detail when displaying brands in the Payment Method List. As shown in the screenshot below the brands are cut after 3 brands and depending on the configuration either show the remaining number or "other". 
<img width="440" height="201" alt="image" src="https://github.com/user-attachments/assets/dc558dcc-43db-4d5d-8566-0b16b4f4481e" />

However, the most important brands like Visa or Master-Card are hidden. This PR provides a convenient way to simply show all brands with a new property `showAllBrands` that effectively results in this

<img width="440" height="197" alt="image" src="https://github.com/user-attachments/assets/c038e3d4-940e-4236-ae3a-3fb05eae91ed" />

There is enough space for us to show them all and the responsive design works even for very very small dimensions and just hides some payments again worst case, so we'd appreciate such an option.

Ideally, the brands are also sorted by popularity in the first place, but I couldn't see how I can control this inside the library. (Maybe they are already, in which case it's probably a good idea to reverse them inside PaymentMethodBrands so the most popular brands are left and not filtered out potentially) 

Let me know what you think. If this is cherry-picked again (I was told you don't accept 3rd party PRs directly), I'd appreciate that :)

Best,
Christoph

---

## 🧪 Tested scenarios

I tested this locally in our checkout process with a bunch of different dimensions.

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

