### PR TITLE
fix: announcement of results in Select

### DIFF
--- a/.changeset/cute-laws-feel.md
+++ b/.changeset/cute-laws-feel.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Select component a11y issue

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
@@ -162,7 +162,7 @@ test('rejecting onAddressLookupMock should not trigger error', async () => {
     await waitFor(() => expect(onAddressLookupMock.mock.lastCall[0]).toBe('Test'));
 
     // Test if no options are displayed
-    const resultList = screen.getByRole('alert');
+    const resultList = screen.getByRole('listbox');
     expect(resultList).toHaveTextContent('No options found');
 
     // TODO fix this

--- a/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
+++ b/packages/lib/src/components/internal/Address/components/AddressSearch.test.tsx
@@ -162,7 +162,7 @@ test('rejecting onAddressLookupMock should not trigger error', async () => {
     await waitFor(() => expect(onAddressLookupMock.mock.lastCall[0]).toBe('Test'));
 
     // Test if no options are displayed
-    const resultList = screen.getByRole('listbox');
+    const resultList = screen.getByRole('alert');
     expect(resultList).toHaveTextContent('No options found');
 
     // TODO fix this

--- a/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
@@ -46,7 +46,6 @@ describe('Select', () => {
         const button = screen.getByRole('button');
         await user.click(button); // Open dropdown
 
-
         await user.keyboard('[ArrowDown][Enter]');
         expect(onChangeCb).toBeCalledTimes(2);
 
@@ -88,7 +87,6 @@ describe('Select', () => {
         // Test keyboard interaction - focus the combobox first with user event
         const combobox = screen.getByRole('combobox');
         await user.click(combobox); // Open dropdown
-
 
         await user.keyboard('[ArrowDown][Enter]');
         expect(onChangeCb).toBeCalledTimes(2);
@@ -208,44 +206,6 @@ describe('Select', () => {
         const liveRegion = screen.getByRole('status');
         expect(liveRegion).toBeInTheDocument();
         await waitFor(() => expect(liveRegion).toHaveTextContent('No options found'));
-        expect(liveRegion).toHaveAttribute('aria-live', 'polite');
-    });
-
-    test('ARIA live region is empty when options are available', async () => {
-        renderSelect({
-            items: [{ name: 'Apple', id: '1' }],
-            filterable: true,
-            selectedValue: '',
-            onChange: jest.fn()
-        });
-
-        const combobox = screen.getByRole('combobox');
-
-        await user.type(combobox, 'App'); // search for Apple
-
-        // Live region should be present but empty when there are options
-        const liveRegion = screen.getByRole('status');
-        expect(liveRegion).toBeInTheDocument();
-        expect(liveRegion).toBeEmptyDOMElement();
-    });
-
-    test('ARIA live region announces no options found message', async () => {
-        renderSelect({
-            items: [{ name: 'Apple', id: '1' }],
-            filterable: true,
-            selectedValue: '',
-            onChange: jest.fn()
-        });
-
-        const combobox = screen.getByRole('combobox');
-
-        // Type something that won't match any items
-        await user.type(combobox, 'xyz');
-
-        // Check that the live region is present and contains the no options message
-        const liveRegion = screen.getByRole('status');
-        expect(liveRegion).toBeInTheDocument();
-        expect(liveRegion).toHaveTextContent('No options found');
         expect(liveRegion).toHaveAttribute('aria-live', 'polite');
     });
 

--- a/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { render, screen, within } from '@testing-library/preact';
+import { render, screen, within, waitFor } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import Select from './Select';
 import { CoreProvider } from '../../../../core/Context/CoreProvider';
@@ -189,6 +189,44 @@ describe('Select', () => {
         // Typing should open the dropdown
         await user.type(combobox, 'A');
         expect(screen.getByText('Apple')).toBeVisible();
+    });
+
+    test('ARIA live region announces no options found message', async () => {
+        renderSelect({
+            items: [{ name: 'Apple', id: '1' }],
+            filterable: true,
+            selectedValue: '',
+            onChange: jest.fn()
+        });
+
+        const combobox = screen.getByRole('combobox');
+
+        // Type something that won't match any items
+        await user.type(combobox, 'xyz');
+
+        // Check that the live region is present and contains the no options message
+        const liveRegion = screen.getByRole('status');
+        expect(liveRegion).toBeInTheDocument();
+        await waitFor(() => expect(liveRegion).toHaveTextContent('No options found'));
+        expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    });
+
+    test('ARIA live region is empty when options are available', async () => {
+        renderSelect({
+            items: [{ name: 'Apple', id: '1' }],
+            filterable: true,
+            selectedValue: '',
+            onChange: jest.fn()
+        });
+
+        const combobox = screen.getByRole('combobox');
+
+        await user.type(combobox, 'App'); // search for Apple
+
+        // Live region should be present but empty when there are options
+        const liveRegion = screen.getByRole('status');
+        expect(liveRegion).toBeInTheDocument();
+        expect(liveRegion).toBeEmptyDOMElement();
     });
 
     test('ARIA live region announces no options found message', async () => {

--- a/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
@@ -46,6 +46,7 @@ describe('Select', () => {
         const button = screen.getByRole('button');
         await user.click(button); // Open dropdown
 
+
         await user.keyboard('[ArrowDown][Enter]');
         expect(onChangeCb).toBeCalledTimes(2);
 
@@ -87,6 +88,7 @@ describe('Select', () => {
         // Test keyboard interaction - focus the combobox first with user event
         const combobox = screen.getByRole('combobox');
         await user.click(combobox); // Open dropdown
+
 
         await user.keyboard('[ArrowDown][Enter]');
         expect(onChangeCb).toBeCalledTimes(2);

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -84,7 +84,9 @@ function Select({
      */
     const closeList = () => {
         //blurs the field when the list is closed, makes for a better UX for most users, needs more testing
-        blurOnClose && filterInputRef.current.blur();
+        if (blurOnClose) {
+            filterInputRef.current.blur();
+        }
         setShowList(false);
     };
 
@@ -275,13 +277,15 @@ function Select({
      * Update status message for screen readers when no options are found
      */
     useEffect(() => {
-        if (showList && filteredItems.length === 0) {
-            setStatusMessage(null);
-            const timer = setTimeout(() => setStatusMessage(i18n.get('select.noOptionsFound')), 500);
-            return () => clearTimeout(timer);
-        } else {
-            setStatusMessage(null);
-        }
+        const timer = setTimeout(() => {
+            if (filteredItems.length === 0) {
+                setStatusMessage(i18n.get('select.noOptionsFound'));
+            } else {
+                setStatusMessage(i18n.get('select.results', { values: { count: filteredItems.length } }));
+            }
+        }, 500);
+
+        return () => clearTimeout(timer);
     }, [showList, filteredItems.length, i18n]);
 
     return (

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -9,6 +9,7 @@ import { SelectItem, SelectProps } from './types';
 import './Select.scss';
 import { ARIA_CONTEXT_SUFFIX, ARIA_ERROR_SUFFIX } from '../../../../core/Errors/constants';
 import { simulateFocusScroll } from '../utils';
+import { useCoreContext } from '../../../../core/Context/CoreProvider';
 
 function Select({
     items = [],
@@ -31,12 +32,14 @@ function Select({
     onListToggle,
     required
 }: Readonly<SelectProps>) {
+    const { i18n } = useCoreContext();
     const filterInputRef = useRef(null);
     const selectContainerRef = useRef(null);
     const toggleButtonRef = useRef(null);
     const selectListRef = useRef(null);
     const [textFilter, setTextFilter] = useState<string>(null);
     const [showList, setShowList] = useState<boolean>(false);
+    const [statusMessage, setStatusMessage] = useState<string>(null);
     const selectListId: string = useMemo(() => `select-${uuid()}`, []);
 
     const active: SelectItem = items.find(i => i.id === selectedValue) || ({} as SelectItem);
@@ -268,6 +271,19 @@ function Select({
         };
     }, [selectContainerRef]);
 
+    /**
+     * Update status message for screen readers when no options are found
+     */
+    useEffect(() => {
+        if (showList && filteredItems.length === 0) {
+            setStatusMessage(null);
+            const timer = setTimeout(() => setStatusMessage(i18n.get('select.noOptionsFound')), 500);
+            return () => clearTimeout(timer);
+        } else {
+            setStatusMessage(null);
+        }
+    }, [showList, filteredItems.length, i18n]);
+
     return (
         <div
             className={cx(['adyen-checkout__dropdown', className, ...classNameModifiers.map(m => `adyen-checkout__dropdown--${m}`)])}
@@ -304,6 +320,19 @@ function Select({
                 selectListRef={selectListRef}
                 showList={showList}
             />
+            <div
+                key={inputText}
+                role="status"
+                aria-live="polite"
+                // aria-relevant seems to be needed here make make sure a second time we get
+                // "No options found" we still announce the status message.
+                // What happens otherwise is that just the first status message is announced
+                // tested on VoiceOver on Chrome
+                aria-relevant="additions text"
+                className="adyen-checkout-sr-panel--sr-only"
+            >
+                {statusMessage}
+            </div>
         </div>
     );
 }

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -39,7 +39,7 @@ function Select({
     const selectListRef = useRef(null);
     const [textFilter, setTextFilter] = useState<string>(null);
     const [showList, setShowList] = useState<boolean>(false);
-    const [statusMessage, setStatusMessage] = useState<string>(null);
+    const [statusMessage, setStatusMessage] = useState<string | null>(null);
     const selectListId: string = useMemo(() => `select-${uuid()}`, []);
 
     const active: SelectItem = items.find(i => i.id === selectedValue) || ({} as SelectItem);

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -9,7 +9,6 @@ import { SelectItem, SelectProps } from './types';
 import './Select.scss';
 import { ARIA_CONTEXT_SUFFIX, ARIA_ERROR_SUFFIX } from '../../../../core/Errors/constants';
 import { simulateFocusScroll } from '../utils';
-import { useCoreContext } from '../../../../core/Context/CoreProvider';
 
 function Select({
     items = [],
@@ -32,14 +31,12 @@ function Select({
     onListToggle,
     required
 }: Readonly<SelectProps>) {
-    const { i18n } = useCoreContext();
     const filterInputRef = useRef(null);
     const selectContainerRef = useRef(null);
     const toggleButtonRef = useRef(null);
     const selectListRef = useRef(null);
     const [textFilter, setTextFilter] = useState<string>(null);
     const [showList, setShowList] = useState<boolean>(false);
-    const [statusMessage, setStatusMessage] = useState<string>(null);
     const selectListId: string = useMemo(() => `select-${uuid()}`, []);
 
     const active: SelectItem = items.find(i => i.id === selectedValue) || ({} as SelectItem);
@@ -271,17 +268,6 @@ function Select({
         };
     }, [selectContainerRef]);
 
-    /**
-     * Update status message for screen readers when no options are found
-     */
-    useEffect(() => {
-        if (showList && filteredItems.length === 0) {
-            setStatusMessage(i18n.get('select.noOptionsFound'));
-        } else {
-            setStatusMessage(null);
-        }
-    }, [showList, filteredItems.length, i18n]);
-
     return (
         <div
             className={cx(['adyen-checkout__dropdown', className, ...classNameModifiers.map(m => `adyen-checkout__dropdown--${m}`)])}
@@ -318,18 +304,6 @@ function Select({
                 selectListRef={selectListRef}
                 showList={showList}
             />
-            <div
-                role="status"
-                aria-live="polite"
-                // aria-relevant seems to be needed here make make sure a second time we get
-                // "No options found" we still announce the status message.
-                // What happens otherwise is that just the first status message is announced
-                // tested on VoiceOver on Chrome
-                aria-relevant="all"
-                className="adyen-checkout-sr-panel--sr-only"
-            >
-                {statusMessage}
-            </div>
         </div>
     );
 }

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -277,13 +277,15 @@ function Select({
      * Update status message for screen readers when no options are found
      */
     useEffect(() => {
+        // Debounce to avoid announcing on every keystroke
+        const SR_ANNOUNCEMENT_DELAY_MS = 500;
         const timer = setTimeout(() => {
             if (filteredItems.length === 0) {
                 setStatusMessage(i18n.get('select.noOptionsFound'));
             } else {
                 setStatusMessage(i18n.get('select.results', { values: { count: filteredItems.length } }));
             }
-        }, 500);
+        }, SR_ANNOUNCEMENT_DELAY_MS);
 
         return () => clearTimeout(timer);
     }, [showList, filteredItems.length, i18n]);

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
@@ -1,5 +1,4 @@
-import { h, Fragment } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { h } from 'preact';
 import cx from 'classnames';
 import SelectListItem from './SelectListItem';
 import { useCoreContext } from '../../../../../core/Context/CoreProvider';
@@ -7,40 +6,20 @@ import { SelectListProps } from '../types';
 
 function SelectList({ selected, active, filteredItems, showList, ...props }: Readonly<SelectListProps>) {
     const { i18n } = useCoreContext();
-    const [shouldAnnounce, setShouldAnnounce] = useState(false);
-
-    useEffect(() => {
-        if (showList && filteredItems.length === 0) {
-            setShouldAnnounce(false);
-            const timer = setTimeout(() => setShouldAnnounce(true), 500);
-            return () => clearTimeout(timer);
-        } else {
-            setShouldAnnounce(false);
-        }
-    }, [showList, filteredItems.length]);
 
     return (
-        <Fragment>
-            {showList && filteredItems.length === 0 && (
-                <p
-                    role="alert"
-                    aria-hidden={!shouldAnnounce}
-                    className="adyen-checkout__dropdown__element adyen-checkout__dropdown__element--no-options"
-                >
-                    {i18n.get('select.noOptionsFound')}
-                </p>
-            )}
-            {/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */}
-            <ul
-                className={cx({
-                    'adyen-checkout__dropdown__list': true,
-                    'adyen-checkout__dropdown__list--active': showList
-                })}
-                id={props.selectListId}
-                ref={props.selectListRef}
-                role="listbox"
-            >
-                {filteredItems.map(item => (
+        /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+        <ul
+            className={cx({
+                'adyen-checkout__dropdown__list': true,
+                'adyen-checkout__dropdown__list--active': showList
+            })}
+            id={props.selectListId}
+            ref={props.selectListRef}
+            role="listbox"
+        >
+            {filteredItems.length ? (
+                filteredItems.map(item => (
                     <SelectListItem
                         active={item.id === active.id}
                         item={item}
@@ -49,9 +28,15 @@ function SelectList({ selected, active, filteredItems, showList, ...props }: Rea
                         onHover={props.onHover}
                         selected={item.id === selected.id}
                     />
-                ))}
-            </ul>
-        </Fragment>
+                ))
+            ) : (
+                <li>
+                    <div className="adyen-checkout__dropdown__element adyen-checkout__dropdown__element--no-options">
+                        {i18n.get('select.noOptionsFound')}
+                    </div>
+                </li>
+            )}
+        </ul>
     );
 }
 

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectList.tsx
@@ -1,4 +1,5 @@
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 import cx from 'classnames';
 import SelectListItem from './SelectListItem';
 import { useCoreContext } from '../../../../../core/Context/CoreProvider';
@@ -6,20 +7,40 @@ import { SelectListProps } from '../types';
 
 function SelectList({ selected, active, filteredItems, showList, ...props }: Readonly<SelectListProps>) {
     const { i18n } = useCoreContext();
+    const [shouldAnnounce, setShouldAnnounce] = useState(false);
+
+    useEffect(() => {
+        if (showList && filteredItems.length === 0) {
+            setShouldAnnounce(false);
+            const timer = setTimeout(() => setShouldAnnounce(true), 500);
+            return () => clearTimeout(timer);
+        } else {
+            setShouldAnnounce(false);
+        }
+    }, [showList, filteredItems.length]);
 
     return (
-        /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-        <ul
-            className={cx({
-                'adyen-checkout__dropdown__list': true,
-                'adyen-checkout__dropdown__list--active': showList
-            })}
-            id={props.selectListId}
-            ref={props.selectListRef}
-            role="listbox"
-        >
-            {filteredItems.length ? (
-                filteredItems.map(item => (
+        <Fragment>
+            {showList && filteredItems.length === 0 && (
+                <p
+                    role="alert"
+                    aria-hidden={!shouldAnnounce}
+                    className="adyen-checkout__dropdown__element adyen-checkout__dropdown__element--no-options"
+                >
+                    {i18n.get('select.noOptionsFound')}
+                </p>
+            )}
+            {/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */}
+            <ul
+                className={cx({
+                    'adyen-checkout__dropdown__list': true,
+                    'adyen-checkout__dropdown__list--active': showList
+                })}
+                id={props.selectListId}
+                ref={props.selectListRef}
+                role="listbox"
+            >
+                {filteredItems.map(item => (
                     <SelectListItem
                         active={item.id === active.id}
                         item={item}
@@ -28,13 +49,9 @@ function SelectList({ selected, active, filteredItems, showList, ...props }: Rea
                         onHover={props.onHover}
                         selected={item.id === selected.id}
                     />
-                ))
-            ) : (
-                <div className="adyen-checkout__dropdown__element adyen-checkout__dropdown__element--no-options">
-                    {i18n.get('select.noOptionsFound')}
-                </div>
-            )}
-        </ul>
+                ))}
+            </ul>
+        </Fragment>
     );
 }
 

--- a/packages/server/translations/ar.json
+++ b/packages/server/translations/ar.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "الخيارات",
     "upi.intent.apps.dropdown.label": "تطبيقات UPI",
     "upi.intent.apps.dropdown.placeholder": "يُرجى اختيار التطبيق المفضل.",
-    "order.paymentMethod.description": "%{name} المنتهي بـ %{lastFour}"
+    "order.paymentMethod.description": "%{name} المنتهي بـ %{lastFour}",
+    "select.results": "عدد النتائج المتاحة هو %{count}"
 }

--- a/packages/server/translations/bg-BG.json
+++ b/packages/server/translations/bg-BG.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Опции",
     "upi.intent.apps.dropdown.label": "UPI приложения",
     "upi.intent.apps.dropdown.placeholder": "Изберете предпочитано приложение",
-    "order.paymentMethod.description": "%{name}, завършва с %{lastFour}"
+    "order.paymentMethod.description": "%{name}, завършва с %{lastFour}",
+    "select.results": "%{{count} налични резултата"
 }

--- a/packages/server/translations/ca-ES.json
+++ b/packages/server/translations/ca-ES.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opcions",
     "upi.intent.apps.dropdown.label": "Aplicacions UPI",
     "upi.intent.apps.dropdown.placeholder": "Trieu l'aplicació preferida",
-    "order.paymentMethod.description": "%{name} que acaba en %{lastFour}"
+    "order.paymentMethod.description": "%{name} que acaba en %{lastFour}",
+    "select.results": "%{count} resultats disponibles"
 }

--- a/packages/server/translations/cs-CZ.json
+++ b/packages/server/translations/cs-CZ.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Možnosti",
     "upi.intent.apps.dropdown.label": "Aplikace UPI",
     "upi.intent.apps.dropdown.placeholder": "Vyberte preferovanou aplikaci",
-    "order.paymentMethod.description": "%{name} končící na %{lastFour}"
+    "order.paymentMethod.description": "%{name} končící na %{lastFour}",
+    "select.results": "Dostupných výsledků: %{count}"
 }

--- a/packages/server/translations/da-DK.json
+++ b/packages/server/translations/da-DK.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Valgmuligheder",
     "upi.intent.apps.dropdown.label": "UPI-apps",
     "upi.intent.apps.dropdown.placeholder": "Vælg foretrukne app",
-    "order.paymentMethod.description": "%{name} ender på %{lastFour}"
+    "order.paymentMethod.description": "%{name} ender på %{lastFour}",
+    "select.results": "%{count} resultater tilgængelige"
 }

--- a/packages/server/translations/de-DE.json
+++ b/packages/server/translations/de-DE.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Optionen",
     "upi.intent.apps.dropdown.label": "UPI-Apps",
     "upi.intent.apps.dropdown.placeholder": "Bevorzugte App wählen",
-    "order.paymentMethod.description": "%{name} endet mit %{lastFour}"
+    "order.paymentMethod.description": "%{name} endet mit %{lastFour}",
+    "select.results": "%{count} Ergebnisse verfügbar"
 }

--- a/packages/server/translations/el-GR.json
+++ b/packages/server/translations/el-GR.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Επιλογές",
     "upi.intent.apps.dropdown.label": "Εφαρμογές UPI",
     "upi.intent.apps.dropdown.placeholder": "Επιλέξτε την προτιμώμενη εφαρμογή",
-    "order.paymentMethod.description": "%{name} που τελειώνει σε %{lastFour}"
+    "order.paymentMethod.description": "%{name} που τελειώνει σε %{lastFour}",
+    "select.results": "%{count} διαθέσιμα αποτελέσματα"
 }

--- a/packages/server/translations/en-US.json
+++ b/packages/server/translations/en-US.json
@@ -157,6 +157,7 @@
     "select.provinceOrTerritory": "Select province or territory",
     "select.country": "Select country/region",
     "select.noOptionsFound": "No options found",
+    "select.results": "%{count} results available",
     "telephoneNumber.invalid": "Invalid telephone number",
     "qrCodeOrApp": "or",
     "paypal.processingPayment": "Processing payment...",

--- a/packages/server/translations/es-ES.json
+++ b/packages/server/translations/es-ES.json
@@ -446,5 +446,6 @@
     "upi.intent.apps.title": "Opciones",
     "upi.intent.apps.dropdown.label": "Aplicaciones UPI",
     "upi.intent.apps.dropdown.placeholder": "Elija la aplicación que prefiera",
-    "order.paymentMethod.description": "%{name} que termina en %{lastFour}"
+    "order.paymentMethod.description": "%{name} que termina en %{lastFour}",
+    "select.results": "%{count} resultados disponibles"
 }

--- a/packages/server/translations/et-EE.json
+++ b/packages/server/translations/et-EE.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Valikud",
     "upi.intent.apps.dropdown.label": "UPI rakendused",
     "upi.intent.apps.dropdown.placeholder": "Valige eelistatud rakendus",
-    "order.paymentMethod.description": "%{name}, mis lõpeb %{lastFour}-ga"
+    "order.paymentMethod.description": "%{name}, mis lõpeb %{lastFour}-ga",
+    "select.results": "Saadaval on %{count} tulemust"
 }

--- a/packages/server/translations/fi-FI.json
+++ b/packages/server/translations/fi-FI.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Vaihtoehdot",
     "upi.intent.apps.dropdown.label": "UPI-sovellukset",
     "upi.intent.apps.dropdown.placeholder": "Valitse haluamasi sovellus",
-    "order.paymentMethod.description": "%{name}, joka päättyy kirjaimiin %{lastFour}"
+    "order.paymentMethod.description": "%{name}, joka päättyy kirjaimiin %{lastFour}",
+    "select.results": "%{count} tulosta saatavilla"
 }

--- a/packages/server/translations/fr-FR.json
+++ b/packages/server/translations/fr-FR.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Options",
     "upi.intent.apps.dropdown.label": "Applications UPI",
     "upi.intent.apps.dropdown.placeholder": "Choisissez votre application préférée",
-    "order.paymentMethod.description": "%{name} se terminant par %{lastFour}"
+    "order.paymentMethod.description": "%{name} se terminant par %{lastFour}",
+    "select.results": "%{count} résultats disponibles"
 }

--- a/packages/server/translations/hr-HR.json
+++ b/packages/server/translations/hr-HR.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opcije",
     "upi.intent.apps.dropdown.label": "UPI aplikacije",
     "upi.intent.apps.dropdown.placeholder": "Odaberite željenu aplikaciju",
-    "order.paymentMethod.description": "%{name} završava s %{lastFour}"
+    "order.paymentMethod.description": "%{name} završava s %{lastFour}",
+    "select.results": "Dostupno rezultata: %{count}"
 }

--- a/packages/server/translations/hu-HU.json
+++ b/packages/server/translations/hu-HU.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Lehetőségek",
     "upi.intent.apps.dropdown.label": "UPI-alkalmazások",
     "upi.intent.apps.dropdown.placeholder": "Válassza ki a kívánt alkalmazást",
-    "order.paymentMethod.description": "%{name} (kártyaszám vége: %{lastFour})"
+    "order.paymentMethod.description": "%{name} (kártyaszám vége: %{lastFour})",
+    "select.results": "%{count} találat elérhető"
 }

--- a/packages/server/translations/is-IS.json
+++ b/packages/server/translations/is-IS.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Valkostir",
     "upi.intent.apps.dropdown.label": "UPI-forrit",
     "upi.intent.apps.dropdown.placeholder": "Veldu forritið sem þér hentar best",
-    "order.paymentMethod.description": "%{name} sem endar á %{lastFour}"
+    "order.paymentMethod.description": "%{name} sem endar á %{lastFour}",
+    "select.results": "%{count} niðurstöður í boði"
 }

--- a/packages/server/translations/it-IT.json
+++ b/packages/server/translations/it-IT.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opzioni",
     "upi.intent.apps.dropdown.label": "App UPI",
     "upi.intent.apps.dropdown.placeholder": "Scegli la tua app preferita",
-    "order.paymentMethod.description": "%{name} che termina con %{lastFour}"
+    "order.paymentMethod.description": "%{name} che termina con %{lastFour}",
+    "select.results": "%{count} risultati disponibili"
 }

--- a/packages/server/translations/ja-JP.json
+++ b/packages/server/translations/ja-JP.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "オプション",
     "upi.intent.apps.dropdown.label": "UPIアプリ",
     "upi.intent.apps.dropdown.placeholder": "希望するアプリを選択",
-    "order.paymentMethod.description": "末尾が%{lastFour}の%{name}"
+    "order.paymentMethod.description": "末尾が%{lastFour}の%{name}",
+    "select.results": "%{count}件の結果が利用可能です"
 }

--- a/packages/server/translations/ko-KR.json
+++ b/packages/server/translations/ko-KR.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "옵션",
     "upi.intent.apps.dropdown.label": "UPI 앱",
     "upi.intent.apps.dropdown.placeholder": "선호하는 앱 선택",
-    "order.paymentMethod.description": "끝자리가 %{lastFour}인 %{name}"
+    "order.paymentMethod.description": "끝자리가 %{lastFour}인 %{name}",
+    "select.results": "결과 %{count}개"
 }

--- a/packages/server/translations/lt-LT.json
+++ b/packages/server/translations/lt-LT.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Parinktys",
     "upi.intent.apps.dropdown.label": "UPI programos",
     "upi.intent.apps.dropdown.placeholder": "Pasirinkite pageidaujamą programą",
-    "order.paymentMethod.description": "%{name}, kuris baigiasi %{lastFour}"
+    "order.paymentMethod.description": "%{name}, kuris baigiasi %{lastFour}",
+    "select.results": "Rasta rezultatų: %{count}"
 }

--- a/packages/server/translations/lv-LV.json
+++ b/packages/server/translations/lv-LV.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opcijas",
     "upi.intent.apps.dropdown.label": "UPI lietotnes",
     "upi.intent.apps.dropdown.placeholder": "Izvēlieties vēlamo lietotni",
-    "order.paymentMethod.description": "%{name}, kas beidzas ar %{lastFour}"
+    "order.paymentMethod.description": "%{name}, kas beidzas ar %{lastFour}",
+    "select.results": "Pieejami %{count} rezultāti"
 }

--- a/packages/server/translations/nl-NL.json
+++ b/packages/server/translations/nl-NL.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opties",
     "upi.intent.apps.dropdown.label": "UPI-apps",
     "upi.intent.apps.dropdown.placeholder": "Kies de gewenste app",
-    "order.paymentMethod.description": "%{name} eindigend op %{lastFour}"
+    "order.paymentMethod.description": "%{name} eindigend op %{lastFour}",
+    "select.results": "%{count} resultaten beschikbaar"
 }

--- a/packages/server/translations/no-NO.json
+++ b/packages/server/translations/no-NO.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Alternativer",
     "upi.intent.apps.dropdown.label": "UPI-apper",
     "upi.intent.apps.dropdown.placeholder": "Velg app",
-    "order.paymentMethod.description": "%{name} som slutter på %{lastFour}"
+    "order.paymentMethod.description": "%{name} som slutter på %{lastFour}",
+    "select.results": "%{count} tilgjengelige resultater"
 }

--- a/packages/server/translations/pl-PL.json
+++ b/packages/server/translations/pl-PL.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opcje",
     "upi.intent.apps.dropdown.label": "Aplikacje UPI",
     "upi.intent.apps.dropdown.placeholder": "Wybierz preferowaną aplikację",
-    "order.paymentMethod.description": "%{name} kończy się za %{lastFour}"
+    "order.paymentMethod.description": "%{name} kończy się za %{lastFour}",
+    "select.results": "%{count} dostępne wyniki"
 }

--- a/packages/server/translations/pt-BR.json
+++ b/packages/server/translations/pt-BR.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opções",
     "upi.intent.apps.dropdown.label": "Aplicativos UPI",
     "upi.intent.apps.dropdown.placeholder": "Escolha o aplicativo preferencial",
-    "order.paymentMethod.description": "%{name} terminando em %{lastFour}"
+    "order.paymentMethod.description": "%{name} terminando em %{lastFour}",
+    "select.results": "%{count} resultados disponíveis"
 }

--- a/packages/server/translations/pt-PT.json
+++ b/packages/server/translations/pt-PT.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opções",
     "upi.intent.apps.dropdown.label": "aplicações de UPI",
     "upi.intent.apps.dropdown.placeholder": "Escolha a sua aplicação preferencial",
-    "order.paymentMethod.description": "%{name} que termina em %{lastFour}"
+    "order.paymentMethod.description": "%{name} que termina em %{lastFour}",
+    "select.results": "%{count} resultados disponíveis"
 }

--- a/packages/server/translations/ro-RO.json
+++ b/packages/server/translations/ro-RO.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Opțiuni",
     "upi.intent.apps.dropdown.label": "Aplicații UPI",
     "upi.intent.apps.dropdown.placeholder": "Alege aplicația preferată",
-    "order.paymentMethod.description": "%{name} care se termină în %{lastFour}"
+    "order.paymentMethod.description": "%{name} care se termină în %{lastFour}",
+    "select.results": "%{count} rezultate disponibile"
 }

--- a/packages/server/translations/ru-RU.json
+++ b/packages/server/translations/ru-RU.json
@@ -446,5 +446,6 @@
     "upi.intent.apps.title": "Опции",
     "upi.intent.apps.dropdown.label": "Приложения UPI",
     "upi.intent.apps.dropdown.placeholder": "Выберите предпочтительное приложение",
-    "order.paymentMethod.description": "%{name}, заканчивающаяся на %{lastFour}"
+    "order.paymentMethod.description": "%{name}, заканчивающаяся на %{lastFour}",
+    "select.results": "Доступно результатов: %{count}"
 }

--- a/packages/server/translations/sk-SK.json
+++ b/packages/server/translations/sk-SK.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Možnosti",
     "upi.intent.apps.dropdown.label": "Aplikácie UPI",
     "upi.intent.apps.dropdown.placeholder": "Vyberte preferovanú aplikáciu",
-    "order.paymentMethod.description": "%{name} končiaca sa číslom %{lastFour}"
+    "order.paymentMethod.description": "%{name} končiaca sa číslom %{lastFour}",
+    "select.results": "Dostupné výsledky: %{count}"
 }

--- a/packages/server/translations/sl-SI.json
+++ b/packages/server/translations/sl-SI.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Možnosti",
     "upi.intent.apps.dropdown.label": "Aplikacije UPI",
     "upi.intent.apps.dropdown.placeholder": "Izberite želeno aplikacijo",
-    "order.paymentMethod.description": "%{name}, ki se konča z %{lastFour}"
+    "order.paymentMethod.description": "%{name}, ki se konča z %{lastFour}",
+    "select.results": "Na voljo je toliko rezultatov: %{count}"
 }

--- a/packages/server/translations/sv-SE.json
+++ b/packages/server/translations/sv-SE.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "Alternativ",
     "upi.intent.apps.dropdown.label": "UPI-appar",
     "upi.intent.apps.dropdown.placeholder": "Välj önskad app",
-    "order.paymentMethod.description": "%{name} som slutar på %{lastFour}"
+    "order.paymentMethod.description": "%{name} som slutar på %{lastFour}",
+    "select.results": "%{count} resultat tillgängliga"
 }

