### PR TITLE
Improved contrast ratio on ClickToPay "read more" text

### DIFF
--- a/.changeset/little-horses-show.md
+++ b/.changeset/little-horses-show.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Improved contrast ratio on ClickToPay "read more" text

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPSaveCookiesCheckbox/CtPSaveCookiesCheckbox.scss
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPSaveCookiesCheckbox/CtPSaveCookiesCheckbox.scss
@@ -32,5 +32,5 @@
   all: unset;
   text-transform: lowercase;
   cursor: pointer;
-  color:  variable-generator.token(color-label-on-background-highlight-weak);
+  color: variable-generator.token(color-label-on-background-highlight-weak);
 }

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPSaveCookiesCheckbox/CtPSaveCookiesCheckbox.scss
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPSaveCookiesCheckbox/CtPSaveCookiesCheckbox.scss
@@ -32,5 +32,5 @@
   all: unset;
   text-transform: lowercase;
   cursor: pointer;
-  color: #0075ff;
+  color:  variable-generator.token(color-label-on-background-highlight-weak);
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Improved contrast ratio on ClickToPay "read more" text. Used the pre-existing Bento value `color-label-on-background-highlight-weak` which raised the contrast ratio to 5.24:1

---

## 🧪 Tested scenarios

Confirmed contrast ratio in separate [tool](https://accessibleweb.com/color-contrast-checker/)

---

## 🔗 Related GitHub Issue / Internal Ticket number

COSDK-1183

---

