### PR TITLE
Improve types of amazonpay component and add unit tests

### DIFF
--- a/.changeset/jolly-rats-sin.md
+++ b/.changeset/jolly-rats-sin.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Improved: Types of amazon pay component

--- a/packages/lib/config/setupTests.ts
+++ b/packages/lib/config/setupTests.ts
@@ -14,6 +14,10 @@ import './testMocks/commonCorePropsMock';
 // https://github.com/mswjs/msw/issues/1916
 import { ReadableStream, WritableStream, TransformStream } from 'node:stream/web';
 
+const DEFAULT_TEST_TIMEOUT = 10_000;
+
+jest.setTimeout(DEFAULT_TEST_TIMEOUT);
+
 process.env.VERSION = 'X.Y.Z';
 process.env.BUNDLE_TYPE = 'esm';
 

--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -142,7 +142,6 @@ const config = tseslint.config(
             // ══════════════════════════════════════════════════════════
 
             // ── Components
-            'src/components/AmazonPay/**',
             'src/components/ANCV/**',
             'src/components/ApplePay/**',
             'src/components/BankTransfer/**',

--- a/packages/lib/src/components/AmazonPay/AmazonPay.test.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.test.tsx
@@ -1,4 +1,5 @@
 import AmazonPay from './AmazonPay';
+import AmazonPayDefault from './index';
 import defaultProps from './defaultProps';
 import { httpPost } from '../../core/Services/http';
 import { mock } from 'jest-mock-extended';
@@ -34,18 +35,110 @@ describe('AmazonPay', () => {
         expect(amazonPay.data.paymentMethod.type).toBe('amazonpay');
     });
 
-    test('format props correctly', () => {
-        const props = {
-            environment: 'test',
-            locale: 'en-US',
-            configuration: {
-                region: 'EU'
-            }
-        };
-        const amazonPay = getElement(props);
-        expect(amazonPay.props.environment).toBe('TEST');
-        expect(amazonPay.props.locale).toBe('en_US');
-        expect(amazonPay.props.configuration.region).toBe('EU');
+    test('is exported as default from index', () => {
+        expect(AmazonPayDefault).toBe(AmazonPay);
+    });
+
+    describe('formatProps', () => {
+        test('formats props correctly', () => {
+            const props = {
+                environment: 'test',
+                locale: 'en-US',
+                configuration: {
+                    region: 'EU'
+                }
+            };
+            const amazonPay = getElement(props);
+            expect(amazonPay.props.environment).toBe('TEST');
+            expect(amazonPay.props.locale).toBe('en_US');
+            expect(amazonPay.props.configuration.region).toBe('EU');
+        });
+
+        test('sets checkoutMode to ProcessOrder when isDropin is true', () => {
+            const amazonPay = getElement({ isDropin: true });
+            // @ts-ignore checkoutMode is set dynamically by formatProps
+            expect(amazonPay.props.checkoutMode).toBe('ProcessOrder');
+        });
+
+        test('preserves checkoutMode when isDropin is false', () => {
+            // @ts-ignore checkoutMode is set dynamically by formatProps
+            const amazonPay = getElement({ isDropin: false, checkoutMode: 'ReviewOrder' });
+            // @ts-ignore checkoutMode is set dynamically by formatProps
+            expect(amazonPay.props.checkoutMode).toBe('ReviewOrder');
+        });
+
+        test('sets productType to PayOnly when isDropin is true and no addressDetails', () => {
+            const amazonPay = getElement({ isDropin: true });
+            expect(amazonPay.props.productType).toBe('PayOnly');
+        });
+
+        test('preserves productType when isDropin is true but addressDetails is provided', () => {
+            const amazonPay = getElement({
+                isDropin: true,
+                addressDetails: { name: 'Test' },
+                productType: 'PayAndShip'
+            });
+            expect(amazonPay.props.productType).toBe('PayAndShip');
+        });
+    });
+
+    describe('formatData', () => {
+        test('includes checkoutSessionId when amazonCheckoutSessionId is provided', () => {
+            const amazonPay = getElement({ amazonCheckoutSessionId: 'SESSION123' });
+            expect(amazonPay.data.paymentMethod.checkoutSessionId).toBe('SESSION123');
+        });
+
+        test('does not include checkoutSessionId when not provided', () => {
+            const amazonPay = getElement({ amazonCheckoutSessionId: undefined });
+            expect(amazonPay.data.paymentMethod.checkoutSessionId).toBeUndefined();
+        });
+
+        test('includes browserInfo in data', () => {
+            const amazonPay = getElement();
+            expect(amazonPay.data.browserInfo).toBeDefined();
+            expect(amazonPay.data.browserInfo).toHaveProperty('userAgent');
+        });
+    });
+
+    describe('browserInfo', () => {
+        test('returns browser info object', () => {
+            const amazonPay = getElement();
+            expect(amazonPay.browserInfo).toBeDefined();
+            expect(amazonPay.browserInfo).toHaveProperty('userAgent');
+        });
+    });
+
+    describe('submit', () => {
+        test('calls makePaymentsCall when no componentRef submit function exists', () => {
+            const amazonPay = getElement();
+            // @ts-ignore accessing protected method for testing
+            const makePaymentsCallSpy = jest.spyOn(amazonPay, 'makePaymentsCall').mockResolvedValue({ resultCode: 'Authorised' });
+            amazonPay.submit();
+            expect(makePaymentsCallSpy).toHaveBeenCalled();
+        });
+
+        test('calls componentRef getSubmitFunction when available', () => {
+            const amazonPay = getElement();
+            const mockSubmitFn = jest.fn();
+            // @ts-ignore setting componentRef for testing
+            amazonPay.componentRef = {
+                getSubmitFunction: () => mockSubmitFn
+            };
+            amazonPay.submit();
+            expect(mockSubmitFn).toHaveBeenCalled();
+        });
+
+        test('falls back to makePaymentsCall when getSubmitFunction returns null', () => {
+            const amazonPay = getElement();
+            // @ts-ignore setting componentRef for testing
+            amazonPay.componentRef = {
+                getSubmitFunction: () => null
+            };
+            // @ts-ignore accessing protected method for testing
+            const makePaymentsCallSpy = jest.spyOn(amazonPay, 'makePaymentsCall').mockResolvedValue({ resultCode: 'Authorised' });
+            amazonPay.submit();
+            expect(makePaymentsCallSpy).toHaveBeenCalled();
+        });
     });
 
     describe('getShopperDetails', () => {
@@ -81,6 +174,30 @@ describe('AmazonPay', () => {
             /* eslint-disable @typescript-eslint/await-thenable */
             void (await amazonPay.handleDeclineFlow());
             expect(window.location.assign).toHaveBeenCalledTimes(1);
+        });
+
+        test('calls onError if declineFlowUrl is missing from response', async () => {
+            const onError = jest.fn();
+            spyFetch.mockResolvedValueOnce({});
+            const amazonPay = getElement({
+                amazonCheckoutSessionId: 'ABC123',
+                onError
+            });
+            amazonPay.handleDeclineFlow();
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(onError).toHaveBeenCalled();
+        });
+
+        test('calls onError if the request fails', async () => {
+            const onError = jest.fn();
+            spyFetch.mockRejectedValueOnce(new Error('Network error'));
+            const amazonPay = getElement({
+                amazonCheckoutSessionId: 'ABC123',
+                onError
+            });
+            amazonPay.handleDeclineFlow();
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(onError).toHaveBeenCalled();
         });
     });
 });

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -105,9 +105,6 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
     protected override componentToRender(): h.JSX.Element {
         return (
             <AmazonPayComponent
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
                 showPayButton={this.props.showPayButton}
                 onClick={this.props.onClick}
                 onError={this.props.onError}

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -5,10 +5,11 @@ import AmazonPayComponent from './components/AmazonPayComponent';
 import { AmazonPayElementData, AmazonPayConfiguration, CheckoutDetailsRequest } from './types';
 import defaultProps from './defaultProps';
 import { getCheckoutDetails } from './services';
-import './AmazonPay.scss';
 import { TxVariants } from '../tx-variants';
 import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement/utils';
 import { AnalyticsInfoEvent, InfoEventType } from '../../core/Analytics/events/AnalyticsInfoEvent';
+
+import './AmazonPay.scss';
 
 export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
     public static readonly type = TxVariants.amazonpay;
@@ -95,9 +96,9 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
     }
 
     public submit(): void {
-        const amazonComponentSubmit = this.componentRef && this.componentRef.getSubmitFunction();
-        if (amazonComponentSubmit) {
-            return amazonComponentSubmit();
+        const amazonComponentSubmitFunction = this.componentRef?.getSubmitFunction() || null;
+        if (amazonComponentSubmitFunction) {
+            return amazonComponentSubmitFunction();
         }
         this.makePaymentsCall().then(sanitizeResponse).then(verifyPaymentDidNotFail).then(this.handleResponse).catch(this.handleFailedResult);
     }
@@ -105,6 +106,7 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
     protected override componentToRender(): h.JSX.Element {
         return (
             <AmazonPayComponent
+                setComponentRef={this.setComponentRef}
                 showPayButton={this.props.showPayButton}
                 onClick={this.props.onClick}
                 onError={this.props.onError}

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayButton.test.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayButton.test.tsx
@@ -1,0 +1,187 @@
+import { createRef, h } from 'preact';
+import { render, screen, waitFor } from '@testing-library/preact';
+import AmazonPayButton from './AmazonPayButton';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
+import { AmountProvider } from '../../../core/Context/AmountProvider';
+import { AmazonPayButtonProps, AmazonWindowObject } from '../types';
+import { getAmazonSignature } from '../services';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
+
+jest.mock('../services', () => ({
+    getAmazonSignature: jest.fn()
+}));
+
+const mockOnClickFn = jest.fn();
+const mockRenderButton = jest.fn().mockReturnValue({ onClick: mockOnClickFn });
+const mockInitCheckout = jest.fn();
+
+const mockAmazonRef: AmazonWindowObject = {
+    Pay: {
+        renderButton: mockRenderButton,
+        initCheckout: mockInitCheckout,
+        signout: jest.fn(),
+        bindChangeAction: jest.fn()
+    }
+};
+
+const core = setupCoreMock();
+
+const defaultProps: AmazonPayButtonProps = {
+    amazonRef: mockAmazonRef,
+    configuration: { region: 'EU', storeId: 'test-store', merchantId: 'test-merchant' },
+    environment: 'TEST',
+    locale: 'en_GB',
+    clientKey: 'test_client_key',
+    showPayButton: true,
+    onClick: resolve => Promise.resolve(resolve()),
+    onError: jest.fn(),
+    placement: 'Cart',
+    productType: 'PayAndShip',
+    ref: createRef()
+};
+
+const customRender = (props: Partial<AmazonPayButtonProps> = {}) => {
+    return render(
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources} analytics={core.modules.analytics}>
+            <AmountProvider amount={{ currency: 'EUR', value: 1000 }} providerRef={createRef()}>
+                <AmazonPayButton {...defaultProps} {...props} />
+            </AmountProvider>
+        </CoreProvider>
+    );
+};
+
+describe('AmazonPayButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should render the button container when showPayButton is true', () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        customRender();
+        expect(screen.getByTestId('amazon-pay-button')).toBeInTheDocument();
+    });
+
+    test('should not render anything when showPayButton is false', () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        const { container } = customRender({ showPayButton: false });
+        expect(container.innerHTML).toBe('');
+    });
+
+    test('should fetch the Amazon signature on mount', async () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        customRender();
+        await waitFor(() => {
+            expect(getAmazonSignature).toHaveBeenCalledWith('test', 'test_client_key', expect.any(Object));
+        });
+    });
+
+    test('should call renderButton after receiving a valid signature', async () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        customRender();
+        await waitFor(() => {
+            expect(mockRenderButton).toHaveBeenCalledWith('#amazonPayButton', expect.any(Object));
+        });
+    });
+
+    test('should register onClick handler on the rendered button', async () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        customRender();
+        await waitFor(() => {
+            expect(mockOnClickFn).toHaveBeenCalledWith(expect.any(Function));
+        });
+    });
+
+    test('should log error if signature response is empty', async () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        customRender();
+        await waitFor(() => {
+            expect(console.error).toHaveBeenCalledWith('Could not get AmazonPay signature');
+        });
+    });
+
+    test('should not call renderButton if signature is missing', async () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        customRender();
+        await waitFor(() => {
+            expect(getAmazonSignature).toHaveBeenCalled();
+        });
+        expect(mockRenderButton).not.toHaveBeenCalled();
+    });
+
+    test('should call onError when signature request fails', async () => {
+        const onError = jest.fn();
+        const error = new Error('Network failure');
+        (getAmazonSignature as jest.Mock).mockRejectedValue(error);
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        customRender({ onError });
+        await waitFor(() => {
+            expect(console.error).toHaveBeenCalledWith(error);
+        });
+        expect(onError).toHaveBeenCalled();
+    });
+
+    test('should log the error to console when signature request fails', async () => {
+        const error = new Error('Request failed');
+        (getAmazonSignature as jest.Mock).mockRejectedValue(error);
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        customRender();
+        await waitFor(() => {
+            expect(console.error).toHaveBeenCalledWith(error);
+        });
+    });
+
+    test('should not call renderButton when showPayButton is false even with valid signature', async () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        customRender({ showPayButton: false });
+        await waitFor(() => {
+            expect(getAmazonSignature).toHaveBeenCalled();
+        });
+        expect(mockRenderButton).not.toHaveBeenCalled();
+    });
+
+    test('should call initCheckout via the button onClick handler', async () => {
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        customRender();
+
+        await waitFor(() => {
+            expect(mockOnClickFn).toHaveBeenCalled();
+        });
+
+        // Get the onClick handler that was registered and invoke it
+        const registeredHandler = mockOnClickFn.mock.calls[0][0];
+        await registeredHandler();
+
+        expect(mockInitCheckout).toHaveBeenCalledWith(
+            expect.objectContaining({
+                createCheckoutSessionConfig: expect.objectContaining({
+                    signature: 'test-signature',
+                    publicKeyId: undefined
+                })
+            })
+        );
+    });
+
+    test('should call onError when onClick handler rejects', async () => {
+        const onError = jest.fn();
+        (getAmazonSignature as jest.Mock).mockResolvedValue({ signature: 'test-signature' });
+        customRender({
+            onError,
+            onClick: (_resolve: (value?: unknown) => void, reject: () => void) => {
+                reject();
+                return Promise.resolve();
+            }
+        });
+
+        await waitFor(() => {
+            expect(mockOnClickFn).toHaveBeenCalled();
+        });
+
+        const registeredHandler = mockOnClickFn.mock.calls[0][0];
+        await registeredHandler();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(onError).toHaveBeenCalled();
+    });
+});

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
@@ -15,7 +15,7 @@ export default function AmazonPayButton(props: Readonly<AmazonPayButtonProps>) {
     const settings = getAmazonPaySettings(props, amount);
 
     const handleOnClick = () => {
-        return new Promise(() => void props.onClick()).then(this.initCheckout).catch(error => {
+        return new Promise((resolve, reject) => void props.onClick(resolve, reject)).then(this.initCheckout).catch(error => {
             if (props.onError) props.onError(error, this.componentRef);
         });
     };

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
@@ -54,5 +54,5 @@ export default function AmazonPayButton(props: Readonly<AmazonPayButtonProps>) {
     }, []);
 
     if (!props.showPayButton) return null;
-    return <div className="adyen-checkout__amazonpay__button" id="amazonPayButton" />;
+    return <div className="adyen-checkout__amazonpay__button" id="amazonPayButton" data-testid="amazon-pay-button" />;
 }

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayButton.tsx
@@ -15,15 +15,14 @@ export default function AmazonPayButton(props: Readonly<AmazonPayButtonProps>) {
     const settings = getAmazonPaySettings(props, amount);
 
     const handleOnClick = () => {
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        new Promise(props.onClick).then(this.initCheckout).catch(error => {
+        return new Promise(() => void props.onClick()).then(this.initCheckout).catch(error => {
             if (props.onError) props.onError(error, this.componentRef);
         });
     };
 
     const renderAmazonPayButton = (): void => {
         const amazonPayButton = amazonRef.Pay.renderButton('#amazonPayButton', settings);
-        amazonPayButton.onClick(handleOnClick);
+        amazonPayButton.onClick(() => void handleOnClick());
     };
 
     this.initCheckout = () => {

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayComponent.test.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayComponent.test.tsx
@@ -1,0 +1,118 @@
+import { createRef, h } from 'preact';
+import { render, screen, waitFor } from '@testing-library/preact';
+import AmazonPayComponent from './AmazonPayComponent';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
+import { AmountProvider } from '../../../core/Context/AmountProvider';
+import { AmazonPayComponentProps, AmazonWindowObject } from '../types';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
+import { mock } from 'jest-mock-extended';
+
+jest.mock('../../../utils/Script', () => {
+    return jest.fn().mockImplementation(() => {
+        return { load: jest.fn().mockResolvedValue(undefined), remove: jest.fn() };
+    });
+});
+
+const mockAmazonRef: AmazonWindowObject = {
+    Pay: {
+        renderButton: jest.fn().mockReturnValue({ onClick: jest.fn() }),
+        initCheckout: jest.fn(),
+        signout: jest.fn(),
+        bindChangeAction: jest.fn()
+    }
+};
+
+const core = setupCoreMock();
+
+const defaultProps: AmazonPayComponentProps = {
+    ...mock<AmazonPayComponentProps>(),
+    configuration: { region: 'EU', storeId: 'test-store' },
+    environment: 'TEST',
+    locale: 'en_GB',
+    clientKey: 'test_client_key',
+    showPayButton: true,
+    showSignOutButton: false,
+    showOrderButton: true,
+    showChangePaymentDetailsButton: false,
+    onClick: resolve => Promise.resolve(resolve()),
+    onSignOut: resolve => Promise.resolve(resolve()),
+    onError: jest.fn(),
+    setComponentRef: jest.fn()
+};
+
+const customRender = (props: Partial<AmazonPayComponentProps> = {}) => {
+    return render(
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources} analytics={core.modules.analytics}>
+            <AmountProvider amount={{ currency: 'EUR', value: 1000 }} providerRef={createRef()}>
+                <AmazonPayComponent {...defaultProps} {...props} />
+            </AmountProvider>
+        </CoreProvider>
+    );
+};
+
+describe('AmazonPayComponent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // @ts-ignore mock window.amazon
+        window.amazon = mockAmazonRef;
+    });
+
+    afterEach(() => {
+        // @ts-ignore cleanup
+        delete window.amazon;
+    });
+
+    test('should show a spinner while the Amazon Pay script is loading', () => {
+        // @ts-ignore remove amazon from window to simulate loading
+        delete window.amazon;
+        customRender();
+        expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    });
+
+    test('should render the AmazonPayButton when the script is loaded', async () => {
+        customRender();
+        await waitFor(() => {
+            expect(screen.getByTestId('amazon-pay-button')).toBeInTheDocument();
+        });
+    });
+
+    test('should render SignOutButton when showSignOutButton is true', async () => {
+        customRender({ showSignOutButton: true });
+        await waitFor(() => {
+            expect(screen.getByText('Sign out from Amazon')).toBeInTheDocument();
+        });
+    });
+
+    test('should render OrderButton when amazonCheckoutSessionId is provided', async () => {
+        customRender({
+            amazonCheckoutSessionId: 'test-session-id',
+            showOrderButton: true,
+            returnUrl: 'https://example.com'
+        });
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Confirm purchase' })).toBeInTheDocument();
+        });
+    });
+
+    test('should render ChangePaymentDetailsButton when showChangePaymentDetailsButton is true', async () => {
+        customRender({
+            amazonCheckoutSessionId: 'test-session-id',
+            showChangePaymentDetailsButton: true
+        });
+        await waitFor(() => {
+            expect(screen.getByTestId('amazon-pay-change-payment-details-button')).toBeInTheDocument();
+        });
+    });
+
+    test('should call setComponentRef on mount', async () => {
+        const setComponentRef = jest.fn();
+        customRender({ setComponentRef });
+        await waitFor(() => {
+            expect(setComponentRef).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    getSubmitFunction: expect.any(Function)
+                })
+            );
+        });
+    });
+});

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayComponent.test.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayComponent.test.tsx
@@ -115,4 +115,15 @@ describe('AmazonPayComponent', () => {
             );
         });
     });
