### PR TITLE
Optimize e2e test runners

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -1,0 +1,56 @@
+name: Setup E2E Environment
+description: >
+  Shared setup for E2E / Playwright jobs: checkout, Node + yarn cache,
+  corepack, install dependencies, extract Playwright version, and optionally
+  download a prebuilt Storybook artifact.
+
+inputs:
+  checkout-ref:
+    description: Git ref to check out. Defaults to the workflow's default ref.
+    required: false
+    default: ''
+  checkout-token:
+    description: Token used for checkout (needed when the job must push back).
+    required: false
+    default: ${{ github.token }}
+  storybook-artifact-name:
+    description: >
+      If set, downloads a Storybook build artifact produced by an upstream
+      `build-storybook` job into `packages/lib/storybook-static`. Leave empty
+      to skip.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.checkout-ref }}
+        token: ${{ inputs.checkout-token }}
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: yarn
+
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Install Project Dependencies
+      shell: bash
+      run: yarn install --immutable
+
+    - name: Extract Playwright version
+      shell: bash
+      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> "$GITHUB_ENV"
+
+    - name: Download prebuilt Storybook
+      if: inputs.storybook-artifact-name != ''
+      uses: actions/download-artifact@v5
+      with:
+        name: ${{ inputs.storybook-artifact-name }}
+        path: packages/lib/storybook-static

--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -50,3 +50,19 @@ runs:
       with:
         name: ${{ inputs.storybook-artifact-name }}
         path: packages/lib/storybook-static
+
+    # Diagnostic: confirm the artifact is in the exact layout expected by
+    # packages/server/index.js → `express.static('../lib/storybook-static')`.
+    # If `index.html` and `index.json` are NOT at the root of this listing,
+    # the webServer will 404 every request and every test will hit the 30s
+    # action timeout.
+    - name: Verify Storybook artifact layout
+      if: inputs.storybook-artifact-name != ''
+      shell: bash
+      run: |
+        echo "--- packages/lib/storybook-static ---"
+        ls -la packages/lib/storybook-static
+        echo
+        echo "--- sanity checks ---"
+        test -f packages/lib/storybook-static/index.html && echo "OK: index.html present" || { echo "FAIL: index.html missing"; exit 1; }
+        test -f packages/lib/storybook-static/index.json && echo "OK: index.json present" || { echo "FAIL: index.json missing"; exit 1; }

--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -1,18 +1,14 @@
 name: Setup E2E Environment
 description: >
-  Shared setup for E2E / Playwright jobs: checkout, Node + yarn cache,
-  corepack, install dependencies, extract Playwright version, and optionally
-  download a prebuilt Storybook artifact.
+  Shared setup for E2E / Playwright jobs: enable Corepack, Node + yarn cache,
+  install dependencies, extract Playwright version, and optionally download a
+  prebuilt Storybook artifact.
+
+  NOTE: callers MUST run `actions/checkout` themselves before invoking this
+  composite action, because GitHub needs to locate `action.yml` on disk before
+  it can run. We do not checkout here.
 
 inputs:
-  checkout-ref:
-    description: Git ref to check out. Defaults to the workflow's default ref.
-    required: false
-    default: ''
-  checkout-token:
-    description: Token used for checkout (needed when the job must push back).
-    required: false
-    default: ${{ github.token }}
   storybook-artifact-name:
     description: >
       If set, downloads a Storybook build artifact produced by an upstream
@@ -24,21 +20,21 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ inputs.checkout-ref }}
-        token: ${{ inputs.checkout-token }}
+    # Enable Corepack BEFORE setup-node so that `yarn --version` (invoked by
+    # setup-node's `cache: yarn` logic) resolves to the yarn version declared
+    # in package.json#packageManager (yarn 4.x), not the yarn 1.22 that ships
+    # globally on the runner / container image.
+    - name: Enable Corepack
+      shell: bash
+      run: |
+        corepack enable
+        corepack prepare --activate
 
     - name: Setup Node
       uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: yarn
-
-    - name: Enable Corepack
-      shell: bash
-      run: corepack enable
 
     - name: Install Project Dependencies
       shell: bash

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -10,6 +10,12 @@ jobs:
     timeout-minutes: 20
     outputs:
       playwright-version: ${{ steps.pw-version.outputs.version }}
+    env:
+      # Vite inlines these into the Storybook bundle at build time. Without
+      # them the SDK cannot initialize and a11y tests time out waiting for
+      # #component-root.
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
+      CLIENT_ENV: test
     steps:
       - uses: actions/checkout@v6
 
@@ -67,6 +73,8 @@ jobs:
       # Actions containers): overrides GitHub's HOME=/github/home so Firefox
       # and related browsers launch correctly.
       HOME: /root
+      # Silences "open /root/.docker/config.json: permission denied" warnings.
+      DOCKER_CONFIG: /tmp/.docker
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -13,14 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare --activate
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: yarn
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install Project Dependencies
         run: yarn install --immutable
@@ -63,6 +65,8 @@ jobs:
       API_VERSION: ${{ matrix.api-version }}
       STORYBOOK_PREBUILT: "1"
     steps:
+      - uses: actions/checkout@v6
+
       - name: Setup E2E environment
         uses: ./.github/actions/setup-e2e
         with:

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -61,9 +61,16 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
 
-    - name: Install Playwright Dependencies
+    - name: Install Playwright Browser
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
+      run: npx playwright install ${{ matrix.runner-browser }}
+
+    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
+    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
+    # be installed on every run — even on a cache hit — otherwise cached browser
+    # binaries fail to load their shared-library dependencies.
+    - name: Install Playwright System Dependencies
+      run: npx playwright install-deps ${{ matrix.runner-browser }}
 
     - name: Run Automated Accessibility Tests
       run: yarn test:automated-a11y --project=${{ matrix.runner-browser }}

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -4,75 +4,78 @@ on:
   workflow_call:
 
 jobs:
+  build-storybook:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      playwright-version: ${{ steps.pw-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Project Dependencies
+        run: yarn install --immutable
+
+      - name: Extract Playwright version
+        id: pw-version
+        run: echo "version=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Build Storybook
+        run: yarn build:storybook:e2e
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: storybook-static-${{ github.sha }}
+          path: packages/lib/storybook-static
+          retention-days: 1
+          if-no-files-found: error
+
   automated-a11y:
-    timeout-minutes: 60
+    name: A11y (${{ matrix.api-version }} / ${{ matrix.runner-browser }} / shard ${{ matrix.shard }})
+    needs: build-storybook
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
       options: --user 1001
     strategy:
       fail-fast: false
       matrix:
         api-version: ["v71"]
         runner-browser: ["chromium"]
+        shard: [1, 2]
     env:
-      CHECKOUT_API_KEY: ${{secrets.ADYEN_CHECKOUT_API_KEY}}
-      MERCHANT_ACCOUNT: ${{secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT}}
-      CLIENT_KEY: ${{secrets.ADYEN_CHECKOUT_CLIENT_KEY}}
+      CHECKOUT_API_KEY: ${{ secrets.ADYEN_CHECKOUT_API_KEY }}
+      MERCHANT_ACCOUNT: ${{ secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT }}
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
       CLIENT_ENV: test
-      TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{matrix.api-version}}
-      API_VERSION: ${{matrix.api-version}}
+      TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{ matrix.api-version }}
+      API_VERSION: ${{ matrix.api-version }}
+      STORYBOOK_PREBUILT: "1"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+      - name: Setup E2E environment
+        uses: ./.github/actions/setup-e2e
+        with:
+          storybook-artifact-name: storybook-static-${{ github.sha }}
 
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: 24
-        package-manager-cache: false
+      - name: Run Automated Accessibility Tests
+        run: yarn test:automated-a11y --project=${{ matrix.runner-browser }} --shard=${{ matrix.shard }}/2
 
-    - name: Cache node modules
-      id: node-modules-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: node-modules-v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
-    - name: Enable Corepack
-      run: corepack enable
-
-    - name: Install Project Dependencies
-      if: steps.node-modules-cache.outputs.cache-hit != 'true'
-      run: yarn install --immutable
-
-    - name: Extract Playwright version
-      id: playwright-version
-      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
-
-    - name: Cache Playwright
-      id: playwright-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: playwright-v1
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
-
-    - name: Install Playwright Dependencies
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
-
-    - name: Run Automated Accessibility Tests
-      run: yarn test:automated-a11y --project=${{ matrix.runner-browser }}
-
-    - name: Archive test result artifacts
-      id: upload-artifact
-      if: always()
-      uses: actions/upload-artifact@v6
-      with:
-        name: a11y-report-${{matrix.api-version}}-${{matrix.runner-browser}}-${{ github.sha }}
-        path: packages/e2e-playwright/playwright-report
-        retention-days: 5
+      - name: Upload HTML report (failures only)
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: a11y-report-${{ matrix.api-version }}-${{ matrix.runner-browser }}-${{ matrix.shard }}-${{ github.sha }}
+          path: packages/e2e-playwright/playwright-report
+          retention-days: 5
+          if-no-files-found: ignore

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -49,7 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
-      options: --user 1001
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -49,7 +49,7 @@ jobs:
           if-no-files-found: error
 
   automated-a11y:
-    name: A11y ${{ matrix.api-version }}-${{ matrix.runner-browser }} shard ${{ matrix.shard }}/2
+    name: A11y ${{ matrix.api-version }}-${{ matrix.runner-browser }} - ${{ matrix.shard }}/2
     needs: build-storybook
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -63,6 +63,10 @@ jobs:
       TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{ matrix.api-version }}
       API_VERSION: ${{ matrix.api-version }}
       STORYBOOK_PREBUILT: "1"
+      # Required when the Playwright container runs as root (default for GH
+      # Actions containers): overrides GitHub's HOME=/github/home so Firefox
+      # and related browsers launch correctly.
+      HOME: /root
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -49,7 +49,7 @@ jobs:
           if-no-files-found: error
 
   automated-a11y:
-    name: A11y (${{ matrix.api-version }} / ${{ matrix.runner-browser }} / shard ${{ matrix.shard }})
+    name: A11y ${{ matrix.api-version }}-${{ matrix.runner-browser }} shard ${{ matrix.shard }}/2
     needs: build-storybook
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -48,6 +48,23 @@ jobs:
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: yarn install --immutable
 
+    - name: Extract Playwright version
+      id: playwright-version
+      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
+
+    - name: Cache Playwright
+      id: playwright-cache
+      uses: actions/cache@v5
+      env:
+        cache-name: playwright-v1
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
+
+    - name: Install Playwright Dependencies
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
+
     - name: Run Automated Accessibility Tests
       run: yarn test:automated-a11y --project=${{ matrix.runner-browser }}
 

--- a/.github/workflows/automated-a11y.yml
+++ b/.github/workflows/automated-a11y.yml
@@ -61,16 +61,9 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
 
-    - name: Install Playwright Browser
+    - name: Install Playwright Dependencies
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install ${{ matrix.runner-browser }}
-
-    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
-    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
-    # be installed on every run — even on a cache hit — otherwise cached browser
-    # binaries fail to load their shared-library dependencies.
-    - name: Install Playwright System Dependencies
-      run: npx playwright install-deps ${{ matrix.runner-browser }}
+      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
 
     - name: Run Automated Accessibility Tests
       run: yarn test:automated-a11y --project=${{ matrix.runner-browser }}

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -61,16 +61,9 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
 
-    - name: Install Playwright Browser
+    - name: Install Playwright Dependencies
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install ${{ matrix.runner-browser }}
-
-    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
-    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
-    # be installed on every run — even on a cache hit — otherwise cached browser
-    # binaries fail to load their shared-library dependencies.
-    - name: Install Playwright System Dependencies
-      run: npx playwright install-deps ${{ matrix.runner-browser }}
+      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
 
     - name: Run Visual Tests
       run: yarn test:automated-visual --project=${{ matrix.runner-browser }}

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -13,14 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare --activate
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: yarn
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install Project Dependencies
         run: yarn install --immutable