--- a/packages/server/translations/zh-CN.json
+++ b/packages/server/translations/zh-CN.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "选项",
     "upi.intent.apps.dropdown.label": "UPI 应用",
     "upi.intent.apps.dropdown.placeholder": "选择首选应用",
-    "order.paymentMethod.description": "尾号为 %{lastFour} 的 %{name}"
+    "order.paymentMethod.description": "尾号为 %{lastFour} 的 %{name}",
+    "select.results": "%{count} 个可用结果"
 }

--- a/packages/server/translations/zh-TW.json
+++ b/packages/server/translations/zh-TW.json
@@ -448,5 +448,6 @@
     "upi.intent.apps.title": "選項",
     "upi.intent.apps.dropdown.label": "UPI 應用程式",
     "upi.intent.apps.dropdown.placeholder": "選擇偏好的應用程式",
-    "order.paymentMethod.description": "%{name} 結尾為 %{lastFour}"
+    "order.paymentMethod.description": "%{name} 結尾為 %{lastFour}",
+    "select.results": "有 %{count} 項結果"
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Accessibility fixes for the Select component's filtered results announcement:

- Added a debounced (500ms) ARIA live region (role="status", aria-live="polite") that announces the number of available results or "no options found" when the list is filtered
- Changed aria-relevant to "additions text" and added key={inputText} to ensure repeated identical messages are re-announced (tested on VoiceOver/Chrome)
- Fixed the "no options found" item to render inside a <li> for semantic validity within the <ul> listbox
- Added select.results translation key
---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

COSDK-1181 & COSDK-1182
---

