### PR TITLE
Add new message for click to pay invalid email error

### DIFF
--- a/.changeset/fruity-moose-study.md
+++ b/.changeset/fruity-moose-study.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Suggestion for invalid email error in click to pay

--- a/packages/lib/.size-limit.cjs
+++ b/packages/lib/.size-limit.cjs
@@ -59,14 +59,14 @@ module.exports = [
         name: 'ESM - Core + Card',
         path: 'dist/es/index.js',
         import: '{ AdyenCheckout, Card }',
-        limit: '78 KB',
+        limit: '79 KB',
         running: false
     },
     {
         name: 'ESM - Core + Dropin with Card',
         path: 'dist/es/index.js',
         import: '{ AdyenCheckout, Dropin, Card }',
-        limit: '84 KB',
+        limit: '85 KB',
         running: false
     }
 ];

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
@@ -55,8 +55,9 @@ const CtPLogin = (): h.JSX.Element => {
         } catch (error: unknown) {
             if (error instanceof SrciError) console.warn(`CtP - Login error: ${error.toString()}`);
             if (error instanceof TimeoutError) console.warn(error.toString());
-            if (isSrciError(error)) setErrorCode(error?.reason);
-            else console.error(error);
+            if (isSrciError(error)) {
+                setErrorCode(error?.reason == 'INVALID_PARAMETER' ? 'INVALID_EMAIL' : error?.reason);
+            } else console.error(error);
 
             setIsLoggingIn(false);
         }

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLogin.tsx
@@ -56,7 +56,7 @@ const CtPLogin = (): h.JSX.Element => {
             if (error instanceof SrciError) console.warn(`CtP - Login error: ${error.toString()}`);
             if (error instanceof TimeoutError) console.warn(error.toString());
             if (isSrciError(error)) {
-                setErrorCode(error?.reason == 'INVALID_PARAMETER' ? 'INVALID_EMAIL' : error?.reason);
+                setErrorCode(error.reason === 'INVALID_PARAMETER' ? 'INVALID_EMAIL' : error.reason);
             } else console.error(error);
 
             setIsLoggingIn(false);

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
@@ -76,7 +76,7 @@ const CtPLoginInput = (props: Readonly<CtPLoginInputProps>): h.JSX.Element => {
             <Field
                 name="shopperLogin"
                 label={i18n.get('ctp.login.inputLabel')}
-                errorMessage={isLoginInputDirty ? props.errorMessage || !!errors.shopperLogin : null}
+                errorMessage={isLoginInputDirty ? props.errorMessage || (errors.shopperLogin && i18n.get(errors.shopperLogin.errorMessage)) : null}
                 classNameModifiers={['shopperLogin']}
                 errorLive={true}
             >

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtpLogin.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtpLogin.test.tsx
@@ -95,6 +95,23 @@ test('should display not found if the email is not registered', async () => {
     expect(button).not.toHaveClass('adyen-checkout__button--loading');
 });
 
+test('should display local validation error message if the user clicks Continue without typing an email', async () => {
+    const user = userEvent.setup();
+
+    const contextProps = mock<IClickToPayContext>();
+    contextProps.isCtpPrimaryPaymentMethod = true;
+    contextProps.setIsCtpPrimaryPaymentMethod.mockImplementation(() => {});
+    contextProps.schemes = ['mc', 'visa'];
+
+    customRender(<CtPLogin />, contextProps);
+
+    const button = await screen.findByRole('button', { name: 'Continue' });
+    await user.click(button);
+
+    expect(contextProps.verifyIfShopperIsEnrolled).not.toHaveBeenCalled();
+    expect(await screen.findByText('Enter a valid email address (e.g. name@example.com)')).toBeInTheDocument();
+});
+
 test('should start the identity validation if the user is enrolled', async () => {
     const user = userEvent.setup();
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/validate.ts
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/validate.ts
@@ -3,7 +3,7 @@ import { ValidatorRules } from '../../../../../utils/Validator/types';
 export const loginValidationRules: ValidatorRules = {
     shopperLogin: {
         validate: value => !!value && value.length > 0,
-        errorMessage: '',
+        errorMessage: 'ctp.errors.INVALID_EMAIL',
         modes: ['blur']
     },
     default: {

--- a/packages/server/translations/ar.json
+++ b/packages/server/translations/ar.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "تطبيقات UPI",
     "upi.intent.apps.dropdown.placeholder": "يُرجى اختيار التطبيق المفضل.",
     "order.paymentMethod.description": "%{name} المنتهي بـ %{lastFour}",
-    "select.results": "عدد النتائج المتاحة هو %{count}"
+    "select.results": "عدد النتائج المتاحة هو %{count}",
+    "ctp.errors.INVALID_EMAIL": "أدخل عنوان بريد إلكتروني صالح (مثلاً: name@example.com)"
 }

--- a/packages/server/translations/bg-BG.json
+++ b/packages/server/translations/bg-BG.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI приложения",
     "upi.intent.apps.dropdown.placeholder": "Изберете предпочитано приложение",
     "order.paymentMethod.description": "%{name}, завършва с %{lastFour}",
-    "select.results": "%{{count} налични резултата"
+    "select.results": "%{{count} налични резултата",
+    "ctp.errors.INVALID_EMAIL": "Въведете валиден имейл адрес (напр. име@пример.com)"
 }

--- a/packages/server/translations/ca-ES.json
+++ b/packages/server/translations/ca-ES.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Aplicacions UPI",
     "upi.intent.apps.dropdown.placeholder": "Trieu l'aplicació preferida",
     "order.paymentMethod.description": "%{name} que acaba en %{lastFour}",
-    "select.results": "%{count} resultats disponibles"
+    "select.results": "%{count} resultats disponibles",
+    "ctp.errors.INVALID_EMAIL": "Introduïu una adreça de correu electrònic vàlida (p. ex. name@example.com)"
 }

--- a/packages/server/translations/cs-CZ.json
+++ b/packages/server/translations/cs-CZ.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Aplikace UPI",
     "upi.intent.apps.dropdown.placeholder": "Vyberte preferovanou aplikaci",
     "order.paymentMethod.description": "%{name} končící na %{lastFour}",
-    "select.results": "Dostupných výsledků: %{count}"
+    "select.results": "Dostupných výsledků: %{count}",
+    "ctp.errors.INVALID_EMAIL": "Zadejte platnou e-mailovou adresu (např. jmeno@priklad.cz)"
 }

--- a/packages/server/translations/da-DK.json
+++ b/packages/server/translations/da-DK.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-apps",
     "upi.intent.apps.dropdown.placeholder": "Vælg foretrukne app",
     "order.paymentMethod.description": "%{name} ender på %{lastFour}",
-    "select.results": "%{count} resultater tilgængelige"
+    "select.results": "%{count} resultater tilgængelige",
+    "ctp.errors.INVALID_EMAIL": "Indtast en gyldig e-mailadresse (f.eks. navn@eksempel.dk)"
 }

--- a/packages/server/translations/de-DE.json
+++ b/packages/server/translations/de-DE.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-Apps",
     "upi.intent.apps.dropdown.placeholder": "Bevorzugte App wählen",
     "order.paymentMethod.description": "%{name} endet mit %{lastFour}",
-    "select.results": "%{count} Ergebnisse verfügbar"
+    "select.results": "%{count} Ergebnisse verfügbar",
+    "ctp.errors.INVALID_EMAIL": "Geben Sie eine gültige E-Mail-Adresse ein (z. B. name@example.com)"
 }

