### PR TITLE
Add html inert property to disable focus of payment method item details when the payment method is not selected

### DIFF
--- a/.changeset/full-schools-own.md
+++ b/.changeset/full-schools-own.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: add html inert property to disable focus of payment method item details when the payment method is not selected

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.test.tsx
@@ -66,4 +66,22 @@ describe('PaymentMethodItem', () => {
 
         expect(onSelect.mock.calls.length).toBe(0);
     });
+
+    test('should not have inert attribute on details when payment method is selected', () => {
+        const { container } = customRender(<PaymentMethodItem {...requiredProps} paymentMethod={paymentMethod} isSelected={true} />);
+
+        /* eslint-disable testing-library/no-container, testing-library/no-node-access */
+        const detailsElement = container.querySelector('.adyen-checkout__payment-method__details');
+        expect(detailsElement).not.toHaveAttribute('inert');
+        /* eslint-enable testing-library/no-container, testing-library/no-node-access */
+    });
+
+    test('should have inert attribute on details when payment method is not selected', () => {
+        const { container } = customRender(<PaymentMethodItem {...requiredProps} paymentMethod={paymentMethod} isSelected={false} />);
+
+        /* eslint-disable testing-library/no-container, testing-library/no-node-access */
+        const detailsElement = container.querySelector('.adyen-checkout__payment-method__details');
+        expect(detailsElement).toHaveAttribute('inert');
+        /* eslint-enable testing-library/no-container, testing-library/no-node-access */
+    });
 });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -139,7 +139,7 @@ class PaymentMethodItem extends Component<Readonly<PaymentMethodItemProps>> {
                 </div>
 
                 <div className="adyen-checkout-pm-details-wrapper" aria-hidden={!isSelected}>
-                    <div className="adyen-checkout__payment-method__details" id={containerId}>
+                    <div className="adyen-checkout__payment-method__details" id={containerId} inert={!isSelected}>
                         {showRemovePaymentMethodButton && (
                             <DisableOneClickConfirmation
                                 id={disableConfirmationId}

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -51,7 +51,7 @@ class PaymentMethodItem extends Component<Readonly<PaymentMethodItemProps>> {
         this.toggleDisableConfirmation();
     };
 
-    private handleOnListItemClick = (): void => {
+    private readonly handleOnListItemClick = (): void => {
         const { onSelect, paymentMethod } = this.props;
         onSelect(paymentMethod);
     };
@@ -139,7 +139,7 @@ class PaymentMethodItem extends Component<Readonly<PaymentMethodItemProps>> {
                 </div>
 
                 <div className="adyen-checkout-pm-details-wrapper" aria-hidden={!isSelected}>
-                    <div className="adyen-checkout__payment-method__details" id={containerId} inert={!isSelected}>
+                    <div className="adyen-checkout__payment-method__details" id={containerId} inert={isSelected ? undefined : true}>
                         {showRemovePaymentMethodButton && (
                             <DisableOneClickConfirmation
                                 id={disableConfirmationId}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

This PR improves keyboard navigation and accessibility for payment method items by adding the inert attribute to payment method details when they are not selected.

### Problem
Payment method item details were visually hidden (aria-hidden) when not selected, but interactive elements within them remained focusable via keyboard navigation. This created a poor user experience where users could tab to elements that weren't visible.

### Solution
Added the HTML inert property to the payment method details wrapper. When a payment method is not selected (!isSelected), the entire details section becomes:
   •  Non-focusable (all interactive elements inside are removed from tab order)
   •  Inert to user interactions
   •  Properly hidden from assistive technologies (complementing the existing aria-hidden)

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

- COSDK-166

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  https://github.com/Adyen/adyen-web/issues/3670

---

