### PR TITLE
Fix: use semantic list markup for brand icon components

### DIFF
--- a/.changeset/four-rivers-shave.md
+++ b/.changeset/four-rivers-shave.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Brand icon lists in Card and Drop-in now use correct list semantics

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.scss
@@ -3,11 +3,11 @@
 .adyen-checkout__card__brands {
     margin-top: calc(-1 * variable-generator.token(spacer-040));
     margin-bottom: variable-generator.token(spacer-060);
-}
 
-.adyen-checkout__card__brands--hidden {
-    opacity: 0;
-    max-height: 0;
-    min-height: 0;
-    margin: -8px 0 8px;
+    &--hidden {
+        opacity: 0;
+        max-height: 0;
+        min-height: 0;
+        margin: -8px 0 8px;
+    }
 }

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.test.tsx
@@ -16,11 +16,6 @@ describe('AvailableBrands', () => {
         expect(screen.queryByRole('list')).not.toBeInTheDocument();
     });
 
-    test('renders null when brands is undefined', () => {
-        renderAvailableBrands({ brands: undefined as BrandConfiguration[], activeBrand: 'card' });
-        expect(screen.queryByRole('list')).not.toBeInTheDocument();
-    });
-
     test('renders brand icons when brands are provided', () => {
         renderAvailableBrands({ brands: BRANDS, activeBrand: 'card' });
         const images = screen.getAllByRole('img');
@@ -39,7 +34,7 @@ describe('AvailableBrands', () => {
             renderAvailableBrands({ brands: BRANDS, activeBrand: 'card' });
             const list = screen.getByRole('list');
 
-            expect(list).toHaveAttribute('aria-hidden', 'false');
+            expect(list).not.toHaveAttribute('aria-hidden');
             expect(screen.getAllByRole('img')).toHaveLength(2);
         });
     });

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.test.tsx
@@ -1,0 +1,46 @@
+import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
+import AvailableBrands from './AvailableBrands';
+import { BrandConfiguration } from '../../../../types';
+
+const BRANDS: BrandConfiguration[] = [
+    { name: 'visa', icon: 'https://example.com/visa.svg' },
+    { name: 'mc', icon: 'https://example.com/mc.svg' }
+];
+
+const renderAvailableBrands = (props: { brands: BrandConfiguration[]; activeBrand: string }) => render(<AvailableBrands {...props} />);
+
+describe('AvailableBrands', () => {
+    test('renders null when brands array is empty', () => {
+        renderAvailableBrands({ brands: [], activeBrand: 'card' });
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    test('renders null when brands is undefined', () => {
+        renderAvailableBrands({ brands: undefined as BrandConfiguration[], activeBrand: 'card' });
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    test('renders brand icons when brands are provided', () => {
+        renderAvailableBrands({ brands: BRANDS, activeBrand: 'card' });
+        const images = screen.getAllByRole('img');
+        expect(images).toHaveLength(2);
+    });
+
+    describe('Accessibility – hidden state', () => {
+        test('applies the hidden class and aria-hidden when activeBrand is not "card"', () => {
+            renderAvailableBrands({ brands: BRANDS, activeBrand: 'visa' });
+            const list = screen.getByRole('list', { hidden: true });
+
+            expect(list).toHaveAttribute('aria-hidden', 'true');
+        });
+
+        test('does not apply the hidden class when activeBrand is "card"', () => {
+            renderAvailableBrands({ brands: BRANDS, activeBrand: 'card' });
+            const list = screen.getByRole('list');
+
+            expect(list).toHaveAttribute('aria-hidden', 'false');
+            expect(screen.getAllByRole('img')).toHaveLength(2);
+        });
+    });
+});

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
@@ -39,6 +39,7 @@ const AvailableBrands = ({ brands, activeBrand }: Readonly<PaymentMethodBrandsPr
             smallIcons
             showIconOnError
             containerType="grid"
+            ariaHidden={isValidBrand}
         />
     );
 };

--- a/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/AvailableBrands/AvailableBrands.tsx
@@ -39,7 +39,7 @@ const AvailableBrands = ({ brands, activeBrand }: Readonly<PaymentMethodBrandsPr
             smallIcons
             showIconOnError
             containerType="grid"
-            ariaHidden={isValidBrand}
+            ariaHidden={isValidBrand || undefined}
         />
     );
 };

--- a/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/CardNumber.tsx
@@ -66,7 +66,7 @@ export default function CardNumber(props: Readonly<CardNumberProps>) {
                     'adyen-checkout__input--valid': isValid,
                     'adyen-checkout__card__cardNumber__input--noBrand': !props.showBrandIcon
                 })}