--- a/packages/server/translations/el-GR.json
+++ b/packages/server/translations/el-GR.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Εφαρμογές UPI",
     "upi.intent.apps.dropdown.placeholder": "Επιλέξτε την προτιμώμενη εφαρμογή",
     "order.paymentMethod.description": "%{name} που τελειώνει σε %{lastFour}",
-    "select.results": "%{count} διαθέσιμα αποτελέσματα"
+    "select.results": "%{count} διαθέσιμα αποτελέσματα",
+    "ctp.errors.INVALID_EMAIL": "Εισαγάγετε μια έγκυρη διεύθυνση email (π.χ. name@example.com)"
 }

--- a/packages/server/translations/en-US.json
+++ b/packages/server/translations/en-US.json
@@ -315,6 +315,7 @@
     "ctp.errors.SERVICE_ERROR": "Something went wrong, try again or use the manual card entry",
     "ctp.errors.SERVER_ERROR": "Something went wrong, try again or use the manual card entry",
     "ctp.errors.INVALID_PARAMETER": "Something went wrong, try again or use the manual card entry",
+    "ctp.errors.INVALID_EMAIL": "Enter a valid email address",
     "ctp.errors.AUTH_ERROR": "Something went wrong, try again or use the manual card entry",
     "paymentMethodsList.aria.label": "Choose a payment method",
     "paymentMethodsList.storedPayments.label": "Saved payment methods",

