### PR TITLE
Analytics - Converted module to class based

### DIFF
--- a/packages/lib/config/testMocks/setup-core-mock.ts
+++ b/packages/lib/config/testMocks/setup-core-mock.ts
@@ -1,12 +1,12 @@
 import { mock } from 'jest-mock-extended';
 import { ICore } from '../../src/core/types';
 import PaymentMethods from '../../src/core/ProcessResponse/PaymentMethods';
-import { AnalyticsModule } from '../../src/types/global-types';
 import { Resources } from '../../src/core/Context/Resources';
 import Language from '../../src/language';
 import CheckoutSession from '../../src/core/CheckoutSession';
 import { SRPanel } from '../../src/core/Errors/SRPanel';
 import enUS from '../../../server/translations/en-US.json';
+import type { IAnalytics } from '../../src/core/Analytics/Analytics';
 
 interface SetupCoreMockProps {
     mockSessions?: boolean;
@@ -16,7 +16,7 @@ interface SetupCoreMockProps {
 function setupCoreMock({ mockSessions = true, paymentMethods = null }: SetupCoreMockProps = {}): ICore {
     const core = mock<ICore>({});
 
-    const analytics = mock<AnalyticsModule>();
+    const analytics = mock<IAnalytics>();
     const resources = mock<Resources>();
     const i18n = new Language({ locale: 'en-US', translations: enUS });
     const srPanel = new SRPanel(global.core, {

--- a/packages/lib/src/components/ApplePay/services/ApplePaySdkLoader.test.ts
+++ b/packages/lib/src/components/ApplePay/services/ApplePaySdkLoader.test.ts
@@ -2,7 +2,7 @@ import ApplePaySdkLoader, { APPLE_PAY_SDK_URL } from './ApplePaySdkLoader';
 import Script from '../../../utils/Script';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../types/global-types';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
 jest.mock('../../../utils/Script');
 
@@ -12,7 +12,7 @@ const mockLoad = jest.fn().mockImplementation(() => {
     return Promise.resolve(true);
 });
 
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 describe('ApplePaySdkLoader', () => {
     let loader;

--- a/packages/lib/src/components/ApplePay/services/ApplePaySdkLoader.ts
+++ b/packages/lib/src/components/ApplePay/services/ApplePaySdkLoader.ts
@@ -1,14 +1,14 @@
 import Script from '../../../utils/Script';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
-import { AnalyticsModule } from '../../../types/global-types';
+import { IAnalytics } from '../../../core/Analytics/Analytics';
 
 export const APPLE_PAY_SDK_URL = 'https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js';
 
 class ApplePaySdkLoader {
     private sdkLoadingPromise: Promise<void>;
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
 
-    constructor({ analytics }: { analytics: AnalyticsModule }) {
+    constructor({ analytics }: { analytics: IAnalytics }) {
         this.analytics = analytics;
     }
 

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -30,9 +30,9 @@ import { DisclaimerMsgObject } from '../../../internal/DisclaimerMessage/Disclai
 import { OnAddressLookupType, OnAddressSelectedType } from '../../../internal/Address/components/AddressSearch';
 import { ComponentMethodsRef } from '../../../internal/UIElement/types';
 import { AddressData, PaymentAmount } from '../../../../types/global-types';
-import { AnalyticsModule } from '../../../../types/global-types';
 import type { FastlaneSignupConfiguration } from '../../../PayPalFastlane/types';
 import { AbstractAnalyticsEvent } from '../../../../core/Analytics/events/AbstractAnalyticsEvent';
+import { IAnalytics } from '../../../../core/Analytics/Analytics';
 
 export interface CardInputValidState {
     holderName?: boolean;
@@ -106,7 +106,7 @@ export interface CardInputProps {
     minimumExpiryDate?: string;
     modules?: {
         srPanel: SRPanel;
-        analytics: AnalyticsModule;
+        analytics: IAnalytics;
         risk: RiskElement;
         resources: Resources;
     };

--- a/packages/lib/src/components/CashAppPay/services/CashAppSdkLoader.test.ts
+++ b/packages/lib/src/components/CashAppPay/services/CashAppSdkLoader.test.ts
@@ -3,9 +3,9 @@ import Script from '../../../utils/Script';
 import { CASHAPPPAY_PROD_SDK, CASHAPPPAY_SANDBOX_SDK } from './config';
 import { ICashAppWindowObject } from './types';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../types/global-types';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 const mockLoad = jest.fn().mockImplementation(() => {
     const mockCashAppWindowObj = mock<ICashAppWindowObject>();

--- a/packages/lib/src/components/CashAppPay/services/CashAppSdkLoader.ts
+++ b/packages/lib/src/components/CashAppPay/services/CashAppSdkLoader.ts
@@ -1,17 +1,17 @@
 import { CASHAPPPAY_PROD_SDK, CASHAPPPAY_SANDBOX_SDK } from './config';
 import Script from '../../../utils/Script';
 import { ICashAppWindowObject } from './types';
-import { AnalyticsModule } from '../../../types/global-types';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
 export interface ICashAppSdkLoader {
     load(environment: string): Promise<ICashAppWindowObject>;
 }
 
 class CashAppSdkLoader implements ICashAppSdkLoader {
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
     private readonly environment: string;
 
-    constructor({ analytics, environment }: { analytics: AnalyticsModule; environment: string }) {
+    constructor({ analytics, environment }: { analytics: IAnalytics; environment: string }) {
         this.analytics = analytics;
         this.environment = environment;
     }

--- a/packages/lib/src/components/ClickToPay/ClickToPay.test.ts
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.test.ts
@@ -9,7 +9,7 @@ import { ClickToPayCheckoutPayload, IClickToPayService } from '../internal/Click
 import { CtpState } from '../internal/ClickToPay/services/ClickToPayService';
 import { Resources } from '../../core/Context/Resources';
 import ShopperCard from '../internal/ClickToPay/models/ShopperCard';
-import { AnalyticsModule } from '../../types/global-types';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
 
 jest.mock('../internal/ClickToPay/services/create-clicktopay-service');
 
@@ -27,7 +27,7 @@ test('should initialize ClickToPayService when creating the element', () => {
         shopperEmail: 'shopper@example.com'
     };
 
-    const mockAnalytics = mock<AnalyticsModule>();
+    const mockAnalytics = mock<IAnalytics>();
     global.core.modules.analytics = mockAnalytics;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/lib/src/components/GooglePay/GooglePayService.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayService.ts
@@ -3,14 +3,14 @@ import { resolveEnvironment } from './utils';
 import Script from '../../utils/Script';
 import config from './config';
 import type { GooglePayConfiguration } from './types';
-import { AnalyticsModule } from '../../types/global-types';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
 
 class GooglePayService {
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
 
     public readonly paymentsClient: Promise<google.payments.api.PaymentsClient>;
 
-    constructor(environment: string, analytics: AnalyticsModule, paymentDataCallbacks: google.payments.api.PaymentDataCallbacks) {
+    constructor(environment: string, analytics: IAnalytics, paymentDataCallbacks: google.payments.api.PaymentDataCallbacks) {
         const googlePayEnvironment = resolveEnvironment(environment);
 
         this.analytics = analytics;

--- a/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/preact';
 import KlarnaPayments from './KlarnaPayments';
 import Dropin from '../Dropin';
-import { AnalyticsModule, PaymentAction } from '../../types/global-types';
+import { PaymentAction } from '../../types/global-types';
 import { mock } from 'jest-mock-extended';
 import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
 
 describe('KlarnaPayments', () => {
     const coreProps = {
@@ -80,7 +81,7 @@ describe('KlarnaPayments', () => {
                 }
             };
 
-            global.core.modules.analytics = mock<AnalyticsModule>();
+            global.core.modules.analytics = mock<IAnalytics>();
             const klarna = new KlarnaPayments(global.core, {
                 ...coreProps,
                 type: 'klarna_paynow',
@@ -107,7 +108,7 @@ describe('KlarnaPayments', () => {
                 method: 'GET'
             };
 
-            global.core.modules.analytics = mock<AnalyticsModule>();
+            global.core.modules.analytics = mock<IAnalytics>();
             const klarna = new KlarnaPayments(global.core, {
                 ...coreProps,
                 type: 'klarna_paynow',

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
@@ -7,8 +7,8 @@ import { KLARNA_WIDGET_URL } from '../../constants';
 import { KlarnaWidgetAuthorizeResponse, type KlarnaWidgetProps } from '../../types';
 import { CoreProvider } from '../../../../core/Context/CoreProvider';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../../types/global-types';
 import { PayButtonFunctionProps } from '../../../internal/UIElement/types';
+import type { IAnalytics } from '../../../../core/Analytics/Analytics';
 
 jest.mock('../../../../utils/Script', () => {
     return jest.fn().mockImplementation(() => {
@@ -19,7 +19,7 @@ const mockScriptLoaded = jest.fn().mockImplementation(() => {
     window.klarnaAsyncCallback();
 });
 
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 const customRender = (props: KlarnaWidgetProps) => {
     return render(

--- a/packages/lib/src/components/PayByBankPix/services/PasskeySdkLoader.test.ts
+++ b/packages/lib/src/components/PayByBankPix/services/PasskeySdkLoader.test.ts
@@ -2,7 +2,7 @@ import { PasskeySdkLoader } from './PasskeySdkLoader';
 import { getUrlFromMap } from '../../../core/Environment/Environment';
 import Script from '../../../utils/Script';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../types/global-types';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
 jest.mock('../../../core/Environment/Environment', () => ({
     getUrlFromMap: jest.fn()
@@ -18,7 +18,7 @@ describe('PasskeySdkLoader', () => {
     const mockEnvironment = 'test';
     const mockCdnUrl = 'https://cdn.example.com/';
     const mockAdyenPasskey = { default: { someMethod: jest.fn() } };
-    const mockAnalytics = mock<AnalyticsModule>();
+    const mockAnalytics = mock<IAnalytics>();
 
     let loader: PasskeySdkLoader;
 

--- a/packages/lib/src/components/PayByBankPix/services/PasskeySdkLoader.ts
+++ b/packages/lib/src/components/PayByBankPix/services/PasskeySdkLoader.ts
@@ -4,20 +4,20 @@ import type { CoreConfiguration } from '../../../core/types';
 import { CDN_ENVIRONMENTS } from '../../../core/Environment/constants';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import Script from '../../../utils/Script';
-import { AnalyticsModule } from '../../../types/global-types';
+import { IAnalytics } from '../../../core/Analytics/Analytics';
 
 export interface IPasskeySdkLoader {
-    load(environment: CoreConfiguration['environment'], analytics: AnalyticsModule): Promise<IAdyenPasskey>;
+    load(environment: CoreConfiguration['environment'], analytics: IAnalytics): Promise<IAdyenPasskey>;
 }
 
 class PasskeySdkLoader implements IPasskeySdkLoader {
     private static readonly PASSKEY_SDK_URL = 'js/adyenpasskey/1.1.0/adyen-passkey.js';
     private AdyenPasskey: IAdyenPasskey;
 
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
     private readonly environment: string;
 
-    constructor({ analytics, environment }: { analytics: AnalyticsModule; environment: string }) {
+    constructor({ analytics, environment }: { analytics: IAnalytics; environment: string }) {
         this.analytics = analytics;
         this.environment = environment;
     }

--- a/packages/lib/src/components/PayByBankPix/services/PasskeyService.test.ts
+++ b/packages/lib/src/components/PayByBankPix/services/PasskeyService.test.ts
@@ -4,7 +4,7 @@ import AdyenCheckoutError, { SDK_ERROR } from '../../../core/Errors/AdyenCheckou
 import { mock, mockDeep } from 'jest-mock-extended';
 import { IAdyenPasskey, PasskeyErrorTypes } from './types';
 import base64 from '../../../utils/base64';
-import { AnalyticsModule } from '../../../types/global-types';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
 jest.mock('./PasskeySdkLoader');
 beforeAll(() => {
@@ -17,7 +17,7 @@ beforeAll(() => {
 describe('PasskeyService', () => {
     const mockPasskeySdk = mockDeep<IAdyenPasskey>();
     const mockPasskeyServiceConfig = { environment: 'test', deviceId: 'test-device-id' };
-    const mockAnalytics = mock<AnalyticsModule>();
+    const mockAnalytics = mock<IAnalytics>();
 
     let passkeyService: PasskeyService;
 

--- a/packages/lib/src/components/PayByBankPix/services/PasskeyService.ts
+++ b/packages/lib/src/components/PayByBankPix/services/PasskeyService.ts
@@ -10,18 +10,19 @@ import {
     NavigatorCredentialRetrievalError
 } from './types';
 import AdyenCheckoutError, { SDK_ERROR } from '../../../core/Errors/AdyenCheckoutError';
-import { AnalyticsModule, DecodeObject } from '../../../types/global-types';
+import { DecodeObject } from '../../../types/global-types';
 import base64 from '../../../utils/base64';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
 export class PasskeyService implements IPasskeyService {
     private readonly passkeyServiceConfig: PasskeyServiceConfig;
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
 
     private passkeySdk: IAdyenPasskey;
     private riskSignals: RiskSignalsEnrollment | RiskSignalsAuthentication;
     private initialized: Promise<void>;
 
-    constructor(configuration: PasskeyServiceConfig, analytics: AnalyticsModule) {
+    constructor(configuration: PasskeyServiceConfig, analytics: IAnalytics) {
         this.analytics = analytics;
         this.passkeyServiceConfig = configuration;
     }

--- a/packages/lib/src/components/PayPal/Paypal.test.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.test.tsx
@@ -2,7 +2,7 @@ import Paypal from './Paypal';
 import { render, screen } from '@testing-library/preact';
 import { NO_CHECKOUT_ATTEMPT_ID } from '../../core/Analytics/constants';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../types/global-types';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
 
 describe('Paypal', () => {
     test('Returns a data object', () => {
@@ -50,7 +50,7 @@ describe('Paypal', () => {
     });
 
     test('should pass the required callbacks to the Component', async () => {
-        global.core.modules.analytics = mock<AnalyticsModule>();
+        global.core.modules.analytics = mock<IAnalytics>();
         const paypal = new Paypal(global.core);
         render(paypal.render());
 

--- a/packages/lib/src/components/PayPal/components/PaypalComponent.test.tsx
+++ b/packages/lib/src/components/PayPal/components/PaypalComponent.test.tsx
@@ -3,10 +3,10 @@ import { render, screen } from '@testing-library/preact';
 import PaypalComponent from './PaypalComponent';
 import { mock } from 'jest-mock-extended';
 import { PayPalComponentProps } from './types';
-import { AnalyticsModule } from '../../../types/global-types';
 import { CoreProvider } from '../../../core/Context/CoreProvider';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 const customRender = (props: PayPalComponentProps) =>
     render(

--- a/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
+++ b/packages/lib/src/components/PayPalFastlane/FastlaneSDK.ts
@@ -16,7 +16,7 @@ import {
 
 import Analytics from '../../core/Analytics';
 import { AnalyticsInfoEvent, InfoEventType } from '../../core/Analytics/events/AnalyticsInfoEvent';
-import type { AnalyticsModule } from '../../types/global-types';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
 
 class FastlaneSDK {
     private readonly clientKey: string;
@@ -24,7 +24,7 @@ class FastlaneSDK {
     private readonly fastlaneLocale: string;
     private readonly forceConsentDetails: boolean;
 
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
 
     private fastlaneSdk?: FastlaneWindowInstance;
     private latestShopperDetails?: { email: string; customerId: string };
@@ -44,11 +44,11 @@ class FastlaneSDK {
         this.forceConsentDetails = configuration.forceConsentDetails || false;
         this.fastlaneLocale = convertAdyenLocaleToFastlaneLocale(configuration.locale || 'en-US');
 
-        this.analytics = Analytics({
-            analytics: configuration.analytics,
+        this.analytics = new Analytics({
             locale: configuration.locale || 'en-US',
             analyticsContext: analyticsUrl,
-            clientKey: this.clientKey
+            clientKey: this.clientKey,
+            enabled: configuration.analytics?.enabled
         });
 
         document.addEventListener('visibilitychange', this.handlePageVisibilityChanges);

--- a/packages/lib/src/components/PayPalFastlane/types.ts
+++ b/packages/lib/src/components/PayPalFastlane/types.ts
@@ -1,6 +1,6 @@
 import type { CoreConfiguration } from '../../core/types';
 import type { UIElementProps } from '../internal/UIElement/types';
-import { AnalyticsOptions } from '../../core/Analytics/types';
+import type { AnalyticsOptions } from '../../core/Analytics/types';
 
 /**
  * PayPal Fastlane Reference:

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -1,16 +1,17 @@
 import UIElement from '../internal/UIElement';
-import { ActionHandledReturnObject, AnalyticsModule } from '../../types/global-types';
+import { ActionHandledReturnObject } from '../../types/global-types';
 import Language from '../../language';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import { UIElementProps } from '../internal/UIElement/types';
 import { ErrorEventCode } from '../../core/Analytics/events/AnalyticsErrorEvent';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
 
 interface ThreeDS2Configuration extends UIElementProps {
     dataKey?: string;
     environment?: string;
     isMDFlow?: boolean;
     loadingContext?: string;
-    modules?: { analytics: AnalyticsModule };
+    modules?: { analytics: IAnalytics };
     notificationURL?: string;
     onActionHandled?: (rtnObj: ActionHandledReturnObject) => void;
     onError?: (error: AdyenCheckoutError, element?: UIElement) => void;

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -6,7 +6,6 @@ import { NO_CHECKOUT_ATTEMPT_ID } from '../../../core/Analytics/constants';
 import type { ICore } from '../../../core/types';
 import type { BaseElementProps, IBaseElement } from './types';
 import type { PaymentData } from '../../../types/global-types';
-import { AnalyticsInitialEvent } from '../../../core/Analytics/types';
 import { off, on } from '../../../utils/listenerUtils';
 import { AbstractAnalyticsEvent } from '../../../core/Analytics/events/AbstractAnalyticsEvent';
 
@@ -70,11 +69,6 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
     }
 
     /* eslint-disable-next-line */
-    protected setUpAnalytics(setUpAnalyticsObj: AnalyticsInitialEvent) {
-        return null;
-    }
-
-    /* eslint-disable-next-line */
     protected submitAnalytics(analyticsObj?: AbstractAnalyticsEvent) {
         return null;
     }
@@ -135,8 +129,6 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
             throw new Error('Component could not mount. Root node was not found.');
         }
 
-        const setupAnalytics = !this._node;
-
         if (this._node) {
             this.unmount(); // new, if this._node exists then we are "remounting" so we first need to unmount if it's not already been done
         }
@@ -149,17 +141,6 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
         this._component = this.render();
 
         render(this._component, node);
-
-        // Set up analytics (once, since this._node is currently undefined) now that we have mounted and rendered
-        if (setupAnalytics) {
-            if (this.props.modules && this.props.modules.analytics) {
-                this.setUpAnalytics({
-                    containerWidth: node && node.offsetWidth,
-                    component: this.constructor['type'],
-                    flavor: !this.props.isDropin ? 'components' : 'dropin'
-                });
-            }
-        }
 
         return this;
     }

--- a/packages/lib/src/components/internal/BaseElement/types.ts
+++ b/packages/lib/src/components/internal/BaseElement/types.ts
@@ -1,15 +1,15 @@
 import { Order } from '../../../types/global-types';
 import { SRPanel } from '../../../core/Errors/SRPanel';
-import { AnalyticsModule } from '../../../types/global-types';
 import { Resources } from '../../../core/Context/Resources';
 import RiskElement from '../../../core/RiskModule';
 import { ComponentChild } from 'preact';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
 export interface BaseElementProps {
     order?: Order;
     modules?: {
         srPanel?: SRPanel;
-        analytics?: AnalyticsModule;
+        analytics?: IAnalytics;
         resources?: Resources;
         risk?: RiskElement;
     };

--- a/packages/lib/src/components/internal/ClickToPay/services/ClickToPayService.test.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/ClickToPayService.test.ts
@@ -8,9 +8,9 @@ import { SrciCheckoutResponse, SrciIdentityLookupResponse, SrcProfile } from './
 import SrciError from './sdks/SrciError';
 import ShopperCard from '../models/ShopperCard';
 import TimeoutError from '../errors/TimeoutError';
-import { AnalyticsModule } from '../../../../types/global-types';
+import type { IAnalytics } from '../../../../core/Analytics/Analytics';
 
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 describe('Timeout handling', () => {
     test('should report timeout to Visa SDK passing srciDpaId since correlationId is unavailable', async () => {

--- a/packages/lib/src/components/internal/ClickToPay/services/ClickToPayService.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/ClickToPayService.ts
@@ -19,7 +19,7 @@ import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
 import { isFulfilled, isRejected } from '../../../../utils/promise-util';
 import TimeoutError from '../errors/TimeoutError';
 import { executeWithTimeout } from './execute-with-timeout';
-import type { AnalyticsModule } from '../../../../types/global-types';
+import type { IAnalytics } from '../../../../core/Analytics/Analytics';
 
 export enum CtpState {
     Idle = 'Idle',
@@ -36,7 +36,7 @@ class ClickToPayService implements IClickToPayService {
     private readonly schemesConfig: SchemesConfiguration;
     private readonly shopperIdentity?: IdentityLookupParams;
     private readonly environment: string;
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
 
     private readonly onTimeout?: (error: TimeoutError) => void;
 
@@ -62,7 +62,7 @@ class ClickToPayService implements IClickToPayService {
         schemesConfig: SchemesConfiguration,
         sdkLoader: ISrcSdkLoader,
         environment: string,
-        analytics: AnalyticsModule,
+        analytics: IAnalytics,
         shopperIdentity?: IdentityLookupParams,
         onTimeout?: (error: TimeoutError) => void
     ) {

--- a/packages/lib/src/components/internal/ClickToPay/services/create-clicktopay-service.test.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/create-clicktopay-service.test.ts
@@ -3,10 +3,10 @@ import { CtpState } from './ClickToPayService';
 import { IClickToPayService } from './types';
 import { CardBackendConfiguration } from '../../../Card/types';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../../types/global-types';
+import type { IAnalytics } from '../../../../core/Analytics/Analytics';
 
 const ENVIRONMENT = 'test';
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 test('should not create the service if card `configuration` property is not provided', () => {
     let service: IClickToPayService,

--- a/packages/lib/src/components/internal/ClickToPay/services/create-clicktopay-service.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/create-clicktopay-service.ts
@@ -4,7 +4,7 @@ import { IClickToPayService, IdentityLookupParams } from './types';
 import { SrcInitParams } from './sdks/types';
 import { CardBackendConfiguration } from '../../../Card/types';
 import { ClickToPayProps, ClickToPayScheme } from '../types';
-import type { AnalyticsModule } from '../../../../types/global-types';
+import type { IAnalytics } from '../../../../core/Analytics/Analytics';
 
 /**
  * Creates the Click to Pay service in case the required configuration is provided
@@ -13,7 +13,7 @@ export default function createClickToPayService(
     configuration: CardBackendConfiguration,
     clickToPayConfiguration: ClickToPayProps | undefined,
     environment: string,
-    analytics: AnalyticsModule
+    analytics: IAnalytics
 ): IClickToPayService | null {
     const schemesConfig = createSchemesInitConfiguration(configuration);
 

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/AbstractSrcInitiator.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/AbstractSrcInitiator.ts
@@ -13,7 +13,7 @@ import {
 import SrciError, { MastercardError, VisaError } from './SrciError';
 import { ClickToPayScheme } from '../../types';
 import Script from '../../../../../utils/Script';
-import { AnalyticsModule } from '../../../../../types/global-types';
+import { IAnalytics } from '../../../../../core/Analytics/Analytics';
 
 export interface ISrcInitiator {
     schemeName: ClickToPayScheme;
@@ -37,11 +37,11 @@ export default abstract class AbstractSrcInitiator implements ISrcInitiator {
 
     protected readonly customSdkConfiguration: CustomSdkConfiguration;
 
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
     private readonly sdkUrl: string;
     private scriptElement: Script | null = null;
 
-    protected constructor(sdkUrl: string, customSdkConfiguration: CustomSdkConfiguration, analytics: AnalyticsModule) {
+    protected constructor(sdkUrl: string, customSdkConfiguration: CustomSdkConfiguration, analytics: IAnalytics) {
         if (!sdkUrl) throw Error('AbstractSrcInitiator: Invalid SDK URL');
 
         this.sdkUrl = sdkUrl;

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/MastercardSdk.test.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/MastercardSdk.test.ts
@@ -2,7 +2,7 @@ import MastercardSdk from './MastercardSdk';
 import Script from '../../../../../utils/Script';
 import { MC_SDK_PROD, MC_SDK_TEST } from './config';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../../../types/global-types';
+import { IAnalytics } from '../../../../../core/Analytics/Analytics';
 
 const mockScriptLoaded = jest.fn().mockImplementation(() => {
     window.SRCSDK_MASTERCARD = {
@@ -44,7 +44,7 @@ const mockScriptLoaded = jest.fn().mockImplementation(() => {
     };
 });
 
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 const mockScriptRemoved = jest.fn();
 
 jest.mock('../../../../../utils/Script', () => {

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/MastercardSdk.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/MastercardSdk.ts
@@ -8,7 +8,7 @@ import {
     SrciIdentityLookupResponse,
     SrcInitParams
 } from './types';
-import { AnalyticsModule } from '../../../../../types/global-types';
+import type { IAnalytics } from '../../../../../core/Analytics/Analytics';
 
 const IdentityTypeMap = {
     email: 'EMAIL_ADDRESS',
@@ -18,7 +18,7 @@ const IdentityTypeMap = {
 class MastercardSdk extends AbstractSrcInitiator {
     public readonly schemeName = 'mc';
 
-    constructor(environment: string, customSdkConfig: CustomSdkConfiguration, analytics: AnalyticsModule) {
+    constructor(environment: string, customSdkConfig: CustomSdkConfiguration, analytics: IAnalytics) {
         super(environment.toLowerCase().includes('live') ? MC_SDK_PROD : MC_SDK_TEST, customSdkConfig, analytics);
     }
 

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/SrcSdkLoader.test.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/SrcSdkLoader.test.ts
@@ -4,12 +4,12 @@ import VisaSdk from './VisaSdk';
 import MastercardSdk from './MastercardSdk';
 import AdyenCheckoutError from '../../../../../core/Errors/AdyenCheckoutError';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../../../types/global-types';
+import type { IAnalytics } from '../../../../../core/Analytics/Analytics';
 
 jest.mock('./VisaSdk');
 jest.mock('./MastercardSdk');
 
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 describe('load()', () => {
     test('should resolve Promise when all SDKs load sucessfully', async () => {

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/SrcSdkLoader.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/SrcSdkLoader.ts
@@ -4,7 +4,7 @@ import MastercardSdk from './MastercardSdk';
 import { CustomSdkConfiguration } from './types';
 import AdyenCheckoutError from '../../../../../core/Errors/AdyenCheckoutError';
 import { isFulfilled, isRejected } from '../../../../../utils/promise-util';
-import { AnalyticsModule } from '../../../../../types/global-types';
+import type { IAnalytics } from '../../../../../core/Analytics/Analytics';
 
 const sdkMap: Record<string, typeof VisaSdk | typeof MastercardSdk | null> = {
     visa: VisaSdk,
@@ -12,18 +12,13 @@ const sdkMap: Record<string, typeof VisaSdk | typeof MastercardSdk | null> = {
     default: null
 };
 
-const getSchemeSdk = (
-    scheme: string,
-    environment: string,
-    customConfig: CustomSdkConfiguration,
-    analytics: AnalyticsModule
-): ISrcInitiator | null => {
+const getSchemeSdk = (scheme: string, environment: string, customConfig: CustomSdkConfiguration, analytics: IAnalytics): ISrcInitiator | null => {
     const SchemeSdkClass = sdkMap[scheme] || sdkMap.default;
     return SchemeSdkClass ? new SchemeSdkClass(environment, customConfig, analytics) : null;
 };
 
 export interface ISrcSdkLoader {
-    load(environment: string, analytics: AnalyticsModule): Promise<ISrcInitiator[]>;
+    load(environment: string, analytics: IAnalytics): Promise<ISrcInitiator[]>;
     schemes: string[];
 }
 
@@ -37,7 +32,7 @@ class SrcSdkLoader implements ISrcSdkLoader {
         this.customSdkConfiguration = { dpaLocale, dpaPresentationName };
     }
 
-    public async load(environment: string, analytics: AnalyticsModule): Promise<ISrcInitiator[]> {
+    public async load(environment: string, analytics: IAnalytics): Promise<ISrcInitiator[]> {
         if (!this.schemes || this.schemes.length === 0) {
             throw new AdyenCheckoutError('ERROR', 'ClickToPay -> SrcSdkLoader: There are no schemes set to be loaded');
         }

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.test.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.test.ts
@@ -3,7 +3,7 @@ import Script from '../../../../../utils/Script';
 import { VISA_SDK_PROD, VISA_SDK_TEST } from './config';
 import { VisaError } from './SrciError';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../../../../../types/global-types';
+import type { IAnalytics } from '../../../../../core/Analytics/Analytics';
 
 const mockScriptLoaded = jest.fn().mockImplementation(() => {
     window.vAdapters = {
@@ -14,7 +14,7 @@ const mockScriptLoaded = jest.fn().mockImplementation(() => {
         }))
     };
 });
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 const mockScriptRemoved = jest.fn();
 
 jest.mock('../../../../../utils/Script', () => {

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.ts
@@ -8,7 +8,7 @@ import type {
     SrciIdentityLookupResponse,
     SrcInitParams
 } from './types';
-import { AnalyticsModule } from '../../../../../types/global-types';
+import type { IAnalytics } from '../../../../../core/Analytics/Analytics';
 
 const IdentityTypeMap = {
     email: 'EMAIL',
@@ -18,7 +18,7 @@ const IdentityTypeMap = {
 class VisaSdk extends AbstractSrcInitiator {
     public readonly schemeName = 'visa';
 
-    constructor(environment: string, customSdkConfig: CustomSdkConfiguration, analytics: AnalyticsModule) {
+    constructor(environment: string, customSdkConfig: CustomSdkConfiguration, analytics: IAnalytics) {
         super(environment.toLowerCase().includes('live') ? VISA_SDK_PROD : VISA_SDK_TEST, customSdkConfig, analytics);
     }
 

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -6,13 +6,11 @@ import AdyenCheckoutError, { NETWORK_ERROR } from '../../../core/Errors/AdyenChe
 import { hasOwnProperty } from '../../../utils/hasOwnProperty';
 import { Resources } from '../../../core/Context/Resources';
 
-import { AnalyticsInitialEvent } from '../../../core/Analytics/types';
 import type { CoreConfiguration, ICore, AdditionalDetailsData } from '../../../core/types';
 import type { ComponentMethodsRef, PayButtonFunctionProps, UIElementProps, UIElementStatus } from './types';
 import type { CheckoutSessionDetailsResponse, CheckoutSessionPaymentResponse } from '../../../core/CheckoutSession/types';
 import type {
     ActionHandledReturnObject,
-    AnalyticsModule,
     CheckoutAdvancedFlowResponse,
     Order,
     PaymentAction,
@@ -32,6 +30,7 @@ import { AnalyticsInfoEvent, InfoEventType } from '../../../core/Analytics/event
 
 import './UIElement.scss';
 import { SRPanel } from '../../../core/Errors/SRPanel';
+import type { IAnalytics } from '../../../core/Analytics/Analytics';
 
 export abstract class UIElement<P extends UIElementProps = UIElementProps> extends BaseElement<P> {
     protected componentRef: any;
@@ -108,7 +107,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         this.analytics.sendAnalytics(event);
     }
 
-    get analytics(): AnalyticsModule {
+    get analytics(): IAnalytics {
         return this.core.modules.analytics;
     }
 
@@ -205,16 +204,6 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
             },
             this.elementRef
         );
-    }
-
-    // Only called once, for UIElements (including Dropin), as they are being mounted
-    protected setUpAnalytics(setUpAnalyticsObj: AnalyticsInitialEvent) {
-        const sessionId = this.props.session?.id;
-
-        return this.props.modules.analytics.setUp({
-            ...setUpAnalyticsObj,
-            ...(sessionId && { sessionId })
-        });
     }
 
     protected override submitAnalytics(event: AbstractAnalyticsEvent) {

--- a/packages/lib/src/core/Analytics/EventsQueue.test.ts
+++ b/packages/lib/src/core/Analytics/EventsQueue.test.ts
@@ -1,32 +1,64 @@
-import EventsQueue from './EventsQueue';
+import EventsQueue, { EventsQueueModule } from './EventsQueue';
 import { ANALYTICS_PATH } from './constants';
 import { AnalyticsInfoEvent, InfoEventType } from './events/AnalyticsInfoEvent';
+import { AnalyticsLogEvent, LogEventType } from './events/AnalyticsLogEvent';
+import { AnalyticsErrorEvent, ErrorEventCode, ErrorEventType } from './events/AnalyticsErrorEvent';
 
-const event = new AnalyticsInfoEvent({ type: InfoEventType.rendered, component: 'scheme' });
+describe('EventsQueue', () => {
+    let queue: EventsQueueModule;
 
-describe('CAEventsQueue', () => {
-    const queue = EventsQueue({ analyticsContext: 'https://mydomain.com', clientKey: 'fsdjkh', analyticsPath: ANALYTICS_PATH });
-
-    test('adds log to the queue', () => {
-        queue.add('logs', event);
-        expect(queue.getQueue().logs.length).toBe(1);
+    beforeEach(() => {
+        queue = EventsQueue({ analyticsContext: 'https://mydomain.com', clientKey: 'test_client_key', analyticsPath: ANALYTICS_PATH });
     });
 
-    test('adds event to the queue', () => {
-        queue.add('info', event);
-        expect(queue.getQueue().info.length).toBe(1);
+    describe('Adding events to their respective queues', () => {
+        test('should add to log queue', () => {
+            const queue = EventsQueue({ analyticsContext: 'https://mydomain.com', clientKey: 'fsdjkh', analyticsPath: ANALYTICS_PATH });
+            const event = new AnalyticsLogEvent({ type: LogEventType.action, component: 'card', message: '3DS2 showed' });
+            queue.add(event);
+            expect(queue.getQueue().logs.length).toBe(1);
+        });
+
+        test('should add to info queue', () => {
+            const event = new AnalyticsInfoEvent({ type: InfoEventType.rendered, component: 'scheme' });
+            queue.add(event);
+            expect(queue.getQueue().info.length).toBe(1);
+        });
+
+        test('should add to error queue', () => {
+            const event = new AnalyticsErrorEvent({
+                code: ErrorEventCode.THREEDS2_TOKEN_IS_MISSING_OTHER_PROPS,
+                component: 'card',
+                errorType: ErrorEventType.apiError,
+                message: '3DS2 error'
+            });
+            queue.add(event);
+            expect(queue.getQueue().errors.length).toBe(1);
+        });
     });
 
-    test('adds error to the queue', () => {
-        queue.add('errors', event);
-        expect(queue.getQueue().errors.length).toBe(1);
-    });
+    describe('Flushing events', () => {
+        test('run flushes the queue', () => {
+            queue.add(new AnalyticsInfoEvent({ type: InfoEventType.rendered, component: 'scheme' }));
+            queue.add(new AnalyticsLogEvent({ type: LogEventType.action, component: 'card', message: '3DS2 showed' }));
+            queue.add(
+                new AnalyticsErrorEvent({
+                    code: ErrorEventCode.REDIRECT,
+                    component: 'redirect',
+                    errorType: ErrorEventType.apiError,
+                    message: 'redirect'
+                })
+            );
 
-    test('run flushes the queue', () => {
-        void queue.run('checkoutAttemptId');
+            expect(queue.getQueue().logs.length).toBe(1);
+            expect(queue.getQueue().info.length).toBe(1);
+            expect(queue.getQueue().errors.length).toBe(1);
 
-        expect(queue.getQueue().logs.length).toBe(0);
-        expect(queue.getQueue().info.length).toBe(0);
-        expect(queue.getQueue().errors.length).toBe(0);
+            void queue.run('mocked-attempt-id');
+
+            expect(queue.getQueue().logs.length).toBe(0);
+            expect(queue.getQueue().info.length).toBe(0);
+            expect(queue.getQueue().errors.length).toBe(0);
+        });
     });
 });

--- a/packages/lib/src/core/Analytics/constants.ts
+++ b/packages/lib/src/core/Analytics/constants.ts
@@ -8,17 +8,7 @@ import {
 
 export const ANALYTICS_PATH = 'v3/analytics';
 
-export const ANALYTICS_INFO_TIMER_INTERVAL = process.env.NODE_ENV === 'development' ? 5000 : 10000;
-
 export const ANALYTICS_SEARCH_DEBOUNCE_TIME = 3000;
-
-export const ANALYTICS_EVENT = {
-    log: 'log',
-    error: 'error',
-    info: 'info'
-};
-
-export const ANALYTICS_QR_CODE_DOWNLOAD = 'qr_download_button';
 
 /**
  * Function to map errorCodes based on translation keys to the codes expected by the analytics endpoint
@@ -40,11 +30,4 @@ export const errorCodeMapping: Record<string, string> = {
     //
 };
 
-export const ALLOWED_ANALYTICS_DATA = ['applicationInfo', 'checkoutAttemptId'];
-
 export const NO_CHECKOUT_ATTEMPT_ID = 'fetch-checkoutAttemptId-failed';
-
-export const ANALYTIC_LEVEL = {
-    all: 'all',
-    initial: 'initial'
-};

--- a/packages/lib/src/core/Analytics/events/AbstractAnalyticsEvent.ts
+++ b/packages/lib/src/core/Analytics/events/AbstractAnalyticsEvent.ts
@@ -10,7 +10,7 @@ export abstract class AbstractAnalyticsEvent {
      */
     private readonly component: string;
 
-    public abstract getEventCategory(): string;
+    public abstract getEventCategory(): 'info' | 'log' | 'error';
 
     protected constructor(component: string) {
         this.component = component;

--- a/packages/lib/src/core/Analytics/events/AnalyticsErrorEvent.ts
+++ b/packages/lib/src/core/Analytics/events/AnalyticsErrorEvent.ts
@@ -1,5 +1,4 @@
 import { AbstractAnalyticsEvent } from './AbstractAnalyticsEvent';
-import { ANALYTICS_EVENT } from '../constants';
 
 type AnalyticsErrorEventProps = {
     component: string;
@@ -67,7 +66,7 @@ export class AnalyticsErrorEvent extends AbstractAnalyticsEvent {
         if (props.message) this.message = props.message;
     }
 
-    public getEventCategory(): string {
-        return ANALYTICS_EVENT.error;
+    public getEventCategory(): 'error' {
+        return 'error';
     }
 }

--- a/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.ts
+++ b/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.ts
@@ -1,5 +1,4 @@
 import { AbstractAnalyticsEvent } from './AbstractAnalyticsEvent';
-import { ANALYTICS_EVENT } from '../constants';
 import { mapErrorCodesForAnalytics } from '../utils';
 
 type AnalyticsInfoEventProps = {
@@ -174,7 +173,7 @@ export class AnalyticsInfoEvent extends AbstractAnalyticsEvent {
         }
     }
 
-    public getEventCategory(): string {
-        return ANALYTICS_EVENT.info;
+    public getEventCategory(): 'info' {
+        return 'info';
     }
 }

--- a/packages/lib/src/core/Analytics/events/AnalyticsLogEvent.ts
+++ b/packages/lib/src/core/Analytics/events/AnalyticsLogEvent.ts
@@ -1,5 +1,4 @@
 import { AbstractAnalyticsEvent } from './AbstractAnalyticsEvent';
-import { ANALYTICS_EVENT } from '../constants';
 import type { PaymentAction } from '../../../types/global-types';
 
 type AnalyticsLogEventProps = {
@@ -51,8 +50,8 @@ export class AnalyticsLogEvent extends AbstractAnalyticsEvent {
         if (props.result) this.result = props.result;
     }
 
-    public getEventCategory(): string {
-        return ANALYTICS_EVENT.log;
+    public getEventCategory(): 'log' {
+        return 'log';
     }
 
     public static getSubtypeFromActionType(type: PaymentAction['type']): LogEventSubtype {

--- a/packages/lib/src/core/Analytics/types.ts
+++ b/packages/lib/src/core/Analytics/types.ts
@@ -1,166 +1,37 @@
-import { PaymentAmount } from '../../types';
-import { SocialSecurityMode } from '../../components/Card/types';
-import { ANALYTICS_EVENT } from './constants';
-
-export interface Experiment {
-    controlGroup: boolean;
-    experimentId: string;
-    experimentName?: string;
-}
-
-export interface AnalyticsData {
-    /**
-     * Relates to PMs used within Plugins
-     * https://docs.adyen.com/development-resources/application-information/?tab=integrator_built_2#application-information-fields
-     * @internal
-     */
-    applicationInfo?: {
-        externalPlatform: {
-            name: string;
-            version: string;
-            integrator: string;
-        };
-        merchantApplication: {
-            name: string;
-            version: string;
-        };
-        merchantDevice?: {
-            os: string;
-            osVersion: string;
-        };
-    };
-
-    /**
-     * Use a checkoutAttemptId from a previous page
-     */
-    checkoutAttemptId?: string;
-}
-
 export interface AnalyticsOptions {
     /**
      * Enable/Disable all analytics
      */
     enabled?: boolean;
-
-    /**
-     * Data to be sent along with the event data
-     */
-    payload?: any;
-
-    /**
-     * List of experiments to be sent in the collectId call // TODO - still used?
-     */
-    experiments?: Experiment[];
-
     /**
      * A wrapper to pass data needed when analytics is setup
      */
-    analyticsData?: AnalyticsData;
+    analyticsData?: {
+        /**
+         * Relates to PMs used within Plugins
+         * https://docs.adyen.com/development-resources/application-information/?tab=integrator_built_2#application-information-fields
+         * @internal
+         */
+        applicationInfo?: ApplicationInfo;
+        /**
+         * Use a checkoutAttemptId from a previous page
+         */
+        checkoutAttemptId?: string;
+    };
 }
 
-export type AnalyticsProps = {
-    clientKey: string;
-    analyticsContext: string;
-    locale: string;
-    analytics?: AnalyticsOptions;
-};
-
-export type AnalyticsEventCategory = (typeof ANALYTICS_EVENT)[keyof typeof ANALYTICS_EVENT];
-
-export type AnalyticsInitialEvent = {
-    containerWidth?: number;
-    component?: string;
-    flavor?: string;
-    paymentMethods?: any[];
-    sessionId?: string;
-    checkoutStage?: 'precheckout' | 'checkout';
-};
-
-export type AnalyticsConfig = {
-    analyticsContext?: string;
-    clientKey?: string;
-    locale?: string;
-    amount?: PaymentAmount;
-    loadingContext?: string;
-};
-
-export interface AnalyticsObject {
-    timestamp: string;
-    id: string;
-    component: string;
-    code?: string;
-    errorType?: string;
-    message?: string;
-    type?: string;
-    subType?: string;
-    target?: string;
-    metadata?: Record<string, any>;
-    isStoredPaymentMethod?: boolean;
-    brand?: string;
-    validationErrorCode?: string;
-    validationErrorMessage?: string;
-    issuer?: string;
-    isExpress?: boolean;
-    expressPage?: string;
-    result?: string;
-    configData?: Record<string, string | boolean>;
+export interface ApplicationInfo {
+    externalPlatform: {
+        name: string;
+        version: string;
+        integrator: string;
+    };
+    merchantApplication: {
+        name: string;
+        version: string;
+    };
+    merchantDevice?: {
+        os: string;
+        osVersion: string;
+    };
 }
-
-export type EventQueueProps = Pick<AnalyticsConfig, 'analyticsContext' | 'clientKey'> & { analyticsPath: string };
-
-export type ConfigData = CardConfigData; // TODO extend in future as we get Dropin & Checkout related config data
-
-export type CardConfigData = {
-    autoFocus: boolean;
-    billingAddressAllowedCountries: string;
-    billingAddressMode: 'full' | 'partial' | 'lookup' | 'none';
-    billingAddressRequired: boolean;
-    billingAddressRequiredFields: string;
-    brands: string;
-    challengeWindowSize: string;
-    disableIOSArrowKeys: boolean;
-    doBinLookup: boolean;
-    enableStoreDetails: boolean;
-    exposeExpiryDate: boolean;
-    forceCompat: boolean;
-    hasBrandsConfiguration: boolean;
-    hasData: boolean;
-    hasDisclaimerMessage: boolean;
-    hasHolderName: boolean;
-    hasPlaceholders: boolean;
-    hasInstallmentOptions: boolean;
-    hideCVC: boolean;
-    holderNameRequired: boolean;
-    hasStylesConfigured: boolean;
-    keypadFix: boolean;
-    legacyInputMode: boolean;
-    maskSecurityCode: boolean;
-    minimumExpiryDate: boolean;
-    name: string;
-    positionHolderNameOnTop: boolean;
-    riskEnabled: boolean;
-    showBrandIcon: boolean;
-    showInstallmentAmounts: boolean;
-    showKCPType: 'none' | 'auto' | 'atStart';
-    showPayButton: boolean;
-    socialSecurityNumberMode: SocialSecurityMode;
-    srPanelEnabled: boolean;
-    srPanelMoveFocus: boolean;
-    trimTrailingSeparator: boolean;
-    // callbacks
-    hasOnAllValid: boolean;
-    hasOnBinLookup: boolean;
-    hasOnBinValue: boolean;
-    hasOnBlur: boolean;
-    hasOnBrand: boolean;
-    hasOnConfigSuccess: boolean;
-    hasOnFieldValid: boolean;
-    hasOnFocus: boolean;
-    hasOnLoad: boolean;
-    hasOnEnterKeyPressed: boolean;
-    /**
-     * Fastlane
-     */
-    hasFastlaneConfigured?: boolean;
-    isFastlaneConsentDefaultOn?: boolean;
-};

--- a/packages/lib/src/core/Analytics/utils.ts
+++ b/packages/lib/src/core/Analytics/utils.ts
@@ -1,7 +1,7 @@
-import { AnalyticsData } from './types';
-import { errorCodeMapping, ALLOWED_ANALYTICS_DATA } from './constants';
+import { errorCodeMapping } from './constants';
 import { digitsOnlyFormatter } from '../../utils/Formatters/formatters';
 import { ERROR_FIELD_REQUIRED, ERROR_INVALID_FORMAT_EXPECTS } from '../Errors/constants';
+import type { AnalyticsOptions } from './types';
 
 export const mapErrorCodesForAnalytics = (errorCode: string, target: string) => {
     // Some of the more generic error codes required combination with target to retrieve a specific code
@@ -20,7 +20,9 @@ export const mapErrorCodesForAnalytics = (errorCode: string, target: string) => 
     return errCode;
 };
 
-export const processAnalyticsData = (analyticsData?: AnalyticsData): AnalyticsData => {
+export const processAnalyticsData = (analyticsData?: AnalyticsOptions['analyticsData']): AnalyticsOptions['analyticsData'] => {
+    const ALLOWED_ANALYTICS_DATA = ['applicationInfo', 'checkoutAttemptId'];
+
     if (!analyticsData) return {};
 
     return Object.keys(analyticsData).reduce((acc, prop) => {

--- a/packages/lib/src/core/Context/CoreProvider.tsx
+++ b/packages/lib/src/core/Context/CoreProvider.tsx
@@ -4,21 +4,21 @@ import { Resources } from './Resources';
 import Language from '../../language';
 
 import type { ComponentChildren } from 'preact';
-import type { AnalyticsModule } from '../../types/global-types';
+import type { IAnalytics } from '../Analytics/Analytics';
 
 interface CoreProviderProps {
     loadingContext: string;
     i18n: Language;
     resources: Resources;
     children: ComponentChildren;
-    analytics?: AnalyticsModule;
+    analytics?: IAnalytics;
 }
 
 type ContextValue = {
     i18n: Language;
     loadingContext: string;
     resources: Resources;
-    analytics: AnalyticsModule;
+    analytics: IAnalytics;
 };
 
 const CoreContext = createContext<ContextValue | undefined>(undefined);

--- a/packages/lib/src/core/Services/analytics/collect-id.test.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.test.ts
@@ -1,7 +1,6 @@
 import { httpPost } from '../http';
-import collectId, { FAILURE_MSG } from './collect-id';
+import collectId, { CollectIdProps, FAILURE_MSG } from './collect-id';
 import { ANALYTICS_PATH } from '../../Analytics/constants';
-import type { CollectIdProps } from './types';
 
 jest.mock('../http');
 jest.mock('../../config', () => {

--- a/packages/lib/src/core/Services/analytics/collect-id.ts
+++ b/packages/lib/src/core/Services/analytics/collect-id.ts
@@ -1,10 +1,40 @@
 import { HttpOptions, httpPost } from '../http';
-import type { CollectIdEvent, CollectIdProps, TelemetryEvent } from './types';
 import AdyenCheckoutError from '../../Errors/AdyenCheckoutError';
 import { LIBRARY_BUNDLE_TYPE, LIBRARY_VERSION } from '../../config';
+import type { ApplicationInfo } from '../../Analytics/types';
 
 export const FAILURE_MSG =
     'WARNING: Failed to retrieve "checkoutAttemptId". Consequently, analytics will not be available for this payment. The payment process, however, will not be affected.';
+
+export interface CollectIdProps {
+    analyticsContext: string;
+    clientKey: string;
+    locale: string;
+    analyticsPath: string;
+}
+
+export interface AttemptIdPayload {
+    checkoutStage: 'precheckout' | 'checkout';
+    level: 'initial' | 'all';
+    sessionId?: string;
+    checkoutAttemptId?: string;
+    applicationInfo?: ApplicationInfo;
+}
+
+interface CheckoutAttemptIdRequest {
+    version: string;
+    channel: 'Web';
+    platform: 'Web';
+    locale: string;
+    checkoutStage: 'precheckout' | 'checkout';
+    referrer: string;
+    screenWidth: number;
+    buildType: string;
+    level: 'initial' | 'all';
+    sessionId?: string;
+    checkoutAttemptId?: string;
+    applicationInfo?: ApplicationInfo;
+}
 
 /**
  * Send an event to Adyen with some basic telemetry info and receive a checkoutAttemptId in response
@@ -21,13 +51,13 @@ const collectId = ({ analyticsContext, clientKey, locale, analyticsPath }: Colle
         errorMessage: FAILURE_MSG
     };
 
-    return (event: CollectIdEvent): Promise<string> => {
+    return (event: AttemptIdPayload): Promise<string> => {
         // Prevents multiple standalone components on the same page from making multiple calls to collect a checkoutAttemptId
         if (memoizedPromise !== null) {
             return memoizedPromise;
         }
 
-        const telemetryEvent: TelemetryEvent = {
+        const telemetryEvent: CheckoutAttemptIdRequest = {
             version: LIBRARY_VERSION,
             buildType: LIBRARY_BUNDLE_TYPE,
             channel: 'Web',

--- a/packages/lib/src/core/Services/analytics/types.ts
+++ b/packages/lib/src/core/Services/analytics/types.ts
@@ -1,28 +1,4 @@
-import { AnalyticsConfig, AnalyticsData, AnalyticsInitialEvent } from '../../Analytics/types';
-import { PaymentAmount } from '../../../types';
-
-export type CheckoutAttemptIdSession = {
+export type CheckoutAttemptIdSessionStorage = {
     id: string;
     timestamp: number;
 };
-
-export type CollectIdProps = Pick<AnalyticsConfig, 'clientKey' | 'analyticsContext' | 'locale' | 'amount'> & {
-    analyticsPath: string;
-};
-
-export type TelemetryEvent = {
-    version: string;
-    channel: 'Web';
-    platform: 'Web';
-    locale?: string;
-    referrer?: string;
-    screenWidth?: number;
-    containerWidth?: number;
-    component?: string;
-    flavor?: string;
-    buildType?: string;
-    amount?: PaymentAmount;
-} & AnalyticsInitialEvent &
-    AnalyticsData;
-
-export type CollectIdEvent = AnalyticsInitialEvent & AnalyticsData;

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -108,6 +108,7 @@ class Core implements ICore {
         await this.initializeCore();
         this.validateCoreConfiguration();
         await this.createCoreModules();
+        this.requestAnalyticsAttemptId();
         return this;
     }
 
@@ -374,11 +375,12 @@ class Core implements ICore {
 
         this.modules = Object.freeze({
             risk: new RiskModule(this, { ...this.options, loadingContext: this.loadingContext }),
-            analytics: Analytics({
+            analytics: new Analytics({
                 analyticsContext: this.analyticsContext,
                 clientKey: this.options.clientKey,
                 locale: this.options.locale,
-                analytics: this.options.analytics
+                enabled: this.options.analytics?.enabled,
+                analyticsData: this.options.analytics?.analyticsData
             }),
             resources: new Resources(this.cdnImagesUrl),
             i18n: new Language({
@@ -387,6 +389,12 @@ class Core implements ICore {
                 customTranslations: this.options.translations
             }),
             srPanel: new SRPanel(this, { ...this.options.srConfig })
+        });
+    }
+
+    private requestAnalyticsAttemptId() {
+        void this.modules.analytics.setUp({
+            ...(this.session?.id && { sessionId: this.session.id })
         });
     }
 }

--- a/packages/lib/src/core/types.ts
+++ b/packages/lib/src/core/types.ts
@@ -14,8 +14,7 @@ import type {
     SessionsResponse,
     ResultCode,
     PaymentData,
-    AddressData,
-    AnalyticsModule
+    AddressData
 } from '../types/global-types';
 import type { AnalyticsOptions } from './Analytics/types';
 import RiskModule, { RiskModuleOptions } from './RiskModule/RiskModule';
@@ -26,6 +25,7 @@ import type { onOrderCancelType } from '../components/Dropin/types';
 import { Resources } from './Context/Resources';
 import Language from '../language';
 import { SRPanel } from './Errors/SRPanel';
+import { IAnalytics } from './Analytics/Analytics';
 
 export interface ICore {
     initialize(): Promise<ICore>;
@@ -45,7 +45,7 @@ export interface ICore {
 
 export type CoreModules = Readonly<{
     risk: RiskModule;
-    analytics: AnalyticsModule;
+    analytics: IAnalytics;
     resources: Resources;
     i18n: Language;
     srPanel: SRPanel;

--- a/packages/lib/src/types/global-types.ts
+++ b/packages/lib/src/types/global-types.ts
@@ -1,9 +1,6 @@
 import { ADDRESS_SCHEMA } from '../components/internal/Address/constants';
 import actionTypes from '../core/ProcessResponse/PaymentAction/actionTypes';
-import { AnalyticsInitialEvent } from '../core/Analytics/types';
-import { EventsQueueModule } from '../core/Analytics/EventsQueue';
 import { CardFocusData } from '../components/internal/SecuredFields/lib/types';
-import { AbstractAnalyticsEvent } from '../core/Analytics/events/AbstractAnalyticsEvent';
 
 export type PaymentActionsType = keyof typeof actionTypes;
 
@@ -378,15 +375,6 @@ export interface ActionHandledReturnObject {
     componentType: string;
     actionDescription: ActionDescriptionType;
     originalAction?: PaymentAction;
-}
-
-export interface AnalyticsModule {
-    setUp: (setupProps?: AnalyticsInitialEvent) => Promise<void>;
-    flush(): void;
-    getCheckoutAttemptId: () => string;
-    getEventsQueue: () => EventsQueueModule;
-    getEnabled: () => boolean;
-    sendAnalytics: (analyticsObj: AbstractAnalyticsEvent) => boolean;
 }
 
 export type ComponentFocusObject = {

--- a/packages/lib/src/utils/Script.test.ts
+++ b/packages/lib/src/utils/Script.test.ts
@@ -1,10 +1,10 @@
 import Script from './Script';
 import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
 import { mock } from 'jest-mock-extended';
-import { AnalyticsModule } from '../types/global-types';
+import type { IAnalytics } from '../core/Analytics/Analytics';
 
 const SCRIPT_SRC = 'https://example.com/script.js';
-const mockAnalytics = mock<AnalyticsModule>();
+const mockAnalytics = mock<IAnalytics>();
 
 describe('Script', () => {
     beforeEach(() => {

--- a/packages/lib/src/utils/Script.ts
+++ b/packages/lib/src/utils/Script.ts
@@ -1,6 +1,6 @@
 import AdyenCheckoutError from '../core/Errors/AdyenCheckoutError';
 import { AnalyticsInfoEvent, InfoEventType } from '../core/Analytics/events/AnalyticsInfoEvent';
-import { AnalyticsModule } from '../types/global-types';
+import type { IAnalytics } from '../core/Analytics/Analytics';
 
 interface IScript {
     load(): Promise<void>;
@@ -10,7 +10,7 @@ interface IScript {
 interface IScriptProps {
     src: string;
     component: string;
-    analytics: AnalyticsModule;
+    analytics: IAnalytics;
     node?: string;
     attributes?: Partial<HTMLScriptElement>;
     dataAttributes?: Record<string, string | undefined>;
@@ -28,7 +28,7 @@ class Script implements IScript {
     private readonly node: string;
     private readonly attributes: Partial<HTMLScriptElement>;
     private readonly dataAttributes: Record<string, string | undefined>;
-    private readonly analytics: AnalyticsModule;
+    private readonly analytics: IAnalytics;
     private readonly baseUrl: string;
 
     private script: HTMLScriptElement;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

We are moving the attempt ID request to be earlier in the flow. In order to keep capturing the 'flavor' , we need to send another request to report that eventually. 

As we have to touch the Analytics module to support this behavior accordingly, I decided to refactor the Analytics module to class based since it might be the best opportunity to do it, before actually adding new features to it.

Core changes:
- Refactored `Analytics.ts` to be class based. 
- Adjusted `core.ts` to request the ID as soon as the analytics module is created
- Removed the Analytics setup part from the `UIEelement`
- Removed `experiments` and `payload` property configurations from the Analytics (these values were used in the previous analytics and not in the current one)

Next PR:
- Adjust `Analytics.ts` to report the flavor

Disclaimer: There are quite some files changes, but majority is just renaming the type `AnalyticsModule` to `IAnalytics`.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