+
+    test('getSubmitFunction should return a function when the AmazonPayButton is rendered', async () => {
+        const setComponentRef = jest.fn();
+        customRender({ setComponentRef });
+        await waitFor(() => {
+            expect(setComponentRef).toHaveBeenCalled();
+        });
+        const ref = setComponentRef.mock.calls[0][0];
+        const submitFn = ref.getSubmitFunction();
+        expect(typeof submitFn).toBe('function');
+    });
 });

--- a/packages/lib/src/components/AmazonPay/components/AmazonPayComponent.tsx
+++ b/packages/lib/src/components/AmazonPay/components/AmazonPayComponent.tsx
@@ -20,10 +20,17 @@ export default function AmazonPayComponent(props: Readonly<AmazonPayComponentPro
         setStatus('ready');
     };
 
-    this.getSubmitFunction = () => {
-        if (amazonPayButtonRef.current && amazonPayButtonRef.current.initCheckout) return () => amazonPayButtonRef.current.initCheckout();
-        if (orderButtonRef.current && orderButtonRef.current.createOrder) return () => orderButtonRef.current.createOrder();
-    };
+    const amazonPayRef = useRef({
+        getSubmitFunction: () => {
+            if (amazonPayButtonRef.current?.initCheckout) return () => amazonPayButtonRef.current.initCheckout();
+            if (orderButtonRef.current?.createOrder) return () => orderButtonRef.current.createOrder();
+            return null;
+        }
+    });
+
+    useEffect(() => {
+        props.setComponentRef(amazonPayRef.current);
+    }, [props.setComponentRef]);
 
     useEffect(() => {
         const src = getAmazonPayUrl(props.configuration.region);
@@ -88,7 +95,27 @@ export default function AmazonPayComponent(props: Readonly<AmazonPayComponentPro
 
     return (
         <div className="adyen-checkout__amazonpay">
-            <AmazonPayButton {...props} showPayButton={this.props.showPayButton} amazonRef={window.amazon} ref={amazonPayButtonRef} />
+            <AmazonPayButton
+                showPayButton={props.showPayButton}
+                amazonRef={window.amazon}
+                ref={amazonPayButtonRef}
+                buttonColor={props.buttonColor}
+                cancelUrl={props.cancelUrl}
+                chargePermissionType={props.chargePermissionType}
+                onClick={props.onClick}
+                onError={props.onError}
+                clientKey={props.clientKey}
+                configuration={props.configuration}
+                currency={props.currency}
+                deliverySpecifications={props.deliverySpecifications}
+                design={props.design}
+                environment={props.environment}
+                locale={props.locale}
+                placement={props.placement}
+                productType={props.productType}
+                recurringMetadata={props.recurringMetadata}
+                returnUrl={props.returnUrl}
+            />
         </div>
     );
 }

--- a/packages/lib/src/components/AmazonPay/components/ChangePaymentDetailsButton.test.tsx
+++ b/packages/lib/src/components/AmazonPay/components/ChangePaymentDetailsButton.test.tsx
@@ -1,0 +1,55 @@
+import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
+import ChangePaymentDetailsButton from './ChangePaymentDetailsButton';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
+import { AmazonWindowObject } from '../types';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
+
+const core = setupCoreMock();
+
+const mockAmazonRef: AmazonWindowObject = {
+    Pay: {
+        renderButton: jest.fn().mockReturnValue({ onClick: jest.fn() }),
+        initCheckout: jest.fn(),
+        signout: jest.fn(),
+        bindChangeAction: jest.fn()
+    }
+};
+
+const renderChangePaymentDetailsButton = (props = {}) => {
+    return render(
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
+            <ChangePaymentDetailsButton amazonCheckoutSessionId="test-session-id" amazonRef={mockAmazonRef} {...props} />
+        </CoreProvider>
+    );
+};
+
+describe('ChangePaymentDetailsButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should render a change address button', () => {
+        renderChangePaymentDetailsButton();
+        const button = screen.getByTestId('amazon-pay-change-payment-details-button');
+        expect(button).toBeInTheDocument();
+    });
+
+    test('should call bindChangeAction on mount with correct options', () => {
+        renderChangePaymentDetailsButton();
+        expect(mockAmazonRef.Pay.bindChangeAction).toHaveBeenCalledWith('.adyen-checkout__amazonpay__button--changeAddress', {
+            amazonCheckoutSessionId: 'test-session-id',
+            changeAction: 'changeAddress'
+        });
+    });
+
+    test('should pass the correct checkoutSessionId to bindChangeAction', () => {
+        renderChangePaymentDetailsButton({ amazonCheckoutSessionId: 'custom-session-123' });
+        expect(mockAmazonRef.Pay.bindChangeAction).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                amazonCheckoutSessionId: 'custom-session-123'
+            })
+        );
+    });
+});