--- a/packages/server/translations/en-US.json
+++ b/packages/server/translations/en-US.json
@@ -315,7 +315,7 @@
     "ctp.errors.SERVICE_ERROR": "Something went wrong, try again or use the manual card entry",
     "ctp.errors.SERVER_ERROR": "Something went wrong, try again or use the manual card entry",
     "ctp.errors.INVALID_PARAMETER": "Something went wrong, try again or use the manual card entry",
-    "ctp.errors.INVALID_EMAIL": "Enter a valid email address",
+    "ctp.errors.INVALID_EMAIL": "Enter a valid email address (e.g. name@example.com)",
     "ctp.errors.AUTH_ERROR": "Something went wrong, try again or use the manual card entry",
     "paymentMethodsList.aria.label": "Choose a payment method",
     "paymentMethodsList.storedPayments.label": "Saved payment methods",

--- a/packages/server/translations/es-ES.json
+++ b/packages/server/translations/es-ES.json
@@ -447,5 +447,6 @@
     "upi.intent.apps.dropdown.label": "Aplicaciones UPI",
     "upi.intent.apps.dropdown.placeholder": "Elija la aplicación que prefiera",
     "order.paymentMethod.description": "%{name} que termina en %{lastFour}",
-    "select.results": "%{count} resultados disponibles"
+    "select.results": "%{count} resultados disponibles",
+    "ctp.errors.INVALID_EMAIL": "Escribe una dirección de correo electrónico válida (por ejemplo, nombre@ejemplo.com)"
 }

--- a/packages/server/translations/et-EE.json
+++ b/packages/server/translations/et-EE.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI rakendused",
     "upi.intent.apps.dropdown.placeholder": "Valige eelistatud rakendus",
     "order.paymentMethod.description": "%{name}, mis lõpeb %{lastFour}-ga",
-    "select.results": "Saadaval on %{count} tulemust"
+    "select.results": "Saadaval on %{count} tulemust",
+    "ctp.errors.INVALID_EMAIL": "Sisestage kehtiv e-posti aadress (nt name@example.com)"
 }

--- a/packages/server/translations/fi-FI.json
+++ b/packages/server/translations/fi-FI.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-sovellukset",
     "upi.intent.apps.dropdown.placeholder": "Valitse haluamasi sovellus",
     "order.paymentMethod.description": "%{name}, joka päättyy kirjaimiin %{lastFour}",
-    "select.results": "%{count} tulosta saatavilla"
+    "select.results": "%{count} tulosta saatavilla",
+    "ctp.errors.INVALID_EMAIL": "Anna kelvollinen sähköpostiosoite (esimerkiksi name@example.com)"
 }

--- a/packages/server/translations/fr-FR.json
+++ b/packages/server/translations/fr-FR.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Applications UPI",
     "upi.intent.apps.dropdown.placeholder": "Choisissez votre application préférée",
     "order.paymentMethod.description": "%{name} se terminant par %{lastFour}",
