### PR TITLE
Refactor SegmentedControl to WAI-ARIA Tab pattern

### DIFF
--- a/.changeset/cool-planes-eat.md
+++ b/.changeset/cool-planes-eat.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: SegmentedControl component to follow proper tablist and tabpanel WAI-ARIA semantics

--- a/packages/e2e-playwright/models/iris.ts
+++ b/packages/e2e-playwright/models/iris.ts
@@ -5,9 +5,9 @@ import { IssuerList } from './issuer-list';
  * Iris extends IssuerList with segmented control for QR Code / Bank List modes
  */
 class Iris extends IssuerList {
-    // Segmented control buttons
-    readonly qrCodeModeButton: Locator;
-    readonly bankListModeButton: Locator;
+    // Segmented control tabs
+    readonly qrCodeModeTab: Locator;
+    readonly bankListModeTab: Locator;
     readonly segmentedControlGroup: Locator;
 
     // QR Code mode elements
@@ -22,8 +22,8 @@ class Iris extends IssuerList {
 
         // Segmented control (outside of .adyen-checkout__issuer-list, so use page-level locator)
         this.segmentedControlGroup = page.locator('.adyen-checkout__segmented-control');
-        this.qrCodeModeButton = this.segmentedControlGroup.getByRole('button', { name: 'QR code' });
-        this.bankListModeButton = this.segmentedControlGroup.getByRole('button', { name: 'Bank list' });
+        this.qrCodeModeTab = this.segmentedControlGroup.getByRole('tab', { name: 'QR code' });
+        this.bankListModeTab = this.segmentedControlGroup.getByRole('tab', { name: 'Bank list' });
 
         // QR Code mode (QR elements are in a separate panel, not inside .adyen-checkout__issuer-list)
         this.generateQrCodeButton = page.getByRole('button', { name: 'Generate QR code' });
@@ -42,21 +42,21 @@ class Iris extends IssuerList {
     }
 
     async switchToQrCodeMode() {
-        await this.qrCodeModeButton.click();
+        await this.qrCodeModeTab.click();
     }
 
     async switchToBankListMode() {
-        await this.bankListModeButton.click();
+        await this.bankListModeTab.click();
     }
 
     async isQrCodeModeSelected(): Promise<boolean> {
-        const ariaExpanded = await this.qrCodeModeButton.getAttribute('aria-expanded');
-        return ariaExpanded === 'true';
+        const ariaSelected = await this.qrCodeModeTab.getAttribute('aria-selected');
+        return ariaSelected === 'true';
     }
 
     async isBankListModeSelected(): Promise<boolean> {
-        const ariaExpanded = await this.bankListModeButton.getAttribute('aria-expanded');
-        return ariaExpanded === 'true';
+        const ariaSelected = await this.bankListModeTab.getAttribute('aria-selected');
+        return ariaSelected === 'true';
     }
 
     async generateQrCode() {

--- a/packages/e2e-playwright/tests/a11y/issuerList/iris.spec.ts
+++ b/packages/e2e-playwright/tests/a11y/issuerList/iris.spec.ts
@@ -1,52 +1,52 @@
 import { test, expect } from '../../../fixtures/issuer-list.fixture';
 
 test.describe('IRIS - Accessibility', () => {
-    test('should have proper aria-expanded attributes on segmented control buttons', async ({ iris }) => {
+    test('should have proper aria-selected attributes on segmented control tabs', async ({ iris }) => {
         // QR Code mode is selected by default
-        await expect(iris.qrCodeModeButton).toHaveAttribute('aria-expanded', 'true');
-        await expect(iris.bankListModeButton).toHaveAttribute('aria-expanded', 'false');
+        await expect(iris.qrCodeModeTab).toHaveAttribute('aria-selected', 'true');
+        await expect(iris.bankListModeTab).toHaveAttribute('aria-selected', 'false');
     });
 
     test('should have proper aria-controls attributes linking to content panels', async ({ iris }) => {
-        await expect(iris.qrCodeModeButton).toHaveAttribute('aria-controls');
-        await expect(iris.bankListModeButton).toHaveAttribute('aria-controls');
+        await expect(iris.qrCodeModeTab).toHaveAttribute('aria-controls');
+        await expect(iris.bankListModeTab).toHaveAttribute('aria-controls');
     });
 
-    test('should update aria-expanded when switching between modes', async ({ iris }) => {
+    test('should update aria-selected when switching between modes', async ({ iris }) => {
         // Initial state: QR Code selected
-        await expect(iris.qrCodeModeButton).toHaveAttribute('aria-expanded', 'true');
-        await expect(iris.bankListModeButton).toHaveAttribute('aria-expanded', 'false');
+        await expect(iris.qrCodeModeTab).toHaveAttribute('aria-selected', 'true');
+        await expect(iris.bankListModeTab).toHaveAttribute('aria-selected', 'false');
 
         // Switch to Bank List mode
         await iris.switchToBankListMode();
 
-        // Verify aria-expanded is updated
-        await expect(iris.qrCodeModeButton).toHaveAttribute('aria-expanded', 'false');
-        await expect(iris.bankListModeButton).toHaveAttribute('aria-expanded', 'true');
+        // Verify aria-selected is updated
+        await expect(iris.qrCodeModeTab).toHaveAttribute('aria-selected', 'false');
+        await expect(iris.bankListModeTab).toHaveAttribute('aria-selected', 'true');
 
         // Switch back to QR Code mode
         await iris.switchToQrCodeMode();
 
-        // Verify aria-expanded is updated again
-        await expect(iris.qrCodeModeButton).toHaveAttribute('aria-expanded', 'true');
-        await expect(iris.bankListModeButton).toHaveAttribute('aria-expanded', 'false');
+        // Verify aria-selected is updated again
+        await expect(iris.qrCodeModeTab).toHaveAttribute('aria-selected', 'true');
+        await expect(iris.bankListModeTab).toHaveAttribute('aria-selected', 'false');
     });
 
-    test('should be keyboard navigable between segmented control options', async ({ page, iris }) => {
-        // Focus on the QR Code button
-        await iris.qrCodeModeButton.focus();
-        await expect(iris.qrCodeModeButton).toBeFocused();
+    test('should be keyboard navigable between segmented control tabs', async ({ page, iris }) => {
+        // Focus on the QR Code tab
+        await iris.qrCodeModeTab.focus();
+        await expect(iris.qrCodeModeTab).toBeFocused();
 
-        // Tab to Bank List button
+        // Tab to Bank List tab
         await page.keyboard.press('Tab');
-        await expect(iris.bankListModeButton).toBeFocused();
+        await expect(iris.bankListModeTab).toBeFocused();
 
         // Press Enter to activate Bank List mode
         await page.keyboard.press('Enter');
 
         // Verify Bank List mode is now selected
         expect(await iris.isBankListModeSelected()).toBe(true);
-        await expect(iris.bankListModeButton).toHaveAttribute('aria-expanded', 'true');
+        await expect(iris.bankListModeTab).toHaveAttribute('aria-selected', 'true');
     });
 
 });

--- a/packages/lib/src/components/Iris/Iris.test.tsx
+++ b/packages/lib/src/components/Iris/Iris.test.tsx
@@ -47,8 +47,8 @@ describe('Iris', () => {
         const iris = createIris();
         render(iris.render());
 
-        const qrCodeButton = await screen.findByRole('button', { name: 'QR code' });
-        expect(qrCodeButton).toHaveAttribute('aria-expanded', 'true');
+        const qrCodeTab = await screen.findByRole('tab', { name: 'QR code' });
+        expect(qrCodeTab).toHaveAttribute('aria-selected', 'true');
         expect(await screen.findByRole('button', { name: /Generate QR code/i })).toBeInTheDocument();
     });
 
@@ -57,8 +57,8 @@ describe('Iris', () => {
         const iris = createIris();
         render(iris.render());
 
-        const bankListButton = await screen.findByRole('button', { name: 'Bank list' });
-        expect(bankListButton).toHaveAttribute('aria-expanded', 'true');
+        const bankListTab = await screen.findByRole('tab', { name: 'Bank list' });
+        expect(bankListTab).toHaveAttribute('aria-selected', 'true');
         expect(screen.queryByRole('button', { name: /Generate QR code/i })).not.toBeInTheDocument();
     });
 
@@ -135,8 +135,8 @@ describe('Iris', () => {
         await user.click(issuerOption);
 
         // Switch to QR Code mode
-        const qrCodeButton = await screen.findByRole('button', { name: 'QR code' });
-        await user.click(qrCodeButton);
+        const qrCodeTab = await screen.findByRole('tab', { name: 'QR code' });
+        await user.click(qrCodeTab);
 
         await waitFor(() => {
             expect(screen.getByRole('button', { name: /Generate QR code/i })).toBeInTheDocument();
@@ -163,9 +163,9 @@ describe('Iris', () => {
         const generateQrButton = await screen.findByRole('button', { name: /Generate QR code/i });
         expect(generateQrButton).toBeInTheDocument();
 
-        // Should NOT show the segment control buttons or issuer list
-        expect(screen.queryByRole('button', { name: 'QR code' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: 'Bank list' })).not.toBeInTheDocument();
+        // Should NOT show the segment control tabs or issuer list
+        expect(screen.queryByRole('tab', { name: 'QR code' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('tab', { name: 'Bank list' })).not.toBeInTheDocument();
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 
         // Component should be valid without issuer selection
@@ -237,12 +237,12 @@ describe('Iris', () => {
             render(iris.render());
 
             // Verify QR code is initially selected
-            const qrCodeButton = await screen.findByRole('button', { name: 'QR code' });
-            expect(qrCodeButton).toHaveAttribute('aria-expanded', 'true');
+            const qrCodeTab = await screen.findByRole('tab', { name: 'QR code' });
+            expect(qrCodeTab).toHaveAttribute('aria-selected', 'true');
 
             // Click on Bank list
-            const bankListButton = await screen.findByRole('button', { name: 'Bank list' });
-            await user.click(bankListButton);
+            const bankListTab = await screen.findByRole('tab', { name: 'Bank list' });
+            await user.click(bankListTab);
 
             expect(core.modules.analytics.sendAnalytics).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -260,12 +260,12 @@ describe('Iris', () => {
             render(iris.render());
 
             // Verify Bank list is initially selected
-            const bankListButton = await screen.findByRole('button', { name: 'Bank list' });
-            expect(bankListButton).toHaveAttribute('aria-expanded', 'true');
+            const bankListTab = await screen.findByRole('tab', { name: 'Bank list' });
+            expect(bankListTab).toHaveAttribute('aria-selected', 'true');
 
             // Click on QR code
-            const qrCodeButton = await screen.findByRole('button', { name: 'QR code' });
-            await user.click(qrCodeButton);
+            const qrCodeTab = await screen.findByRole('tab', { name: 'QR code' });
+            await user.click(qrCodeTab);
 
             expect(core.modules.analytics.sendAnalytics).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -283,8 +283,8 @@ describe('Iris', () => {
 
             // Should show Generate QR code button directly (no segmented control)
             expect(await screen.findByRole('button', { name: 'Generate QR code' })).toBeInTheDocument();
-            expect(screen.queryByRole('button', { name: 'QR code' })).not.toBeInTheDocument();
-            expect(screen.queryByRole('button', { name: 'Bank list' })).not.toBeInTheDocument();
+            expect(screen.queryByRole('tab', { name: 'QR code' })).not.toBeInTheDocument();
+            expect(screen.queryByRole('tab', { name: 'Bank list' })).not.toBeInTheDocument();
 
             // No segmented control click events should be sent (only rendered event)
             expect(core.modules.analytics.sendAnalytics).not.toHaveBeenCalledWith(

--- a/packages/lib/src/components/PayTo/PayTo.test.ts
+++ b/packages/lib/src/components/PayTo/PayTo.test.ts
@@ -224,7 +224,7 @@ describe('PayTo', () => {
 
             render(payTo.render());
 
-            await user.click(screen.queryByRole('button', { name: /BSB and account number/i }));
+            await user.click(screen.queryByRole('tab', { name: /BSB and account number/i }));
 
             await user.type(screen.queryByLabelText(/Bank account number/i), '12300123');
             await user.type(screen.queryByLabelText(/Bank State Branch/i), '123456');

--- a/packages/lib/src/components/PayTo/components/PayToComponent.tsx
+++ b/packages/lib/src/components/PayTo/components/PayToComponent.tsx
@@ -30,7 +30,9 @@ export default function PayToComponent(props: Readonly<PayToComponentProps>) {
 
     const [status, setStatus] = useState<UIElementStatus>('ready');
 
-    // Generate unique IDs for the input sections
+    // Generate unique IDs for the tab panels and input sections
+    const payidPanelId = useMemo(() => getUniqueId('payid-panel'), []);
+    const bsbPanelId = useMemo(() => getUniqueId('bsb-panel'), []);
     const payidInputId = useMemo(() => getUniqueId('payid-input'), []);
     const bsbInputId = useMemo(() => getUniqueId('bsb-input'), []);
 
@@ -40,16 +42,16 @@ export default function PayToComponent(props: Readonly<PayToComponentProps>) {
                 value: 'payid-option',
                 label: 'PayID',
                 id: 'payid-option',
-                controls: payidInputId
+                controls: payidPanelId
             },
             {
                 value: 'bsb-option',
                 label: i18n.get('payto.bsb.option.label'),
                 id: 'bsb-option',
-                controls: bsbInputId
+                controls: bsbPanelId
             }
         ],
-        [i18n, payidInputId, bsbInputId]
+        [i18n, payidPanelId, bsbPanelId]
     );
 
     const defaultOption = inputOptions[0].value;
@@ -69,7 +71,7 @@ export default function PayToComponent(props: Readonly<PayToComponentProps>) {
         >
             <SegmentedControl selectedValue={selectedInput} options={inputOptions} onChange={setSelectedInput} />
             {selectedInput === 'payid-option' && (
-                <SegmentedControlRegion id={payidInputId} ariaLabelledBy="payid-option">
+                <SegmentedControlRegion id={payidPanelId} ariaLabelledBy="payid-option">
                     <PayIDInput
                         id={payidInputId}
                         status={status}
@@ -82,7 +84,7 @@ export default function PayToComponent(props: Readonly<PayToComponentProps>) {
                 </SegmentedControlRegion>
             )}
             {selectedInput === 'bsb-option' && (
-                <SegmentedControlRegion id={bsbInputId} ariaLabelledBy="bsb-option">
+                <SegmentedControlRegion id={bsbPanelId} ariaLabelledBy="bsb-option">
                     <BSBInput
                         id={bsbInputId}
                         status={status}

--- a/packages/lib/src/components/PayTo/components/PayToComponent.tsx
+++ b/packages/lib/src/components/PayTo/components/PayToComponent.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { SegmentedControl } from '../../internal/SegmentedControl';
+import { SegmentedControl, SegmentedControlRegion } from '../../internal/SegmentedControl';
 import { useMemo, useState } from 'preact/hooks';
 import { SegmentedControlOptions } from '../../internal/SegmentedControl/SegmentedControl';
 import PayIDInput from './PayIDInput';
@@ -69,26 +69,30 @@ export default function PayToComponent(props: Readonly<PayToComponentProps>) {
         >
             <SegmentedControl selectedValue={selectedInput} options={inputOptions} onChange={setSelectedInput} />
             {selectedInput === 'payid-option' && (
-                <PayIDInput
-                    id={payidInputId}
-                    status={status}
-                    setStatus={setStatus}
-                    setComponentRef={props.setComponentRef}
-                    onChange={onChange}
-                    defaultData={props.data}
-                    placeholders={props.placeholders}
-                />
+                <SegmentedControlRegion id={payidInputId} ariaLabelledBy="payid-option">
+                    <PayIDInput
+                        id={payidInputId}
+                        status={status}
+                        setStatus={setStatus}
+                        setComponentRef={props.setComponentRef}
+                        onChange={onChange}
+                        defaultData={props.data}
+                        placeholders={props.placeholders}
+                    />
+                </SegmentedControlRegion>
             )}
             {selectedInput === 'bsb-option' && (
-                <BSBInput
-                    id={bsbInputId}
-                    status={status}
-                    setStatus={setStatus}
-                    setComponentRef={props.setComponentRef}
-                    onChange={onChange}
-                    defaultData={props.data}
-                    placeholders={props.placeholders}
-                />
+                <SegmentedControlRegion id={bsbInputId} ariaLabelledBy="bsb-option">
+                    <BSBInput
+                        id={bsbInputId}
+                        status={status}
+                        setStatus={setStatus}
+                        setComponentRef={props.setComponentRef}
+                        onChange={onChange}
+                        defaultData={props.data}
+                        placeholders={props.placeholders}
+                    />
+                </SegmentedControlRegion>
             )}
 
             {props.showPayButton && props.payButton({ status, label: i18n.get('continue') })}

--- a/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.stories.tsx
@@ -4,9 +4,9 @@ import { SegmentedControl, SegmentedControlProps } from './SegmentedControl';
 import { useState } from 'preact/hooks';
 
 const options = [
-    { label: 'Master Card', value: 'mc' },
-    { label: 'Visa Card', value: 'visa' },
-    { label: 'American Express', value: 'amex' }
+    { label: 'Master Card', value: 'mc', id: 'tab-mc', controls: 'panel-mc' },
+    { label: 'Visa Card', value: 'visa', id: 'tab-visa', controls: 'panel-visa' },
+    { label: 'American Express', value: 'amex', id: 'tab-amex', controls: 'panel-amex' }
 ];
 
 const meta: Meta = {

--- a/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { Meta, StoryObj } from '@storybook/preact-vite';
 import { SegmentedControl, SegmentedControlProps } from './SegmentedControl';
+import { SegmentedControlRegion } from './SegmentedControlRegion';
 import { useState } from 'preact/hooks';
 
 const options = [
@@ -29,7 +30,15 @@ const meta: Meta = {
 export const Default: StoryObj<SegmentedControlProps<string>> = {
     render: args => {
         const [selected, setSelected] = useState<string>(args.selectedValue);
-        return <SegmentedControl {...args} selectedValue={selected} onChange={v => setSelected(v)} />;
+        const selectedOption = options.find(opt => opt.value === selected) || options[0];
+        return (
+            <div>
+                <SegmentedControl {...args} selectedValue={selected} onChange={v => setSelected(v)} />
+                <SegmentedControlRegion id={selectedOption.controls} ariaLabelledBy={selectedOption.id}>
+                    <p>{selectedOption.label} content</p>
+                </SegmentedControlRegion>
+            </div>
+        );
     },
     parameters: {
         controls: { exclude: ['useSessions', 'countryCode', 'shopperLocale', 'amount', 'showPayButton'] }

--- a/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.test.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useState } from 'preact/hooks';
 import { render, screen, waitFor } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
+
 import { SegmentedControl, SegmentedControlOptions } from './SegmentedControl';
 
 const DEFAULT_OPTIONS: SegmentedControlOptions<string> = [
@@ -9,20 +10,18 @@ const DEFAULT_OPTIONS: SegmentedControlOptions<string> = [
         value: 'option 1',
         label: 'Option 1',
         id: 'option-1',
-        controls: '1'
+        controls: 'panel-1'
     },
     {
         value: 'option 2',
         label: 'Option 2',
         id: 'option-2',
-        controls: '2'
+        controls: 'panel-2'
     }
 ];
 
-const getOption1 = () => screen.getByRole('button', { name: DEFAULT_OPTIONS[0].label });
-const getOption2 = () => screen.getByRole('button', { name: DEFAULT_OPTIONS[1].label });
-const findOption1 = () => screen.findByRole('button', { name: DEFAULT_OPTIONS[0].label });
-const findOption2 = () => screen.findByRole('button', { name: DEFAULT_OPTIONS[1].label });
+const getTab1 = () => screen.getByRole('tab', { name: DEFAULT_OPTIONS[0].label });
+const getTab2 = () => screen.getByRole('tab', { name: DEFAULT_OPTIONS[1].label });
 
 const Component = ({ options }: Readonly<{ options: SegmentedControlOptions<string> }>) => {
     const defaultOption = options[0].value;
@@ -36,35 +35,77 @@ const renderSegmentedControl = (options: SegmentedControlOptions<string>) => {
 };
 
 describe('SegmentedControl', () => {
-    test('should render segmented controls', () => {
-        renderSegmentedControl(DEFAULT_OPTIONS);
-        expect(getOption1()).toBeInTheDocument();
-        expect(getOption2()).toBeInTheDocument();
+    describe('ARIA roles and attributes', () => {
+        test('should render a tablist container', () => {
+            renderSegmentedControl(DEFAULT_OPTIONS);
+            const tablist = screen.getByRole('tablist');
+            expect(tablist).toBeInTheDocument();
+        });
+
+        test('should render tabs with role="tab"', () => {
+            renderSegmentedControl(DEFAULT_OPTIONS);
+            const tabs = screen.getAllByRole('tab');
+            expect(tabs).toHaveLength(2);
+        });
+
+        test('should set id attribute on each tab', () => {
+            renderSegmentedControl(DEFAULT_OPTIONS);
+            expect(getTab1()).toHaveAttribute('id', 'option-1');
+            expect(getTab2()).toHaveAttribute('id', 'option-2');
+        });
+
+        test('should mark selected tab with aria-selected="true"', () => {
+            renderSegmentedControl(DEFAULT_OPTIONS);
+            expect(getTab1()).toHaveAttribute('aria-selected', 'true');
+            expect(getTab2()).toHaveAttribute('aria-selected', 'false');
+        });
+
+        test('should NOT use aria-expanded', () => {
+            renderSegmentedControl(DEFAULT_OPTIONS);
+            expect(getTab1()).not.toHaveAttribute('aria-expanded');
+            expect(getTab2()).not.toHaveAttribute('aria-expanded');
+        });
+
+        test('should set aria-controls on each tab', () => {
+            renderSegmentedControl(DEFAULT_OPTIONS);
+            expect(getTab1()).toHaveAttribute('aria-controls', 'panel-1');
+            expect(getTab2()).toHaveAttribute('aria-controls', 'panel-2');
+        });
     });
 
-    test('should switch between options', async () => {
-        const user = userEvent.setup();
-        renderSegmentedControl(DEFAULT_OPTIONS);
+    describe('Selection behavior', () => {
+        test('should switch aria-selected on click', async () => {
+            const user = userEvent.setup();
+            renderSegmentedControl(DEFAULT_OPTIONS);
 
-        expect(getOption1()).toHaveAttribute('aria-expanded', 'true');
-        expect(getOption2()).toHaveAttribute('aria-expanded', 'false');
+            expect(getTab1()).toHaveAttribute('aria-selected', 'true');
+            expect(getTab2()).toHaveAttribute('aria-selected', 'false');
 
-        const option2Button = await findOption2();
-        await user.click(option2Button);
+            await user.click(getTab2());
 
-        await waitFor(() => {
-            expect(getOption2()).toHaveAttribute('aria-expanded', 'true');
+            await waitFor(() => {
+                expect(getTab2()).toHaveAttribute('aria-selected', 'true');
+            });
+            expect(getTab1()).toHaveAttribute('aria-selected', 'false');
+
+            await user.click(getTab1());
+
+            await waitFor(() => {
+                expect(getTab1()).toHaveAttribute('aria-selected', 'true');
+            });
+            expect(getTab2()).toHaveAttribute('aria-selected', 'false');
+        });
+    });
+
+    describe('Edge cases', () => {
+        test('should not render when options are empty', () => {
+            const { container } = render(<SegmentedControl selectedValue="x" options={[]} onChange={jest.fn()} />);
+            expect(container).toBeEmptyDOMElement();
         });
 
-        expect(getOption1()).toHaveAttribute('aria-expanded', 'false');
-
-        const option1Button = await findOption1();
-        await user.click(option1Button);
-
-        await waitFor(() => {
-            expect(getOption1()).toHaveAttribute('aria-expanded', 'true');
+        test('should not render when options are undefined', () => {
+            const { container } = render(<SegmentedControl selectedValue="x" options={undefined as any} onChange={jest.fn()} />);
+            expect(container).toBeEmptyDOMElement();
         });
-
-        expect(getOption2()).toHaveAttribute('aria-expanded', 'false');
     });
 });

--- a/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.tsx
+++ b/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.tsx
@@ -1,5 +1,6 @@
 import { h } from 'preact';
 import cx from 'classnames';
+
 import './SegmentedControl.scss';
 import { stopPropagationForActionKeys } from '../Button/stopPropagationForActionKeys';
 
@@ -57,10 +58,12 @@ export const SegmentedControl = <T,>({
                 { 'adyen-checkout__segmented-control--disabled': disabled },
                 ...classNameModifiers.map(modifier => `adyen-checkout__segmented-control--${modifier}`)
             )}
-            role="group"
+            role="tablist"
         >
-            {options.map(({ label, value, controls, htmlProps }: SegmentedControlOption<T>) => (
+            {options.map(({ label, value, id, controls, htmlProps }: SegmentedControlOption<T>) => (
                 <button
+                    role="tab"
+                    id={id}
                     disabled={disabled}
                     key={value}
                     onClick={(event: MouseEvent) => onChange(value, event)}
@@ -71,7 +74,7 @@ export const SegmentedControl = <T,>({
                         'adyen-checkout__segmented-control-segment--selected': selectedValue === value
                     })}
                     aria-controls={controls}
-                    aria-expanded={selectedValue === value}
+                    aria-selected={selectedValue === value}
                     type="button"
                     {...htmlProps}
                 >

--- a/packages/lib/src/components/internal/SegmentedControl/SegmentedControlRegion.test.tsx
+++ b/packages/lib/src/components/internal/SegmentedControl/SegmentedControlRegion.test.tsx
@@ -1,0 +1,42 @@
+import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
+
+import { SegmentedControlRegion } from './SegmentedControlRegion';
+
+describe('SegmentedControlRegion', () => {
+    test('should render with role="tabpanel"', () => {
+        render(
+            <SegmentedControlRegion id="panel-1" ariaLabelledBy="tab-1">
+                <span>Panel content</span>
+            </SegmentedControlRegion>
+        );
+        expect(screen.getByRole('tabpanel')).toBeInTheDocument();
+    });
+
+    test('should set id attribute', () => {
+        render(
+            <SegmentedControlRegion id="panel-1" ariaLabelledBy="tab-1">
+                <span>Panel content</span>
+            </SegmentedControlRegion>
+        );
+        expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'panel-1');
+    });
+
+    test('should set aria-labelledby linking to tab id', () => {
+        render(
+            <SegmentedControlRegion id="panel-1" ariaLabelledBy="tab-1">
+                <span>Panel content</span>
+            </SegmentedControlRegion>
+        );
+        expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', 'tab-1');
+    });
+
+    test('should render children', () => {
+        render(
+            <SegmentedControlRegion id="panel-1" ariaLabelledBy="tab-1">
+                <span>Visible content</span>
+            </SegmentedControlRegion>
+        );
+        expect(screen.getByText('Visible content')).toBeInTheDocument();
+    });
+});

--- a/packages/lib/src/components/internal/SegmentedControl/SegmentedControlRegion.tsx
+++ b/packages/lib/src/components/internal/SegmentedControl/SegmentedControlRegion.tsx
@@ -9,7 +9,7 @@ export interface SegmentedControlRegionProps {
 
 export const SegmentedControlRegion = ({ id, ariaLabelledBy, className, children }: Readonly<SegmentedControlRegionProps>) => {
     return (
-        <div id={id} aria-labelledby={ariaLabelledBy} className={className} role="region">
+        <div id={id} aria-labelledby={ariaLabelledBy} className={className} role="tabpanel">
             {children}
         </div>
     );


### PR DESCRIPTION

## Level Access Report
```
Ensure page tabs provide state and role.
For tabs, the following information is expected:
- The container for the set of tabs must have role="tablist".
- Each tab must have role="tab" and must be a descendant of the tablist element.
- Each panel container must have role="tabpanel".
- If the tablist has a visible label, the tablist element must have aria-labelledby set to the ID of the labelling element. Otherwise, the tablist element must have aria-label set to the accessible name.
- Each tab must have aria-controls set to the ID of its corresponding tabpanel.
- The selected tab must have aria-selected="true". All other tabs must have aria-selected="false".
- Tabpanel elements must have aria-labelledby set to the ID of their corresponding tab.
- If the tablist is vertically oriented, it must have aria-orientation="vertical".
```
<img width="1496" height="228" alt="image" src="https://github.com/user-attachments/assets/0443e3ce-2f76-49bc-885c-0884d5a094e8" />


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [x] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [x] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

This PR refactors the SegmentedControl component, used in Iris, PayTo, and UPI payment methods, to align with the W3C WAI-ARIA Tab pattern. The previous implementation used button roles and expansion states, which caused misidentification by screen readers.

[COW–E103 – Ensure page tabs provide state and role]
[COW–E14 – Ensure page tabs provide state and role]

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

[COSDK-1160] [a11y] Change SegmentedControl markup (Ensure page tabs provide state and role)

---

