### PR TITLE
Fix aria-live announcement at Button component

### DIFF
--- a/.changeset/sunny-ends-send.md
+++ b/.changeset/sunny-ends-send.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed aria-live announcement at Button component to announce loading and redirect states to screen readers for improved accessibility.

--- a/packages/lib/src/components/internal/Button/Button.test.tsx
+++ b/packages/lib/src/components/internal/Button/Button.test.tsx
@@ -72,4 +72,32 @@ describe('Button', () => {
         const wrapper = getWrapper({ variant: 'ghost' });
         expect(wrapper.find('.adyen-checkout__button--ghost').length).toBe(1);
     });
+
+    test('Renders aria-live status region with loading text', () => {
+        const wrapper = getWrapper({ label: 'Pay', status: 'loading' });
+        const statusRegion = wrapper.find('[role="status"]');
+
+        expect(statusRegion.length).toBe(1);
+        expect(statusRegion.hasClass('adyen-checkout__button__text--sr-only')).toBe(true);
+        expect(statusRegion.prop('aria-live')).toBe('polite');
+        expect(statusRegion.text()).toContain('Loading');
+    });
+
+    test('Renders aria-live status region with redirecting text', () => {
+        const wrapper = getWrapper({ label: 'Pay', status: 'redirect' });
+        const statusRegion = wrapper.find('[role="status"]');
+
+        expect(statusRegion.length).toBe(1);
+        expect(statusRegion.hasClass('adyen-checkout__button__text--sr-only')).toBe(true);
+        expect(statusRegion.prop('aria-live')).toBe('polite');
+        expect(statusRegion.text()).toContain('Redirecting');
+    });
+
+    test('Aria-live status region is empty for default status', () => {
+        const wrapper = getWrapper({ label: 'Pay', status: 'default' });
+        const statusRegion = wrapper.find('[role="status"]');
+
+        expect(statusRegion.length).toBe(1);
+        expect(statusRegion.text()).toBe('');
+    });
 });

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from 'preact';
+import { Component, h, Fragment } from 'preact';
 import classNames from 'classnames';
 import Spinner from '../Spinner';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
@@ -28,6 +28,15 @@ class Button extends Component<ButtonProps, ButtonState> {
         setTimeout(() => {
             this.setState({ completed: false });
         }, delay);
+    };
+
+    private readonly buttonStatusSRLabel = (status: string): string => {
+        const srLabels: Record<string, string> = {
+            loading: 'loading',
+            redirect: 'payButton.redirecting'
+        };
+
+        return srLabels[status] || '';
     };
 
     render() {
@@ -81,11 +90,10 @@ class Button extends Component<ButtonProps, ButtonState> {
             loading: (
                 <span className="adyen-checkout__button__content">
                     <Spinner size="medium" inline />
-                    <span className={'adyen-checkout__button__text--sr-only'}>{i18n.get('loading')}</span>
                 </span>
             ),
             redirect: (
-                <span className="adyen-checkout__button__content">
+                <span aria-hidden="true" className="adyen-checkout__button__content">
                     <Spinner size="medium" inline />
                     {i18n.get('payButton.redirecting')}
                 </span>
@@ -109,24 +117,29 @@ class Button extends Component<ButtonProps, ButtonState> {
         }
 
         return (
-            <button
-                ref={buttonRef}
-                className={buttonClasses}
-                type="button"
-                disabled={disabled}
-                onClick={this.onClick}
-                aria-label={ariaLabel}
-                aria-describedby={ariaDescribedBy}
-                onMouseEnter={onMouseEnter}
-                onMouseLeave={onMouseLeave}
-                onKeyDown={onKeyDown}
-                onFocus={onFocus}
-                onBlur={onBlur}
-                onKeyPress={onKeyPress}
-            >
-                {buttonText}
-                {status !== 'loading' && status !== 'redirect' && this.props.children}
-            </button>
+            <Fragment>
+                <button
+                    ref={buttonRef}
+                    className={buttonClasses}
+                    type="button"
+                    disabled={disabled}
+                    onClick={this.onClick}
+                    aria-label={ariaLabel}
+                    aria-describedby={ariaDescribedBy}
+                    onMouseEnter={onMouseEnter}
+                    onMouseLeave={onMouseLeave}
+                    onKeyDown={onKeyDown}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    onKeyPress={onKeyPress}
+                >
+                    {buttonText}
+                    {status !== 'loading' && status !== 'redirect' && this.props.children}
+                </button>
+                <div role="status" aria-live="polite" className="adyen-checkout__button__text--sr-only">
+                    {i18n.get(this.buttonStatusSRLabel(status))}
+                </div>
+            </Fragment>
         );
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

When forms were submitted without moving focus to the Button (e.g., via keyboard shortcuts, programmatic submission, or pressing Enter in a focused field), screen readers received no announcement that the action entered a loading state. Because the loading feedback was only rendered within the button’s visible content, assistive technologies missed it when the button wasn’t focused, resulting in a silent wait and poor user feedback. 

<img width="1102" height="520" alt="image" src="https://github.com/user-attachments/assets/ef82835f-38fc-4d06-ac2e-ad8b2c83fe2a" />

Adding a dedicated, visually hidden live region (role="status" with aria-live="polite") ensures loading and redirect updates are announced regardless of focus, so users relying on screen readers are informed immediately after submission.


---

## 🧪 Tested scenarios

### Click To Pay, PayTo & CoBranded Cards
- Fill the one time code field, navigate to the continue button and press enter to activate.
- Enable a screen reader.
- Using the Down Arrow key or Tab key, navigate to the dynamically updating content. Trigger it with the Enter key if necessary.
- Review any announcements given by the screen reader in response to the dynamic content update.

---

## 🔗 Related GitHub Issue / Internal Ticket number

[COSDK-785](https://youtrack.is.adyen.com/issue/COSDK-785/Ensure-that-loading-status-messages-can-be-determined-programmatically-without-receiving-focus)

**Closes**: COSDK-785:

---

