### PR TITLE
Fix incorrect heading levels

### DIFF
--- a/.changeset/brave-owls-stand.md
+++ b/.changeset/brave-owls-stand.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: ClickToPay info modal title and Address section title now use `<h2>` for correct heading hierarchy.

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -197,7 +197,7 @@ export default function Address(props: Readonly<AddressProps>) {
 
     return (
         <Fragment>
-            <Fieldset classNameModifiers={[label, 'address']} label={label} useHeading>
+            <Fieldset classNameModifiers={[label, 'address']} label={label} renderLabelAsSectionHeading>
                 {showAddressSearch && (
                     <AddressSearch
                         onAddressLookup={props.onAddressLookup}

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -197,7 +197,7 @@ export default function Address(props: Readonly<AddressProps>) {
 
     return (
         <Fragment>
-            <Fieldset classNameModifiers={[label, 'address']} label={label}>
+            <Fieldset classNameModifiers={[label, 'address']} label={label} useHeading>
                 {showAddressSearch && (
                     <AddressSearch
                         onAddressLookup={props.onAddressLookup}

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPInfo/CtPInfoModal/CtPInfoModal.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPInfo/CtPInfoModal/CtPInfoModal.tsx
@@ -42,9 +42,9 @@ const CtPInfoModal = ({ isOpen, onClose, focusAfterClose }: Readonly<CtPInfoModa
             {({ onCloseModal }) => (
                 <Fragment>
                     <Img className="adyen-checkout__ctp-modal-header-image" src={getImage({ imageFolder: 'components/' })('ctp_landscape')} alt="" />
-                    <h1 id={labelledBy} className="adyen-checkout__ctp-modal-title">
+                    <h2 id={labelledBy} className="adyen-checkout__ctp-modal-title">
                         {i18n.get('ctp.infoPopup.title')}
-                    </h1>
+                    </h2>
 
                     <div id={describedBy}>
                         <p tabIndex={-1} ref={focusFirstElement} className="adyen-checkout__ctp-modal-text">

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.scss
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.scss
@@ -46,6 +46,13 @@
     }
 }
 
+.adyen-checkout__fieldset__title-heading {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+}
+
 .adyen-checkout__fieldset__fields {
     @include index.fieldset-fields-layout;
 }

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
@@ -13,6 +13,7 @@ interface FieldsetProps {
     description?: string;
     readonly?: boolean;
     id?: string;
+    useHeading?: boolean;
 }
 
 export default function Fieldset({
@@ -22,7 +23,8 @@ export default function Fieldset({
     label,
     readonly = false,
     description,
-    id
+    id,
+    useHeading = false
 }: Readonly<FieldsetProps>) {
     const { i18n } = useCoreContext();
 
@@ -38,7 +40,11 @@ export default function Fieldset({
             ])}
             aria-describedby={description ? describedById : null}
         >
-            {label && <legend className="adyen-checkout__fieldset__title">{i18n.get(label)}</legend>}
+            {label && (
+                <legend className="adyen-checkout__fieldset__title">
+                    {useHeading ? <h2 className="adyen-checkout__fieldset__title-heading">{i18n.get(label)}</h2> : i18n.get(label)}
+                </legend>
+            )}
             {description && (
                 <p id={describedById} className="adyen-checkout__fieldset__description">
                     {i18n.get(description)}

--- a/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
+++ b/packages/lib/src/components/internal/FormFields/Fieldset/Fieldset.tsx
@@ -13,7 +13,7 @@ interface FieldsetProps {
     description?: string;
     readonly?: boolean;
     id?: string;
-    useHeading?: boolean;
+    renderLabelAsSectionHeading?: boolean;
 }
 
 export default function Fieldset({
@@ -24,7 +24,7 @@ export default function Fieldset({
     readonly = false,
     description,
     id,
-    useHeading = false
+    renderLabelAsSectionHeading = false
 }: Readonly<FieldsetProps>) {
     const { i18n } = useCoreContext();
 
@@ -42,7 +42,7 @@ export default function Fieldset({
         >
             {label && (
                 <legend className="adyen-checkout__fieldset__title">
-                    {useHeading ? <h2 className="adyen-checkout__fieldset__title-heading">{i18n.get(label)}</h2> : i18n.get(label)}
+                    {renderLabelAsSectionHeading ? <h2 className="adyen-checkout__fieldset__title-heading">{i18n.get(label)}</h2> : i18n.get(label)}
                 </legend>
             )}
             {description && (


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Replace the ClickToPay info-modal `<h1>` with `<h2>`, add an opt-in headingLevel prop to the shared Fieldset so the legend text renders inside an `<hN>` (Address opts in with level 2), and tighten the changeset description. 
[Headers can be used inside Legend](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/legend)

 
---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

[COSDK-1188](https://youtrack.is.adyen.com/issue/COSDK-1188/a11y-incorrect-heading-level)

**Closes**:  <!-- #-prefixed issue number -->

---

