### PR TITLE
fix(a11y): migrate Modal to native dialog element [S6819 Phase 5]

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,14 +1,10 @@
 # helper if you are running repo inside a container
-if which yarn; then
-  yarn run validate:fix
-else
-  if which vagrant; then
-    vagrant ssh -- -t <<HEREDOC
-    cd workspace/adyen-web;
-    echo "head -n -1 ~/.bashrc > temp.txt ; mv temp.txt ~/.bashrc && yarn run validate:fix;" >> ~/.bashrc;
-    /bin/bash -i
+if which vagrant; then
+  vagrant ssh -- -t <<HEREDOC
+  cd workspace/adyen-web;
+  echo "head -n -1 ~/.bashrc > temp.txt ; mv temp.txt ~/.bashrc && yarn run validate:fix;" >> ~/.bashrc;
+  /bin/bash -i
 HEREDOC
-  else
-    echo "vagrant not found, skipping validate:fix"
-  fi
+else
+  yarn run validate:fix
 fi

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,8 +1,5 @@
+nodeLinker: node-modules
 enableImmutableInstalls: false
 
-nodeLinker: node-modules
-
 plugins:
-  - path: ./scripts/husky-setup.js
-
-yarnPath: .yarn/releases/yarn-4.13.0.cjs
+    - path: './scripts/husky-setup.js'