-    "select.results": "%{count} résultats disponibles"
+    "select.results": "%{count} résultats disponibles",
+    "ctp.errors.INVALID_EMAIL": "Saisissez une adresse e-mail valide (par ex. nom@exemple.com)"
 }

--- a/packages/server/translations/hr-HR.json
+++ b/packages/server/translations/hr-HR.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI aplikacije",
     "upi.intent.apps.dropdown.placeholder": "Odaberite željenu aplikaciju",
     "order.paymentMethod.description": "%{name} završava s %{lastFour}",
-    "select.results": "Dostupno rezultata: %{count}"
+    "select.results": "Dostupno rezultata: %{count}",
+    "ctp.errors.INVALID_EMAIL": "Unesite važeću adresu e-pošte (npr. ime@primjer.com)"
 }

--- a/packages/server/translations/hu-HU.json
+++ b/packages/server/translations/hu-HU.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-alkalmazások",
     "upi.intent.apps.dropdown.placeholder": "Válassza ki a kívánt alkalmazást",
     "order.paymentMethod.description": "%{name} (kártyaszám vége: %{lastFour})",
-    "select.results": "%{count} találat elérhető"
+    "select.results": "%{count} találat elérhető",
+    "ctp.errors.INVALID_EMAIL": "Adjon meg egy érvényes e-mail-címet (pl. name@example.com)"
 }

--- a/packages/server/translations/is-IS.json
+++ b/packages/server/translations/is-IS.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-forrit",
     "upi.intent.apps.dropdown.placeholder": "Veldu forritið sem þér hentar best",
     "order.paymentMethod.description": "%{name} sem endar á %{lastFour}",
-    "select.results": "%{count} niðurstöður í boði"
+    "select.results": "%{count} niðurstöður í boði",
+    "ctp.errors.INVALID_EMAIL": "Sláðu inn gilt netfang (t.d. name@example.com)"
 }

--- a/packages/server/translations/it-IT.json
+++ b/packages/server/translations/it-IT.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "App UPI",
     "upi.intent.apps.dropdown.placeholder": "Scegli la tua app preferita",
     "order.paymentMethod.description": "%{name} che termina con %{lastFour}",
-    "select.results": "%{count} risultati disponibili"
+    "select.results": "%{count} risultati disponibili",
+    "ctp.errors.INVALID_EMAIL": "Inserisci un indirizzo e-mail valido (ad es. name@example.com)"
 }

--- a/packages/server/translations/ja-JP.json
+++ b/packages/server/translations/ja-JP.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPIアプリ",
     "upi.intent.apps.dropdown.placeholder": "希望するアプリを選択",
     "order.paymentMethod.description": "末尾が%{lastFour}の%{name}",
-    "select.results": "%{count}件の結果が利用可能です"
+    "select.results": "%{count}件の結果が利用可能です",
+    "ctp.errors.INVALID_EMAIL": "有効なメールアドレスを入力してください（例：name@example.com）"
 }

--- a/packages/server/translations/ko-KR.json
+++ b/packages/server/translations/ko-KR.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI 앱",
     "upi.intent.apps.dropdown.placeholder": "선호하는 앱 선택",
     "order.paymentMethod.description": "끝자리가 %{lastFour}인 %{name}",
-    "select.results": "결과 %{count}개"
+    "select.results": "결과 %{count}개",
+    "ctp.errors.INVALID_EMAIL": "유효한 이메일 주소를 입력하세요(예: name@example.com)"
 }

--- a/packages/server/translations/lt-LT.json
+++ b/packages/server/translations/lt-LT.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI programos",
     "upi.intent.apps.dropdown.placeholder": "Pasirinkite pageidaujamą programą",
     "order.paymentMethod.description": "%{name}, kuris baigiasi %{lastFour}",
-    "select.results": "Rasta rezultatų: %{count}"
+    "select.results": "Rasta rezultatų: %{count}",
+    "ctp.errors.INVALID_EMAIL": "Įveskite galiojantį el. pašto adresą (pvz., name@example.com)"
 }

