### PR TITLE
Fixing issues with binding & TS transpilation that emerged after merge

### DIFF
--- a/.changeset/upset-impalas-prove.md
+++ b/.changeset/upset-impalas-prove.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixing issues with binding & TS transpilation that emerged after merge with main

--- a/.changeset/upset-impalas-prove.md
+++ b/.changeset/upset-impalas-prove.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Fixing issues with binding & TS transpilation that emerged after merge with main
+Fixed: Issues with binding & TS transpilation that emerged after merge with main

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
@@ -35,9 +35,9 @@ const notConfiguredWarning = (str = 'You cannot use secured fields') => {
 };
 
 class CSF extends AbstractCSF {
-    protected override callbacks: CSFCallbacksConfig;
-    protected override config: CSFConfigObject;
-    protected override state: CSFStateObject;
+    declare protected callbacks: CSFCallbacksConfig;
+    declare protected config: CSFConfigObject;
+    declare protected state: CSFStateObject;
 
     constructor(setupObj: CSFSetupObject) {
         /**
@@ -80,9 +80,9 @@ class CSF extends AbstractCSF {
         const thisObj: CSFThisObject = { csfState: this.state, csfConfig: this.config, csfProps: this.props, csfCallbacks: this.callbacks };
 
         // Setup 'this' references
-        this.configHandler = handleConfig;
+        this.configHandler = handleConfig.bind(this);
 
-        this.callbacksHandler = configureCallbacks;
+        this.callbacksHandler = configureCallbacks.bind(this);
 
         this.validateForm = partial(validateForm, thisObj);
 
@@ -91,12 +91,12 @@ class CSF extends AbstractCSF {
 
         this.processBrand = partial(processBrand, thisObj);
 
-        this.handleValidation = handleValidation;
-        this.handleEncryption = handleEncryption;
+        this.handleValidation = handleValidation.bind(this);
+        this.handleEncryption = handleEncryption.bind(this);
 
-        this.createSecuredFields = createSecuredFields;
-        this.createNonCardSecuredFields = createNonCardSecuredFields;
-        this.createCardSecuredFields = createCardSecuredFields;
+        this.createSecuredFields = createSecuredFields.bind(this);
+        this.createNonCardSecuredFields = createNonCardSecuredFields.bind(this);
+        this.createCardSecuredFields = createCardSecuredFields.bind(this);
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.setupSecuredField = setupSecuredField;
 
@@ -111,18 +111,18 @@ class CSF extends AbstractCSF {
         this.setFocusOnFrame = partial(setFocusOnFrame, thisObj);
         this.handleFocus = partial(handleFocus, thisObj, this.handleIOSTouchEvents);
 
-        this.handleSFShiftTab = handleTab.handleSFShiftTab;
-        this.handleShiftTab = handleTab.handleShiftTab;
+        this.handleSFShiftTab = handleTab.handleSFShiftTab.bind(this);
+        this.handleShiftTab = handleTab.handleShiftTab.bind(this);
 
-        this.destroySecuredFields = destroySecuredFields;
+        this.destroySecuredFields = destroySecuredFields.bind(this);
 
         this.processAutoComplete = partial(processAutoComplete, thisObj);
 
         this.handleBinValue = partial(handleBinValue, thisObj);
 
-        this.handleBrandFromBinLookup = handleBrandFromBinLookup;
-        this.sendBrandToCardSF = sendBrandToCardSF;
-        this.sendExpiryDatePolicyToSF = sendExpiryDatePolicyToSF;
+        this.handleBrandFromBinLookup = handleBrandFromBinLookup.bind(this);
+        this.sendBrandToCardSF = sendBrandToCardSF.bind(this);
+        this.sendExpiryDatePolicyToSF = sendExpiryDatePolicyToSF.bind(this);
 
         // Populate config & callbacks objects & create securedFields
         this.init();

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/CSF.ts
@@ -97,8 +97,8 @@ class CSF extends AbstractCSF {
         this.createSecuredFields = createSecuredFields.bind(this);
         this.createNonCardSecuredFields = createNonCardSecuredFields.bind(this);
         this.createCardSecuredFields = createCardSecuredFields.bind(this);
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        this.setupSecuredField = setupSecuredField;
+         
+        this.setupSecuredField = setupSecuredField.bind(this);
 
         this.postMessageToAllIframes = partial(postMessageToAllIframes, thisObj);
 


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary

Fixing issues with binding in `CSF.ts` that emerged after merging Tech debt PR (#3922) with main.
It seems that the binding was never correct — it just happened to work before due to how the code was structured or how TypeScript was transpiling it. The type changes from the Tech debt PR, may have triggered a different transpilation path exposing a latent bug.

---

## 🧪 Tested scenarios

The card component can now render, which had stopped happening