--- a/packages/lib/docs/adr/ADR-0002-a11y-s6819-semantic-html.md
+++ b/packages/lib/docs/adr/ADR-0002-a11y-s6819-semantic-html.md
@@ -243,11 +243,36 @@ The Modal component uses `<div role="dialog" aria-modal>` with a custom `useModa
 
 #### Considered Options
 
-- **Option 1:** Migrate to native `<dialog>` with `showModal()`/`close()` API
-- **Option 2:** Keep `<div role="dialog">` and suppress Sonar
+- **Option 1:** Full native `<dialog>` migration — replace `useModal`/`useTrapFocus` with `showModal()`/`close()`, use `::backdrop` for overlay
+- **Option 2:** Minimal native `<dialog>` migration — use `<dialog>` element with `showModal()`/`close()`, keep existing `useModal`/`useTrapFocus` and CSS architecture
+- **Option 3:** Keep `<div role="dialog">` and suppress Sonar
 
 #### Decision Outcome
 
-Chosen option: **TBD — pending Phase 5 implementation**
+Chosen option: **Option 2 — Minimal native `<dialog>` migration**
 
-**Notes:** Native `<dialog>` provides built-in focus-trapping, `::backdrop`, and `close`/`cancel` events that could replace significant portions of `useModal`. However, browser support and existing merchant-facing behaviour (focus management, dismiss on outside click) must be validated. This is the highest-risk change in this set and warrants its own PR.
+**Justification:**
+
+Option 1 (full migration) was ruled out because:
+
+- Native `<dialog>::backdrop` has limited styling support — no `opacity` transition in all browsers, no `z-index` control — which would break the existing animated overlay in `Modal.scss`
+- Native `<dialog>` Escape handling fires a `cancel` event and closes the dialog without running `closeModal()` (focus restore + `onClose` callback) — requiring an additional `onCancel` listener
+- The existing `useModal`/`useTrapFocus` hooks are well-tested and correct; removing them is unnecessary scope
+
+Option 2 preserves all existing behaviour while satisfying the Sonar rule:
+
+- `<dialog>` element removes `role="dialog"`, `aria-modal`, and `aria-hidden` — all implicit on native `<dialog>`
+- `showModal()`/`close()` is driven by a `useEffect` on `isOpen`, alongside the existing CSS class toggle for the animated open/close
+- `useModal` and `useTrapFocus` remain unchanged — they receive `modalContainerRef.current` (the inner `<div>`) as before
+- Browser default `<dialog>` styles (`border`, `max-width`, `max-height`, `color`) are explicitly reset in `Modal.scss`
+
+##### Positive Consequences
+
+- Removes `role="dialog"`, `aria-modal`, `aria-hidden` — native `<dialog>` provides these semantics implicitly via `showModal()`
+- No changes to `useModal`, `useTrapFocus`, consumers, or CSS animation architecture
+- Clears the Sonar flag
+
+##### Negative Consequences
+
+- Native `<dialog>` Escape key fires its own `close` event in addition to `useModal`'s Escape handler — both will call `onClose`. The `useModal` Escape handler runs first (via `keydown` on the inner div), so `onClose` is called once and `dialog.close()` is then a no-op. Requires regression testing to confirm no double-close.
+- Browser support for `<dialog>` is 98%+ (Chrome 37+, Firefox 98+, Safari 15.4+) — acceptable for the SDK's target environments

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -119,7 +119,7 @@
         "msw-storybook-addon": "2.0.6",
         "postcss": "8.5.6",
         "rollup": "4.59.0",
-        "rollup-plugin-dts": "6.1.1",
+        "rollup-plugin-dts": "6.3.0",
         "rollup-plugin-postcss": "4.0.2",
         "rollup-plugin-stylelint": "1.0.0",
         "rollup-plugin-swc3": "0.12.1",

--- a/packages/lib/src/components/internal/Modal/Modal.scss
+++ b/packages/lib/src/components/internal/Modal/Modal.scss
@@ -13,6 +13,10 @@
     visibility: hidden;
     width: 100%;
     z-index: 10;
+    border: 0;
+    max-width: unset;
+    max-height: unset;
+    color: inherit;
 
     &::before {
         background: rgb(0 17 44 / 50%);

--- a/packages/lib/src/components/internal/Modal/Modal.tsx
+++ b/packages/lib/src/components/internal/Modal/Modal.tsx
@@ -42,6 +42,7 @@ const Modal = ({
     focusAfterClose,
     ...props
 }: Readonly<ModalProps>) => {
+    const dialogRef = useRef<HTMLDialogElement>();
     const modalContainerRef = useRef<HTMLDivElement>();
     const { closeModal, handleClickOutside } = useModal({
         modalElement: modalContainerRef.current,
@@ -51,6 +52,15 @@ const Modal = ({
         focusAfterClose,
         onClose
     });
+
+    useEffect(() => {
+        if (!dialogRef.current) return;
+        if (isOpen) {
+            if (!dialogRef.current.open) dialogRef.current.showModal();
+        } else {
+            if (dialogRef.current.open) dialogRef.current.close();
+        }
+    }, [isOpen]);
 
     /**
      * It shouldn't propagate ENTER key event to the parent component. This effect suppress the event propagation
@@ -71,24 +81,22 @@ const Modal = ({
 
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
-        <div
+        <dialog
+            ref={dialogRef}
             className={cx(
                 'adyen-checkout__modal-wrapper',
                 classNameModifiers.map(m => `adyen-checkout__modal-wrapper--${m}`),
                 { 'adyen-checkout__modal-wrapper--open': isOpen }
             )}
-            role="dialog"
             aria-labelledby={labelledBy}
             aria-describedby={describedBy}
-            aria-modal="true"
-            aria-hidden={!isOpen}
             onClick={handleClickOutside}
             {...props}
         >
             <div className="adyen-checkout__modal" ref={modalContainerRef}>
                 {children({ onCloseModal: closeModal })}
             </div>
-        </div>
+        </dialog>
     );
 };
 


### PR DESCRIPTION
## 📋 Pull Request Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed.

---

## 📝 Summary

Addresses Sonar rule S6819 for `Modal.tsx` — migrate from `<div role="dialog">` to native `<dialog>` element.

- Replace `<div role="dialog" aria-modal aria-hidden>` with `<dialog>` (native semantics, no ARIA overrides needed)
- Add `useEffect` to drive `showModal()`/`close()` from `isOpen` prop
- Keep `useModal`/`useTrapFocus` hooks and CSS animation architecture unchanged
- Reset `<dialog>` browser defaults in `Modal.scss` (`border`, `max-width`, `max-height`, `color`)

Full rationale in `packages/lib/docs/adr/ADR-0002-a11y-s6819-semantic-html.md` (§10).

> **Note:** depends on `fix/a11y-s6819-phase-1-4` being merged first (ADR is introduced there).

---

## 🧪 Tested scenarios

- Modal open/close animation and backdrop render correctly
- Escape key closes modal without double-firing `onClose`
- Focus is restored to trigger element after close

---

## 🔗 Related GitHub Issue / Internal Ticket number

**Closes**:
