### PR TITLE
Fix: PayByBankUS brand icons reflow

### DIFF
--- a/packages/e2e-playwright/fixtures/URL_MAP.ts
+++ b/packages/e2e-playwright/fixtures/URL_MAP.ts
@@ -7,6 +7,7 @@ export const URL_MAP = {
     dropinSessions_zeroAuthCard_fail:
         '/iframe.html?globals=&args=amount:0;sessionData.recurringProcessingModel:CardOnFile;sessionData.storePaymentMethodMode:askForConsent;sessionData.enableOneClick:!true&id=drop-in-drop-in-component--default&viewMode=story',
     dropinWithSession_BCMC_noStoredPms: '/iframe.html?args=countryCode:BE&globals=&id=drop-in-drop-in-component--default&viewMode=story',
+    dropinWithSession_US: '/iframe.html?args=countryCode:US&globals=&id=drop-in-drop-in-component--default&viewMode=story',
 
     /**
      * Card

--- a/packages/e2e-playwright/tests/ui/dropin/payByBankUS/payByBankUS.brands.spec.ts
+++ b/packages/e2e-playwright/tests/ui/dropin/payByBankUS/payByBankUS.brands.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '../../../../fixtures/dropin.fixture';
+import { URL_MAP } from '../../../../fixtures/URL_MAP';
+import { toHaveScreenshot } from '../../../utils/assertions';
+import { TAGS } from '../../../utils/constants';
+
+const PAYBYBANK_US_LABEL = 'Pay by Bank';
+const PAYBYBANK_US_BRAND_COUNT = 4;
+
+test.describe('Dropin - PayByBankUS brand icons reflow (WCAG 1.4.10)', () => {
+    test(
+        'should display all brand icons at default viewport width',
+        { tag: [TAGS.SCREENSHOT] },
+        async ({ dropinWithSession, browserName }) => {
+            await dropinWithSession.goto(URL_MAP.dropinWithSession_US);
+
+            const header = dropinWithSession.getPaymentMethodHeader(PAYBYBANK_US_LABEL);
+            await header.rootElement.scrollIntoViewIfNeeded();
+
+            const brands = await header.getVisibleCardBrands();
+            expect(brands).toHaveLength(PAYBYBANK_US_BRAND_COUNT);
+
+            await toHaveScreenshot(header.rootElement, browserName, 'paybybank-us-brands-default.png');
+        }
+    );
+
+    test(
+        'should display all brand icons at 320px viewport width without hiding any',
+        { tag: [TAGS.SCREENSHOT] },
+        async ({ dropinWithSession, page, browserName }) => {
+            await page.setViewportSize({ width: 320, height: 800 });
+            await dropinWithSession.goto(URL_MAP.dropinWithSession_US);
+
+            const header = dropinWithSession.getPaymentMethodHeader(PAYBYBANK_US_LABEL);
+            await header.rootElement.scrollIntoViewIfNeeded();
+
+            const brands = await header.getVisibleCardBrands();
+            expect(brands).toHaveLength(PAYBYBANK_US_BRAND_COUNT);
+
+            await toHaveScreenshot(header.rootElement, browserName, 'paybybank-us-brands-320px.png');
+        }
+    );
+});

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.scss
@@ -1,4 +1,5 @@
 @use 'styles/variable-generator';
+@use 'styles/mixins';
 
 .adyen-checkout__payment-method {
     position: relative;
@@ -51,9 +52,10 @@
 .adyen-checkout__payment-method__header {
     align-items: center;
     color: variable-generator.token(color-label-primary);
-    display: flex;
-    flex-wrap: nowrap;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: auto auto 1fr auto;
+    grid-template-rows: auto auto;
+    column-gap: 0;
     font-weight: variable-generator.token(text-body-font-weight);
     font-size: variable-generator.token(text-title-font-size);
     padding: variable-generator.token(spacer-070);
@@ -87,9 +89,6 @@
     cursor: default;
 }
 
-.adyen-checkout__payment-method--selected .adyen-checkout__payment-method__header {
-    flex-wrap: wrap;
-}
 
 .adyen-checkout__payment-method__details {
     padding: variable-generator.token(spacer-000) variable-generator.token(spacer-070);
@@ -111,6 +110,12 @@
     overflow: hidden;
 }
 
+.adyen-checkout__payment-method__header > .adyen-checkout__payment-method__header__title > .adyen-checkout__payment-method__image__wrapper {
+    grid-column: 2;
+    grid-row: 1 / -1; // to wrap the icon
+    margin-right: variable-generator.token(spacer-060);
+}
+
 .adyen-checkout__payment-method__image {
     display: block;
     border-radius: var(--adyen-checkout-border-radius-s);
@@ -121,27 +126,27 @@
 }
 
 .adyen-checkout__payment-method__brands {
+    grid-column: 4;
+    grid-row: 1;
     display: flex;
     align-items: center;
     gap: variable-generator.token(spacer-020);
     flex-wrap: wrap;
     margin: variable-generator.token(spacer-020) variable-generator.token(spacer-000);
     height: variable-generator.token(spacer-090);
-    flex-basis: auto;
-    flex-shrink: 1;
-    text-align: right;
     overflow: hidden;
+
+    @include mixins.media-s-and-down {
+        grid-column: 3 / -1;
+        grid-row: 2;
+        height: auto;
+        overflow: visible;
+    }
 
     & .adyen-checkout__payment-method__brand-number {
         color: variable-generator.token(color-label-secondary);
         font-size: variable-generator.token(text-body-font-size);
     }
-}
-
-.adyen-checkout__payment-method--selected .adyen-checkout__payment-method__brands {
-    text-align: left;
-    overflow: visible;
-    height: auto;
 }
 
 .adyen-checkout__payment-method__brands .adyen-checkout__payment-method__image__wrapper {

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodName.scss
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodName.scss
@@ -16,6 +16,8 @@
     }
 
     &__name_wrapper {
+        grid-column: 3;
+        grid-row: 1 / span -1;
         display: flex;
         gap: variable-generator.token(spacer-020);
         min-width: variable-generator.token(spacer-120);

--- a/packages/lib/src/components/PayByBankUS/PayByBankUS.scss
+++ b/packages/lib/src/components/PayByBankUS/PayByBankUS.scss
@@ -20,31 +20,3 @@
     }
 }
 
-// apply the rule to the main dropin intem
-.adyen-checkout__payment-method--paybybank_AIS_DD {
-    .adyen-checkout__payment-method__brands {
-        // a bit hacky but makes constum breakpoints to hide each set of images
-        @media (max-width: 330px) {
-            .adyen-checkout__payment-method__image__wrapper:nth-child(2) {
-                display: none;
-            }
-        }
-
-        @media (max-width: 360px) {
-            .adyen-checkout__payment-method__image__wrapper:nth-child(3) {
-                display: none;
-            }
-        }
-
-        @media (max-width: 390px) {
-            .adyen-checkout__payment-method__image__wrapper:nth-child(4) {
-                display: none;
-            }
-        }
-    }
-
-    .adyen-checkout__payment-method__brand-number {
-        text-overflow: clip;
-        white-space: nowrap;
-    }
-}

--- a/packages/lib/src/components/PayByBankUS/a11y.md
+++ b/packages/lib/src/components/PayByBankUS/a11y.md
@@ -1,0 +1,70 @@
+# PayByBankUS Accessibility Guide
+
+## Overview
+
+This document describes the accessibility requirements and testing procedures for the PayByBankUS component.
+
+---
+
+## WCAG Requirements Addressed
+
+### 1.4.10 Reflow (Level AA)
+
+**Application to PayByBankUS**: All bank brand icons (Wells Fargo, Bank of America, Chase, Citi) must remain visible and accessible at all viewport sizes, including 320px width. This can be tested with VoiceOver.
+
+### Screen Reader Support
+
+Each brand icon includes:
+
+- `alt` attribute with the full bank name (e.g., "Wells Fargo", "Bank of America")
+- Images are decorative context alongside text, providing additional visual cues
+
+---
+
+## Manual Testing with VoiceOver (macOS)
+
+### Testing Steps
+
+#### 1. Navigate to PayByBankUS Component
+
+1. Open the test page or Storybook with PayByBankUS in Drop-in
+2. Use **VO + → (Control + Option + Right Arrow)** to navigate through elements
+
+#### 2. Test at Default Viewport (Desktop and Mobile 320 pixels)
+
+1. Navigate to the PayByBankUS payment method in the Drop-in list
+2. **Expected**: VoiceOver announces the payment method name "Pay by Bank"
+3. Continue navigating with **VO + →**
+4. **Expected**: VoiceOver announces each brand icon:
+    - "Wells Fargo, image"
+    - "Bank of America, image"
+    - "Chase, image"
+    - "Citi, image"
+    - "+ other" (text indicating more options available after selection)
+5. **Repeat at 320px viewport width** (DevTools → device toolbar → 320px) and verify all brands are still announced
+
+#### 3. Test Keyboard Navigation
+
+1. Use **Tab** key to navigate through the Drop-in
+2. **Expected**: PayByBankUS payment method is focusable
+3. Press **Enter** or **Space** to select
+4. **Expected**: Payment method expands, brands remain visible
+
+### VoiceOver Quick Reference
+
+| Action                | Shortcut                   |
+| --------------------- | -------------------------- |
+| Turn VoiceOver On/Off | ⌘ + F5                     |
+| Next Element          | VO + → (Ctrl + Option + →) |
+| Previous Element      | VO + ← (Ctrl + Option + ←) |
+| Activate/Click        | VO + Space                 |
+| Read All              | VO + A                     |
+| Stop Reading          | Ctrl                       |
+
+---
+
+## Related Issues
+
+- **LevelAccess Findings**: CW-51, CW-52
+- **WCAG Success Criterion**: 1.4.10 Reflow
+- **Reference**: https://www.w3.org/WAI/WCAG21/Understanding/reflow.html

--- a/packages/lib/src/components/internal/ExpandButton/ExpandButton.scss
+++ b/packages/lib/src/components/internal/ExpandButton/ExpandButton.scss
@@ -1,13 +1,7 @@
 @use 'styles/variable-generator';
 
 .adyen-checkout__payment-method__header__title {
-    max-height: 38px;
-    display: flex;
-    gap: variable-generator.token(spacer-060);
-    align-items: center;
-    flex-shrink: 0;
-    margin-right: variable-generator.token(spacer-070);
-    max-width: 100%;
+    display: contents;
 
     // reset button styles
     border: none;
@@ -18,11 +12,6 @@
     font-size: 1em;
     font-weight: variable-generator.token(text-body-stronger-font-weight);
 
-    [dir='rtl'] & {
-        margin-right: variable-generator.token(spacer-000);
-        margin-left: variable-generator.token(spacer-070);
-    }
-
     &--standalone {
         cursor: default;
     }
@@ -30,20 +19,17 @@
 
 /*  Payment Method Radio Button */
 .adyen-checkout__payment-method__radio {
+    grid-column: 1;
+    grid-row: 1;
+    margin-right: variable-generator.token(spacer-060);
     background-color: variable-generator.token(color-background-primary);
     border: variable-generator.token(border-width-s) solid variable-generator.token(color-outline-secondary);
     border-radius: 50%;
     height: variable-generator.token(spacer-070);
     width: variable-generator.token(spacer-070);
-    left: variable-generator.token(spacer-070);
     transition:
         border-color 0.2s ease-out,
         box-shadow 0.2s ease-out;
-
-    [dir='rtl'] & {
-        right: variable-generator.token(spacer-070);
-        left: auto;
-    }
 }
 
 .adyen-checkout__payment-method__radio::after {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

### Problem

The PayByBankUS component was hiding bank brand icons on smaller screen sizes using CSS media queries. This violated **WCAG 1.4.10 Reflow**, which requires all content to remain available when the viewport reflows to 320 pixels.

**Previous behavior**: At smaller viewports (330px, 360px, 390px), brand icons were progressively hidden, potentially misleading users into thinking fewer banking options were available.

### Solution

Following LevelAccess recommendations (findings CW-51 and CW-52):

1. **Removed hiding media queries** from `PayByBankUS.scss` that used `display: none` on brand icons
2. **Refactored payment method header layout** from flexbox to CSS Grid, this so we could achieve the desired layout without any markup and classes changes
3. **Responsive brand placement** using `media-s-and-down` mixin (≤480px)
4. **Added E2E Playwright tests** with screenshot comparison at default and 320px viewport widths

> **Note**: `display: contents` on the ExpandButton (`<button role="radio">`) makes its children direct grid participants. Modern browsers (Chrome 90+, Firefox 80+, Safari 15+) correctly preserve the button's accessibility semantics. Manual VoiceOver verification is recommended.

---

## 🧪 Tested scenarios

### E2E Tests (Playwright)
- All 4 brand icons visible at default viewport width (with screenshot)
- All 4 brand icons visible at 320px viewport width without hiding any (with screenshot)

### Manual Testing

#### Visual Testing
- ✅ All 4 brand icons visible at 320px viewport
- ✅ Brands wrap gracefully to second line when space is limited
- ✅ No visual regression on larger viewports

#### VoiceOver Testing (macOS)

1. **Enable VoiceOver**: Press ⌘ + F5
2. **Set viewport to 320px**: Open DevTools → Toggle device toolbar → Set width to 320px
3. **Navigate to PayByBankUS**: Use VO + → (Ctrl + Option + →)
4. **Verify all brands announced**:
   - ✅ "Wells Fargo, image"
   - ✅ "Bank of America, image"
   - ✅ "Chase, image"
   - ✅ "Citi, image"
   - ✅ "+ other" text
5. **Verify visual wrapping**: Brand icons wrap to second line (not hidden)

| VoiceOver Action | Shortcut |
|------------------|----------|
| Turn On/Off | ⌘ + F5 |
| Next Element | Ctrl + Option + → |
| Previous Element | Ctrl + Option + ← |

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**: CW-51, CW-52 (LevelAccess findings)

---