### PR TITLE
Fix: Select add additional aria attributes

### DIFF
--- a/.changeset/solid-phones-spend.md
+++ b/.changeset/solid-phones-spend.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixes: Select not annoucing name, and association with listbox

--- a/.changeset/solid-phones-spend.md
+++ b/.changeset/solid-phones-spend.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Fixes: Select not annoucing name, and association with listbox
+Fixed: Select not announcing name, and association with listbox

--- a/packages/lib/src/components/PayTo/PayTo.test.ts
+++ b/packages/lib/src/components/PayTo/PayTo.test.ts
@@ -91,7 +91,7 @@ describe('PayTo', () => {
         await user.click(screen.queryByRole('option', { name: /Email/i }));
 
         expect(screen.queryByLabelText(/Prefix/i)).toBeFalsy();
-        expect(screen.getByLabelText(/Email/i)).toBeTruthy();
+        expect(screen.getByRole('textbox', { name: /Email/i })).toBeTruthy();
     });
 
     describe('PayTo shopperIdentifier', () => {
@@ -147,7 +147,7 @@ describe('PayTo', () => {
             await user.click(screen.queryByRole('button', { name: 'Mobile' }));
             await user.click(screen.queryByRole('option', { name: /Email/i }));
 
-            await user.type(screen.queryByLabelText(/Email/i), 'example@example.com');
+            await user.type(screen.getByRole('textbox', { name: /Email/i }), 'example@example.com');
             await user.type(screen.queryByLabelText(/First name/i), 'John');
             await user.type(screen.queryByLabelText(/Last name/i), 'Doe');
 
@@ -187,7 +187,7 @@ describe('PayTo', () => {
             await user.click(screen.queryByRole('button', { name: 'Mobile' }));
             await user.click(screen.queryByRole('option', { name: /ABN/i }));
 
-            await user.type(screen.queryByLabelText(/ABN/i), '123123123');
+            await user.type(screen.getByRole('textbox', { name: /ABN/i }), '123123123');
             await user.type(screen.queryByLabelText(/First name/i), 'John');
             await user.type(screen.queryByLabelText(/Last name/i), 'Doe');
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.test.tsx
@@ -76,7 +76,7 @@ test('should pre selected available card', async () => {
 
     expect(screen.getByRole('button', { name: 'Pay €20.00 with •••• 3456' })).toBeEnabled();
 
-    const selectButton = screen.getByRole('button', { name: 'Select a card to use.' });
+    const selectButton = screen.getByRole('button', { name: /Select a card to use\./ });
     expect(selectButton.textContent).toBe('Mastercard •••• 3456 ');
 
     await user.click(selectButton);
@@ -183,7 +183,7 @@ test('should not be able to checkout with expired card (card list)', async () =>
 
     expect(screen.getByRole('button', { name: 'Pay €20.00 with •••• 3456' })).toBeDisabled();
 
-    const selectButton = screen.getByRole('button', { name: 'Select a card to use.' });
+    const selectButton = screen.getByRole('button', { name: /Select a card to use\./ });
 
     expect(selectButton.textContent).toBe('Mastercard •••• 3456 Expired');
 
@@ -259,7 +259,7 @@ test('should be able to checkout (card list)', async () => {
     expect(screen.getByRole('button', { name: 'Pay €20.00 with •••• 8902' })).toBeTruthy();
 
     // Shows available cards by clicking in the Select
-    await user.click(screen.getByRole('button', { name: 'Select a card to use.' }));
+    await user.click(screen.getByRole('button', { name: /Select a card to use\./ }));
     expect(screen.getAllByRole('option').length).toBe(2);
 
     // Selects Mastercard, then pay button label gets updated

--- a/packages/lib/src/components/internal/FormFields/Field/Field.tsx
+++ b/packages/lib/src/components/internal/FormFields/Field/Field.tsx
@@ -204,7 +204,7 @@ const Field: FunctionalComponent<Readonly<FieldProps>> = props => {
 
             return useLabelElement ? (
                 // if we are NOT dealing with the label for a securedField... we can give it a `for` attribute
-                <label {...defaultWrapperProps} {...(!isSecuredField && name && { htmlFor: uniqueId })}>
+                <label {...defaultWrapperProps} {...(!isSecuredField && name && { htmlFor: uniqueId, id: `${uniqueId}-label` })}>
                     {children}
                 </label>
             ) : (

--- a/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { render, screen } from '@testing-library/preact';
+import { render, screen, within } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import Select from './Select';
 import { CoreProvider } from '../../../../core/Context/CoreProvider';
@@ -239,6 +239,20 @@ describe('Select', () => {
         test('button has aria-haspopup="listbox"', () => {
             renderSelect({ filterable: false });
             expect(screen.getByRole('button')).toHaveAttribute('aria-haspopup', 'listbox');
+        });
+
+        test('button has aria-controls pointing to the listbox', () => {
+            renderSelect({ filterable: false });
+            const button = screen.getByRole('button');
+            const listbox = screen.getByRole('listbox');
+            expect(button).toHaveAttribute('aria-controls', listbox.id);
+        });
+
+        test('button has aria-labelledby combining label and selected value when uniqueId is provided', () => {
+            renderSelect({ filterable: false, uniqueId: 'test-select', selectedValue: '1', items: [{ id: '1', name: 'Mobile' }] });
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('aria-labelledby', 'test-select-label test-select-value');
+            expect(within(button).getByText('Mobile')).toBeInTheDocument();
         });
     });
 });

--- a/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
@@ -45,7 +45,7 @@ describe('Select', () => {
         // Test keyboard interaction - focus the button first with user event
         const button = screen.getByRole('button');
         await user.click(button); // Open dropdown
-        
+
         await user.keyboard('[ArrowDown][Enter]');
         expect(onChangeCb).toBeCalledTimes(2);
 
@@ -87,7 +87,7 @@ describe('Select', () => {
         // Test keyboard interaction - focus the combobox first with user event
         const combobox = screen.getByRole('combobox');
         await user.click(combobox); // Open dropdown
-        
+
         await user.keyboard('[ArrowDown][Enter]');
         expect(onChangeCb).toBeCalledTimes(2);
 
@@ -110,18 +110,18 @@ describe('Select', () => {
         });
 
         const combobox = screen.getByRole('combobox');
-        
+
         // Focus should not open the dropdown
         await user.tab(); // Focus the combobox using tab navigation
-        
+
         // Debug visibility
         const option1 = screen.getByText('Option 1');
         const option2 = screen.getByText('Option 2');
-        
+
         // Elements should be hidden (offsetParent is null and getBoundingClientRect is all zeros)
         expect(option1.offsetParent).toBeNull();
         expect(option2.offsetParent).toBeNull();
-        
+
         // Click should open the dropdown
         await user.click(combobox);
         expect(screen.getByText('Option 1')).toBeVisible();
@@ -142,18 +142,18 @@ describe('Select', () => {
         });
 
         const button = screen.getByRole('button');
-        
+
         // Focus should not open the dropdown
         await user.tab(); // Focus the button using tab navigation
-        
+
         // Debug visibility
         const option1 = screen.getByText('Option 1');
         const option2 = screen.getByText('Option 2');
-        
+
         // Elements should be hidden (offsetParent is null and getBoundingClientRect is all zeros)
         expect(option1.offsetParent).toBeNull();
         expect(option2.offsetParent).toBeNull();
-        
+
         // Click should open the dropdown
         await user.click(button);
         expect(screen.getByText('Option 1')).toBeVisible();
@@ -175,15 +175,15 @@ describe('Select', () => {
         });
 
         const combobox = screen.getByRole('combobox');
-        
+
         // Initially dropdown should be closed
         const apple = screen.getByText('Apple');
         const banana = screen.getByText('Banana');
-        
+
         // Elements should be hidden (offsetParent is null and getBoundingClientRect is all zeros)
         expect(apple.offsetParent).toBeNull();
         expect(banana.offsetParent).toBeNull();
-        
+
         // Typing should open the dropdown
         await user.type(combobox, 'A');
         expect(screen.getByText('Apple')).toBeVisible();
@@ -198,10 +198,10 @@ describe('Select', () => {
         });
 
         const combobox = screen.getByRole('combobox');
-        
+
         // Type something that won't match any items
         await user.type(combobox, 'xyz');
-        
+
         // Check that the live region is present and contains the no options message
         const liveRegion = screen.getByRole('status');
         expect(liveRegion).toBeInTheDocument();
@@ -225,5 +225,20 @@ describe('Select', () => {
         const liveRegion = screen.getByRole('status');
         expect(liveRegion).toBeInTheDocument();
         expect(liveRegion).toBeEmptyDOMElement();
+    });
+
+    describe('select-only (filterable=false)', () => {
+        test('aria-expanded is false initially and true when open', async () => {
+            renderSelect({ filterable: false });
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('aria-expanded', 'false');
+            await user.click(button);
+            expect(button).toHaveAttribute('aria-expanded', 'true');
+        });
+
+        test('button has aria-haspopup="listbox"', () => {
+            renderSelect({ filterable: false });
+            expect(screen.getByRole('button')).toHaveAttribute('aria-haspopup', 'listbox');
+        });
     });
 });

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -12,7 +12,19 @@ function SelectButtonElement({ filterable, toggleButtonRef, ...props }) {
         return <div {...strippedProps} ref={toggleButtonRef} />;
     }
 
-    return <button id={props.id} aria-expanded={props.showList} aria-disabled={props.readonly} aria-describedby={props.ariaDescribedBy} type={'button'} {...props} ref={toggleButtonRef} />;
+    return (
+        <button
+            id={props.id}
+            aria-haspopup="listbox"
+            aria-expanded={props.showList}
+            aria-controls={props.selectListId}
+            aria-disabled={props.readonly}
+            aria-describedby={props.ariaDescribedBy}
+            type={'button'}
+            {...props}
+            ref={toggleButtonRef}
+        />
+    );
 }
 
 function SelectButton(props: Readonly<SelectButtonProps>) {
@@ -45,7 +57,6 @@ function SelectButton(props: Readonly<SelectButtonProps>) {
     // 3. Otherwise we just toggle the list
     const onClickHandler = readonly ? null : props.filterable ? setFocus : props.toggleList;
 
-
     // check COWEB-1301 [Investigate] Drop-in Accessibility - ADA Compliance questions
     const currentSelectedItemId = active.id ? `listItem-${active.id}` : '';
 
@@ -65,6 +76,8 @@ function SelectButton(props: Readonly<SelectButtonProps>) {
             onKeyDown={!readonly ? props.onButtonKeyDown : null}
             toggleButtonRef={props.toggleButtonRef}
             id={props.id}
+            showList={showList}
+            selectListId={props.selectListId}
         >
             {!props.filterable ? (
                 <Fragment>

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -5,7 +5,7 @@ import Img from '../../../Img';
 import { useMemo } from 'preact/hooks';
 import classnames from 'classnames';
 
-function SelectButtonElement({ filterable, toggleButtonRef, ...props }) {
+function SelectButtonElement({ filterable, toggleButtonRef, showList, selectListId, ...props }) {
     if (filterable) {
         // Even if passed, we can't add an id to this div since it is not allowed to associate a div with a label element
         const { id, ...strippedProps } = props;
@@ -16,8 +16,8 @@ function SelectButtonElement({ filterable, toggleButtonRef, ...props }) {
         <button
             id={props.id}
             aria-haspopup="listbox"
-            aria-expanded={props.showList}
-            aria-controls={props.selectListId}
+            aria-expanded={showList}
+            aria-controls={selectListId}
             aria-disabled={props.readonly}
             aria-describedby={props.ariaDescribedBy}
             aria-labelledby={props.id ? `${props.id}-label ${props.id}-value` : undefined}

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -20,6 +20,7 @@ function SelectButtonElement({ filterable, toggleButtonRef, ...props }) {
             aria-controls={props.selectListId}
             aria-disabled={props.readonly}
             aria-describedby={props.ariaDescribedBy}
+            aria-labelledby={props.id ? `${props.id}-label ${props.id}-value` : undefined}
             type={'button'}
             {...props}
             ref={toggleButtonRef}
@@ -83,6 +84,7 @@ function SelectButton(props: Readonly<SelectButtonProps>) {
                 <Fragment>
                     {selected.icon && <Img className="adyen-checkout__dropdown__button__icon" src={selected.icon} alt={selected.name} />}
                     <span
+                        id={props.id ? `${props.id}-value` : undefined}
                         className={classnames('adyen-checkout__dropdown__button__text', {
                             'adyen-checkout__dropdown__button__text-placeholder': isShowingPlaceholder
                         })}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

**Problem:** The non-filterable `<select>` button was missing ARIA attributes required for the listbox disclosure pattern, making it non-compliant for screen readers. Additionally, the button's accessible name did not include the selected value.
 
**Changes:**
- Added `aria-haspopup="listbox"` — announces to screen readers that the button opens a listbox (not a menu or dialog)
- Added `aria-controls={selectListId}` — programmatically links the button to the listbox it controls
- Fixed `aria-expanded` — was already present but `showList` was not being passed down; now correctly reflects open/closed state
- Added `aria-labelledby` combining label id + selected value span id — ensures the button's accessible name includes both the field label and the currently selected option (e.g., "Identifier, Mobile, button")
- Added `id` to the label element in Field component to enable the `aria-labelledby` reference
 
**Note:** The combobox (filterable) path already had all required ARIA attributes — no changes needed there.


---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

1. Button announcement on focus

- Tab to the select button
- Expected: SR announces "[selected value or placeholder], collapsed, button" (or similar per SR)
- Verifies: aria-haspopup="listbox" and aria-expanded="false" are read correctly

2. Open/close state

- Click or press Space/Enter to open
- Expected: SR announces "expanded" on open, "collapsed" on close
- Verifies: aria-expanded toggling

3. Listbox association

- Open the dropdown
- Expected: SR moves focus into the listbox and announces it as a listbox (not an orphan element)
- Verifies: aria-controls linking button → listbox

4. Keyboard-only navigation

- Tab to button → Space to open → Arrow keys to navigate → Enter to select → Escape to close without selecting
- Expected: no focus traps, list closes and focus returns to button on Escape/Tab
- Verifies: full keyboard flow

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

