### PR TITLE
Increase web server timeout for storybook

### DIFF
--- a/packages/e2e-playwright/playwright.config.ts
+++ b/packages/e2e-playwright/playwright.config.ts
@@ -100,7 +100,7 @@ const config: PlaywrightTestConfig = {
             cwd: '../..',
             url: storybookLocalHostUrl,
             reuseExistingServer: !process.env.CI,
-            timeout: 120_000
+            timeout: 180_000
         }
     ]
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary
Recently we have been having a lot of timeout errors with the storybook webserver on our CI workflows

```bash
Error: Timed out waiting 120000ms from config.webServer.
```

This PR increases the limit for the timeout in the meantime so we don't need to keep rerunning e2e jobs.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