--- a/packages/server/translations/lv-LV.json
+++ b/packages/server/translations/lv-LV.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI lietotnes",
     "upi.intent.apps.dropdown.placeholder": "Izvēlieties vēlamo lietotni",
     "order.paymentMethod.description": "%{name}, kas beidzas ar %{lastFour}",
-    "select.results": "Pieejami %{count} rezultāti"
+    "select.results": "Pieejami %{count} rezultāti",
+    "ctp.errors.INVALID_EMAIL": "Ievadiet derīgu e-pasta adresi (piemēram, vards@piemers.com)"
 }

--- a/packages/server/translations/nl-NL.json
+++ b/packages/server/translations/nl-NL.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-apps",
     "upi.intent.apps.dropdown.placeholder": "Kies de gewenste app",
     "order.paymentMethod.description": "%{name} eindigend op %{lastFour}",
-    "select.results": "%{count} resultaten beschikbaar"
+    "select.results": "%{count} resultaten beschikbaar",
+    "ctp.errors.INVALID_EMAIL": "Voer een geldig e-mailadres in (bijv. naam@example.com)"
 }

--- a/packages/server/translations/no-NO.json
+++ b/packages/server/translations/no-NO.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-apper",
     "upi.intent.apps.dropdown.placeholder": "Velg app",
     "order.paymentMethod.description": "%{name} som slutter på %{lastFour}",
-    "select.results": "%{count} tilgjengelige resultater"
+    "select.results": "%{count} tilgjengelige resultater",
+    "ctp.errors.INVALID_EMAIL": "Skriv inn en gyldig e-postadresse (f.eks. navn@eksempel.no)"
 }

--- a/packages/server/translations/pl-PL.json
+++ b/packages/server/translations/pl-PL.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Aplikacje UPI",
     "upi.intent.apps.dropdown.placeholder": "Wybierz preferowaną aplikację",
     "order.paymentMethod.description": "%{name} kończy się za %{lastFour}",
-    "select.results": "%{count} dostępne wyniki"
+    "select.results": "%{count} dostępne wyniki",
+    "ctp.errors.INVALID_EMAIL": "Wprowadź poprawny adres e-mail (np. name@example.com)"
 }

--- a/packages/server/translations/pt-BR.json
+++ b/packages/server/translations/pt-BR.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Aplicativos UPI",
     "upi.intent.apps.dropdown.placeholder": "Escolha o aplicativo preferencial",
     "order.paymentMethod.description": "%{name} terminando em %{lastFour}",
-    "select.results": "%{count} resultados disponíveis"
+    "select.results": "%{count} resultados disponíveis",
+    "ctp.errors.INVALID_EMAIL": "Digite um endereço de e-mail válido (por ex., nome@exemplo.com)"
 }

--- a/packages/server/translations/pt-PT.json
+++ b/packages/server/translations/pt-PT.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "aplicações de UPI",
     "upi.intent.apps.dropdown.placeholder": "Escolha a sua aplicação preferencial",
     "order.paymentMethod.description": "%{name} que termina em %{lastFour}",
-    "select.results": "%{count} resultados disponíveis"
+    "select.results": "%{count} resultados disponíveis",
+    "ctp.errors.INVALID_EMAIL": "Introduza um endereço de e-mail válido (p. ex. name@example.com)"
 }

--- a/packages/server/translations/ro-RO.json
+++ b/packages/server/translations/ro-RO.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Aplicații UPI",
     "upi.intent.apps.dropdown.placeholder": "Alege aplicația preferată",
     "order.paymentMethod.description": "%{name} care se termină în %{lastFour}",
-    "select.results": "%{count} rezultate disponibile"
+    "select.results": "%{count} rezultate disponibile",
+    "ctp.errors.INVALID_EMAIL": "Introduceți o adresă de email validă (de exemplu, name@example.com)"
 }

--- a/packages/server/translations/ru-RU.json
+++ b/packages/server/translations/ru-RU.json
@@ -447,5 +447,6 @@
     "upi.intent.apps.dropdown.label": "Приложения UPI",
     "upi.intent.apps.dropdown.placeholder": "Выберите предпочтительное приложение",
     "order.paymentMethod.description": "%{name}, заканчивающаяся на %{lastFour}",
