### PR TITLE
Analytics - Requesting attempt ID without blocking initialization

### DIFF
--- a/.changeset/new-zebras-throw.md
+++ b/.changeset/new-zebras-throw.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Attempt ID request blocking the UI rendering

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -239,9 +239,11 @@ describe('Analytics', () => {
             expect(eventQueue.infoEvents).toHaveLength(0);
         });
 
-        it('should send info events after debounce delay', async () => {
+        test('should send info events after debounce delay', async () => {
             const analytics = new Analytics({ service: mockService, eventQueue });
             await analytics.setUp({ locale: 'en-US' });
+
+            expect(mockService.sendEvents).not.toHaveBeenCalled();
 
             const infoEvent = new AnalyticsInfoEvent({ type: InfoEventType.rendered, component: 'card' });
             analytics.sendAnalytics(infoEvent);
@@ -253,9 +255,11 @@ describe('Analytics', () => {
             expect(mockService.sendEvents).toHaveBeenCalled();
         });
 
-        it('should send error/log events after shorter debounce delay', async () => {
+        test('should send error/log events after shorter debounce delay', async () => {
             const analytics = new Analytics({ service: mockService, eventQueue });
             await analytics.setUp({ locale: 'en-US' });
+
+            expect(mockService.sendEvents).not.toHaveBeenCalled();
 
             const errorEvent = new AnalyticsErrorEvent({
                 component: 'card',
@@ -352,7 +356,8 @@ describe('Analytics', () => {
 
             void analytics.sendFlavor('dropin');
             void analytics.sendFlavor('components');
-            void analytics.sendFlavor('dropin');
+
+            expect(mockService.reportIntegrationFlavor).not.toHaveBeenCalled();
 
             await analytics.setUp({ locale: 'en-US' });
 
@@ -380,8 +385,7 @@ describe('Analytics', () => {
             await analytics.setUp({ locale: 'en-US' });
 
             expect(callOrder[0]).toBe('flavor');
-            expect(callOrder).toContain('events');
-            expect(callOrder.indexOf('flavor')).toBeLessThan(callOrder.indexOf('events'));
+            expect(callOrder[1]).toBe('events');
         });
 
         test('should not dispatch queued flavor if setUp fails to obtain attempt ID', async () => {

--- a/packages/lib/src/core/Analytics/Analytics.test.ts
+++ b/packages/lib/src/core/Analytics/Analytics.test.ts
@@ -334,6 +334,68 @@ describe('Analytics', () => {
             expect(mockService.reportIntegrationFlavor).not.toHaveBeenCalled();
         });
 
+        test('should queue flavor when called before setUp and dispatch after setUp resolves', async () => {
+            const analytics = new Analytics({ service: mockService, eventQueue });
+
+            void analytics.sendFlavor('dropin');
+
+            expect(mockService.reportIntegrationFlavor).not.toHaveBeenCalled();
+
+            await analytics.setUp({ locale: 'en-US' });
+
+            expect(mockService.reportIntegrationFlavor).toHaveBeenCalledTimes(1);
+            expect(mockService.reportIntegrationFlavor).toHaveBeenCalledWith('dropin', MOCK_CHECKOUT_ATTEMPT_ID);
+        });
+
+        test('should keep the first queued flavor when sendFlavor is called multiple times before setUp', async () => {
+            const analytics = new Analytics({ service: mockService, eventQueue });
+
+            void analytics.sendFlavor('dropin');
+            void analytics.sendFlavor('components');
+            void analytics.sendFlavor('dropin');
+
+            await analytics.setUp({ locale: 'en-US' });
+
+            expect(mockService.reportIntegrationFlavor).toHaveBeenCalledTimes(1);
+            expect(mockService.reportIntegrationFlavor).toHaveBeenCalledWith('dropin', MOCK_CHECKOUT_ATTEMPT_ID);
+        });
+
+        test('should dispatch queued flavor before sending queued events when setUp resolves', async () => {
+            const callOrder: string[] = [];
+            mockService.reportIntegrationFlavor.mockImplementation(() => {
+                callOrder.push('flavor');
+                return Promise.resolve();
+            });
+            mockService.sendEvents.mockImplementation(() => {
+                callOrder.push('events');
+                return Promise.resolve();
+            });
+
+            const analytics = new Analytics({ service: mockService, eventQueue });
+
+            const infoEvent = new AnalyticsInfoEvent({ type: InfoEventType.rendered, component: 'card' });
+            analytics.sendAnalytics(infoEvent);
+            void analytics.sendFlavor('dropin');
+
+            await analytics.setUp({ locale: 'en-US' });
+
+            expect(callOrder[0]).toBe('flavor');
+            expect(callOrder).toContain('events');
+            expect(callOrder.indexOf('flavor')).toBeLessThan(callOrder.indexOf('events'));
+        });
+
+        test('should not dispatch queued flavor if setUp fails to obtain attempt ID', async () => {
+            jest.spyOn(console, 'warn').mockImplementation();
+            mockService.requestCheckoutAttemptId.mockRejectedValue(new Error('Network error'));
+
+            const analytics = new Analytics({ service: mockService, eventQueue });
+
+            void analytics.sendFlavor('dropin');
+            await analytics.setUp({ locale: 'en-US' });
+
+            expect(mockService.reportIntegrationFlavor).not.toHaveBeenCalled();
+        });
+
         it('should warn on flavor report failure', async () => {
             const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
             mockService.reportIntegrationFlavor.mockRejectedValue(new Error('Network error'));

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -71,7 +71,6 @@ class Analytics implements IAnalytics {
 
     private set checkoutAttemptId(checkoutAttemptId: string) {
         this._checkoutAttemptId = checkoutAttemptId;
-        void this.onCheckoutAttemptIdReceived();
     }
 
     public async setUp({
@@ -103,6 +102,8 @@ class Analytics implements IAnalytics {
             };
 
             this.checkoutAttemptId = await this.service.requestCheckoutAttemptId(payload);
+
+            this.dispatchPendingAnalytics();
 
             this.storage.set({
                 id: this.checkoutAttemptId,
@@ -183,7 +184,7 @@ class Analytics implements IAnalytics {
             return;
         }
 
-        if (!this.eventsQueue.hasEventsInQueue) {
+        if (!this.eventsQueue.hasEvents) {
             return;
         }
 
@@ -207,7 +208,7 @@ class Analytics implements IAnalytics {
     /**
      * Report the integration flavor and send queued analyic events once the attempt ID is available
      */
-    private onCheckoutAttemptIdReceived(): void {
+    private dispatchPendingAnalytics(): void {
         if (!this.isFlavorReported && this.pendingFlavor) {
             const flavor = this.pendingFlavor;
             this.pendingFlavor = undefined;

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -49,8 +49,8 @@ class Analytics implements IAnalytics {
     private readonly debouncedSendInfoEvents: () => void;
     private readonly debouncedSendEvents: () => void;
 
+    private _checkoutAttemptId?: string;
     private enabled: boolean = true;
-    private capturedCheckoutAttemptId?: string;
     private isFlavorReported = false;
     private pendingFlavor?: 'dropin' | 'components';
 
@@ -66,12 +66,12 @@ class Analytics implements IAnalytics {
     }
 
     public get checkoutAttemptId(): string {
-        return this.capturedCheckoutAttemptId;
+        return this._checkoutAttemptId;
     }
 
     private set checkoutAttemptId(checkoutAttemptId: string) {
-        this.capturedCheckoutAttemptId = checkoutAttemptId;
-        void this.onCheckoutAttemptIdReceived(checkoutAttemptId);
+        this._checkoutAttemptId = checkoutAttemptId;
+        void this.onCheckoutAttemptIdReceived();
     }
 
     public async setUp({
@@ -136,7 +136,7 @@ class Analytics implements IAnalytics {
     public async sendFlavor(flavor: 'dropin' | 'components'): Promise<void> {
         if (this.isFlavorReported) return;
 
-        if (!this.capturedCheckoutAttemptId) {
+        if (!this.checkoutAttemptId) {
             if (!this.pendingFlavor) this.pendingFlavor = flavor;
             return;
         }
@@ -146,7 +146,7 @@ class Analytics implements IAnalytics {
 
     private async dispatchFlavor(flavor: 'dropin' | 'components'): Promise<void> {
         if (this.isFlavorReported) return;
-        if (!this.capturedCheckoutAttemptId) return;
+        if (!this.checkoutAttemptId) return;
 
         this.isFlavorReported = true;
 
@@ -179,7 +179,11 @@ class Analytics implements IAnalytics {
     }
 
     private async sendEvents(): Promise<void> {
-        if (!this.capturedCheckoutAttemptId || !this.enabled) {
+        if (!this.checkoutAttemptId || !this.enabled) {
+            return;
+        }
+
+        if (!this.eventsQueue.hasEventsInQueue) {
             return;
         }
 
@@ -194,22 +198,22 @@ class Analytics implements IAnalytics {
         this.eventsQueue.clear();
 
         try {
-            await this.service.sendEvents(payload, this.capturedCheckoutAttemptId);
+            await this.service.sendEvents(payload, this.checkoutAttemptId);
         } catch (error) {
             console.warn('Analytics: Error sending events', error);
         }
     }
 
-    private async onCheckoutAttemptIdReceived(checkoutAttemptId: string): Promise<void> {
-        // TODO
-        console.log('Checkout attempt ID received:', checkoutAttemptId);
+    /**
+     * Report the integration flavor and send queued analyic events once the attempt ID is available
+     */
+    private onCheckoutAttemptIdReceived(): void {
+        const shouldReportFlavor = !this.isFlavorReported && this.pendingFlavor;
 
-        const hasIntegrationFlavorToBeReported = this.pendingFlavor && !this.isFlavorReported;
-
-        if (hasIntegrationFlavorToBeReported) {
+        if (shouldReportFlavor) {
             const flavor = this.pendingFlavor;
             this.pendingFlavor = undefined;
-            await this.dispatchFlavor(flavor);
+            void this.dispatchFlavor(flavor);
         }
 
         void this.sendEvents();

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -52,6 +52,7 @@ class Analytics implements IAnalytics {
     private enabled: boolean = true;
     private capturedCheckoutAttemptId?: string;
     private isFlavorReported = false;
+    private pendingFlavor?: 'dropin' | 'components';
 
     constructor({ service, eventQueue, enabled, analyticsData }: AnalyticsProps) {
         this.service = service;
@@ -66,6 +67,11 @@ class Analytics implements IAnalytics {
 
     public get checkoutAttemptId(): string {
         return this.capturedCheckoutAttemptId;
+    }
+
+    private set checkoutAttemptId(checkoutAttemptId: string) {
+        this.capturedCheckoutAttemptId = checkoutAttemptId;
+        void this.onCheckoutAttemptIdReceived(checkoutAttemptId);
     }
 
     public async setUp({
@@ -96,10 +102,10 @@ class Analytics implements IAnalytics {
                 ...(availableCheckoutAttemptId && { checkoutAttemptId: availableCheckoutAttemptId })
             };
 
-            this.capturedCheckoutAttemptId = await this.service.requestCheckoutAttemptId(payload);
+            this.checkoutAttemptId = await this.service.requestCheckoutAttemptId(payload);
 
             this.storage.set({
-                id: this.capturedCheckoutAttemptId,
+                id: this.checkoutAttemptId,
                 timestamp: isSessionReusable ? checkoutAttemptIdSession.timestamp : Date.now()
             });
         } catch (error: unknown) {
@@ -120,14 +126,32 @@ class Analytics implements IAnalytics {
         }
     }
 
+    /**
+     * Sends the integration flavor to the analytics service.
+     * If the checkout attempt ID is not available, it will be stored and sent when it becomes available.
+     *
+     * @param flavor The integration flavor to send.
+     * @returns A promise that resolves when the flavor is sent.
+     */
     public async sendFlavor(flavor: 'dropin' | 'components'): Promise<void> {
-        if (!this.capturedCheckoutAttemptId) return;
         if (this.isFlavorReported) return;
+
+        if (!this.capturedCheckoutAttemptId) {
+            if (!this.pendingFlavor) this.pendingFlavor = flavor;
+            return;
+        }
+
+        await this.dispatchFlavor(flavor);
+    }
+
+    private async dispatchFlavor(flavor: 'dropin' | 'components'): Promise<void> {
+        if (this.isFlavorReported) return;
+        if (!this.capturedCheckoutAttemptId) return;
 
         this.isFlavorReported = true;
 
         try {
-            await this.service.reportIntegrationFlavor(flavor, this.capturedCheckoutAttemptId);
+            await this.service.reportIntegrationFlavor(flavor, this.checkoutAttemptId);
         } catch (error) {
             console.warn('Analytics: Error reporting flavor', error);
         }
@@ -174,6 +198,21 @@ class Analytics implements IAnalytics {
         } catch (error) {
             console.warn('Analytics: Error sending events', error);
         }
+    }
+
+    private async onCheckoutAttemptIdReceived(checkoutAttemptId: string): Promise<void> {
+        // TODO
+        console.log('Checkout attempt ID received:', checkoutAttemptId);
+
+        const hasIntegrationFlavorToBeReported = this.pendingFlavor && !this.isFlavorReported;
+
+        if (hasIntegrationFlavorToBeReported) {
+            const flavor = this.pendingFlavor;
+            this.pendingFlavor = undefined;
+            await this.dispatchFlavor(flavor);
+        }
+
+        void this.sendEvents();
     }
 }
 

--- a/packages/lib/src/core/Analytics/Analytics.ts
+++ b/packages/lib/src/core/Analytics/Analytics.ts
@@ -65,7 +65,7 @@ class Analytics implements IAnalytics {
         if (analyticsData) this.analyticsData = analyticsData;
     }
 
-    public get checkoutAttemptId(): string {
+    public get checkoutAttemptId(): string | undefined {
         return this._checkoutAttemptId;
     }
 
@@ -83,9 +83,9 @@ class Analytics implements IAnalytics {
             const checkoutAttemptIdSession = this.storage.get();
             const isSessionReusable = isSessionCreatedUnderFifteenMinutes(checkoutAttemptIdSession);
 
-            const { applicationInfo, checkoutAttemptId: checkoutAttemptIdFromPayByLink } = processAnalyticsData(this.analyticsData);
+            const { applicationInfo, checkoutAttemptId: checkoutAttemptIdFromPayByLink } = processAnalyticsData(this.analyticsData) ?? {};
 
-            const availableCheckoutAttemptId: string | undefined = isSessionReusable ? checkoutAttemptIdSession.id : checkoutAttemptIdFromPayByLink;
+            const availableCheckoutAttemptId: string | undefined = isSessionReusable ? checkoutAttemptIdSession?.id : checkoutAttemptIdFromPayByLink;
 
             const payload: RequestAttemptIdPayload = {
                 version: LIBRARY_VERSION,
@@ -208,9 +208,7 @@ class Analytics implements IAnalytics {
      * Report the integration flavor and send queued analyic events once the attempt ID is available
      */
     private onCheckoutAttemptIdReceived(): void {
-        const shouldReportFlavor = !this.isFlavorReported && this.pendingFlavor;
-
-        if (shouldReportFlavor) {
+        if (!this.isFlavorReported && this.pendingFlavor) {
             const flavor = this.pendingFlavor;
             this.pendingFlavor = undefined;
             void this.dispatchFlavor(flavor);

--- a/packages/lib/src/core/Analytics/AnalyticsEventQueue.test.ts
+++ b/packages/lib/src/core/Analytics/AnalyticsEventQueue.test.ts
@@ -160,5 +160,59 @@ describe('AnalyticsEventQueue', () => {
 
             expect(infoEvents1).toBe(infoEvents2);
         });
+
+        describe('hasEventsInQueue', () => {
+            test('should return false when no events are in the queue', () => {
+                expect(queue.hasEventsInQueue).toBe(false);
+            });
+
+            test('should return true when info events are in the queue', () => {
+                const infoEvent = new AnalyticsInfoEvent({
+                    type: InfoEventType.rendered,
+                    component: 'card'
+                });
+
+                queue.add(infoEvent);
+
+                expect(queue.hasEventsInQueue).toBe(true);
+            });
+
+            test('should return true when error events are in the queue', () => {
+                const errorEvent = new AnalyticsErrorEvent({
+                    component: 'card',
+                    errorType: ErrorEventType.network,
+                    code: '500'
+                });
+
+                queue.add(errorEvent);
+
+                expect(queue.hasEventsInQueue).toBe(true);
+            });
+
+            test('should return true when log events are in the queue', () => {
+                const logEvent = new AnalyticsLogEvent({
+                    type: LogEventType.submit,
+                    component: 'card',
+                    message: 'Payment submitted'
+                });
+
+                queue.add(logEvent);
+
+                expect(queue.hasEventsInQueue).toBe(true);
+            });
+
+            test('should return false after clearing the queue', () => {
+                const infoEvent = new AnalyticsInfoEvent({
+                    type: InfoEventType.rendered,
+                    component: 'card'
+                });
+
+                queue.add(infoEvent);
+                expect(queue.hasEventsInQueue).toBe(true);
+
+                queue.clear();
+                expect(queue.hasEventsInQueue).toBe(false);
+            });
+        });
     });
 });

--- a/packages/lib/src/core/Analytics/AnalyticsEventQueue.test.ts
+++ b/packages/lib/src/core/Analytics/AnalyticsEventQueue.test.ts
@@ -161,9 +161,9 @@ describe('AnalyticsEventQueue', () => {
             expect(infoEvents1).toBe(infoEvents2);
         });
 
-        describe('hasEventsInQueue', () => {
+        describe('hasEvents', () => {
             test('should return false when no events are in the queue', () => {
-                expect(queue.hasEventsInQueue).toBe(false);
+                expect(queue.hasEvents).toBe(false);
             });
 
             test('should return true when info events are in the queue', () => {
@@ -174,7 +174,7 @@ describe('AnalyticsEventQueue', () => {
 
                 queue.add(infoEvent);
 
-                expect(queue.hasEventsInQueue).toBe(true);
+                expect(queue.hasEvents).toBe(true);
             });
 
             test('should return true when error events are in the queue', () => {
@@ -186,7 +186,7 @@ describe('AnalyticsEventQueue', () => {
 
                 queue.add(errorEvent);
 
-                expect(queue.hasEventsInQueue).toBe(true);
+                expect(queue.hasEvents).toBe(true);
             });
 
             test('should return true when log events are in the queue', () => {
@@ -198,7 +198,7 @@ describe('AnalyticsEventQueue', () => {
 
                 queue.add(logEvent);
 
-                expect(queue.hasEventsInQueue).toBe(true);
+                expect(queue.hasEvents).toBe(true);
             });
 
             test('should return false after clearing the queue', () => {
@@ -208,10 +208,10 @@ describe('AnalyticsEventQueue', () => {
                 });
 
                 queue.add(infoEvent);
-                expect(queue.hasEventsInQueue).toBe(true);
+                expect(queue.hasEvents).toBe(true);
 
                 queue.clear();
-                expect(queue.hasEventsInQueue).toBe(false);
+                expect(queue.hasEvents).toBe(false);
             });
         });
     });

--- a/packages/lib/src/core/Analytics/AnalyticsEventQueue.ts
+++ b/packages/lib/src/core/Analytics/AnalyticsEventQueue.ts
@@ -25,6 +25,10 @@ class AnalyticsEventQueue {
         return this.logs;
     }
 
+    public get hasEventsInQueue(): boolean {
+        return this.info.length > 0 || this.errors.length > 0 || this.logs.length > 0;
+    }
+
     public clear(): void {
         this.info = [];
         this.errors = [];

--- a/packages/lib/src/core/Analytics/AnalyticsEventQueue.ts
+++ b/packages/lib/src/core/Analytics/AnalyticsEventQueue.ts
@@ -25,7 +25,7 @@ class AnalyticsEventQueue {
         return this.logs;
     }
 
-    public get hasEventsInQueue(): boolean {
+    public get hasEvents(): boolean {
         return this.info.length > 0 || this.errors.length > 0 || this.logs.length > 0;
     }
 

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -112,6 +112,7 @@ describe('Core', () => {
 
         test('should not block the rendering while analytics is setting up', async () => {
             let resolveSetUp: () => void;
+            // Delay setUp call to simulate slow analytics setup
             analyticsSetupSpy.mockImplementation(
                 () =>
                     new Promise<void>(resolve => {

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -110,6 +110,28 @@ describe('Core', () => {
             expect(setupSessionSpy).toHaveBeenCalledWith(expect.objectContaining({ session: { id: 'session-id', sessionData: 'session-data' } }));
         });
 
+        test('should not block initialize() on analytics setUp (fire-and-forget)', async () => {
+            let resolveSetUp: () => void;
+            analyticsSetupSpy.mockImplementation(
+                () =>
+                    new Promise<void>(resolve => {
+                        resolveSetUp = resolve;
+                    })
+            );
+
+            const checkout = new AdyenCheckout({
+                countryCode: 'US',
+                environment: 'test',
+                clientKey: 'test_123456'
+            });
+
+            await checkout.initialize();
+
+            expect(analyticsSetupSpy).toHaveBeenCalled();
+            // resolve the pending promise so jest doesn't leak it
+            resolveSetUp();
+        });
+
         test('should call analytics setUp when initialized', async () => {
             const checkout = new AdyenCheckout({
                 countryCode: 'US',

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -10,6 +10,7 @@ import Redirect from '../components/Redirect';
 import { PaymentActionsType } from '../types/global-types';
 import Analytics from './Analytics';
 import type { CoreConfiguration } from './types';
+import type { DropinComponent } from '../components/Dropin/components/DropinComponent';
 
 jest.mock('./CheckoutSession');
 
@@ -35,7 +36,7 @@ const setupSessionSpy = jest.spyOn(Session.prototype, 'setupSession').mockImplem
     return Promise.resolve(sessionSetupResponseMock);
 });
 
-let analyticsSetupSpy;
+let analyticsSetupSpy: jest.SpyInstance;
 
 describe('Core', () => {
     beforeEach(() => {
@@ -111,7 +112,7 @@ describe('Core', () => {
         });
 
         test('should not block the rendering while analytics is setting up', async () => {
-            let resolveSetUp: () => void;
+            let resolveSetUp: () => void = () => {};
             // Delay setUp call to simulate slow analytics setup
             analyticsSetupSpy.mockImplementation(
                 () =>
@@ -226,7 +227,7 @@ describe('Core', () => {
                 url: 'https://example.com'
             }) as Redirect;
 
-            expect(paymentAction.constructor['type']).toBe('redirect');
+            expect((paymentAction.constructor as typeof Redirect).type).toBe('redirect');
             expect(paymentAction.props.url).toBe('https://example.com');
         });
 
@@ -248,7 +249,7 @@ describe('Core', () => {
 
             const actionComponent = checkout.createFromAction(fingerprintAction, { challengeWindowSize: '04' }) as ThreeDS2DeviceFingerprint;
 
-            expect(actionComponent.constructor['type']).toBe('threeDS2Fingerprint');
+            expect((actionComponent.constructor as typeof ThreeDS2DeviceFingerprint).type).toBe('threeDS2Fingerprint');
 
             expect(actionComponent.props.elementRef).not.toBeDefined();
             expect(actionComponent.props.showSpinner).toEqual(true);
@@ -274,7 +275,7 @@ describe('Core', () => {
 
             const actionComponent = checkout.createFromAction(challengeAction, { challengeWindowSize: '03' }) as ThreeDS2Challenge;
 
-            expect(actionComponent.constructor['type']).toBe('threeDS2Challenge');
+            expect((actionComponent.constructor as typeof ThreeDS2Challenge).type).toBe('threeDS2Challenge');
             expect(actionComponent.props.elementRef).not.toBeDefined();
             expect(actionComponent.props.statusType).toEqual('custom');
             expect(actionComponent.props.challengeWindowSize).toEqual('03');
@@ -384,7 +385,7 @@ describe('Core', () => {
             const flushPromises = () => new Promise(process.nextTick);
             await flushPromises();
 
-            const ach = dropin.dropinRef.state.elements[0];
+            const ach = (dropin.dropinRef as unknown as DropinComponent).state.elements[0];
 
             expect(ach.props.onAdditionalDetails).toBe(onAdditionalDetailsPaymentMethodConfig);
         });

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -385,7 +385,7 @@ describe('Core', () => {
             const flushPromises = () => new Promise(process.nextTick);
             await flushPromises();
 
-            const ach = (dropin.dropinRef as unknown as DropinComponent).state.elements[0];
+            const ach = (dropin.dropinRef as DropinComponent).state.elements[0];
 
             expect(ach.props.onAdditionalDetails).toBe(onAdditionalDetailsPaymentMethodConfig);
         });

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/preact';
+import { render, screen } from '@testing-library/preact';
 import AdyenCheckout from './core';
 import BCMCMobileElement from '../components/BcmcMobile';
 import Session from './CheckoutSession';
@@ -110,7 +110,7 @@ describe('Core', () => {
             expect(setupSessionSpy).toHaveBeenCalledWith(expect.objectContaining({ session: { id: 'session-id', sessionData: 'session-data' } }));
         });
 
-        test('should not block initialize() on analytics setUp (fire-and-forget)', async () => {
+        test('should not block the rendering while analytics is setting up', async () => {
             let resolveSetUp: () => void;
             analyticsSetupSpy.mockImplementation(
                 () =>
@@ -122,13 +122,28 @@ describe('Core', () => {
             const checkout = new AdyenCheckout({
                 countryCode: 'US',
                 environment: 'test',
-                clientKey: 'test_123456'
+                clientKey: 'test_123456',
+                paymentMethodsResponse: {
+                    paymentMethods: [
+                        {
+                            name: 'iDeal',
+                            type: 'ideal'
+                        }
+                    ]
+                }
             });
 
             await checkout.initialize();
-
             expect(analyticsSetupSpy).toHaveBeenCalled();
-            // resolve the pending promise so jest doesn't leak it
+
+            const ideal = new Redirect(checkout, {
+                type: 'ideal'
+            });
+
+            render(ideal.render());
+
+            expect(screen.getByRole('button', { name: 'Continue to iDeal' })).toBeInTheDocument();
+            // Resolve the pending promise so we don't leak it
             resolveSetUp();
         });
 

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -444,15 +444,9 @@ class Core implements ICore {
     }
 
     private async requestAnalyticsAttemptId(): Promise<void> {
-        /** SIMULATING DELAY FOR REQUESTING ID*/
-        return new Promise((resolve, _reject) => {
-            setTimeout(() => {
-                void this.modules.analytics.setUp({
-                    locale: this.options.locale,
-                    ...(this.session?.id && { sessionId: this.session.id })
-                });
-                resolve();
-            }, 15000);
+        await this.modules.analytics.setUp({
+            locale: this.options.locale,
+            ...(this.session?.id && { sessionId: this.session.id })
         });
     }
 }

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -106,12 +106,12 @@ class Core implements ICore {
     }
 
     public async initialize(): Promise<this> {
-        await this.initializeCore();
         this.validateCoreConfiguration();
+        await this.initializeCore();
         this.createCoreModules();
         this.assignLocaleToCore();
-        await Promise.allSettled([this.requestAnalyticsAttemptId(), this.requestTranslations()]);
-
+        void this.requestAnalyticsAttemptId();
+        await this.requestTranslations();
         return this;
     }
 
@@ -444,9 +444,15 @@ class Core implements ICore {
     }
 
     private async requestAnalyticsAttemptId(): Promise<void> {
-        await this.modules.analytics.setUp({
-            locale: this.options.locale,
-            ...(this.session?.id && { sessionId: this.session.id })
+        /** SIMULATING DELAY FOR REQUESTING ID*/
+        return new Promise((resolve, _reject) => {
+            setTimeout(() => {
+                void this.modules.analytics.setUp({
+                    locale: this.options.locale,
+                    ...(this.session?.id && { sessionId: this.session.id })
+                });
+                resolve();
+            }, 15000);
         });
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary
Attempt ID request was being awaited in the core initialization, potentially adding some delay for the UI to be rendered. This PR fixes it by not awaiting for it anymore. 

Changes:
- The request is done on `core.ts`  but not awaited anymore. It is fire-and-forget call.
- In the meantime, while the request is being executed, the analytics module might receive the flavor and events to be sent. The analytics module was adjusted to send this data once the attempt ID is available.

---

## 🧪 Tested scenarios
- Added tests to Core to make sure UI does not block if setUp is not finalized
- Added tests to Analytics module to make sure flavor and events are sent once attempt ID is fetched
- Manually added a delay to setup call, and checked that UI is not blocked and flavor + events are sent after ID is retrieved
- Tested that flavor is reported accordingly for dropin and components integration