@@ -63,6 +65,8 @@ jobs:
       API_VERSION: ${{ matrix.api-version }}
       STORYBOOK_PREBUILT: "1"
     steps:
+      - uses: actions/checkout@v6
+
       - name: Setup E2E environment
         uses: ./.github/actions/setup-e2e
         with:

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -48,6 +48,23 @@ jobs:
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: yarn install --immutable
 
+    - name: Extract Playwright version
+      id: playwright-version
+      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
+
+    - name: Cache Playwright
+      id: playwright-cache
+      uses: actions/cache@v5
+      env:
+        cache-name: playwright-v1
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
+
+    - name: Install Playwright Dependencies
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
+
     - name: Run Visual Tests
       run: yarn test:automated-visual --project=${{ matrix.runner-browser }}
 

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -61,9 +61,16 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
 
-    - name: Install Playwright Dependencies
+    - name: Install Playwright Browser
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
+      run: npx playwright install ${{ matrix.runner-browser }}
+
+    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
+    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
+    # be installed on every run — even on a cache hit — otherwise cached browser
+    # binaries fail to load their shared-library dependencies.
+    - name: Install Playwright System Dependencies
+      run: npx playwright install-deps ${{ matrix.runner-browser }}
 
     - name: Run Visual Tests
       run: yarn test:automated-visual --project=${{ matrix.runner-browser }}

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -49,7 +49,7 @@ jobs:
           if-no-files-found: error
 
   visual-tests:
-    name: Visual (${{ matrix.api-version }} / ${{ matrix.runner-browser }} / shard ${{ matrix.shard }})
+    name: Visual ${{ matrix.api-version }}-${{ matrix.runner-browser }}
     needs: build-storybook
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -60,7 +60,6 @@ jobs:
       matrix:
         api-version: ["v71"]
         runner-browser: ["chromium"]
-        shard: [1, 2]
     env:
       CHECKOUT_API_KEY: ${{ secrets.ADYEN_CHECKOUT_API_KEY }}
       MERCHANT_ACCOUNT: ${{ secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT }}
@@ -83,13 +82,15 @@ jobs:
           storybook-artifact-name: storybook-static-${{ github.sha }}
 
       - name: Run Visual Tests
-        run: yarn test:automated-visual --project=${{ matrix.runner-browser }} --shard=${{ matrix.shard }}/2
+        # Not sharded: the visual suite is a single spec with a for-loop;
+        # sharding would add container startup overhead without speedup.
+        run: yarn test:automated-visual --project=${{ matrix.runner-browser }}
 
       - name: Upload HTML report (failures only)
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: visual-report-${{ matrix.api-version }}-${{ matrix.runner-browser }}-${{ matrix.shard }}-${{ github.sha }}
+          name: visual-report-${{ matrix.api-version }}-${{ matrix.runner-browser }}-${{ github.sha }}
           path: packages/e2e-playwright/playwright-report
           retention-days: 5
           if-no-files-found: ignore

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -4,75 +4,78 @@ on:
   workflow_call:
 
 jobs:
+  build-storybook:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      playwright-version: ${{ steps.pw-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Project Dependencies
+        run: yarn install --immutable
+
+      - name: Extract Playwright version
+        id: pw-version
+        run: echo "version=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Build Storybook
+        run: yarn build:storybook:e2e
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: storybook-static-${{ github.sha }}
+          path: packages/lib/storybook-static
+          retention-days: 1
+          if-no-files-found: error
+
   visual-tests:
-    timeout-minutes: 60
+    name: Visual (${{ matrix.api-version }} / ${{ matrix.runner-browser }} / shard ${{ matrix.shard }})
+    needs: build-storybook
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
       options: --user 1001
     strategy:
       fail-fast: false
       matrix:
         api-version: ["v71"]
         runner-browser: ["chromium"]
+        shard: [1, 2]
     env:
-      CHECKOUT_API_KEY: ${{secrets.ADYEN_CHECKOUT_API_KEY}}
-      MERCHANT_ACCOUNT: ${{secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT}}
-      CLIENT_KEY: ${{secrets.ADYEN_CHECKOUT_CLIENT_KEY}}
+      CHECKOUT_API_KEY: ${{ secrets.ADYEN_CHECKOUT_API_KEY }}
+      MERCHANT_ACCOUNT: ${{ secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT }}
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
       CLIENT_ENV: test
-      TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{matrix.api-version}}
-      API_VERSION: ${{matrix.api-version}}
+      TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{ matrix.api-version }}
+      API_VERSION: ${{ matrix.api-version }}
+      STORYBOOK_PREBUILT: "1"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+      - name: Setup E2E environment
+        uses: ./.github/actions/setup-e2e
+        with:
+          storybook-artifact-name: storybook-static-${{ github.sha }}
 
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: 24
-        package-manager-cache: false
+      - name: Run Visual Tests
+        run: yarn test:automated-visual --project=${{ matrix.runner-browser }} --shard=${{ matrix.shard }}/2
 