--- a/packages/lib/src/components/AmazonPay/components/ChangePaymentDetailsButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/ChangePaymentDetailsButton.tsx
@@ -17,7 +17,11 @@ export default function ChangePaymentDetailsButton(props: Readonly<ChangePayment
     }, []);
 
     return (
-        <button type="button" className="adyen-checkout__button adyen-checkout__button--ghost adyen-checkout__amazonpay__button--changeAddress">
+        <button
+            type="button"
+            className="adyen-checkout__button adyen-checkout__button--ghost adyen-checkout__amazonpay__button--changeAddress"
+            data-testid="amazon-pay-change-payment-details-button"
+        >
             {i18n.get('amazonpay.changePaymentDetails')}
         </button>
     );

--- a/packages/lib/src/components/AmazonPay/components/OrderButton.test.tsx
+++ b/packages/lib/src/components/AmazonPay/components/OrderButton.test.tsx
@@ -122,4 +122,19 @@ describe('OrderButton', () => {
             expect(console.error).toHaveBeenCalledWith('Something went wrong');
         });
     });
+
+    test('should call onError when updateAmazonCheckoutSession rejects', async () => {
+        const onError = jest.fn();
+        const error = new Error('Network error');
+        (updateAmazonCheckoutSession as jest.Mock).mockRejectedValue(error);
+
+        const user = userEvent.setup();
+        renderOrderButton({ onError });
+
+        await user.click(screen.getByRole('button', { name: 'Confirm purchase' }));
+
+        await waitFor(() => {
+            expect(onError).toHaveBeenCalledWith(error, undefined);
+        });
+    });
 });