-    "select.results": "Доступно результатов: %{count}"
+    "select.results": "Доступно результатов: %{count}",
+    "ctp.errors.INVALID_EMAIL": "Введите действительный адрес эл. почты (например, name@example.com)"
 }

--- a/packages/server/translations/sk-SK.json
+++ b/packages/server/translations/sk-SK.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Aplikácie UPI",
     "upi.intent.apps.dropdown.placeholder": "Vyberte preferovanú aplikáciu",
     "order.paymentMethod.description": "%{name} končiaca sa číslom %{lastFour}",
-    "select.results": "Dostupné výsledky: %{count}"
+    "select.results": "Dostupné výsledky: %{count}",
+    "ctp.errors.INVALID_EMAIL": "Zadajte platnú e-mailovú adresu (napr. meno@priklad.com)"
 }

--- a/packages/server/translations/sl-SI.json
+++ b/packages/server/translations/sl-SI.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "Aplikacije UPI",
     "upi.intent.apps.dropdown.placeholder": "Izberite želeno aplikacijo",
     "order.paymentMethod.description": "%{name}, ki se konča z %{lastFour}",
-    "select.results": "Na voljo je toliko rezultatov: %{count}"
+    "select.results": "Na voljo je toliko rezultatov: %{count}",
+    "ctp.errors.INVALID_EMAIL": "Vnesite veljaven e-poštni naslov (npr. ime@primer.com)"
 }

--- a/packages/server/translations/sv-SE.json
+++ b/packages/server/translations/sv-SE.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI-appar",
     "upi.intent.apps.dropdown.placeholder": "Välj önskad app",
     "order.paymentMethod.description": "%{name} som slutar på %{lastFour}",
-    "select.results": "%{count} resultat tillgängliga"
+    "select.results": "%{count} resultat tillgängliga",
+    "ctp.errors.INVALID_EMAIL": "Ange en giltig e-postadress (t.ex. namn@exempel.com)"
 }

--- a/packages/server/translations/zh-CN.json
+++ b/packages/server/translations/zh-CN.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI 应用",
     "upi.intent.apps.dropdown.placeholder": "选择首选应用",
     "order.paymentMethod.description": "尾号为 %{lastFour} 的 %{name}",
-    "select.results": "%{count} 个可用结果"
+    "select.results": "%{count} 个可用结果",
+    "ctp.errors.INVALID_EMAIL": "输入有效的电子邮件地址（例如：name@example.com）"
 }

--- a/packages/server/translations/zh-TW.json
+++ b/packages/server/translations/zh-TW.json
@@ -449,5 +449,6 @@
     "upi.intent.apps.dropdown.label": "UPI 應用程式",
     "upi.intent.apps.dropdown.placeholder": "選擇偏好的應用程式",
     "order.paymentMethod.description": "%{name} 結尾為 %{lastFour}",
-    "select.results": "有 %{count} 項結果"
+    "select.results": "有 %{count} 項結果",
+    "ctp.errors.INVALID_EMAIL": "輸入有效的電子郵件地址（例如 name@example.com）"
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [x] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

#### Issue
When a user entered an invalid email on the Click to Pay login screen, INVALID_PARAMETER error was returned. This was surfaced to the user with a generic fallback message: "Something went wrong, try again or use the manual card entry", which is not helpful to them.

#### Changes
- CtPLogin.tsx:  In the login error handler, INVALID_PARAMETER errors are now remapped to the new INVALID_EMAIL error code, so the UI can show a specific, contextual message instead of the generic fallback. Since currently we are only supporting logging in through email, this is the only parameter entered by the user that could be invalid.
- en-US.json — Added the new translation key ctp.errors.INVALID_EMAIL with the value:
"Enter a valid email address (e.g. name@example.com)"which  gives users a concrete suggestion on the expected format.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->
COSDK-1185
---

