### PR TITLE
Adjusting static props to be readonly

### DIFF
--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -56,7 +56,6 @@ const config = tseslint.config(
                     ]
                 }
             ],
-
             '@typescript-eslint/no-unsafe-assignment': 'off',
             '@typescript-eslint/no-unsafe-return': 'off',
             '@typescript-eslint/no-unsafe-call': 'off',

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -10,7 +10,7 @@ import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 
 export class ANCVElement extends UIElement<ANCVConfiguration> {
-    public static type = 'ancv';
+    public static readonly type = 'ancv';
 
     /**
      * Formats the component data output

--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -8,9 +8,9 @@ import defaultProps from './defaultProps';
 import type { AchConfiguration } from './types';
 
 export class AchElement extends UIElement<AchConfiguration> {
-    public static type = TxVariants.ach;
+    public static readonly type = TxVariants.ach;
 
-    protected static defaultProps = defaultProps;
+    protected static readonly defaultProps = defaultProps;
 
     public override formatData() {
         const recurringPayment = !!this.props.storedPaymentMethodId;

--- a/packages/lib/src/components/Address/Address.tsx
+++ b/packages/lib/src/components/Address/Address.tsx
@@ -9,7 +9,7 @@ import { UIElementProps } from '../internal/UIElement/types';
 export type AddressConfiguration = AddressProps & UIElementProps;
 
 export class AddressElement extends UIElement<AddressConfiguration> {
-    public static type = TxVariants.address;
+    public static readonly type = TxVariants.address;
 
     protected override beforeRender(configSetByMerchant?: AddressConfiguration): void {
         const event = new AnalyticsInfoEvent({

--- a/packages/lib/src/components/Affirm/Affirm.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.tsx
@@ -4,7 +4,7 @@ import { TxVariants } from '../tx-variants';
 import type { OpenInvoiceConfiguration } from '../types';
 
 export default class Affirm extends OpenInvoiceContainer {
-    public static type = TxVariants.affirm;
+    public static readonly type = TxVariants.affirm;
 
     formatProps(props: OpenInvoiceConfiguration) {
         return {

--- a/packages/lib/src/components/AfterPay/AfterPay.tsx
+++ b/packages/lib/src/components/AfterPay/AfterPay.tsx
@@ -7,8 +7,8 @@ import { TxVariants } from '../tx-variants';
 import type { OpenInvoiceConfiguration } from '../types';
 
 export default class AfterPay extends OpenInvoiceContainer {
-    public static type = TxVariants.afterpay_default;
-    public static txVariants = [TxVariants.afterpay_default, TxVariants.afterpay];
+    public static readonly type = TxVariants.afterpay_default;
+    public static readonly txVariants = [TxVariants.afterpay_default, TxVariants.afterpay];
 
     formatProps(props: OpenInvoiceConfiguration) {
         return {

--- a/packages/lib/src/components/AfterPay/AfterPayB2B.tsx
+++ b/packages/lib/src/components/AfterPay/AfterPayB2B.tsx
@@ -4,9 +4,9 @@ import { ALLOWED_COUNTRIES } from './config';
 import type { OpenInvoiceConfiguration } from '../helpers/OpenInvoiceContainer/types';
 
 export default class AfterPayB2B extends OpenInvoiceContainer {
-    public static type = TxVariants.afterpay_b2b;
+    public static readonly type = TxVariants.afterpay_b2b;
 
-    protected static defaultProps: Partial<OpenInvoiceConfiguration> = {
+    protected static readonly defaultProps: Partial<OpenInvoiceConfiguration> = {
         onChange: () => {},
         data: { companyDetails: {}, personalDetails: {}, billingAddress: {}, deliveryAddress: {} },
         visibility: {

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -11,9 +11,9 @@ import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement
 import { AnalyticsInfoEvent, InfoEventType } from '../../core/Analytics/events/AnalyticsInfoEvent';
 
 export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
-    public static type = TxVariants.amazonpay;
+    public static readonly type = TxVariants.amazonpay;
 
-    protected static defaultProps = defaultProps;
+    protected static readonly defaultProps = defaultProps;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/ApplePay/ApplePay.tsx
+++ b/packages/lib/src/components/ApplePay/ApplePay.tsx
@@ -23,9 +23,9 @@ import { AnalyticsInfoEvent, InfoEventType, UiTarget } from '../../core/Analytic
 const LATEST_APPLE_PAY_VERSION = 14;
 
 class ApplePayElement extends UIElement<ApplePayConfiguration> {
-    public static type = TxVariants.applepay;
+    public static readonly type = TxVariants.applepay;
 
-    protected static defaultProps = defaultProps;
+    protected static readonly defaultProps = defaultProps;
 
     private sdkLoader: ApplePaySdkLoader;
     private applePayVersionNumber: number = undefined;

--- a/packages/lib/src/components/Atome/Atome.tsx
+++ b/packages/lib/src/components/Atome/Atome.tsx
@@ -4,7 +4,7 @@ import { TxVariants } from '../tx-variants';
 import type { OpenInvoiceConfiguration } from '../types';
 
 export default class Atome extends OpenInvoiceContainer {
-    public static type = TxVariants.atome;
+    public static readonly type = TxVariants.atome;
 
     formatProps(props: OpenInvoiceConfiguration) {
         return {

--- a/packages/lib/src/components/BacsDD/BacsDD.tsx
+++ b/packages/lib/src/components/BacsDD/BacsDD.tsx
@@ -9,7 +9,7 @@ import { BacsElementData } from './types';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 
 class BacsElement extends UIElement<VoucherConfiguration> {
-    public static type = TxVariants.directdebit_GB;
+    public static readonly type = TxVariants.directdebit_GB;
 
     formatData(): BacsElementData {
         return {

--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -7,8 +7,8 @@ import BankTransferInput from './components/BankTransferInput';
 import { TxVariants } from '../tx-variants';
 
 export class BankTransferElement extends UIElement<BankTransferConfiguration> {
-    public static type = TxVariants.bankTransfer_IBAN;
-    public static txVariants = [
+    public static readonly type = TxVariants.bankTransfer_IBAN;
+    public static readonly txVariants = [
         TxVariants.bankTransfer_IBAN,
         TxVariants.bankTransfer_BE,
         TxVariants.bankTransfer_NL,
@@ -38,7 +38,7 @@ export class BankTransferElement extends UIElement<BankTransferConfiguration> {
         TxVariants.bankTransfer_US
     ];
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         showEmailAddress: true,
         showContextualElement: true,
         data: { shopperEmail: '' }

--- a/packages/lib/src/components/BcmcMobile/BcmcMobile.ts
+++ b/packages/lib/src/components/BcmcMobile/BcmcMobile.ts
@@ -3,8 +3,8 @@ import { STATUS_INTERVAL, COUNTDOWN_MINUTES } from './config';
 import { TxVariants } from '../tx-variants';
 
 class BCMCMobileElement extends QRLoaderContainer {
-    public static type = TxVariants.bcmc_mobile;
-    public static txVariants = [TxVariants.bcmc_mobile, TxVariants.bcmc_mobile_QR];
+    public static readonly type = TxVariants.bcmc_mobile;
+    public static readonly txVariants = [TxVariants.bcmc_mobile, TxVariants.bcmc_mobile_QR];
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/BillDesk/BillDeskOnline.ts
+++ b/packages/lib/src/components/BillDesk/BillDeskOnline.ts
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class BillDeskOnlineElement extends IssuerListContainer {
-    public static type = TxVariants.billdesk_online;
+    public static readonly type = TxVariants.billdesk_online;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/BillDesk/BillDeskWallet.ts
+++ b/packages/lib/src/components/BillDesk/BillDeskWallet.ts
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class BillDeskWalletElement extends IssuerListContainer {
-    public static type = TxVariants.billdesk_wallet;
+    public static readonly type = TxVariants.billdesk_wallet;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -15,7 +15,7 @@ interface BlikElementData {
 }
 
 class BlikElement extends UIElement<AwaitConfiguration> {
-    public static type = TxVariants.blik;
+    public static readonly type = TxVariants.blik;
 
     formatData(): BlikElementData {
         const recurringPayment = !!this.props.storedPaymentMethodId;

--- a/packages/lib/src/components/Boleto/Boleto.tsx
+++ b/packages/lib/src/components/Boleto/Boleto.tsx
@@ -8,9 +8,9 @@ import { TxVariants } from '../tx-variants';
 import type { BoletoConfiguration } from './types';
 
 export class BoletoElement extends UIElement<BoletoConfiguration> {
-    public static type = TxVariants.boletobancario;
+    public static readonly type = TxVariants.boletobancario;
 
-    public static txVariants = [
+    public static readonly txVariants = [
         TxVariants.boletobancario,
         TxVariants.boletobancario_itau,
         TxVariants.boletobancario_santander,

--- a/packages/lib/src/components/Card/Bancontact.ts
+++ b/packages/lib/src/components/Card/Bancontact.ts
@@ -5,13 +5,13 @@ import { TxVariants } from '../tx-variants';
 import type { ICore } from '../../core/types';
 
 class BancontactElement extends CardElement {
-    public static type = TxVariants.bcmc;
+    public static override readonly type: TxVariants = TxVariants.bcmc;
 
     constructor(checkout: ICore, props?: CardConfiguration) {
         super(checkout, props);
     }
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         ...CardElement.defaultProps,
         brands: ['bcmc', 'maestro', 'visa']
     };

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -23,7 +23,7 @@ import { PayButtonProps } from '../internal/PayButton/PayButton';
 import { AnalyticsInfoEvent, InfoEventType, UiTarget } from '../../core/Analytics/events/AnalyticsInfoEvent';
 
 export class CardElement extends UIElement<CardConfiguration> {
-    public static type = TxVariants.scheme;
+    public static readonly type: TxVariants = TxVariants.scheme;
 
     private readonly clickToPayService: IClickToPayService | null;
 
@@ -47,7 +47,7 @@ export class CardElement extends UIElement<CardConfiguration> {
         }
     }
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         showFormInstruction: true,
         _disableClickToPay: false,
         doBinLookup: true,

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -13,11 +13,11 @@ import type { ICore } from '../../core/types';
 import { PREFIX } from '../internal/Icon/constants';
 
 export class CashAppPay extends UIElement<CashAppPayConfiguration> {
-    public static type = TxVariants.cashapp;
+    public static readonly type = TxVariants.cashapp;
 
     private readonly cashAppService: ICashAppService | undefined;
 
-    protected static defaultProps = defaultProps;
+    protected static readonly defaultProps = defaultProps;
 
     constructor(checkout: ICore, props?: CashAppPayConfiguration) {
         super(checkout, props);

--- a/packages/lib/src/components/ClickToPay/ClickToPay.tsx
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.tsx
@@ -13,7 +13,7 @@ import { TxVariants } from '../tx-variants';
 import type { ICore } from '../../core/types';
 
 export class ClickToPayElement extends UIElement<ClickToPayConfiguration> {
-    public static type = TxVariants.clicktopay;
+    public static readonly type = TxVariants.clicktopay;
 
     private readonly clickToPayService: IClickToPayService | null;
     private readonly ctpConfiguration: ClickToPayProps;

--- a/packages/lib/src/components/CustomCard/CustomCard.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCard.tsx
@@ -11,9 +11,9 @@ import { CustomCardConfiguration } from './types';
 import { AnalyticsInfoEvent, InfoEventType, UiTarget } from '../../core/Analytics/events/AnalyticsInfoEvent';
 
 export class CustomCard extends UIElement<CustomCardConfiguration> {
-    public static type = TxVariants.customCard;
+    public static readonly type = TxVariants.customCard;
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         onBinLookup: () => {},
         brandsConfiguration: {}
     };

--- a/packages/lib/src/components/Doku/Doku.tsx
+++ b/packages/lib/src/components/Doku/Doku.tsx
@@ -6,8 +6,8 @@ import { TxVariants } from '../tx-variants';
 import { VoucherConfiguration } from '../internal/Voucher/types';
 
 export class DokuElement extends UIElement<VoucherConfiguration> {
-    public static type = TxVariants.doku;
-    public static txVariants = [
+    public static readonly type = TxVariants.doku;
+    public static readonly txVariants = [
         TxVariants.doku,
         TxVariants.doku_alfamart,
         TxVariants.doku_permata_lite_atm,

--- a/packages/lib/src/components/Donation/Donation.tsx
+++ b/packages/lib/src/components/Donation/Donation.tsx
@@ -6,14 +6,14 @@ import type { ICore } from '../../core/types';
 import type { DonationConfiguration } from './types';
 
 class DonationElement extends UIElement<DonationConfiguration> {
-    public static type = TxVariants.donation;
+    public static readonly type = TxVariants.donation;
 
     constructor(checkout: ICore, props?: DonationConfiguration) {
         super(checkout, props);
         this.donate = this.donate.bind(this);
     }
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         onCancel: () => {},
         onDonate: () => {}
     };

--- a/packages/lib/src/components/Dotpay/index.ts
+++ b/packages/lib/src/components/Dotpay/index.ts
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class DotpayElement extends IssuerListContainer {
-    public static type = TxVariants.dotpay;
+    public static readonly type = TxVariants.dotpay;
 }
 
 export default DotpayElement;

--- a/packages/lib/src/components/Dragonpay/Dragonpay.tsx
+++ b/packages/lib/src/components/Dragonpay/Dragonpay.tsx
@@ -6,9 +6,9 @@ import { DragonpayConfiguraton } from './types';
 import { TxVariants } from '../tx-variants';
 
 export class DragonpayElement extends UIElement<DragonpayConfiguraton> {
-    public static type = TxVariants.dragonpay;
+    public static readonly type = TxVariants.dragonpay;
 
-    public static txVariants = [
+    public static readonly txVariants = [
         TxVariants.dragonpay,
         TxVariants.dragonpay_ebanking,
         TxVariants.dragonpay_otc_banking,

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -16,9 +16,9 @@ import type { IDropin } from './types';
 const SUPPORTED_INSTANT_PAYMENTS = ['paywithgoogle', 'googlepay', 'applepay'];
 
 class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
-    public static type = TxVariants.dropin;
+    public static readonly type = TxVariants.dropin;
 
-    protected static defaultProps = defaultProps;
+    protected static readonly defaultProps = defaultProps;
 
     public dropinRef = null;
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -26,7 +26,7 @@ export interface PaymentMethodItemProps {
 }
 
 class PaymentMethodItem extends Component<PaymentMethodItemProps> {
-    public static defaultProps = {
+    public static readonly defaultProps = {
         paymentMethod: null,
         isSelected: false,
         isLoaded: false,

--- a/packages/lib/src/components/DuitNow/DuitNow.ts
+++ b/packages/lib/src/components/DuitNow/DuitNow.ts
@@ -3,7 +3,7 @@ import { delay, countdownTime } from './config';
 import { TxVariants } from '../tx-variants';
 
 class DuitNowElement extends QRLoaderContainer {
-    public static type = TxVariants.duitnow;
+    public static readonly type = TxVariants.duitnow;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/EPS/index.ts
+++ b/packages/lib/src/components/EPS/index.ts
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class EPSElement extends IssuerListContainer {
-    public static type = TxVariants.eps;
+    public static readonly type = TxVariants.eps;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/Econtext/Econtext.tsx
+++ b/packages/lib/src/components/Econtext/Econtext.tsx
@@ -15,7 +15,7 @@ export class EcontextElement extends UIElement<EcontextConfiguration> {
         TxVariants.econtext_stores
     ];
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         personalDetailsRequired: true
     };
 

--- a/packages/lib/src/components/FacilyPay/FacilyPay10x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay10x.ts
@@ -3,7 +3,7 @@ import { ALLOWED_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
 
 export default class FacilyPay10x extends OpenInvoiceContainer {
-    public static type = TxVariants.facilypay_10x;
+    public static readonly type = TxVariants.facilypay_10x;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/FacilyPay/FacilyPay12x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay12x.ts
@@ -3,7 +3,7 @@ import { ALLOWED_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
 
 export default class FacilyPay12x extends OpenInvoiceContainer {
-    public static type = TxVariants.facilypay_12x;
+    public static readonly type = TxVariants.facilypay_12x;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/FacilyPay/FacilyPay3x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay3x.ts
@@ -3,7 +3,7 @@ import { ALLOWED_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
 
 export default class FacilyPay3x extends OpenInvoiceContainer {
-    public static type = TxVariants.facilypay_3x;
+    public static readonly type = TxVariants.facilypay_3x;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/FacilyPay/FacilyPay4x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay4x.ts
@@ -3,7 +3,7 @@ import { ALLOWED_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
 
 export default class FacilyPay4x extends OpenInvoiceContainer {
-    public static type = TxVariants.facilypay_4x;
+    public static readonly type = TxVariants.facilypay_4x;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/FacilyPay/FacilyPay6x.ts
+++ b/packages/lib/src/components/FacilyPay/FacilyPay6x.ts
@@ -3,7 +3,7 @@ import { ALLOWED_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
 
 export default class FacilyPay6x extends OpenInvoiceContainer {
-    public static type = TxVariants.facilypay_6x;
+    public static readonly type = TxVariants.facilypay_6x;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -9,11 +9,11 @@ import { TxVariants } from '../tx-variants';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 
 export class GiftcardElement extends UIElement<GiftCardConfiguration> {
-    public static type = TxVariants.giftcard;
+    public static readonly type: TxVariants = TxVariants.giftcard;
 
     protected componentRef: GiftcardComponent | undefined;
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         brandsConfiguration: {}
     };
 

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -41,7 +41,7 @@ class Giftcard extends Component<GiftcardComponentProps> {
         transformedErrors: {}
     };
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         pinRequired: true,
         expiryDateRequired: false,
         onChange: () => {},

--- a/packages/lib/src/components/Giropay/Giropay.tsx
+++ b/packages/lib/src/components/Giropay/Giropay.tsx
@@ -4,9 +4,9 @@ import RedirectButton from '../internal/RedirectButton';
 import { TxVariants } from '../tx-variants';
 
 class GiropayElement extends RedirectElement {
-    public static type = TxVariants.giropay;
+    public static override readonly type: TxVariants = TxVariants.giropay;
 
-    get displayName() {
+    public override get displayName() {
         return this.props.name || this.constructor['type'];
     }
 

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -18,9 +18,9 @@ import { mapGooglePayBrands } from './utils/map-adyen-brands-to-googlepay-brands
 const DEFAULT_ALLOWED_CARD_NETWORKS: google.payments.api.CardNetwork[] = ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'];
 
 class GooglePay extends UIElement<GooglePayConfiguration> {
-    public static type = TxVariants.googlepay;
-    public static txVariants = [TxVariants.googlepay, TxVariants.paywithgoogle];
-    public static defaultProps = defaultProps;
+    public static readonly type = TxVariants.googlepay;
+    public static readonly txVariants = [TxVariants.googlepay, TxVariants.paywithgoogle];
+    public static readonly defaultProps = defaultProps;
 
     protected readonly googlePay;
 

--- a/packages/lib/src/components/Klarna/KlarnaPayments.tsx
+++ b/packages/lib/src/components/Klarna/KlarnaPayments.tsx
@@ -8,12 +8,12 @@ import type { ICore } from '../../core/types';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 
 class KlarnaPayments extends UIElement<KlarnaConfiguration> {
-    public static type = TxVariants.klarna;
-    public static txVariants = [TxVariants.klarna, TxVariants.klarna_account, TxVariants.klarna_paynow, TxVariants.klarna_b2b];
+    public static readonly type = TxVariants.klarna;
+    public static readonly txVariants = [TxVariants.klarna, TxVariants.klarna_account, TxVariants.klarna_paynow, TxVariants.klarna_b2b];
 
     public componentRef: KlarnaComponentRef;
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         useKlarnaWidget: false
     };
 

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -7,7 +7,7 @@ import { TxVariants } from '../tx-variants';
 import { AwaitConfiguration } from '../internal/Await/types';
 
 export class MBWayElement extends UIElement<AwaitConfiguration> {
-    public static type = TxVariants.mbway;
+    public static readonly type = TxVariants.mbway;
 
     formatProps(props) {
         const { data = {}, placeholders = {} } = props;

--- a/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
+++ b/packages/lib/src/components/MealVoucherFR/MealVoucherFR.tsx
@@ -5,8 +5,8 @@ import { GiftCardConfiguration } from '../Giftcard/types';
 import type { ICore } from '../../core/types';
 
 export class MealVoucherFRElement extends GiftcardElement {
-    public static type = TxVariants.mealVoucher_FR;
-    public static txVariants = [
+    public static override readonly type: TxVariants = TxVariants.mealVoucher_FR;
+    public static readonly txVariants = [
         TxVariants.mealVoucher_FR,
         TxVariants.mealVoucher_FR_natixis,
         TxVariants.mealVoucher_FR_sodexo,

--- a/packages/lib/src/components/MolPayEBanking/MolPayEBankingMY.ts
+++ b/packages/lib/src/components/MolPayEBanking/MolPayEBankingMY.ts
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class MolPayEBankingMYElement extends IssuerListContainer {
-    public static type = TxVariants.molpay_ebanking_fpx_MY;
+    public static readonly type = TxVariants.molpay_ebanking_fpx_MY;
 }
 
 export default MolPayEBankingMYElement;

--- a/packages/lib/src/components/MolPayEBanking/MolPayEBankingTH.ts
+++ b/packages/lib/src/components/MolPayEBanking/MolPayEBankingTH.ts
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class MolPayEBankingTHElement extends IssuerListContainer {
-    public static type = TxVariants.molpay_ebanking_TH;
+    public static readonly type = TxVariants.molpay_ebanking_TH;
 }
 
 export default MolPayEBankingTHElement;

--- a/packages/lib/src/components/MolPayEBanking/MolPayEBankingVN.ts
+++ b/packages/lib/src/components/MolPayEBanking/MolPayEBankingVN.ts
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class MolPayEbankingVNElement extends IssuerListContainer {
-    public static type = TxVariants.molpay_ebanking_VN;
+    public static readonly type = TxVariants.molpay_ebanking_VN;
 }
 
 export default MolPayEbankingVNElement;

--- a/packages/lib/src/components/Multibanco/Multibanco.tsx
+++ b/packages/lib/src/components/Multibanco/Multibanco.tsx
@@ -6,7 +6,7 @@ import { TxVariants } from '../tx-variants';
 import { VoucherConfiguration } from '../internal/Voucher/types';
 
 export class MultibancoElement extends UIElement<VoucherConfiguration> {
-    public static type = TxVariants.multibanco;
+    public static readonly type = TxVariants.multibanco;
 
     get isValid() {
         return true;

--- a/packages/lib/src/components/OnlineBankingCZ/index.ts
+++ b/packages/lib/src/components/OnlineBankingCZ/index.ts
@@ -5,9 +5,9 @@ const TERMS_AND_CONDITIONS = 'https://static.payu.com/sites/terms/files/payu_pri
 const ICON = 'bankTransfer_IBAN';
 
 class OnlineBankingCZElement extends IssuerListContainer {
-    public static type = TxVariants.onlineBanking_CZ;
+    public static readonly type = TxVariants.onlineBanking_CZ;
 
-    private static termsAndConditions = {
+    private static readonly termsAndConditions = {
         translationKey: 'onlineBanking.termsAndConditions',
         urls: [TERMS_AND_CONDITIONS]
     };

--- a/packages/lib/src/components/OnlineBankingFI/OnlineBankingFI.tsx
+++ b/packages/lib/src/components/OnlineBankingFI/OnlineBankingFI.tsx
@@ -1,7 +1,7 @@
 import IssuerListContainer from '../helpers/IssuerListContainer';
 
 class OnlineBankingFI extends IssuerListContainer {
-    public static type = 'ebanking_FI';
+    public static readonly type = 'ebanking_FI';
 }
 
 export default OnlineBankingFI;

--- a/packages/lib/src/components/OnlineBankingIN/index.ts
+++ b/packages/lib/src/components/OnlineBankingIN/index.ts
@@ -3,7 +3,7 @@ import collectBrowserInfo from '../../utils/browserInfo';
 import { TxVariants } from '../tx-variants';
 
 class OnlineBankingINElement extends IssuerListContainer {
-    public static type = TxVariants.onlinebanking_IN;
+    public static readonly type = TxVariants.onlinebanking_IN;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/OnlineBankingPL/OnlineBankingPL.tsx
+++ b/packages/lib/src/components/OnlineBankingPL/OnlineBankingPL.tsx
@@ -4,14 +4,14 @@ import { IssuerListConfiguration } from '../helpers/IssuerListContainer/types';
 import type { ICore } from '../../core/types';
 
 class OnlineBankingPL extends IssuerListContainer {
-    public static type = TxVariants.onlineBanking_PL;
+    public static readonly type = TxVariants.onlineBanking_PL;
 
-    private static disclaimerUrlsMap = {
+    private static readonly disclaimerUrlsMap = {
         regulation: 'https://www.przelewy24.pl/regulamin',
         obligation: 'https://www.przelewy24.pl/obowiazek-informacyjny-rodo-platnicy'
     };
 
-    private static termsAndConditions = {
+    private static readonly termsAndConditions = {
         translationKey: 'onlineBankingPL.termsAndConditions',
         urls: [OnlineBankingPL.disclaimerUrlsMap.regulation, OnlineBankingPL.disclaimerUrlsMap.obligation]
     };

--- a/packages/lib/src/components/OnlineBankingSK/index.ts
+++ b/packages/lib/src/components/OnlineBankingSK/index.ts
@@ -5,9 +5,9 @@ const TERMS_AND_CONDITIONS = 'https://static.payu.com/sites/terms/files/payu_pri
 const ICON = 'bankTransfer_IBAN';
 
 class OnlineBankingSKElement extends IssuerListContainer {
-    public static type = TxVariants.onlineBanking_SK;
+    public static readonly type = TxVariants.onlineBanking_SK;
 
-    private static termsAndConditions = {
+    private static readonly termsAndConditions = {
         translationKey: 'onlineBanking.termsAndConditions',
         urls: [TERMS_AND_CONDITIONS]
     };

--- a/packages/lib/src/components/Oxxo/Oxxo.tsx
+++ b/packages/lib/src/components/Oxxo/Oxxo.tsx
@@ -5,9 +5,9 @@ import { TxVariants } from '../tx-variants';
 import { VoucherConfiguration } from '../internal/Voucher/types';
 
 export class OxxoElement extends UIElement<VoucherConfiguration> {
-    public static type = TxVariants.oxxo;
+    public static readonly type = TxVariants.oxxo;
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         name: 'Oxxo'
     };
 

--- a/packages/lib/src/components/PayByBank/PayByBank.tsx
+++ b/packages/lib/src/components/PayByBank/PayByBank.tsx
@@ -4,7 +4,7 @@ import { IssuerListConfiguration } from '../helpers/IssuerListContainer/types';
 import type { ICore } from '../../core/types';
 
 class PayByBank extends IssuerListContainer {
-    public static type = TxVariants.paybybank;
+    public static readonly type = TxVariants.paybybank;
 
     constructor(checkout: ICore, props?: IssuerListConfiguration) {
         super(checkout, { ...props, showPaymentMethodItemImages: true });

--- a/packages/lib/src/components/PayByBankUS/PayByBankUS.tsx
+++ b/packages/lib/src/components/PayByBankUS/PayByBankUS.tsx
@@ -7,7 +7,7 @@ import getIssuerImageUrl from '../../utils/get-issuer-image';
 import PayButton from '../internal/PayButton';
 import { payAmountLabel } from '../internal/PayButton/utils';
 export default class PayByBankUS extends RedirectElement {
-    public static type = TxVariants.paybybank_AIS_DD;
+    public static override readonly type: TxVariants = TxVariants.paybybank_AIS_DD;
 
     protected formatProps(props) {
         return {

--- a/packages/lib/src/components/PayMe/PayMe.ts
+++ b/packages/lib/src/components/PayMe/PayMe.ts
@@ -3,9 +3,9 @@ import { PayMeInstructions } from './components/PayMeInstructions';
 import { PayMeIntroduction } from './components/PayMeIntroduction';
 
 class PayMeElement extends QRLoaderContainer {
-    public static type = 'payme';
-    private static defaultCountdown = 10; // min
-    private static defaultDelay = 2000; // ms
+    public static readonly type = 'payme';
+    private static readonly defaultCountdown = 10; // min
+    private static readonly defaultDelay = 2000; // ms
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/PayNow/PayNow.ts
+++ b/packages/lib/src/components/PayNow/PayNow.ts
@@ -5,7 +5,7 @@ import { PayNowIntroduction } from './components/PayNowIntroduction';
 import { PayNowInstructions } from './components/PayNowInstructions';
 
 class PayNowElement extends QRLoaderContainer {
-    public static type = TxVariants.paynow;
+    public static readonly type = TxVariants.paynow;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -15,15 +15,15 @@ import './Paypal.scss';
 import { AnalyticsInfoEvent, InfoEventType } from '../../core/Analytics/events/AnalyticsInfoEvent';
 
 class PaypalElement extends UIElement<PayPalConfiguration> {
-    public static type = TxVariants.paypal;
-    public static subtype = 'sdk';
+    public static readonly type = TxVariants.paypal;
+    public static readonly subtype = 'sdk';
 
     public paymentData: string = null;
 
     private resolve = null;
     private reject = null;
 
-    protected static defaultProps = defaultProps;
+    protected static readonly defaultProps = defaultProps;
 
     constructor(checkout: ICore, props?: PayPalConfiguration) {
         super(checkout, props);

--- a/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
+++ b/packages/lib/src/components/PayPalFastlane/Fastlane.tsx
@@ -7,7 +7,7 @@ import type { FastlaneConfiguration } from './types';
 class Fastlane extends UIElement<FastlaneConfiguration> {
     public static readonly type = TxVariants.fastlane;
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         keepBrandsVisible: true
     };
 

--- a/packages/lib/src/components/PayTo/PayTo.tsx
+++ b/packages/lib/src/components/PayTo/PayTo.tsx
@@ -49,7 +49,7 @@ const getAccountIdentifier = (state: PayToData) => {
 export class PayToElement extends UIElement<PayToConfiguration> {
     public static readonly type = TxVariants.payto;
 
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         placeholders: {}
     };
 

--- a/packages/lib/src/components/PayU/PayuCashcard.tsx
+++ b/packages/lib/src/components/PayU/PayuCashcard.tsx
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class PayuNetCashcardElement extends IssuerListContainer {
-    public static type = TxVariants.payu_IN_cashcard;
+    public static readonly type = TxVariants.payu_IN_cashcard;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/PayU/PayuNetBanking.tsx
+++ b/packages/lib/src/components/PayU/PayuNetBanking.tsx
@@ -2,7 +2,7 @@ import IssuerListContainer from '../helpers/IssuerListContainer/IssuerListContai
 import { TxVariants } from '../tx-variants';
 
 class PayuNetBankingElement extends IssuerListContainer {
-    public static type = TxVariants.payu_IN_nb;
+    public static readonly type = TxVariants.payu_IN_nb;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/Pix/Pix.tsx
+++ b/packages/lib/src/components/Pix/Pix.tsx
@@ -9,9 +9,9 @@ import PixQRDetails from './components/PixQRDetails';
 import './Pix.scss';
 
 class PixElement extends QRLoaderContainer<PixConfiguration> {
-    public static type = TxVariants.pix;
+    public static readonly type = TxVariants.pix;
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         personalDetailsRequired: false,
         countdownTime: 15,
         delay: 2000,

--- a/packages/lib/src/components/PreAuthorizedDebitCanada/PreAuthorizedDebitCanada.tsx
+++ b/packages/lib/src/components/PreAuthorizedDebitCanada/PreAuthorizedDebitCanada.tsx
@@ -9,7 +9,7 @@ import { payAmountLabel } from '../internal/PayButton/utils';
 import type { PreAuthorizedDebitCanadaConfiguration } from './types';
 
 export class PreAuthorizedDebitCanada extends UIElement<PreAuthorizedDebitCanadaConfiguration> {
-    public static type = TxVariants.eft_directdebit_CA;
+    public static readonly type = TxVariants.eft_directdebit_CA;
 
     public override formatData() {
         const recurringPayment = !!this.props.storedPaymentMethodId;

--- a/packages/lib/src/components/PromptPay/PromptPay.ts
+++ b/packages/lib/src/components/PromptPay/PromptPay.ts
@@ -3,7 +3,7 @@ import { delay, countdownTime } from './config';
 import { TxVariants } from '../tx-variants';
 
 class PromptPayElement extends QRLoaderContainer {
-    public static type = TxVariants.promptpay;
+    public static readonly type = TxVariants.promptpay;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/RatePay/RatePay.ts
+++ b/packages/lib/src/components/RatePay/RatePay.ts
@@ -3,7 +3,7 @@ import { ALLOWED_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
 
 export default class RatePay extends OpenInvoiceContainer {
-    public static type = TxVariants.ratepay;
+    public static readonly type = TxVariants.ratepay;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/RatePay/RatePayDirectDebit.ts
+++ b/packages/lib/src/components/RatePay/RatePayDirectDebit.ts
@@ -3,7 +3,7 @@ import { ALLOWED_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
 
 export default class RatePayDirectDebit extends OpenInvoiceContainer {
-    public static type = TxVariants.ratepay_directdebit;
+    public static readonly type = TxVariants.ratepay_directdebit;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -8,9 +8,9 @@ import collectBrowserInfo from '../../utils/browserInfo';
 import { AnalyticsErrorEvent, ErrorEventCode, ErrorEventType } from '../../core/Analytics/events/AnalyticsErrorEvent';
 
 class RedirectElement extends UIElement<RedirectConfiguration> {
-    public static type = TxVariants.redirect;
+    public static readonly type: TxVariants = TxVariants.redirect;
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         type: RedirectElement.type
     };
 

--- a/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
+++ b/packages/lib/src/components/Redirect/components/RedirectShopper/RedirectShopper.tsx
@@ -15,7 +15,7 @@ interface RedirectShopperProps {
 
 class RedirectShopper extends Component<RedirectShopperProps> {
     private postForm;
-    public static defaultProps = {
+    public static readonly defaultProps = {
         beforeRedirect: resolve => resolve(),
         onRedirectError: () => {},
         method: 'GET'

--- a/packages/lib/src/components/Riverty/Riverty.tsx
+++ b/packages/lib/src/components/Riverty/Riverty.tsx
@@ -2,7 +2,7 @@ import { TxVariants } from '../tx-variants';
 import RedirectElement from '../Redirect';
 
 class Riverty extends RedirectElement {
-    public static readonly type = TxVariants.riverty;
+    public static override readonly type = TxVariants.riverty;
 
     public static override readonly defaultProps = {
         type: TxVariants.riverty

--- a/packages/lib/src/components/Sepa/Sepa.tsx
+++ b/packages/lib/src/components/Sepa/Sepa.tsx
@@ -7,7 +7,7 @@ import FormInstruction from '../internal/FormInstruction';
 import type { ICore } from '../../core/types';
 
 class SepaElement extends UIElement<SepaConfiguration> {
-    public static type = TxVariants.sepadirectdebit;
+    public static readonly type = TxVariants.sepadirectdebit;
 
     constructor(checkout: ICore, props?: SepaConfiguration) {
         super(checkout, props);

--- a/packages/lib/src/components/Swish/Swish.ts
+++ b/packages/lib/src/components/Swish/Swish.ts
@@ -3,7 +3,7 @@ import { TxVariants } from '../tx-variants';
 import './Swish.scss';
 
 class SwishElement extends QRLoaderContainer {
-    public static type = TxVariants.swish;
+    public static readonly type = TxVariants.swish;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2Challenge.tsx
@@ -12,9 +12,9 @@ import { AnalyticsLogEvent, LogEventSubtype, LogEventType } from '../../core/Ana
 import { AnalyticsErrorEvent, ErrorEventCode, ErrorEventType } from '../../core/Analytics/events/AnalyticsErrorEvent';
 
 class ThreeDS2Challenge extends UIElement<ThreeDS2ChallengeConfiguration> {
-    public static type = TxVariants.threeDS2Challenge;
+    public static readonly type = TxVariants.threeDS2Challenge;
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         dataKey: 'threeDSResult',
         size: DEFAULT_CHALLENGE_WINDOW_SIZE,
         type: THREEDS2_CHALLENGE

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -12,9 +12,9 @@ import { AnalyticsLogEvent, LogEventSubtype, LogEventType } from '../../core/Ana
 import { AnalyticsErrorEvent, ErrorEventCode, ErrorEventType } from '../../core/Analytics/events/AnalyticsErrorEvent';
 
 class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintConfiguration> {
-    public static type = TxVariants.threeDS2Fingerprint;
+    public static readonly type = TxVariants.threeDS2Fingerprint;
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         dataKey: 'fingerprintResult',
         type: THREEDS2_FINGERPRINT
     };

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -17,7 +17,7 @@ import { AnalyticsErrorEvent, ErrorEventCode, ErrorEventType } from '../../../..
 import { AbstractAnalyticsEvent } from '../../../../core/Analytics/events/AbstractAnalyticsEvent';
 
 class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareChallenge3DS2State> {
-    public static defaultProps = {
+    public static readonly defaultProps = {
         onComplete: () => {},
         onError: () => {},
         isMDFlow: false

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -22,7 +22,7 @@ const iframeName = 'threeDSMethodIframe';
 class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3DS2State> {
     private processMessageHandler;
     private fingerPrintPromise: any;
-    public static defaultProps = {
+    public static readonly defaultProps = {
         showSpinner: true
     };
 

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/PrepareFingerprint3DS2.tsx
@@ -11,9 +11,9 @@ import { AbstractAnalyticsEvent } from '../../../../core/Analytics/events/Abstra
 import { AnalyticsErrorEvent, ErrorEventCode, ErrorEventType } from '../../../../core/Analytics/events/AnalyticsErrorEvent';
 
 class PrepareFingerprint3DS2 extends Component<PrepareFingerprint3DS2Props, PrepareFingerprint3DS2State> {
-    public static type = 'scheme';
+    public static readonly type = 'scheme';
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         onComplete: () => {},
         onError: () => {},
         paymentData: '',

--- a/packages/lib/src/components/Trustly/Trustly.tsx
+++ b/packages/lib/src/components/Trustly/Trustly.tsx
@@ -5,9 +5,9 @@ import { TxVariants } from '../tx-variants';
 import './Trustly.scss';
 
 class TrustlyElement extends RedirectElement {
-    public static type = TxVariants.trustly;
+    public static override readonly type: TxVariants = TxVariants.trustly;
 
-    get displayName() {
+    override get displayName() {
         return this.props.name || this.constructor['type'];
     }
 

--- a/packages/lib/src/components/Twint/Twint.tsx
+++ b/packages/lib/src/components/Twint/Twint.tsx
@@ -6,9 +6,9 @@ import { TxVariants } from '../tx-variants';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 
 class TwintElement extends RedirectElement {
-    public static type = TxVariants.twint;
+    public static override readonly type: TxVariants = TxVariants.twint;
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         type: TwintElement.type,
         name: 'Twint'
     };

--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -19,7 +19,7 @@ import { ICore } from '../../types';
  */
 
 class UPI extends UIElement<UPIConfiguration> {
-    public static type = TxVariants.upi;
+    public static readonly type = TxVariants.upi;
     public static readonly txVariants = [TxVariants.upi, TxVariants.upi_qr, TxVariants.upi_intent];
     private mode: UpiMode;
     constructor(checkout: ICore, props: UPIConfiguration) {

--- a/packages/lib/src/components/Vipps/Vipps.ts
+++ b/packages/lib/src/components/Vipps/Vipps.ts
@@ -2,9 +2,9 @@ import RedirectElement from '../Redirect';
 import { TxVariants } from '../tx-variants';
 
 class VippsElement extends RedirectElement {
-    public static type = TxVariants.vipps;
+    public static override readonly type: TxVariants = TxVariants.vipps;
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         type: VippsElement.type,
         name: 'Vipps'
     };

--- a/packages/lib/src/components/WalletIN/index.ts
+++ b/packages/lib/src/components/WalletIN/index.ts
@@ -3,7 +3,7 @@ import collectBrowserInfo from '../../utils/browserInfo';
 import { TxVariants } from '../tx-variants';
 
 class WalletINElement extends IssuerListContainer {
-    public static type = TxVariants.wallet_IN;
+    public static readonly type = TxVariants.wallet_IN;
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/WeChat/WeChat.ts
+++ b/packages/lib/src/components/WeChat/WeChat.ts
@@ -3,8 +3,8 @@ import { delay, countdownTime } from './config';
 import { TxVariants } from '../tx-variants';
 
 class WeChatPayElement extends QRLoaderContainer {
-    public static type = TxVariants.wechatpayQR;
-    public static txVariants = [TxVariants.wechatpay];
+    public static readonly type = TxVariants.wechatpayQR;
+    public static readonly txVariants = [TxVariants.wechatpay];
 
     formatProps(props) {
         return {

--- a/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
@@ -8,7 +8,7 @@ import { IssuerListConfiguration, IssuerListData } from './types';
 import type { ICore } from '../../../core/types';
 
 class IssuerListContainer<TProps extends IssuerListConfiguration = IssuerListConfiguration, TData = IssuerListData> extends UIElement<TProps> {
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         showImage: true,
         issuers: [],
         highlightedIssuers: [],

--- a/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
+++ b/packages/lib/src/components/helpers/OpenInvoiceContainer/OpenInvoiceContainer.tsx
@@ -4,7 +4,7 @@ import OpenInvoice from '../../internal/OpenInvoice';
 import { OpenInvoiceConfiguration } from './types';
 
 export default class OpenInvoiceContainer extends UIElement<OpenInvoiceConfiguration> {
-    protected static defaultProps: Partial<OpenInvoiceConfiguration> = {
+    protected static readonly defaultProps: Partial<OpenInvoiceConfiguration> = {
         onChange: () => {},
         data: { companyDetails: {}, personalDetails: {}, billingAddress: {}, deliveryAddress: {}, bankAccount: {} },
         visibility: {

--- a/packages/lib/src/components/helpers/QRLoaderContainer/QRLoaderContainer.tsx
+++ b/packages/lib/src/components/helpers/QRLoaderContainer/QRLoaderContainer.tsx
@@ -6,7 +6,7 @@ import { QRLoaderConfiguration } from './types';
 
 class QRLoaderContainer<T extends QRLoaderConfiguration = QRLoaderConfiguration> extends UIElement<T> {
     // Using the generic here allow to fully extend the QRLoaderContainer (including it's props)
-    protected static defaultProps = {
+    protected static readonly defaultProps = {
         qrCodeImage: '',
         amount: null,
         paymentData: null,

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -30,7 +30,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
 
     protected _node: HTMLElement = null;
 
-    protected static defaultProps = {};
+    protected static readonly defaultProps = {};
 
     constructor(checkout: ICore, props?: P) {
         const isCoreInstance = assertIsCoreInstance(checkout);

--- a/packages/lib/src/components/internal/IFrame/Iframe.tsx
+++ b/packages/lib/src/components/internal/IFrame/Iframe.tsx
@@ -17,7 +17,7 @@ interface IframeProps {
 }
 
 class Iframe extends Component<IframeProps> {
-    public static defaultProps = {
+    public static readonly defaultProps = {
         width: '0',
         height: '0',
         minWidth: '0',

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
@@ -79,7 +79,7 @@ class IbanInput extends Component<IbanInputProps, IbanInputState> {
         }
     }
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         onChange: () => {},
         countryCode: null,
         holderName: true,

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -100,7 +100,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
         this.destroy = this.destroy.bind(this);
     }
 
-    public static defaultProps = defaultProps;
+    public static readonly defaultProps = defaultProps;
 
     public componentDidMount(): void {
         // When SFP instantiated through SecuredFieldsInput c.f. CardInput

--- a/packages/lib/src/components/internal/Tooltip/TooltipController.ts
+++ b/packages/lib/src/components/internal/Tooltip/TooltipController.ts
@@ -10,7 +10,7 @@ export class TooltipController {
     private static timeoutId: ReturnType<typeof setTimeout> | null = null;
     private static registered = false;
     private static updateGlobalTooltip: setTooltipState = () => {};
-    private static eventTarget = new EventTarget();
+    private static readonly eventTarget = new EventTarget();
 
     public static registerTooltipHandler(fn: setTooltipState): void {
         this.updateGlobalTooltip = fn;

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -43,7 +43,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
 
     public elementRef: UIElement;
 
-    public static type = undefined;
+    public static readonly type = undefined;
 
     /**
      * Reference to the methods exposed by the AmountProvider context
@@ -53,7 +53,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     /**
      * Defines all txVariants that the Component supports (in case it support multiple ones besides the 'type' one)
      */
-    public static txVariants: string[] = [];
+    public static readonly txVariants: string[] = [];
 
     constructor(checkout: ICore, props?: P) {
         super(checkout, props);

--- a/packages/lib/src/core/Errors/AdyenCheckoutError.ts
+++ b/packages/lib/src/core/Errors/AdyenCheckoutError.ts
@@ -12,7 +12,7 @@ export const SCRIPT_ERROR = 'SCRIPT_ERROR';
 export const SDK_ERROR = 'SDK_ERROR';
 
 class AdyenCheckoutError extends Error {
-    protected static errorTypes = {
+    protected static readonly errorTypes = {
         /** Network error. */
         NETWORK_ERROR,
 

--- a/packages/lib/src/core/Errors/SRPanel.tsx
+++ b/packages/lib/src/core/Errors/SRPanel.tsx
@@ -11,9 +11,9 @@ import './SRPanel.scss';
  * For testing purposes can be made visible
  */
 export class SRPanel extends BaseElement<SRPanelProps> {
-    public static type = 'srPanel';
+    public static readonly type = 'srPanel';
 
-    public static defaultProps: Partial<SRPanelProps> = {
+    public static readonly defaultProps: Partial<SRPanelProps> = {
         enabled: true,
         node: 'body',
         showPanel: false,

--- a/packages/lib/src/core/RiskModule/RiskModule.tsx
+++ b/packages/lib/src/core/RiskModule/RiskModule.tsx
@@ -21,8 +21,8 @@ interface RiskModuleProps extends BaseElementProps {
 export type RiskData = string | boolean;
 
 export default class RiskElement extends BaseElement<RiskModuleProps> {
-    public static type = 'risk';
-    public static defaultProps = {
+    public static readonly type = 'risk';
+    public static readonly defaultProps = {
         risk: {
             enabled: true,
             onComplete: () => {},

--- a/packages/lib/src/core/RiskModule/components/DeviceFingerprint/DeviceFingerprint.tsx
+++ b/packages/lib/src/core/RiskModule/components/DeviceFingerprint/DeviceFingerprint.tsx
@@ -16,7 +16,7 @@ class DeviceFingerprint extends Component<DeviceFingerprintProps, DeviceFingerpr
         }
     }
 
-    public static defaultProps = {
+    public static readonly defaultProps = {
         onComplete: () => {},
         onError: () => {}
     };

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -48,7 +48,7 @@ class Core implements ICore {
         bundleType: LIBRARY_BUNDLE_TYPE
     };
 
-    public static registry = registry;
+    public static readonly registry = registry;
 
     public static setBundleType(type: string): void {
         Core.metadata.bundleType = type;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary
- Adjusting static props to be defined as `readonly`
- static props that override others are also marked as `override`

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

