### PR TITLE
fix: visually hidden content leaking to at

### DIFF
--- a/.changeset/nice-comics-learn.md
+++ b/.changeset/nice-comics-learn.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: visually hidden content leaking to AT

--- a/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.ts
+++ b/packages/lib/src/components/internal/ClickToPay/services/sdks/VisaSdk.ts
@@ -42,6 +42,10 @@ class VisaSdk extends AbstractSrcInitiator {
             };
 
             await this.schemeSdk.init(sdkProps);
+            const systemIframe = document.getElementById('vcop-src-system-frame');
+            systemIframe?.setAttribute('aria-hidden', 'true');
+            systemIframe?.setAttribute('tabindex', '-1');
+            systemIframe?.setAttribute('inert', '');
         } catch (err) {
             const srciError = new SrciError(err as VisaError | MastercardError, 'init', this.schemeName);
             throw srciError;


### PR DESCRIPTION
… Pay system iframe

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

- The element leaking was the Visa Click to Pay Communicator Iframe (#vcop-src-system-frame), which is automatically injected into the page's <body> by the Visa SDK script. It's a headless script container used by Visa to manage background merchant sessions and process background security profiling. 
- The iframe was visually hidden by the SDK by giving it dimensions of zero, making it detectable by screen readers. The iframe element has the role="presentation", that tells browsers that it doesn't contain any semantic content meaningful to users. However, this affects only the outer iframe wrapper and it is not 'silencing' its contents. A possible reason why display: none wasn't added, is because many browsers stop executing script if an iframe is given the above style, meaning it would break its functionality.
- As a solution the below properties will be added to #vcop-src-system-frame:
    - inert: blocks focus on modern browsers

    Adding inert would be enough for modern browsers, but since we support older ones, the below additional attributes are added for fallback

    - tabindex="-1": blocks keyboard tab-focus on older engines

    - aria-hidden="true": hides it from reading cursor on older engines

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->
COSDK-1187
---