-            ></DataSfSpan>
+            />
 
             {props.showBrandIcon && !dualBrandingElements && <BrandIcon brandsConfiguration={props.brandsConfiguration} brand={props.brand} />}
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -24,7 +24,7 @@ export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLo
                         <div className="adyen-checkout__order-payment-method__header">
                             <div className="adyen-checkout__payment-method__header__title">
                                 <PaymentMethodIcon
-                                    altDescription={orderPaymentMethod.name}
+                                    alt={orderPaymentMethod.name}
                                     type={orderPaymentMethod.type}
                                     src={brandLogoConfiguration[orderPaymentMethod.type] || getImage()(orderPaymentMethod.type)}
                                 />

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodBrands/PaymentMethodBrands.tsx
@@ -42,7 +42,7 @@ const PaymentMethodBrands = ({
             className="adyen-checkout__payment-method__brands"
             remainingBrandsLabelClassName="adyen-checkout__payment-method__brand-number"
             renderBrandIcon={brandIcon => (
-                <PaymentMethodIcon key={brandIcon.alt} altDescription={brandIcon.alt} type={brandIcon.alt} src={brandIcon.src} />
+                <PaymentMethodIcon key={brandIcon.alt} as="li" alt={brandIcon.alt} type={brandIcon.alt} src={brandIcon.src} />
             )}
         />
     );

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodIcon.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodIcon.tsx
@@ -1,26 +1,23 @@
 import { h } from 'preact';
 import classNames from 'classnames';
 import { BrandImage } from '../../../internal/BrandImage';
+import { ElementType } from 'preact/compat';
 
 interface PaymentMethodIconProps {
-    /** URL to the payment method icon */
     src: string;
-
-    /** Alt description of payment method used of a11y */
-    altDescription: string;
-
-    /** Type of the payment method*/
+    alt: string;
     type: string;
+    as?: ElementType;
 }
 
-const paymentMethodsWithoutBorder = ['googlepay', 'paywithgoogle'];
+const paymentMethodsWithoutBorder = new Set(['googlepay', 'paywithgoogle']);
 
-const PaymentMethodIcon = ({ src, altDescription, type }: Readonly<PaymentMethodIconProps>) => {
-    const classes = paymentMethodsWithoutBorder.includes(type)
+const PaymentMethodIcon = ({ src, alt, type, as }: Readonly<PaymentMethodIconProps>) => {
+    const classes = paymentMethodsWithoutBorder.has(type)
         ? 'adyen-checkout__payment-method__image__wrapper'
         : classNames('adyen-checkout__payment-method__image__wrapper', 'adyen-checkout__payment-method__image__wrapper--outline');
 
-    return <BrandImage wrapperClassName={classes} imgClassName={'adyen-checkout__payment-method__image'} src={src} alt={altDescription} />;
+    return <BrandImage as={as} wrapperClassName={classes} imgClassName={'adyen-checkout__payment-method__image'} src={src} alt={alt} />;
 };
 
 export default PaymentMethodIcon;

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -100,7 +100,7 @@ class PaymentMethodItem extends Component<Readonly<PaymentMethodItemProps>> {
                     >
                         <PaymentMethodIcon
                             // Only add alt attribute to storedPaymentMethods (to avoid SR reading the PM name twice)
-                            {...(paymentMethod.props.oneClick && { altDescription: getFullBrandName(paymentMethod.props.brand) })}
+                            {...(paymentMethod.props.oneClick && { alt: getFullBrandName(paymentMethod.props.brand) })}
                             type={paymentMethod.type}
                             src={paymentMethod.icon}
                         />

--- a/packages/lib/src/components/UPI/components/UPIIntentAppList/UPIIntentAppItem/UPIIntentAppItem.tsx
+++ b/packages/lib/src/components/UPI/components/UPIIntentAppList/UPIIntentAppItem/UPIIntentAppItem.tsx
@@ -30,7 +30,7 @@ const UPIIntentAppItem = ({ app, imgSrc, isSelected, onSelect }: Readonly<UPIInt
         >
             <div className="adyen-checkout-upi-app-item-header">
                 <ExpandButton classNameModifiers={['upi-app-item']} buttonId={buttonId} isSelected={isSelected} expandContentId={containerId}>
-                    <PaymentMethodIcon src={imgSrc} altDescription={app.name} type={app.id}></PaymentMethodIcon>
+                    <PaymentMethodIcon src={imgSrc} alt={app.name} type={app.id}></PaymentMethodIcon>
                     <label className="adyen-checkout-upi-app-item__label" htmlFor={buttonId}>
                         {app.name}
                     </label>

--- a/packages/lib/src/components/internal/BrandIcons/BrandIcons.module.scss
+++ b/packages/lib/src/components/internal/BrandIcons/BrandIcons.module.scss
@@ -7,6 +7,8 @@
     align-items: center;
     gap: variable-generator.token(spacer-040);
     margin: variable-generator.token(spacer-020) variable-generator.token(spacer-000);
+    list-style: none;
+    padding: 0;
 }
 
 .grid {

--- a/packages/lib/src/components/internal/BrandIcons/BrandIcons.stories.tsx
+++ b/packages/lib/src/components/internal/BrandIcons/BrandIcons.stories.tsx
@@ -80,9 +80,9 @@ export const WithCustomRenderBrandIcon: StoryObj<BrandIconsProp> = {
     args: {
         brandIcons: sampleBrands.slice(0, 3),
         renderBrandIcon: (brandIcon: BrandIcon) => (
-            <span key={brandIcon.alt} style={{ border: '1px solid #ccc', padding: '4px', borderRadius: '4px' }}>
+            <li key={brandIcon.alt} style={{ border: '1px solid #ccc', padding: '4px', borderRadius: '4px' }}>
                 <img src={brandIcon.src} alt={brandIcon.alt} style={{ margin: 0, padding: 0 }} />
-            </span>
+            </li>
         )
     }
 };

--- a/packages/lib/src/components/internal/BrandIcons/BrandIcons.tsx
+++ b/packages/lib/src/components/internal/BrandIcons/BrandIcons.tsx
@@ -19,6 +19,7 @@ export type BrandIconsProp = {
     brandImageClassName?: string;
     showIconOnError?: boolean;
     smallIcons?: boolean;
+    ariaHidden?: boolean;
     renderBrandIcon?: (brandIcon: BrandIcon) => h.JSX.Element;
 };
 
@@ -33,7 +34,8 @@ export const BrandIcons = ({
     brandImageWrapperClassName,
     showIconOnError,
     smallIcons,
-    renderBrandIcon
+    renderBrandIcon,
+    ariaHidden
 }: Readonly<BrandIconsProp>) => {
     const visibleBrands = useMemo(() => brandIcons.slice(0, maxBrandsToShow), [brandIcons, maxBrandsToShow]);
     const remainingBrands = useMemo(() => brandIcons.slice(maxBrandsToShow), [brandIcons, maxBrandsToShow]);
@@ -41,18 +43,20 @@ export const BrandIcons = ({
     const hasRemainingBrands = Boolean(remainingBrandsLabel) || remainingBrands.length > 0;
 
     return (
-        <div
+        <ul
             className={cn(
                 styles.container,
                 { [styles.grid]: containerType === 'grid', [styles.smallImgGrid]: smallIcons && containerType === 'grid' },
                 className
             )}
+            aria-hidden={ariaHidden}
         >
             {visibleBrands.map(brandIcon =>
                 renderBrandIcon ? (
                     renderBrandIcon(brandIcon)
                 ) : (
                     <BrandImage
+                        as="li"
                         key={brandIcon.alt}
                         src={brandIcon.src}
                         alt={brandIcon.alt}
@@ -63,10 +67,10 @@ export const BrandIcons = ({
                 )
             )}
             {hasRemainingBrands && (
-                <span className={cn(styles.remainingBrandsLabel, remainingBrandsLabelClassName)}>
+                <li className={cn(styles.remainingBrandsLabel, remainingBrandsLabelClassName)}>
                     {remainingBrandsLabel || `+ ${remainingBrands.length}`}
-                </span>
+                </li>
             )}
-        </div>
+        </ul>
     );
 };

--- a/packages/lib/src/components/internal/BrandImage/BrandImage.tsx
+++ b/packages/lib/src/components/internal/BrandImage/BrandImage.tsx
@@ -3,6 +3,7 @@ import { useState } from 'preact/hooks';
 import cx from 'classnames';
 import Img from '../Img';
 import './BrandImage.scss';
+import { ElementType } from 'preact/compat';
 
 interface BrandImageProps {
     src: string;
@@ -10,16 +11,19 @@ interface BrandImageProps {
     wrapperClassName?: string;
     imgClassName?: string;
     showOnError?: boolean;
+    as?: ElementType;
 }
 
-export const BrandImage = ({ src, alt, wrapperClassName = '', imgClassName = '', showOnError }: Readonly<BrandImageProps>) => {
+export const BrandImage = ({ src, alt, wrapperClassName = '', imgClassName = '', showOnError, as = 'span' }: Readonly<BrandImageProps>) => {
     const [hasError, setHasError] = useState(false);
     const classesOnError = showOnError ? {} : { 'adyen-checkout-brand-wrapper--error': hasError };
     const classes = cx('adyen-checkout-brand-wrapper', wrapperClassName, classesOnError);
 
+    const Component = as ?? 'span';
+
     return (
-        <span className={classes} data-testid="brand-image-wrapper">
+        <Component className={classes} data-testid="brand-image-wrapper">
             <Img className={imgClassName} src={src} alt={alt} onError={() => setHasError(true)} />
-        </span>
+        </Component>
     );
 };

--- a/packages/lib/src/components/internal/BrandImage/BrandImage.tsx
+++ b/packages/lib/src/components/internal/BrandImage/BrandImage.tsx
@@ -14,7 +14,7 @@ interface BrandImageProps {
     as?: ElementType;
 }
 
-export const BrandImage = ({ src, alt, wrapperClassName = '', imgClassName = '', showOnError, as = 'span' }: Readonly<BrandImageProps>) => {
+export const BrandImage = ({ src, alt, wrapperClassName = '', imgClassName = '', showOnError, as }: Readonly<BrandImageProps>) => {
     const [hasError, setHasError] = useState(false);
     const classesOnError = showOnError ? {} : { 'adyen-checkout-brand-wrapper--error': hasError };
     const classes = cx('adyen-checkout-brand-wrapper', wrapperClassName, classesOnError);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Brand icon lists were rendered as `<div>` containers with `<span>` items, which is not semantically correct and causes accessibility issues (implicit list role announced by screen readers without proper list structure).

### Changes

- **`BrandIcons`**: Changed container element from `<div>` to `<ul>` and each brand item from `<span>` to `<li>`, giving the list proper semantic structure. Added `list-style: none; padding: 0` to reset default `<ul>` styles. Added `ariaHidden` prop to allow callers to suppress SR announcement when the brand list is decorative.
- **`BrandImage`**: Added polymorphic `as` prop (defaults to `'span'`) so the wrapper element can be swapped to `<li>` when rendered inside a list context.
- **`AvailableBrands`** (Card): Passes `ariaHidden` to `BrandIcons` when the list is decorative; updated tests to reflect the new list markup.
- **`PaymentMethodIcon`**: Renamed `altDescription` prop to `alt` for consistency; updated all call sites (`PaymentMethodItem`, `UPIIntentAppItem`, `PaymentMethodBrands`, `OrderPaymentMethods`).

### Testing

Existing `AvailableBrands` tests updated to assert against `<ul>`/`<li>` elements. No breaking changes to the public merchant-facing API.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

- COSDK-1186

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