--- a/packages/lib/src/components/AmazonPay/components/OrderButton.test.tsx
+++ b/packages/lib/src/components/AmazonPay/components/OrderButton.test.tsx
@@ -1,0 +1,125 @@
+import { createRef, h } from 'preact';
+import { render, screen, waitFor } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import OrderButton from './OrderButton';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
+import { AmountProvider } from '../../../core/Context/AmountProvider';
+import { updateAmazonCheckoutSession } from '../services';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
+
+jest.mock('../services', () => ({
+    updateAmazonCheckoutSession: jest.fn()
+}));
+
+const core = setupCoreMock();
+
+const defaultProps = {
+    amazonCheckoutSessionId: 'test-session-id',
+    clientKey: 'test_client_key',
+    chargePermissionType: 'OneTime' as const,
+    onError: jest.fn(),
+    recurringMetadata: {
+        frequency: { unit: 'Month', value: 'Month' as const },
+        amount: { amount: '10.00', currencyCode: 'EUR' as const }
+    },
+    publicKeyId: 'test-public-key',
+    region: 'EU' as const,
+    returnUrl: 'https://example.com/return'
+};
+
+const renderOrderButton = (props = {}) => {
+    return render(
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
+            <AmountProvider amount={{ currency: 'EUR', value: 1000 }} providerRef={createRef()}>
+                {/* @ts-ignore ref is handled internally by preact */}
+                <OrderButton {...defaultProps} {...props} />
+            </AmountProvider>
+        </CoreProvider>
+    );
+};
+
+describe('OrderButton', () => {
+    const oldWindowLocation = window.location;
+
+    beforeAll(() => {
+        delete window.location;
+        // @ts-ignore test only
+        window.location = Object.defineProperties(
+            {},
+            {
+                ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+                assign: {
+                    configurable: true,
+                    value: jest.fn()
+                }
+            }
+        );
+    });
+
+    afterAll(() => {
+        window.location = oldWindowLocation as string & Location;
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should render a confirm purchase button', () => {
+        renderOrderButton();
+        expect(screen.getByRole('button', { name: 'Confirm purchase' })).toBeInTheDocument();
+    });
+
+    test('should call updateAmazonCheckoutSession when clicked', async () => {
+        (updateAmazonCheckoutSession as jest.Mock).mockResolvedValue({
+            action: { type: 'redirect', url: 'https://amazon.com/checkout' }
+        });
+
+        const user = userEvent.setup();
+        renderOrderButton();
+
+        await user.click(screen.getByRole('button', { name: 'Confirm purchase' }));
+
+        expect(updateAmazonCheckoutSession).toHaveBeenCalledWith(
+            'test',
+            'test_client_key',
+            expect.objectContaining({
+                checkoutSessionId: 'test-session-id',
+                checkoutResultReturnUrl: 'https://example.com/return',
+                publicKeyId: 'test-public-key',
+                region: 'EU'
+            })
+        );
+    });
+
+    test('should redirect when a redirect action is received', async () => {
+        (updateAmazonCheckoutSession as jest.Mock).mockResolvedValue({
+            action: { type: 'redirect', url: 'https://amazon.com/checkout' }
+        });
+
+        const user = userEvent.setup();
+        renderOrderButton();
+
+        await user.click(screen.getByRole('button', { name: 'Confirm purchase' }));
+
+        await waitFor(() => {
+            expect(window.location.assign).toHaveBeenCalledWith('https://amazon.com/checkout');
+        });
+    });
+
+    test('should log error if response has no action type', async () => {
+        (updateAmazonCheckoutSession as jest.Mock).mockResolvedValue({
+            errorMessage: 'Something went wrong'
+        });
+
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const user = userEvent.setup();
+        renderOrderButton();
+
+        await user.click(screen.getByRole('button', { name: 'Confirm purchase' }));
+
+        await waitFor(() => {
+            expect(console.error).toHaveBeenCalledWith('Something went wrong');
+        });
+    });
+});

