### PR TITLE
Fix - Validate country code after Core setup

### DIFF
--- a/.changeset/better-breads-post.md
+++ b/.changeset/better-breads-post.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Validating countryCode after library initialization

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -575,7 +575,7 @@ describe('Core', () => {
     });
 
     describe('Initialising without a countryCode', () => {
-        test('[advanced flow] should thrown an error if core is initialized without countryCode', () => {
+        test('[advanced flow] should throw an error if core is initialized without countryCode', () => {
             const core = new AdyenCheckout({
                 environment: 'test',
                 _environmentUrls: {

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -587,7 +587,7 @@ describe('Core', () => {
             void expect(async () => await core.initialize()).rejects.toThrow('You must specify a countryCode');
         });
 
-        test('[sessions flow] should thrown an error if Session setup does not return a countryCode', () => {
+        test('[sessions flow] should throw an error if Session setup does not return a countryCode', () => {
             const { countryCode, ...responseWithoutCountryCode } = sessionSetupResponseMock;
             setupSessionSpy.mockResolvedValueOnce({ ...responseWithoutCountryCode });
 

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -575,7 +575,7 @@ describe('Core', () => {
     });
 
     describe('Initialising without a countryCode', () => {
-        test('AdvancedFlow, without a countryCode, should throw an error', () => {
+        test('[advanced flow] should thrown an error if core is initialized without countryCode', () => {
             const core = new AdyenCheckout({
                 environment: 'test',
                 _environmentUrls: {
@@ -587,8 +587,9 @@ describe('Core', () => {
             void expect(async () => await core.initialize()).rejects.toThrow('You must specify a countryCode');
         });
 
-        test('SessionsFlow, without a countryCode, should throw an error', () => {
-            delete sessionSetupResponseMock.countryCode;
+        test('[sessions flow] should thrown an error if Session setup does not return a countryCode', () => {
+            const { countryCode, ...responseWithoutCountryCode } = sessionSetupResponseMock;
+            setupSessionSpy.mockResolvedValueOnce({ ...responseWithoutCountryCode });
 
             const checkout = new AdyenCheckout({
                 environment: 'test',
@@ -597,6 +598,17 @@ describe('Core', () => {
             });
 
             void expect(async () => await checkout.initialize()).rejects.toThrow('You must specify a countryCode');
+        });
+
+        test('[sessions flow] should not thrown an error if core is initialized without countryCode but Session setup returns it', async () => {
+            const checkout = new AdyenCheckout({
+                environment: 'test',
+                clientKey: 'test_123456',
+                session: { id: 'session-id', sessionData: 'session-data' }
+            });
+
+            await expect(checkout.initialize()).resolves.toBe(checkout);
+            expect(checkout.options.countryCode).toBe('US');
         });
     });
 

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -600,7 +600,7 @@ describe('Core', () => {
             void expect(async () => await checkout.initialize()).rejects.toThrow('You must specify a countryCode');
         });
 
-        test('[sessions flow] should not thrown an error if core is initialized without countryCode but Session setup returns it', async () => {
+        test('[sessions flow] should not throw an error if core is initialized without countryCode but Session setup returns it', async () => {
             const checkout = new AdyenCheckout({
                 environment: 'test',
                 clientKey: 'test_123456',

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -106,8 +106,8 @@ class Core implements ICore {
     }
 
     public async initialize(): Promise<this> {
-        this.validateCoreConfiguration();
         await this.initializeCore();
+        this.validateCoreConfiguration();
         this.createCoreModules();
         this.assignLocaleToCore();
         void this.requestAnalyticsAttemptId();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary
The countryCode property must be validated after the library is fully initialized. If the merchant uses Sessions, we need to await for the Session setup in order to validate it.

This PR moves the validation to be done after the Session setup/Core initialization happens.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios
- Added tests 

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

