### PR TITLE
 Fixed: Await component now announces its status text to screen readers

### DIFF
--- a/.changeset/upset-carpets-switch.md
+++ b/.changeset/upset-carpets-switch.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Await component now announces its status text to screen readers via the global SRPanel (WCAG 4.1.3)

--- a/packages/lib/src/components/internal/Await/Await.test.tsx
+++ b/packages/lib/src/components/internal/Await/Await.test.tsx
@@ -13,12 +13,14 @@ jest.mock('../../../core/Services/payment-status');
 
 const renderAwait = ({
     awaitProps,
-    amountProviderProps
+    amountProviderProps,
+    srPanel: externalSrPanel
 }: {
     awaitProps: AwaitComponentProps;
     amountProviderProps?: Partial<AmountProviderProps>;
+    srPanel?: SRPanel;
 }) => {
-    const srPanel = new SRPanel(global.core);
+    const srPanel = externalSrPanel ?? new SRPanel(global.core);
 
     return render(
         <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
@@ -167,6 +169,23 @@ describe('Await', () => {
                     details: { payload: checkPaymentStatusValue.payload },
                     paymentData: defaultProps.paymentData
                 }
+            });
+        });
+    });
+
+    describe('Accessibility', () => {
+        beforeEach(() => {
+            const checkPaymentStatusValue = { payload: 'Ab02b4c0!', resultCode: 'pending', type: 'complete' };
+            (checkPaymentStatus as jest.Mock).mockResolvedValue(checkPaymentStatusValue);
+        });
+
+        test('should report awaitText to SRPanel on mount', async () => {
+            const srPanel = new SRPanel(global.core);
+            const setMessagesSpy = jest.spyOn(srPanel, 'setMessages');
+            renderAwait({ awaitProps: { ...defaultProps, awaitText: 'Awaiting your approval' }, amountProviderProps, srPanel });
+
+            await waitFor(() => {
+                expect(setMessagesSpy).toHaveBeenCalledWith('Awaiting your approval');
             });
         });
     });

--- a/packages/lib/src/components/internal/Await/Await.test.tsx
+++ b/packages/lib/src/components/internal/Await/Await.test.tsx
@@ -8,6 +8,7 @@ import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import SRPanelProvider from '../../../core/Errors/SRPanelProvider';
 import { SRPanel } from '../../../core/Errors/SRPanel';
 import { AmountProvider, AmountProviderProps } from '../../../core/Context/AmountProvider';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
 
 jest.mock('../../../core/Services/payment-status');
 
@@ -20,10 +21,11 @@ const renderAwait = ({
     amountProviderProps?: Partial<AmountProviderProps>;
     srPanel?: SRPanel;
 }) => {
-    const srPanel = externalSrPanel ?? new SRPanel(global.core);
+    const core = setupCoreMock();
+    const srPanel = externalSrPanel ?? core.modules.srPanel;
 
     return render(
-        <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
             <SRPanelProvider srPanel={srPanel}>
                 <AmountProvider {...amountProviderProps} providerRef={createRef()}>
                     <Await {...awaitProps} />
@@ -64,7 +66,7 @@ describe('Await', () => {
     });
 
     describe('In progress', () => {
-        let checkPaymentStatusValue;
+        let checkPaymentStatusValue: { payload?: string; resultCode?: string; type?: string; error?: string };
         beforeEach(() => {
             checkPaymentStatusValue = { payload: 'Ab02b4c0!', resultCode: 'pending', type: 'complete' };
             (checkPaymentStatus as jest.Mock).mockResolvedValue(checkPaymentStatusValue);
@@ -110,7 +112,7 @@ describe('Await', () => {
     });
 
     describe('Expired', () => {
-        let checkPaymentStatusValue;
+        let checkPaymentStatusValue: { payload?: string; resultCode?: string; type?: string; error?: string };
         beforeEach(() => {
             checkPaymentStatusValue = { error: 'Unkown error', payload: 'Ab02b4c0!' };
             (checkPaymentStatus as jest.Mock).mockResolvedValue(checkPaymentStatusValue);
@@ -149,7 +151,7 @@ describe('Await', () => {
     });
 
     describe('Completed', () => {
-        let checkPaymentStatusValue;
+        let checkPaymentStatusValue: { payload?: string; resultCode?: string; type?: string; error?: string };
         beforeEach(() => {
             checkPaymentStatusValue = { payload: 'Ab02b4c0!', resultCode: 'authorised', type: 'complete' };
             (checkPaymentStatus as jest.Mock).mockResolvedValue(checkPaymentStatusValue);
@@ -180,7 +182,7 @@ describe('Await', () => {
         });
 
         test('should report awaitText to SRPanel on mount', async () => {
-            const srPanel = new SRPanel(global.core);
+            const srPanel = setupCoreMock().modules.srPanel;
             const setMessagesSpy = jest.spyOn(srPanel, 'setMessages');
             renderAwait({ awaitProps: { ...defaultProps, awaitText: 'Awaiting your approval' }, amountProviderProps, srPanel });
 

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -18,9 +18,11 @@ import { AwaitComponentProps } from './types';
 import { redirectToApp } from '../../../utils/urls';
 import './Await.scss';
 import { useAmount } from '../../../core/Context/AmountProvider';
+import { useA11yReporter } from '../../../core/Errors/useA11yReporter';
 
 export function Await(props: Readonly<AwaitComponentProps>) {
     const { i18n, loadingContext } = useCoreContext();
+    useA11yReporter(props.awaitText);
 
     const { state: timerState, actions: timerActions } = usePaymentStatusTimer({
         loadingContext,


### PR DESCRIPTION

## 📋 Pull Request Checklist

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed.
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR.

---

## 📝 Summary

After form submission, the PayTo await screen renders the "Awaiting your approval" banner silently — NVDA Speech Viewer shows nothing for that region. This violates **WCAG 4.1.3 (Status Messages)** and **EN 301 549 clause 9.4.1.3**.

This PR adds `useA11yReporter(props.awaitText)` to the shared `Await` component so the await text is announced once through the global `SRPanel` (`role="log"`, `aria-live="polite"`) when the screen mounts. The visible banner remains as plain text — no second live region is added, preventing double announcements.

**Changes:**

- `Await.tsx` — +1 import, +1 `useA11yReporter` hook call (before early returns, per hooks rules)
- `Await.test.tsx` — Added `Accessibility` describe block verifying `srPanel.setMessages` is called with the await text on mount; extended `renderAwait` helper to accept an optional `srPanel` for spying

This fix is payment-agnostic and benefits all payment methods using the `Await` component (PayTo, MBWay, etc.), following the same pattern already used in `QRFinalState`.

---

## 🧪 Tested scenarios

1. **Unit test (new):** Verified `srPanel.setMessages` is called with the `awaitText` value on component mount.
2. **All existing Await tests pass** (14/14).
3. **Manual test with PayToAwaitScreen story:** Confirmed NVDA Speech Viewer announces "Awaiting your approval" once on mount; banner is not focusable; no double announcements.
4. **TypeScript strict scan:** Zero new errors.
5. **Lint + Style lint:** Clean.

---

## 🔗 Related GitHub Issue / Internal Ticket number

**Closes**: <!-- #-prefixed issue number -->