### PR TITLE
Remove skip ci tag from update screenshots workflow

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -61,7 +61,7 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git add packages/e2e-playwright/tests/
         if ! git diff --staged --quiet; then
-          git commit -m "chore: update screenshots [skip ci]"
+          git commit -m "chore: update screenshots"
           git push
         else
           echo "No screenshot changes to commit"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

When you “Squash and merge” a PR on GitHub, the final commit message is composed from:

The PR title (as the first line)

Optionally, all individual commit messages in the PR appended below

If any of those messages contains [skip ci] (or [ci skip], etc.), many CI systems will see that token in the final commit message on the target branch and skip the build for that merge commit.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