-    - name: Cache node modules
-      id: node-modules-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: node-modules-v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
-    - name: Enable Corepack
-      run: corepack enable
-
-    - name: Install Project Dependencies
-      if: steps.node-modules-cache.outputs.cache-hit != 'true'
-      run: yarn install --immutable
-
-    - name: Extract Playwright version
-      id: playwright-version
-      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
-
-    - name: Cache Playwright
-      id: playwright-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: playwright-v1
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
-
-    - name: Install Playwright Dependencies
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
-
-    - name: Run Visual Tests
-      run: yarn test:automated-visual --project=${{ matrix.runner-browser }}
-
-    - name: Archive test result artifacts
-      id: upload-artifact
-      if: always()
-      uses: actions/upload-artifact@v6
-      with:
-        name: visual-report-${{matrix.api-version}}-${{matrix.runner-browser}}-${{ github.sha }}
-        path: packages/e2e-playwright/playwright-report
-        retention-days: 5
+      - name: Upload HTML report (failures only)
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: visual-report-${{ matrix.api-version }}-${{ matrix.runner-browser }}-${{ matrix.shard }}-${{ github.sha }}
+          path: packages/e2e-playwright/playwright-report
+          retention-days: 5
+          if-no-files-found: ignore

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -63,6 +63,9 @@ jobs:
       TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{ matrix.api-version }}
       API_VERSION: ${{ matrix.api-version }}
       STORYBOOK_PREBUILT: "1"
+      # Required when the Playwright container runs as root: overrides GitHub's
+      # HOME=/github/home so Firefox and related browsers launch correctly.
+      HOME: /root
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -10,6 +10,12 @@ jobs:
     timeout-minutes: 20
     outputs:
       playwright-version: ${{ steps.pw-version.outputs.version }}
+    env:
+      # Vite inlines these into the Storybook bundle at build time. Kept here
+      # for parity with a11y/e2e so screenshots don't differ based on whether
+      # CLIENT_KEY was present at build time.
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
+      CLIENT_ENV: test
     steps:
       - uses: actions/checkout@v6
 
@@ -66,6 +72,8 @@ jobs:
       # Required when the Playwright container runs as root: overrides GitHub's
       # HOME=/github/home so Firefox and related browsers launch correctly.
       HOME: /root