--- a/packages/lib/src/components/AmazonPay/components/SignOutButton.test.tsx
+++ b/packages/lib/src/components/AmazonPay/components/SignOutButton.test.tsx
@@ -1,0 +1,63 @@
+import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import SignOutButton from './SignOutButton';
+import { CoreProvider } from '../../../core/Context/CoreProvider';
+import { AmazonWindowObject } from '../types';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
+
+const core = setupCoreMock();
+
+const mockAmazonRef: AmazonWindowObject = {
+    Pay: {
+        renderButton: jest.fn().mockReturnValue({ onClick: jest.fn() }),
+        initCheckout: jest.fn(),
+        signout: jest.fn(),
+        bindChangeAction: jest.fn()
+    }
+};
+
+const renderSignOutButton = (props = {}) => {
+    return render(
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
+            <SignOutButton amazonRef={mockAmazonRef} onSignOut={resolve => Promise.resolve(resolve())} {...props} />
+        </CoreProvider>
+    );
+};
+
+describe('SignOutButton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should render a sign out button', () => {
+        renderSignOutButton();
+        expect(screen.getByRole('button', { name: 'Sign out from Amazon' })).toBeInTheDocument();
+    });
+
+    test('should call amazonRef.Pay.signout when clicked and onSignOut resolves', async () => {
+        const user = userEvent.setup();
+        renderSignOutButton();
+
+        await user.click(screen.getByRole('button', { name: 'Sign out from Amazon' }));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(mockAmazonRef.Pay.signout).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not call signout if onSignOut rejects', async () => {
+        const user = userEvent.setup();
+        renderSignOutButton({
+            onSignOut: (_resolve: (value?: unknown) => void, reject: () => void) => {
+                reject();
+                return Promise.resolve();
+            }
+        });
+
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        await user.click(screen.getByRole('button', { name: 'Sign out from Amazon' }));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(mockAmazonRef.Pay.signout).not.toHaveBeenCalled();
+    });
+});

