### PR TITLE
Split playwright tests into e2e and ui folder

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         api-version: ["v69", "v70", "v71"]
         runner-browser: ["chromium", "firefox", "webkit"]
+        test-group: ["e2e", "ui"]
     env:
       CHECKOUT_API_KEY: ${{secrets.ADYEN_CHECKOUT_API_KEY}}
       MERCHANT_ACCOUNT: ${{secrets.ADYEN_CHECKOUT_MERCHANT_ACCOUNT}}
@@ -49,13 +50,13 @@ jobs:
       run: yarn install --immutable
 
     - name: Run E2E Tests
-      run: yarn test:e2e --project=${{ matrix.runner-browser }}
+      run: yarn test:e2e tests/${{ matrix.test-group }} --project=${{ matrix.runner-browser }}
 
     - name: Archive test result artifacts
       id: upload-artifact
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-report-${{matrix.api-version}}-${{matrix.runner-browser}}-${{ github.sha }}
+        name: playwright-report-${{matrix.api-version}}-${{matrix.runner-browser}}-${{matrix.test-group}}-${{ github.sha }}
         path: packages/e2e-playwright/playwright-report
         retention-days: 5


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

### What
Adds a test-group matrix dimension to .github/workflows/e2e-tests.yml so the e2e and ui folders run as separate jobs.

### Why
Previously every job ran the full Playwright suite. Splitting by top-level folder shortens per-job wall time and makes failures easier to attribute to a specific test area.

###  Changes
- New matrix axis: test-group: ["e2e", "ui"].
- Run step now passes the folder to Playwright: yarn test:e2e tests/${{ matrix.test-group }} --project=${{ matrix.runner-browser }}.
- Artifact name includes test-group to avoid collisions between the two groups.

Impact
- Job count: 9 → 18 (3 api-versions × 3 browsers × 2 groups).
- Total time to run the test suites is now down to ~ 8minutes from `13 minutes

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

