### PR TITLE
Fix: adds roles to CtP OTP button

### DIFF
--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
@@ -67,7 +67,7 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: CtPResendOtpLinkP
 
     if (showConfirmation) {
         return (
-            <div className="adyen-checkout-ctp__otp-resend-code--confirmation">
+            <div role="alert" className="adyen-checkout-ctp__otp-resend-code--confirmation">
                 {i18n.get('ctp.otp.codeResent')}
                 <Icon type={`${PREFIX}checkmark_black`} height={14} width={14} />
             </div>
@@ -76,7 +76,7 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: CtPResendOtpLinkP
 
     if (counter > 0) {
         return (
-            <div className="adyen-checkout-ctp__otp-resend-code--disabled">
+            <div role="timer" className="adyen-checkout-ctp__otp-resend-code--disabled">
                 {i18n.get('ctp.otp.resendCode')} -{' '}
                 <span className="adyen-checkout-ctp__otp-resend-code-counter"> {counter > 0 && `${counter}s`} </span>
             </div>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed.

---

## 📝 Summary

This attempts to fix the missing live regions for the OTP button / content that informs how much time users have.

- `role=alert` for the "Code resent" message;
- `role=timer` for the "Timer" part

Timer and alert are in the suggestion from level access:
> Indicate live regions for dynamically changing content. Live regions can be created by adding a role attribute set to "log", "status", "alert", "progressbar", "marquee", or "timer" as appropriate. Alternatively, custom behavior can be created by using the aria-live, aria-atomic, and aria-relevant attributes. Text injected into this live region element will be announced by screen readers.

Also additional documentation to check the support of these features:
- https://useragentman.com/enable/timer.php
- https://useragentman.com/enable/alert.php
- https://a11ysupport.io/tech/aria/alert_role


This is quite a different approach from what we use for the SRPanel, but it's quite simpler and if given the greenlight by level access could simplify our Timer logic too.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  COSDK-748, CW-31

---

