### PR TITLE
Ignore sonar cloud rule for using globalThis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -31,6 +31,6 @@ sonar.exclusions=\
 
 # typescript:S7764: Prefer `globalThis` over `window`
 # Suppressed because the SDK runs exclusively in the browser; `window` usage is intentional and idiomatic here.
-sonar.issue.ignore.multicriteria=r1
-sonar.issue.ignore.multicriteria.r1.ruleKey=typescript:S7764
-sonar.issue.ignore.multicriteria.r1.resourceKey=**/*
+sonar.issue.ignore.multicriteria=prefer_globalthis
+sonar.issue.ignore.multicriteria.prefer_globalthis.ruleKey=typescript:S7764
+sonar.issue.ignore.multicriteria.prefer_globalthis.resourceKey=**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,11 +7,30 @@ sonar.javascript.lcov.reportPaths=./packages/lib/coverage/lcov.info
 
 sonar.sources=packages/lib/src
 
+#----------------------------------------------------------------------
+# INCLUDED FILES
+#----------------------------------------------------------------------
+
 # Test files are within the source directory and identified by pattern.
 sonar.test.inclusions=**/*.test.*
+
+#----------------------------------------------------------------------
+# EXCLUDED FILES
+#----------------------------------------------------------------------
 
 # Exclude files from quality code checks
 sonar.exclusions=\
   **/stories/**/*,\
   **/*.stories.*,\
   **/types.ts
+
+
+#----------------------------------------------------------------------
+# IGNORED RULES
+#----------------------------------------------------------------------
+
+# typescript:S7764: Prefer `globalThis` over `window`
+# Suppressed because the SDK runs exclusively in the browser; `window` usage is intentional and idiomatic here.
+sonar.issue.ignore.multicriteria=r1
+sonar.issue.ignore.multicriteria.r1.ruleKey=typescript:S7764
+sonar.issue.ignore.multicriteria.r1.resourceKey=**/*


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

Sonar rule `typescript:S7764` flags all usages of `window` in favor of `globalThis`. Since the SDK runs exclusively in the browser, window usage is intentional and idiomatic — suppressing this rule globally avoids unnecessary noise.

`globalThis` is the same as `window` in browsers but we do have many files this change will affect and those need to be tested properly. It is not worth this change since the SDK can only work on the browser anyway.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

COSDK-1080

---