+      # Silences "open /root/.docker/config.json: permission denied" warnings.
+      DOCKER_CONFIG: /tmp/.docker
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/automated-visual.yml
+++ b/.github/workflows/automated-visual.yml
@@ -49,7 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
-      options: --user 1001
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -76,7 +76,7 @@ jobs:
         cache-name: webkit-apt-v1
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-${{ runner.version }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        key: ${{ runner.os }}-${{ runner.name }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
     # For webkit we always run `install --with-deps` — even on a Playwright cache
     # hit — because its system libs live under /usr/lib (not in ~/.cache/ms-playwright)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,16 +61,29 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
 
-    - name: Install Playwright Browser
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install ${{ matrix.runner-browser }}
+    # Webkit needs extra apt packages (libwoff2dec, libvpx, libevent, libopus,
+    # libgstreamer-*, libharfbuzz-icu, libenchant-2, libsecret-1, libhyphen,
+    # libmanette, libflite, libgles2, etc.) that live under /usr/lib and are NOT
+    # inside ~/.cache/ms-playwright. Caching the downloaded .deb files makes
+    # `playwright install --with-deps` skip the network download on subsequent
+    # runs. Key is scoped to OS + runner image version so it invalidates when
+    # GitHub rolls the ubuntu image.
+    - name: Cache webkit system libraries
+      if: matrix.runner-browser == 'webkit'
+      id: webkit-libs-cache
+      uses: actions/cache@v5
+      env:
+        cache-name: webkit-apt-v1
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
-    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
-    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
-    # be installed on every run — even on a cache hit — otherwise cached browser
-    # binaries fail to load their shared-library dependencies.
-    - name: Install Playwright System Dependencies
-      run: npx playwright install-deps ${{ matrix.runner-browser }}
+    # For webkit we always run `install --with-deps` — even on a Playwright cache
+    # hit — because its system libs live under /usr/lib (not in ~/.cache/ms-playwright)
+    # and would otherwise be missing. With the apt cache above, this is fast.
+    - name: Install Playwright Dependencies
+      if: steps.playwright-cache.outputs.cache-hit != 'true' || matrix.runner-browser == 'webkit'
+      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
 
     - name: Run E2E Tests
       run: yarn test:e2e --project=${{ matrix.runner-browser }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,6 +48,23 @@ jobs:
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: yarn install --immutable
 
+    - name: Extract Playwright version
+      id: playwright-version
+      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
+
+    - name: Cache Playwright
+      id: playwright-cache
+      uses: actions/cache@v5
+      env:
+        cache-name: playwright-v1
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
+
+    - name: Install Playwright Dependencies
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
+
     - name: Run E2E Tests
       run: yarn test:e2e --project=${{ matrix.runner-browser }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,14 +19,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Enable Corepack before setup-node so `cache: yarn` sees yarn 4.x, not 1.22.
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare --activate
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: yarn
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install Project Dependencies
         run: yarn install --immutable
@@ -77,6 +80,10 @@ jobs:
       # the prebuilt artifact has already been downloaded into packages/lib/storybook-static.
       STORYBOOK_PREBUILT: "1"
     steps:
+      # Local composite actions require the repo on disk before `uses: ./...`
+      # can resolve action.yml, so we checkout explicitly here.
+      - uses: actions/checkout@v6
+
       - name: Setup E2E environment
         uses: ./.github/actions/setup-e2e
         with:
@@ -114,6 +121,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/checkout@v6
+
       - name: Setup E2E environment
         uses: ./.github/actions/setup-e2e
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
   # preinstalled (especially important for webkit).
   # ---------------------------------------------------------------------------
   e2e-tests:
-    name: E2E ${{ matrix.api-version }}-${{ matrix.runner-browser }} shard ${{ matrix.shard }}/4
+    name: E2E ${{ matrix.api-version }}-${{ matrix.runner-browser }} - ${{ matrix.shard }}/4
     needs: build-storybook
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
   # preinstalled (especially important for webkit).
   # ---------------------------------------------------------------------------
   e2e-tests:
-    name: E2E (${{ matrix.api-version }} / ${{ matrix.runner-browser }} / shard ${{ matrix.shard }})
+    name: E2E ${{ matrix.api-version }}-${{ matrix.runner-browser }} shard ${{ matrix.shard }}/4
     needs: build-storybook
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,95 +4,134 @@ on:
   workflow_call:
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Build Storybook once; all sharded test jobs download the artifact and skip
+  # the Storybook build inside Playwright's webServer command (STORYBOOK_PREBUILT=1).
+  # Also exposes PLAYWRIGHT_VERSION so downstream jobs can pin the Playwright
+  # Docker image to the exact version from packages/e2e-playwright/package.json.
+  # ---------------------------------------------------------------------------
+  build-storybook:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      playwright-version: ${{ steps.pw-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Project Dependencies
+        run: yarn install --immutable
+
+      - name: Extract Playwright version
+        id: pw-version
+        run: echo "version=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Build Storybook
+        run: yarn build:storybook:e2e
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: storybook-static-${{ github.sha }}
+          path: packages/lib/storybook-static
+          retention-days: 1
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Sharded E2E tests: 3 API versions x 3 browsers x 4 shards = 36 parallel jobs.
+  # Runs inside the official Playwright container so browsers + system libs are
+  # preinstalled (especially important for webkit).
+  # ---------------------------------------------------------------------------
   e2e-tests:
-    timeout-minutes: 120
+    name: E2E (${{ matrix.api-version }} / ${{ matrix.runner-browser }} / shard ${{ matrix.shard }})
+    needs: build-storybook
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
       options: --user 1001
     strategy:
       fail-fast: false
+      max-parallel: 36
       matrix:
         api-version: ["v69", "v70", "v71"]
         runner-browser: ["chromium", "firefox", "webkit"]
+        shard: [1, 2, 3, 4]
     env:
-      CHECKOUT_API_KEY: ${{secrets.ADYEN_CHECKOUT_API_KEY}}
-      MERCHANT_ACCOUNT: ${{secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT}}
-      CLIENT_KEY: ${{secrets.ADYEN_CHECKOUT_CLIENT_KEY}}
+      CHECKOUT_API_KEY: ${{ secrets.ADYEN_CHECKOUT_API_KEY }}
+      MERCHANT_ACCOUNT: ${{ secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT }}
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
       CLIENT_ENV: test
-      TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{matrix.api-version}}
-      API_VERSION: ${{matrix.api-version}}
+      TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/${{ matrix.api-version }}
+      API_VERSION: ${{ matrix.api-version }}
+      # Tell playwright.config.ts webServer to skip `build:storybook:e2e` since
+      # the prebuilt artifact has already been downloaded into packages/lib/storybook-static.
+      STORYBOOK_PREBUILT: "1"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+      - name: Setup E2E environment
+        uses: ./.github/actions/setup-e2e
+        with:
+          storybook-artifact-name: storybook-static-${{ github.sha }}
 
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: 24
-        package-manager-cache: false
+      - name: Run E2E Tests
+        run: yarn test:e2e --project=${{ matrix.runner-browser }} --shard=${{ matrix.shard }}/4
 
-    - name: Cache node modules
-      id: node-modules-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: node-modules-v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Upload blob report (for merge)
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: blob-report-${{ matrix.api-version }}-${{ matrix.runner-browser }}-${{ matrix.shard }}
+          path: packages/e2e-playwright/blob-report
+          retention-days: 1
+          if-no-files-found: ignore
 
-    - name: Enable Corepack
-      run: corepack enable
+      - name: Upload HTML report (failures only)
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report-${{ matrix.api-version }}-${{ matrix.runner-browser }}-${{ matrix.shard }}-${{ github.sha }}
+          path: packages/e2e-playwright/playwright-report
+          retention-days: 5
+          if-no-files-found: ignore
 
-    - name: Install Project Dependencies
-      if: steps.node-modules-cache.outputs.cache-hit != 'true'
-      run: yarn install --immutable
+  # ---------------------------------------------------------------------------
+  # Merge blob reports from all shards into a single HTML report.
+  # Runs even when some shards fail so the merged report always reflects reality.
+  # ---------------------------------------------------------------------------
+  merge-reports:
+    name: Merge Playwright Reports
+    needs: e2e-tests
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Setup E2E environment
+        uses: ./.github/actions/setup-e2e
 
-    - name: Extract Playwright version
-      id: playwright-version
-      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
+      - name: Download all blob reports
+        uses: actions/download-artifact@v5
+        with:
+          pattern: blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
 
-    - name: Cache Playwright
-      id: playwright-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: playwright-v1
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
+      - name: Merge into HTML report
+        run: npx playwright merge-reports --reporter html ../../all-blob-reports
+        working-directory: packages/e2e-playwright
 
-    # Webkit needs extra apt packages (libwoff2dec, libvpx, libevent, libopus,
-    # libgstreamer-*, libharfbuzz-icu, libenchant-2, libsecret-1, libhyphen,
-    # libmanette, libflite, libgles2, etc.) that live under /usr/lib and are NOT
-    # inside ~/.cache/ms-playwright. Caching the downloaded .deb files makes
-    # `playwright install --with-deps` skip the network download on subsequent
-    # runs. Key is scoped to OS + runner image version so it invalidates when
-    # GitHub rolls the ubuntu image.
-    - name: Cache webkit system libraries
-      if: matrix.runner-browser == 'webkit'
-      id: webkit-libs-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: webkit-apt-v1
-      with:
-        path: /var/cache/apt/archives
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-
-    # For webkit we always run `install --with-deps` — even on a Playwright cache
-    # hit — because its system libs live under /usr/lib (not in ~/.cache/ms-playwright)
-    # and would otherwise be missing. With the apt cache above, this is fast.
-    - name: Install Playwright Dependencies
-      if: steps.playwright-cache.outputs.cache-hit != 'true' || matrix.runner-browser == 'webkit'
-      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
-
-    - name: Run E2E Tests
-      run: yarn test:e2e --project=${{ matrix.runner-browser }}
-
-    - name: Archive test result artifacts
-      id: upload-artifact
-      if: always()
-      uses: actions/upload-artifact@v6
-      with:
-        name: playwright-report-${{matrix.api-version}}-${{matrix.runner-browser}}-${{ github.sha }}
-        path: packages/e2e-playwright/playwright-report
-        retention-days: 5
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v6
+        with:
+          name: merged-html-report-${{ github.sha }}
+          path: packages/e2e-playwright/playwright-report
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,6 +78,10 @@ jobs:
       # Tell playwright.config.ts webServer to skip `build:storybook:e2e` since
       # the prebuilt artifact has already been downloaded into packages/lib/storybook-static.
       STORYBOOK_PREBUILT: "1"
+      # GitHub sets HOME=/github/home (owned by uid 1001) but the Playwright
+      # container runs as root. Firefox refuses to launch in that combo; chromium
+      # and webkit have related issues. Override HOME to /root (the root user's home).
+      HOME: /root
     steps:
       # Local composite actions require the repo on disk before `uses: ./...`
       # can resolve action.yml, so we checkout explicitly here.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,13 @@ jobs:
     timeout-minutes: 20
     outputs:
       playwright-version: ${{ steps.pw-version.outputs.version }}
+    env:
+      # Vite's loadEnv() inlines CLIENT_KEY and CLIENT_ENV into the Storybook
+      # bundle at build time (see packages/lib/config/environment-variables.js).
+      # Without these, the SDK cannot initialize in the browser, #component-root
+      # never renders, and a11y + e2e tests time out waiting for it.
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
+      CLIENT_ENV: test
     steps:
       - uses: actions/checkout@v6
 
@@ -82,6 +89,9 @@ jobs:
       # container runs as root. Firefox refuses to launch in that combo; chromium
       # and webkit have related issues. Override HOME to /root (the root user's home).
       HOME: /root
+      # Avoid "open /root/.docker/config.json: permission denied" warnings when
+      # tooling probes docker config — point docker CLI at a writable temp dir.
+      DOCKER_CONFIG: /tmp/.docker
     steps:
       # Local composite actions require the repo on disk before `uses: ./...`
       # can resolve action.yml, so we checkout explicitly here.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
-      options: --user 1001
     strategy:
       fail-fast: false
       max-parallel: 36

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -76,7 +76,7 @@ jobs:
         cache-name: webkit-apt-v1
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-${{ runner.name }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
     # For webkit we always run `install --with-deps` — even on a Playwright cache
     # hit — because its system libs live under /usr/lib (not in ~/.cache/ms-playwright)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -76,7 +76,7 @@ jobs:
         cache-name: webkit-apt-v1
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        key: ${{ runner.os }}-${{ runner.version }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
     # For webkit we always run `install --with-deps` — even on a Playwright cache
     # hit — because its system libs live under /usr/lib (not in ~/.cache/ms-playwright)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,9 +61,16 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-browser-${{ matrix.runner-browser }}
 
-    - name: Install Playwright Dependencies
+    - name: Install Playwright Browser
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps ${{ matrix.runner-browser }}
+      run: npx playwright install ${{ matrix.runner-browser }}
+
+    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
+    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
+    # be installed on every run — even on a cache hit — otherwise cached browser
+    # binaries fail to load their shared-library dependencies.
+    - name: Install Playwright System Dependencies
+      run: npx playwright install-deps ${{ matrix.runner-browser }}
 
     - name: Run E2E Tests
       run: yarn test:e2e --project=${{ matrix.runner-browser }}

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -19,14 +19,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare --activate
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: yarn
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install Project Dependencies
         run: yarn install --immutable
@@ -65,11 +67,15 @@ jobs:
       API_VERSION: v71
       STORYBOOK_PREBUILT: "1"
     steps:
+      # Checkout the PR branch so screenshot commits push back to the correct ref.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup E2E environment
         uses: ./.github/actions/setup-e2e
         with:
-          checkout-ref: ${{ github.event.pull_request.head.ref }}
-          checkout-token: ${{ secrets.GITHUB_TOKEN }}
           storybook-artifact-name: storybook-static-${{ github.sha }}
 
       - name: Update automated visual test screenshots

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -65,6 +65,9 @@ jobs:
       TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/v71
       API_VERSION: v71
       STORYBOOK_PREBUILT: "1"
+      # Required when the Playwright container runs as root: overrides GitHub's
+      # HOME=/github/home so Firefox and related browsers launch correctly.
+      HOME: /root
     steps:
       # Checkout the PR branch so screenshot commits push back to the correct ref.
       - uses: actions/checkout@v6

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -76,7 +76,7 @@ jobs:
         cache-name: webkit-apt-v1
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-${{ runner.name }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
     # We always run `install --with-deps` — even on a Playwright cache hit —
     # because webkit's system libs live under /usr/lib (not in ~/.cache/ms-playwright)

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -85,7 +85,6 @@ jobs:
 
       - name: Commit updated screenshots
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add packages/e2e-playwright/tests/

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -76,7 +76,7 @@ jobs:
         cache-name: webkit-apt-v1
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-${{ runner.version }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        key: ${{ runner.os }}-${{ runner.name }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
     # We always run `install --with-deps` — even on a Playwright cache hit —
     # because webkit's system libs live under /usr/lib (not in ~/.cache/ms-playwright)

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -13,6 +13,11 @@ jobs:
     timeout-minutes: 20
     outputs:
       playwright-version: ${{ steps.pw-version.outputs.version }}
+    env:
+      # Vite inlines these into the Storybook bundle at build time (see
+      # packages/lib/config/environment-variables.js). Required for SDK init.
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
+      CLIENT_ENV: test
     steps:
       - uses: actions/checkout@v6
         with:
@@ -68,6 +73,8 @@ jobs:
       # Required when the Playwright container runs as root: overrides GitHub's
       # HOME=/github/home so Firefox and related browsers launch correctly.
       HOME: /root
+      # Silences "open /root/.docker/config.json: permission denied" warnings.
+      DOCKER_CONFIG: /tmp/.docker
     steps:
       # Checkout the PR branch so screenshot commits push back to the correct ref.
       - uses: actions/checkout@v6

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -49,6 +49,30 @@ jobs:
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: yarn install --immutable
 
+    - name: Extract Playwright version
+      id: playwright-version
+      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
+
+    - name: Cache Playwright
+      id: playwright-cache
+      uses: actions/cache@v5
+      env:
+        cache-name: playwright-v1
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-all-browsers
+
+    - name: Install Playwright Browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: npx playwright install
+
+    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
+    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
+    # be installed on every run — even on a cache hit — otherwise cached browser
+    # binaries fail to load their shared-library dependencies.
+    - name: Install Playwright System Dependencies
+      run: npx playwright install-deps
+
     - name: Update automated visual tests screenshots
       run: yarn test:automated-visual:update-screenshots
 

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -5,122 +5,109 @@ on:
     types: [labeled]
 
 jobs:
+  # Build Storybook once (no container needed here).
+  build-storybook:
+    if: github.event.label.name == 'screenshot'
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      playwright-version: ${{ steps.pw-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Project Dependencies
+        run: yarn install --immutable
+
+      - name: Extract Playwright version
+        id: pw-version
+        run: echo "version=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Build Storybook
+        run: yarn build:storybook:e2e
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: storybook-static-${{ github.sha }}
+          path: packages/lib/storybook-static
+          retention-days: 1
+          if-no-files-found: error
+
+  # Update screenshots, commit, and push. Not sharded: shards would race on git push.
   update-screenshots:
     if: github.event.label.name == 'screenshot'
-    timeout-minutes: 60
+    needs: build-storybook
+    name: Update Screenshots
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.50.0-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
       options: --user 1001
-
     env:
-      CHECKOUT_API_KEY: ${{secrets.ADYEN_CHECKOUT_API_KEY}}
-      MERCHANT_ACCOUNT: ${{secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT}}
-      CLIENT_KEY: ${{secrets.ADYEN_CHECKOUT_CLIENT_KEY}}
+      CHECKOUT_API_KEY: ${{ secrets.ADYEN_CHECKOUT_API_KEY }}
+      MERCHANT_ACCOUNT: ${{ secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT }}
+      CLIENT_KEY: ${{ secrets.ADYEN_CHECKOUT_CLIENT_KEY }}
       CLIENT_ENV: test
       TESTING_ENVIRONMENT: https://checkout-test.adyen.com/checkout/v71
       API_VERSION: v71
+      STORYBOOK_PREBUILT: "1"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: 24
-        package-manager-cache: false
+      - name: Setup E2E environment
+        uses: ./.github/actions/setup-e2e
+        with:
+          checkout-ref: ${{ github.event.pull_request.head.ref }}
+          checkout-token: ${{ secrets.GITHUB_TOKEN }}
+          storybook-artifact-name: storybook-static-${{ github.sha }}
 
-    - name: Cache node modules
-      id: node-modules-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: node-modules-v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Update automated visual test screenshots
+        run: yarn test:automated-visual:update-screenshots
 
-    - name: Enable Corepack
-      run: corepack enable
+      - name: Update e2e test screenshots
+        run: yarn test:e2e:update-screenshots
 
-    - name: Install Project Dependencies
-      if: steps.node-modules-cache.outputs.cache-hit != 'true'
-      run: yarn install --immutable
+      - name: Commit updated screenshots
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add packages/e2e-playwright/tests/
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: update screenshots"
+            git push
+          else
+            echo "No screenshot changes to commit"
+          fi
 
-    - name: Extract Playwright version
-      id: playwright-version
-      run: echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' packages/e2e-playwright/package.json)" >> $GITHUB_ENV
+      - name: Upload HTML report (failures only)
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report-update-screenshots-${{ github.sha }}
+          path: packages/e2e-playwright/playwright-report
+          retention-days: 5
+          if-no-files-found: ignore
 
-    - name: Cache Playwright
-      id: playwright-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: playwright-v1
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-all-browsers
-
-    # Webkit needs extra apt packages (libwoff2dec, libvpx, libevent, libopus,
-    # libgstreamer-*, libharfbuzz-icu, libenchant-2, libsecret-1, libhyphen,
-    # libmanette, libflite, libgles2, etc.) that live under /usr/lib and are NOT
-    # inside ~/.cache/ms-playwright. Caching the downloaded .deb files makes
-    # `playwright install --with-deps` skip the network download on subsequent
-    # runs. Key is scoped to OS + runner image version so it invalidates when
-    # GitHub rolls the ubuntu image. This workflow always installs webkit.
-    - name: Cache webkit system libraries
-      id: webkit-libs-cache
-      uses: actions/cache@v5
-      env:
-        cache-name: webkit-apt-v1
-      with:
-        path: /var/cache/apt/archives
-        key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-
-    # We always run `install --with-deps` — even on a Playwright cache hit —
-    # because webkit's system libs live under /usr/lib (not in ~/.cache/ms-playwright)
-    # and would otherwise be missing. With the apt cache above, this is fast.
-    - name: Install Playwright Dependencies
-      run: npx playwright install --with-deps
-
-    - name: Update automated visual tests screenshots
-      run: yarn test:automated-visual:update-screenshots
-
-    - name: Update e2e test screenshots
-      run: yarn test:e2e:update-screenshots
-
-    - name: Commit updated screenshots
-      run: |
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add packages/e2e-playwright/tests/
-        if ! git diff --staged --quiet; then
-          git commit -m "chore: update screenshots"
-          git push
-        else
-          echo "No screenshot changes to commit"
-        fi
-
-    - name: Archive test result artifacts
-      id: upload-artifact
-      if: always()
-      uses: actions/upload-artifact@v6
-      with:
-        name: playwright-report-update-screenshots-${{ github.sha }}
-        path: packages/e2e-playwright/playwright-report
-        retention-days: 5
-
-    - name: Remove screenshot label
-      if: always()
-      id: remove-screenshot-label
-      uses: actions/github-script@v8
-      with:
-        script: |
-          await github.rest.issues.removeLabel({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.payload.pull_request.number,
-            name: 'screenshot'
-          });
-
+      - name: Remove screenshot label
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'screenshot'
+            });

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -57,7 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.build-storybook.outputs.playwright-version }}-jammy
-      options: --user 1001
     env:
       CHECKOUT_API_KEY: ${{ secrets.ADYEN_CHECKOUT_API_KEY }}
       MERCHANT_ACCOUNT: ${{ secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT }}

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -62,16 +62,27 @@ jobs:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-all-browsers
 
-    - name: Install Playwright Browsers
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install
+    # Webkit needs extra apt packages (libwoff2dec, libvpx, libevent, libopus,
+    # libgstreamer-*, libharfbuzz-icu, libenchant-2, libsecret-1, libhyphen,
+    # libmanette, libflite, libgles2, etc.) that live under /usr/lib and are NOT
+    # inside ~/.cache/ms-playwright. Caching the downloaded .deb files makes
+    # `playwright install --with-deps` skip the network download on subsequent
+    # runs. Key is scoped to OS + runner image version so it invalidates when
+    # GitHub rolls the ubuntu image. This workflow always installs webkit.
+    - name: Cache webkit system libraries
+      id: webkit-libs-cache
+      uses: actions/cache@v5
+      env:
+        cache-name: webkit-apt-v1
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
-    # System libraries (libnss3, libgbm1, libasound2t64, libwoff2dec, libvpx, etc.)
-    # live under /usr/lib and are NOT inside ~/.cache/ms-playwright, so they must
-    # be installed on every run — even on a cache hit — otherwise cached browser
-    # binaries fail to load their shared-library dependencies.
-    - name: Install Playwright System Dependencies
-      run: npx playwright install-deps
+    # We always run `install --with-deps` — even on a Playwright cache hit —
+    # because webkit's system libs live under /usr/lib (not in ~/.cache/ms-playwright)
+    # and would otherwise be missing. With the apt cache above, this is fast.
+    - name: Install Playwright Dependencies
+      run: npx playwright install --with-deps
 
     - name: Update automated visual tests screenshots
       run: yarn test:automated-visual:update-screenshots

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -76,7 +76,7 @@ jobs:
         cache-name: webkit-apt-v1
       with:
         path: /var/cache/apt/archives
-        key: ${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        key: ${{ runner.os }}-${{ runner.version }}-cache-${{ env.cache-name }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
     # We always run `install --with-deps` — even on a Playwright cache hit —
     # because webkit's system libs live under /usr/lib (not in ~/.cache/ms-playwright)

--- a/packages/e2e-playwright/playwright.config.ts
+++ b/packages/e2e-playwright/playwright.config.ts
@@ -35,7 +35,7 @@ const config: PlaywrightTestConfig = {
          * Maximum time expect() should wait for the condition to be met.
          * For example in `await expect(locator).toHaveText();`
          */
-        timeout: 30_000,
+        timeout: 3_000,
         toHaveScreenshot: {
             ...SCREENSHOT_CONFIG
         }

--- a/packages/e2e-playwright/playwright.config.ts
+++ b/packages/e2e-playwright/playwright.config.ts
@@ -50,7 +50,10 @@ const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 4 : undefined,
 
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: [['html', { open: 'never' }], ['list']],
+    /* On CI, also emit a `blob` report per shard so `playwright merge-reports` can aggregate them. */
+    reporter: process.env.CI
+        ? [['blob'], ['html', { open: 'never' }], ['list']]
+        : [['html', { open: 'never' }], ['list']],
 
     snapshotPathTemplate,
 
@@ -96,9 +99,12 @@ const config: PlaywrightTestConfig = {
     // outputDir: 'test-results/',
 
     /* Run your local dev server before starting the tests */
+    /* When `STORYBOOK_PREBUILT=1` (CI with a prebuilt Storybook artifact) skip the build step. */
     webServer: [
         {
-            command: 'npm run build:storybook:e2e && npm run start:prod-storybook',
+            command: process.env.STORYBOOK_PREBUILT
+                ? 'npm run start:prod-storybook'
+                : 'npm run build:storybook:e2e && npm run start:prod-storybook',
             cwd: '../..',
             port: STORYBOOK_PORT,
             reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 

---

## 📝 Summary



- **Concurrency cap**: 36 concurrent jobs allowed for `e2e-tests.yml`.
- **`update-screenshots.yml`**: no sharding (avoids git push races); still gets container + composite action + yarn cache + artifact-on-failure.
- **Container user / permissions**: `--user 1001` usually matches the `runner` user; if git or artifact steps fail with permission errors, drop `options:` and let container run as root (Playwright image supports both).
- **`cache: 'yarn'` with Berry**: setup-node correctly detects `yarn.lock` + `packageManager` field and caches `.yarn/berry/cache`. Verified to work with Yarn 4.x Berry; will spot-check on first run.
- **Storybook artifact path mismatch**: will read `packages/playground/package.json` + `.storybook/` config at implementation time to confirm output directory before wiring the artifact upload.
- **Playwright merge-reports version**: requires Playwright ≥ 1.37; will check `packages/e2e-playwright/package.json` during implementation.
- **36 parallel jobs vs GitHub concurrency**: confirmed acceptable. `max-parallel: 36` set explicitly for predictability.
- **Flake change from container**: timing differences (slightly faster) may surface race-condition flakes. Retries stay at 2, so existing tolerance covers it.
## 3. What's being removed

For each workflow (except as noted):
- `actions/cache` for `node_modules` (replaced by `cache: 'yarn'` in setup-node).
- `actions/cache` for `~/.cache/ms-playwright` (container has browsers).
- Webkit apt cache block + `--with-deps` step (container has libs).
- `package-manager-cache: false` (now default-enabled via `cache: 'yarn'`).
- `timeout-minutes: 120` → `30`.
- `if: always()` on HTML report upload → `if: failure()`.



---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

