### PR TITLE
Migration to NPM Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      id-token: write # Required for OpenID Connect (OIDC) for trusted publishing on NPM
     steps:
       - uses: actions/checkout@v6
 
@@ -31,7 +35,5 @@ jobs:
 
       # Build and publish to npm
       - name: Build and release
-        run: cd packages/lib && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          CI: true
+        run: cd packages/lib && npm publish --access public --tag latest
+ 


### PR DESCRIPTION

## 📝 Summary
This PR modernizes our NPM release process by switching from long-lived secrets to Trusted Publishing (OIDC).

🛠️ Key Changes
Permissions: Added id-token: write to allow the GitHub runner to request OIDC tokens.

Publishing: Updated npm publish to include the required --tag parameter.

Security: This eliminates the need for the manually managed NPM_TOKEN secret.
---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