--- a/packages/lib/src/components/AmazonPay/components/SignOutButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/SignOutButton.tsx
@@ -6,8 +6,7 @@ export default function SignOutButton(props: Readonly<SignOutButtonProps>) {
     const { i18n } = useCoreContext();
 
     const handleClick = () => {
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        new Promise(props.onSignOut)
+        new Promise(() => void props.onSignOut())
             .then(() => {
                 props.amazonRef.Pay.signout();
             })
@@ -17,7 +16,7 @@ export default function SignOutButton(props: Readonly<SignOutButtonProps>) {
     return (
         <button
             type="button"
-            className="adyen-checkout__button  adyen-checkout__button--ghost adyen-checkout__amazonpay__button--signOut"
+            className="adyen-checkout__button adyen-checkout__button--ghost adyen-checkout__amazonpay__button--signOut"
             onClick={handleClick}
         >
             {i18n.get('amazonpay.signout')}

--- a/packages/lib/src/components/AmazonPay/components/SignOutButton.tsx
+++ b/packages/lib/src/components/AmazonPay/components/SignOutButton.tsx
@@ -6,7 +6,7 @@ export default function SignOutButton(props: Readonly<SignOutButtonProps>) {
     const { i18n } = useCoreContext();
 
     const handleClick = () => {
-        new Promise(() => void props.onSignOut())
+        new Promise((resolve, reject) => void props.onSignOut(resolve, reject))
             .then(() => {
                 props.amazonRef.Pay.signout();
             })

--- a/packages/lib/src/components/AmazonPay/defaultProps.test.ts
+++ b/packages/lib/src/components/AmazonPay/defaultProps.test.ts
@@ -1,0 +1,35 @@
+import defaultProps from './defaultProps';
+
+describe('defaultProps', () => {
+    test('should have the correct default values', () => {
+        expect(defaultProps.configuration).toEqual({});
+        expect(defaultProps.environment).toBe('TEST');
+        expect(defaultProps.locale).toBe('en_GB');
+        expect(defaultProps.placement).toBe('Cart');
+        expect(defaultProps.productType).toBe('PayAndShip');
+        expect(defaultProps.showOrderButton).toBe(true);
+        expect(defaultProps.showChangePaymentDetailsButton).toBe(false);
+        expect(defaultProps.showSignOutButton).toBe(false);
+        expect(defaultProps.isExpress).toBe(false);
+    });
+
+    test('should set cancelUrl to current window location', () => {
+        expect(defaultProps.cancelUrl).toBe(window.location.href);
+    });
+
+    test('should set returnUrl to current window location', () => {
+        expect(defaultProps.returnUrl).toBe(window.location.href);
+    });
+
+    test('onClick should resolve immediately', async () => {
+        const resolve = jest.fn();
+        await defaultProps.onClick(resolve, jest.fn());
+        expect(resolve).toHaveBeenCalled();
+    });
+
+    test('onSignOut should resolve immediately', async () => {
+        const resolve = jest.fn();
+        await defaultProps.onSignOut(resolve, jest.fn());
+        expect(resolve).toHaveBeenCalled();
+    });
+});

--- a/packages/lib/src/components/AmazonPay/defaultProps.ts
+++ b/packages/lib/src/components/AmazonPay/defaultProps.ts
@@ -11,8 +11,8 @@ const defaultProps: Partial<AmazonPayConfiguration> = {
     showOrderButton: true,
     showChangePaymentDetailsButton: false,
     showSignOutButton: false,
-    onClick: resolve => resolve(),
-    onSignOut: resolve => resolve(),
+    onClick: () => Promise.resolve(),
+    onSignOut: () => Promise.resolve(),
     isExpress: false
 };
 

--- a/packages/lib/src/components/AmazonPay/defaultProps.ts
+++ b/packages/lib/src/components/AmazonPay/defaultProps.ts
@@ -11,8 +11,8 @@ const defaultProps: Partial<AmazonPayConfiguration> = {
     showOrderButton: true,
     showChangePaymentDetailsButton: false,
     showSignOutButton: false,
-    onClick: () => Promise.resolve(),
-    onSignOut: () => Promise.resolve(),
+    onClick: resolve => Promise.resolve(resolve()),
+    onSignOut: resolve => Promise.resolve(resolve()),
     isExpress: false
 };
 

--- a/packages/lib/src/components/AmazonPay/services.ts
+++ b/packages/lib/src/components/AmazonPay/services.ts
@@ -9,7 +9,13 @@ import { CheckoutDetailsRequest, PayloadJSON, UpdateAmazonCheckoutSessionRequest
  * @param payloadJSON - Object to be signed
  * @returns A promise containing the response of the call
  */
-export function getAmazonSignature(loadingContext: string, clientKey: string, payloadJSON: PayloadJSON): Promise<any> {
+export function getAmazonSignature(
+    loadingContext: string,
+    clientKey: string,
+    payloadJSON: PayloadJSON
+): Promise<{
+    signature: string;
+}> {
     const options = {
         loadingContext,
         path: `${AMAZONPAY_SIGN_STRING_ENDPOINT}?clientKey=${clientKey}`
@@ -27,7 +33,15 @@ export function getAmazonSignature(loadingContext: string, clientKey: string, pa
  * @param request - Object to sent
  * @returns A promise containing the response of the call
  */
-export function getCheckoutDetails(loadingContext: string, clientKey: string, request: CheckoutDetailsRequest): Promise<any> {
+export function getCheckoutDetails(
+    loadingContext: string,
+    clientKey: string,
+    request: CheckoutDetailsRequest
+): Promise<
+    {
+        declineFlowUrl?: string;
+    } & Record<string, unknown>
+> {
     const options = {
         loadingContext,
         path: `${AMAZONPAY_GET_CHECKOUT_DETAILS_ENDPOINT}?clientKey=${clientKey}`
@@ -43,7 +57,17 @@ export function getCheckoutDetails(loadingContext: string, clientKey: string, re
  * @param data -
  * @returns A promise containing the response of the call
  */
-export function updateAmazonCheckoutSession(loadingContext: string, clientKey: string, data: UpdateAmazonCheckoutSessionRequest): Promise<any> {
+export function updateAmazonCheckoutSession(
+    loadingContext: string,
+    clientKey: string,
+    data: UpdateAmazonCheckoutSessionRequest
+): Promise<{
+    action?: {
+        type?: string;
+        url?: string;
+    };
+    errorMessage?: string;
+}> {
     const options = {
         loadingContext,
         path: `${AMAZONPAY_UPDATE_CHECKOUT_SESSION_ENDPOINT}?clientKey=${clientKey}`

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -1,15 +1,12 @@
 import { SUPPORTED_LOCALES_EU, SUPPORTED_LOCALES_US } from './config';
-import { UIElementProps } from '../internal/UIElement/types';
+import { ComponentMethodsRef, UIElementProps } from '../internal/UIElement/types';
 import { BrowserInfo, CheckoutAdvancedFlowResponse, PaymentAmount } from '../../types/global-types';
 import { AmazonPayElement } from './AmazonPay';
-import { h } from 'preact';
+import { h, RefObject } from 'preact';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
-
-declare global {
-    interface Window {
-        amazon: object;
-    }
-}
+import { AdyenCheckoutError, SubmitData, UIElement } from '../../types';
+import AmazonPayButton from './components/AmazonPayButton';
+import OrderButton from './components/OrderButton';
 
 type ButtonColor = 'Gold' | 'LightGray' | 'DarkGray';
 type Placement = 'Home' | 'Product' | 'Cart' | 'Checkout' | 'Other';
@@ -19,6 +16,19 @@ type FrequencyUnit = 'Year' | 'Month' | 'Week' | 'Day' | 'Variable';
 export type Currency = 'EUR' | 'GBP' | 'USD';
 export type Region = 'EU' | 'UK' | 'US';
 export type SupportedLocale = (typeof SUPPORTED_LOCALES_EU)[number] | (typeof SUPPORTED_LOCALES_US)[number];
+
+interface AmazonPayButtonInstance {
+    onClick(handler: () => void): void;
+}
+
+export interface AmazonWindowObject {
+    Pay: {
+        renderButton(selector: string, settings: AmazonPayButtonSettings): AmazonPayButtonInstance;
+        initCheckout(options: AmazonPayButtonSettings & { createCheckoutSessionConfig: CheckoutSessionConfig }): void;
+        signout(): void;
+        bindChangeAction(selector: string, options: ChangeActionOptions): void;
+    };
+}
 
 export interface RecurringMetadata {
     frequency: {
@@ -50,12 +60,13 @@ export interface AmazonPayConfiguration extends UIElementProps {
     configuration?: AmazonPayBackendConfiguration;
     currency?: Currency;
     deliverySpecifications?: DeliverySpecifications;
+    design?: string;
     environment?: string;
     loadingContext?: string;
     locale?: string;
     merchantMetadata?: MerchantMetadata;
     onSubmit?(
-        state: any,
+        state: SubmitData,
         element: AmazonPayElement,
         actions: {
             resolve: (response: CheckoutAdvancedFlowResponse) => void;
@@ -71,9 +82,9 @@ export interface AmazonPayConfiguration extends UIElementProps {
     showOrderButton?: boolean;
     showSignOutButton?: boolean;
     signature?: string;
-    onClick?: (resolve, reject) => Promise<void>;
-    onError?: (error, component) => void;
-    onSignOut?: (resolve, reject) => Promise<void>;
+    onClick?: () => Promise<void>;
+    onError?: (error: AdyenCheckoutError, component: UIElement) => void;
+    onSignOut?: () => Promise<void>;
 
     /**
      * Used for analytics
@@ -92,13 +103,11 @@ export interface AmazonPayComponentProps extends AmazonPayConfiguration {
     amazonCheckoutSessionId?: string;
     showOrderButton?: boolean;
     showChangePaymentDetailsButton?: boolean;
-    onClick: (resolve, reject) => Promise<void>;
-    onError: (error, component) => void;
-    onSignOut: (resolve, reject) => Promise<void>;
+    setComponentRef: (ref: ComponentMethodsRef & { getSubmitFunction?: () => () => void }) => void;
 }
 
 export interface AmazonPayButtonProps {
-    amazonRef: any;
+    amazonRef: AmazonWindowObject;
     buttonColor?: ButtonColor;
     cancelUrl?: string;
     chargePermissionType?: ChargePermissionType;
@@ -109,24 +118,24 @@ export interface AmazonPayButtonProps {
     design?: string;
     environment?: string;
     locale?: string;
-    onClick: (resolve, reject) => Promise<void>;
-    onError: (error, component) => void;
+    onClick: () => Promise<void>;
+    onError?: (error: AdyenCheckoutError, component: UIElement) => void;
     placement?: Placement;
     productType?: ProductType;
     recurringMetadata?: RecurringMetadata;
-    ref: any;
+    ref: RefObject<typeof AmazonPayButton>;
     returnUrl?: string;
     showPayButton: boolean;
 }
 
 export interface SignOutButtonProps {
-    amazonRef: any;
-    onSignOut: (resolve, reject) => Promise<void>;
+    amazonRef: AmazonWindowObject;
+    onSignOut: () => Promise<void>;
 }
 
 export interface ChangePaymentDetailsButtonProps {
     amazonCheckoutSessionId: string;
-    amazonRef: any;
+    amazonRef: AmazonWindowObject;
 }
 
 export interface ChangeActionOptions {
@@ -138,9 +147,9 @@ export interface OrderButtonProps {
     amazonCheckoutSessionId: string;
     clientKey: string;
     chargePermissionType?: ChargePermissionType;
-    onError: (error, component) => void;
+    onError: (error: AdyenCheckoutError, component: UIElement) => void;
     recurringMetadata: RecurringMetadata;
-    ref: any;
+    ref: RefObject<typeof OrderButton>;
     region: Region;
     returnUrl: string;
     publicKeyId: string;

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -5,8 +5,6 @@ import { AmazonPayElement } from './AmazonPay';
 import { h, RefObject } from 'preact';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 import { AdyenCheckoutError, SubmitData, UIElement } from '../../types';
-import AmazonPayButton from './components/AmazonPayButton';
-import OrderButton from './components/OrderButton';
 
 type ButtonColor = 'Gold' | 'LightGray' | 'DarkGray';
 type Placement = 'Home' | 'Product' | 'Cart' | 'Checkout' | 'Other';
@@ -82,9 +80,9 @@ export interface AmazonPayConfiguration extends UIElementProps {
     showOrderButton?: boolean;
     showSignOutButton?: boolean;
     signature?: string;
-    onClick?: () => Promise<void>;
+    onClick?: (resolve: (value?: unknown) => void, reject: () => void) => Promise<void>;
     onError?: (error: AdyenCheckoutError, component: UIElement) => void;
-    onSignOut?: () => Promise<void>;
+    onSignOut?: (resolve: (value?: unknown) => void, reject: () => void) => Promise<void>;
 
     /**
      * Used for analytics
@@ -118,19 +116,19 @@ export interface AmazonPayButtonProps {
     design?: string;
     environment?: string;
     locale?: string;
-    onClick: () => Promise<void>;
+    onClick: (resolve: (value?: unknown) => void, reject: () => void) => Promise<void>;
     onError?: (error: AdyenCheckoutError, component: UIElement) => void;
     placement?: Placement;
     productType?: ProductType;
     recurringMetadata?: RecurringMetadata;
-    ref: RefObject<typeof AmazonPayButton>;
+    ref: RefObject<{ initCheckout(): void }>;
     returnUrl?: string;
     showPayButton: boolean;
 }
 
 export interface SignOutButtonProps {
     amazonRef: AmazonWindowObject;
-    onSignOut: () => Promise<void>;
+    onSignOut: (resolve: (value?: unknown) => void, reject: () => void) => Promise<void>;
 }
 
 export interface ChangePaymentDetailsButtonProps {
@@ -149,7 +147,7 @@ export interface OrderButtonProps {
     chargePermissionType?: ChargePermissionType;
     onError: (error: AdyenCheckoutError, component: UIElement) => void;
     recurringMetadata: RecurringMetadata;
-    ref: RefObject<typeof OrderButton>;
+    ref: RefObject<{ createOrder(): void }>;
     region: Region;
     returnUrl: string;
     publicKeyId: string;

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -95,7 +95,6 @@ export interface AmazonPayComponentProps extends AmazonPayConfiguration {
     onClick: (resolve, reject) => Promise<void>;
     onError: (error, component) => void;
     onSignOut: (resolve, reject) => Promise<void>;
-    ref: any;
 }
 
 export interface AmazonPayButtonProps {

--- a/packages/lib/src/types/custom.d.ts
+++ b/packages/lib/src/types/custom.d.ts
@@ -1,6 +1,7 @@
 import { FastlaneWindowInstance, FastlaneOptions } from '../components/PayPalFastlane/types';
 import { ApplePayButtonStyle, ApplePayButtonType, ApplePayWebConfiguration } from '../components/ApplePay/types';
 import { IAdyenPasskey } from '../components/PayByBankPix/services/types';
+import { AmazonWindowObject } from '../types';
 
 declare module '@paypal/paypal-js' {
     export interface PayPalNamespace {
@@ -24,6 +25,7 @@ declare module 'preact' {
 
 declare global {
     interface Window {
+        amazon?: AmazonWindowObject;
         /**
          * ApplePaySession added by ApplePaySDK
          */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

Replace explicit and implicit any types throughout the AmazonPay component with proper type definitions, and add unit tests.

Type changes:
   •  Define AmazonWindowObject interface with typed Amazon Pay SDK methods (renderButton, initCheckout, signout, bindChangeAction) replacing generic object / Record<string, Function>
   •  Type onSubmit state parameter as SubmitData, onClick/onSignOut callbacks with proper signatures, and onError as (error: AdyenCheckoutError, component: UIElement) => void
   •  Add return types to service functions (getAmazonSignature, getCheckoutDetails, updateAmazonCheckoutSession)
   •  Add AmazonWindowObject to the global Window declaration in custom.d.ts
   •  Remove AmazonPay from the eslint ignore list

Refactoring:
   •  Replace implicit this ref pattern with useRef + setComponentRef in AmazonPayComponent
   •  Replace {...this.props} spread with explicit prop passing in AmazonPayComponent

Tests:
   •  Add new test files: AmazonPayButton.test.tsx, AmazonPayComponent.test.tsx, SignOutButton.test.tsx, ChangePaymentDetailsButton.test.tsx, OrderButton.test.tsx, defaultProps.test.ts
   •  Expand existing AmazonPay.test.tsx with tests for formatProps, formatData, submit, browserInfo, and handleDeclineFlow edge cases
   •  Increase default jest timeout to 10s in setup file

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

- COSDK-1068

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

