### PR TITLE
Fix details object for Klarna refused purchases

### DIFF
--- a/.changeset/good-shrimps-serve.md
+++ b/.changeset/good-shrimps-serve.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed details object for Klarna Widget refused purchases

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import { KlarnaWidget } from './KlarnaWidget';
 import Script from '../../../../utils/Script';
-import { KLARNA_WIDGET_URL } from '../../constants';
+import { KLARNA_WIDGET_URL, KLARNA_REFUSED_RESULT_CODE } from '../../constants';
 import { KlarnaWidgetAuthorizeResponse, type KlarnaWidgetProps } from '../../types';
 import { CoreProvider } from '../../../../core/Context/CoreProvider';
 import { mock } from 'jest-mock-extended';
@@ -110,7 +110,7 @@ describe('KlarnaWidget', () => {
             expect(onComplete).toHaveBeenCalledWith({
                 data: {
                     paymentData,
-                    details: {}
+                    details: { resultCode: KLARNA_REFUSED_RESULT_CODE }
                 }
             });
         });
@@ -200,7 +200,7 @@ describe('KlarnaWidget', () => {
             expect(onComplete).toHaveBeenCalledWith({
                 data: {
                     paymentData,
-                    details: {}
+                    details: { resultCode: KLARNA_REFUSED_RESULT_CODE }
                 }
             });
         });

--- a/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
+++ b/packages/lib/src/components/Klarna/components/KlarnaWidget/KlarnaWidget.tsx
@@ -1,9 +1,8 @@
 import { h } from 'preact';
 import { useEffect, useRef, useState, useCallback } from 'preact/hooks';
 import Script from '../../../../utils/Script';
-import { KLARNA_WIDGET_URL } from '../../constants';
+import { KLARNA_WIDGET_URL, KLARNA_REFUSED_RESULT_CODE } from '../../constants';
 import type { KlarnaWidgetAuthorizeResponse, KlarnaWidgetProps } from '../../types';
-
 import './KlarnaWidget.scss';
 import useAnalytics from '../../../../core/Analytics/useAnalytics';
 
@@ -17,7 +16,7 @@ export function KlarnaWidget({ sdkData, paymentMethodType, widgetInitializationT
         props.onComplete({
             data: {
                 paymentData: props.paymentData,
-                details: {}
+                details: { resultCode: KLARNA_REFUSED_RESULT_CODE }
             }
         });
     }, [props.paymentData, props.onComplete]);

--- a/packages/lib/src/components/Klarna/constants.ts
+++ b/packages/lib/src/components/Klarna/constants.ts
@@ -1,1 +1,5 @@
+import { ResultCode } from '../../types/global-types';
+
 export const KLARNA_WIDGET_URL = 'https://x.klarnacdn.net/kp/lib/v1/api.js';
+
+export const KLARNA_REFUSED_RESULT_CODE: ResultCode = 'Refused';

--- a/packages/lib/src/components/Klarna/types.ts
+++ b/packages/lib/src/components/Klarna/types.ts
@@ -1,5 +1,5 @@
 import { type ComponentMethodsRef, UIElementProps } from '../internal/UIElement/types';
-import { PaymentAction } from '../../types/global-types';
+import { PaymentAction, ResultCode } from '../../types/global-types';
 import { AdditionalDetailsData } from '../../core/types';
 
 declare global {
@@ -72,6 +72,7 @@ export interface KlarnaAdditionalDetailsData extends AdditionalDetailsData {
         paymentData: string;
         details: {
             authorization_token?: string;
+            resultCode?: ResultCode;
         };
     };
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

The Klarna inline widget returns an empty details object (details: {}) when a payment is refused or denied. This behavior is inconsistent with the redirect flow and prevents proper handling on the merchant side.

Impact: This bug causes a 422 "Missing payment method details" validation error in the integration and is a blocker for the Lego go-live with Klarna in 14 markets. This also prevents the offer from closing and stops the expected webhook from being sent.

---

## 🧪 Tested scenarios

- Start a Payment: Use the local Checkout Shopper and make a payments call for Klarna with "subtype": "sdk".
- Trigger Payment UI: Click the black "Pay € 11.01" button below the Klarna option in the UI.
- Refuse Payment: In the Klarna popup, log in with the NL phone number 0632167678 and use 123456 as the SMS confirmation to intentionally trigger a payment refusal (NL specific).
- Close Error Screen: Close the "Sorry, je kunt Klarna niet gebruiken voor deze aankoop" screen.
- Check if the /paymentDetails will be sent with refused resionCode
- Check the return of the api is different of 422

---

## 🔗 Related GitHub Issue / Internal Ticket number

[COSDK-824](https://youtrack.is.adyen.com/issue/COSDK-824/WEB-Bug-No-details-object-for-Denied-Klarna-Widget-Purchases)

**Closes**:  COSDK-824

---

