### PR TITLE
Fixing failing e2e tests

### DIFF
--- a/packages/e2e-playwright/models/dropin.ts
+++ b/packages/e2e-playwright/models/dropin.ts
@@ -94,7 +94,8 @@ class Dropin extends Base {
 
         const paymentMethodHeaderLocator = this.page
             .locator('.adyen-checkout__payment-methods-list--otherPayments')
-            .getByRole('radio', { name: pmLabel });
+            .getByRole('radio', { name: pmLabel })
+            .filter({ has: this.page.getByText(pmLabel, { exact: true }) });
 
         await paymentMethodHeaderLocator.check();
 

--- a/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
@@ -174,7 +174,9 @@ test.describe('Bcmc payments with dual branding', () => {
                 await expect(bcmc.expiryDateErrorElement).toHaveText(/Enter the (complete )?expiry date/);
             });
 
-            test('#3c should not submit the bcmc payment with invalid bcmc card number', async ({ bcmc }) => {
+            test('#3c should not submit the bcmc payment with invalid bcmc card number', async ({ bcmc, page }) => {
+                await binLookupMock(page, dualBrandedBcmcAndVisa);
+
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.typeCardNumber(`${BCMC_DUAL_BRANDED_VISA}111`);
@@ -238,7 +240,9 @@ test.describe('Bcmc payments with dual branding', () => {
                 await expect(bcmc.cvcErrorElement).toHaveText('Enter the security code');
             });
 
-            test('#4c should not submit the visa payment with invalid visa card number', async ({ bcmc }) => {
+            test('#4c should not submit the visa payment with invalid visa card number', async ({ bcmc, page }) => {
+                await binLookupMock(page, dualBrandedBcmcAndVisa);
+
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.typeCardNumber(`${BCMC_DUAL_BRANDED_VISA}111`);
@@ -285,7 +289,9 @@ test.describe('Bcmc payments with dual branding', () => {
                 await expect(bcmc.expiryDateErrorElement).toHaveText(/Enter the (complete )?expiry date/);
             });
 
-            test('#5c should not submit the bcmc payment with invalid bcmc card number', async ({ bcmc }) => {
+            test('#5c should not submit the bcmc payment with invalid bcmc card number', async ({ bcmc, page }) => {
+                await binLookupMock(page, dualBrandedBcmcAndMc);
+
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.typeCardNumber(`${BCMC_DUAL_BRANDED_MC}111`);
@@ -347,7 +353,9 @@ test.describe('Bcmc payments with dual branding', () => {
                 await expect(bcmc.cvcErrorElement).toHaveText('Enter the security code');
             });
 
-            test('#6c should not submit the mc payment with invalid mc card number', async ({ bcmc }) => {
+            test('#6c should not submit the mc payment with invalid mc card number', async ({ bcmc, page }) => {
+                await binLookupMock(page, dualBrandedBcmcAndMc);
+
                 await bcmc.goto(URL_MAP.bcmc);
                 await bcmc.isComponentVisible();
                 await bcmc.typeCardNumber(`${BCMC_DUAL_BRANDED_MC}111`);

--- a/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/card/bcmc/dualBranding.spec.ts
@@ -240,7 +240,7 @@ test.describe('Bcmc payments with dual branding', () => {
                 await expect(bcmc.cvcErrorElement).toHaveText('Enter the security code');
             });
 
-            test('#4c should not submit the visa payment with invalid visa card number', async ({ bcmc, page }) => {
+            test('#4c should not submit the visa payment with invalid bcmc card number', async ({ bcmc, page }) => {
                 await binLookupMock(page, dualBrandedBcmcAndVisa);
 
                 await bcmc.goto(URL_MAP.bcmc);
@@ -353,7 +353,7 @@ test.describe('Bcmc payments with dual branding', () => {
                 await expect(bcmc.cvcErrorElement).toHaveText('Enter the security code');
             });
 
-            test('#6c should not submit the mc payment with invalid mc card number', async ({ bcmc, page }) => {
+            test('#6c should not submit the mc payment with invalid bcmc card number', async ({ bcmc, page }) => {
                 await binLookupMock(page, dualBrandedBcmcAndMc);
 
                 await bcmc.goto(URL_MAP.bcmc);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

Fixing e2e tests failing because of a change to BO which altered the order in which card brands are returned (meaning the `panLength` property on the `bcmc` binLookup object was coming into play and causing focus to jump to the date field before we had finished typing in the PAN)

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

COSDK-1065

