### PR TITLE
Bumping securedFields version to one that recognises ionic:// domains

### DIFF
--- a/.changeset/dull-tables-accept.md
+++ b/.changeset/dull-tables-accept.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Bumped SecuredFields version to one that recognises ionic:// domains

--- a/packages/e2e-playwright/tests/ui/card/binLookup/branding/dualBranding.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/branding/dualBranding.spec.ts
@@ -15,32 +15,36 @@ const componentConfig = {
 };
 
 test.describe('Card - Dual branding UI after binLookup gives a dual brand result', () => {
-    test('#1 should show brand options with first selected by default for EU dual branded card', { tag: [TAGS.SCREENSHOT] }, async ({ card, page, browserName }) => {
-        await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
+    test(
+        '#1 should show brand options with first selected by default for EU dual branded card',
+        { tag: [TAGS.SCREENSHOT] },
+        async ({ card, page, browserName }) => {
+            await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
 
-        // Get a binLookup result
-        await card.typeCardNumber(BCMC_DUAL_BRANDED_VISA);
+            // Get a binLookup result
+            await card.typeCardNumber(BCMC_DUAL_BRANDED_VISA);
 
-        // Check brand has been set, by default, in paymentMethod data
-        let cardData: any = await page.evaluate('window.component.data');
-        expect(cardData.paymentMethod.brand).not.toBe(undefined);
+            // Check brand has been set, by default, in paymentMethod data
+            let cardData: any = await page.evaluate('window.component.data');
+            expect(cardData.paymentMethod.brand).not.toBe(undefined);
 
-        // Expect the brand selection UI to be visible (EU dual brand)
-        await expect(card.dualBrandSelector).toBeVisible();
+            // Expect the brand selection UI to be visible (EU dual brand)
+            await expect(card.dualBrandSelector).toBeVisible();
 
-        // Brand selection is visible with 2 options
-        await expect(card.isDualBrandSelectionVisible()).resolves.toBe(true);
-        await expect(card.getBrandOptionCount()).resolves.toBe(2);
+            // Brand selection is visible with 2 options
+            await expect(card.isDualBrandSelectionVisible()).resolves.toBe(true);
+            await expect(card.getBrandOptionCount()).resolves.toBe(2);
 
-        // First brand is selected by default
-        await expect(card.isBrandSelected(/visa/i)).resolves.toBe(true);
+            // First brand is selected by default
+            await expect(card.isBrandSelected(/visa/i)).resolves.toBe(true);
 
-        // Contextual label visible for EU co-badged card
-        await expect(card.isDualBrandContextualLabelVisible()).resolves.toBe(true);
+            // Contextual label visible for EU co-badged card
+            await expect(card.isDualBrandContextualLabelVisible()).resolves.toBe(true);
 
-        // Screenshot: EU dual brand selector with first brand selected
-        await toHaveScreenshot(card.cardNumberField, browserName, 'dual-brand-eu-default-selection.png');
-    });
+            // Screenshot: EU dual brand selector with first brand selected
+            await toHaveScreenshot(card.cardNumberField, browserName, 'dual-brand-eu-default-selection.png');
+        }
+    );
 
     test('#2 should change CVC visibility when interacting with brand selection', { tag: [TAGS.SCREENSHOT] }, async ({ card, page, browserName }) => {
         await binLookupMock(page, dualBrandedBcmcAndVisa);
@@ -78,11 +82,7 @@ test.describe('Card - Dual branding UI after binLookup gives a dual brand result
         await toHaveScreenshot(card.cardNumberField, browserName, 'dual-brand-eu-after-brand-switch.png');
     });
 
-    test('#3 should select brand without triggering error when PAN is incomplete', async ({
-        card,
-        page,
-        browserName
-    }) => {
+    test('#3 should select brand without triggering error when PAN is incomplete', async ({ card, page, browserName }) => {
         test.skip(browserName === 'webkit', 'Skipping tests for WebKit');
         await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
 
@@ -125,7 +125,8 @@ test.describe('Card - Dual branding UI after binLookup gives a dual brand result
         await expect(card.cardNumberErrorElement).not.toBeVisible();
     });
 
-    test('#4 should allow brand switching with incomplete PAN without triggering errors', async ({ card, page }) => {
+    test('#4 should allow brand switching with incomplete PAN without triggering errors', async ({ card, page, browserName }) => {
+        test.skip(browserName === 'webkit', 'Skipping tests for WebKit');
         await binLookupMock(page, dualBrandedBcmcAndVisa);
 
         await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
@@ -172,55 +173,48 @@ test.describe('Card - Dual branding UI after binLookup gives a dual brand result
         await expect(card.cardNumberErrorElement).not.toBeVisible();
     });
 
-    test(
-        '#5 should show no selection UI for excluded dual brand',
-        async ({ card, page }) => {
-            await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
+    test('#5 should show no selection UI for excluded dual brand', async ({ card, page }) => {
+        await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
 
-            await card.typeCardNumber(DUAL_BRANDED_CARD_EXCLUDED);
+        await card.typeCardNumber(DUAL_BRANDED_CARD_EXCLUDED);
 
-            // Check brand has not been set in paymentMethod data
-            let cardData: any = await page.evaluate('window.component.data');
-            expect(cardData.paymentMethod.brand).toBe(undefined);
+        // Check brand has not been set in paymentMethod data
+        let cardData: any = await page.evaluate('window.component.data');
+        expect(cardData.paymentMethod.brand).toBe(undefined);
 
-            // Expect dual brand icons not to be visible
-            await expect(card.dualBrandSelector).not.toBeVisible();
+        // Expect dual brand icons not to be visible
+        await expect(card.dualBrandSelector).not.toBeVisible();
 
-            // No brand selection UI
-            await expect(card.isDualBrandSelectionVisible()).resolves.toBe(false);
+        // No brand selection UI
+        await expect(card.isDualBrandSelectionVisible()).resolves.toBe(false);
 
-            // No contextual label
-            await expect(card.isDualBrandContextualLabelVisible()).resolves.toBe(false);
-        }
-    );
+        // No contextual label
+        await expect(card.isDualBrandContextualLabelVisible()).resolves.toBe(false);
+    });
 
-    test(
-        '#6 should show icons but no selection mechanism for non-EU dual brand',
-        { tag: [TAGS.SCREENSHOT] },
-        async ({ card, page, browserName }) => {
-            const componentConfig = { brands: ['mc', 'visa', 'amex', 'maestro', 'bcmc', 'eftpos_australia'] };
+    test('#6 should show icons but no selection mechanism for non-EU dual brand', { tag: [TAGS.SCREENSHOT] }, async ({ card, page, browserName }) => {
+        const componentConfig = { brands: ['mc', 'visa', 'amex', 'maestro', 'bcmc', 'eftpos_australia'] };
 
-            await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
+        await card.goto(getStoryUrl({ baseUrl: URL_MAP.card, componentConfig }));
 
-            await card.typeCardNumber(DUAL_BRANDED_EFTPOS);
+        await card.typeCardNumber(DUAL_BRANDED_EFTPOS);
 
-            // Check brand has not been set in paymentMethod data
-            let cardData: any = await page.evaluate('window.component.data');
-            expect(cardData.paymentMethod.brand).toBe(undefined);
+        // Check brand has not been set in paymentMethod data
+        let cardData: any = await page.evaluate('window.component.data');
+        expect(cardData.paymentMethod.brand).toBe(undefined);
 
-            // Expect dual brand icons *to* be visible (display-only)
-            await expect(card.brandingIcon.first()).toBeVisible();
+        // Expect dual brand icons *to* be visible (display-only)
+        await expect(card.brandingIcon.first()).toBeVisible();
 
-            // No interactive selection UI
-            await expect(card.isDualBrandSelectionVisible()).resolves.toBe(false);
+        // No interactive selection UI
+        await expect(card.isDualBrandSelectionVisible()).resolves.toBe(false);
 
-            // No contextual label
-            await expect(card.isDualBrandContextualLabelVisible()).resolves.toBe(false);
+        // No contextual label
+        await expect(card.isDualBrandContextualLabelVisible()).resolves.toBe(false);
 
-            // Screenshot: Non-EU dual brand (display-only, no selection border)
-            await toHaveScreenshot(card.cardNumberField, browserName, 'dual-brand-non-eu-display-only.png');
-        }
-    );
+        // Screenshot: Non-EU dual brand (display-only, no selection border)
+        await toHaveScreenshot(card.cardNumberField, browserName, 'dual-brand-non-eu-display-only.png');
+    });
 
     test('#7 should show regex brand "mc" while typing, then bcmc/mc dual brand from binLookup', async ({ card, page }) => {
         await binLookupMock(page, dualBrandedBcmcAndMc);

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -99,7 +99,7 @@ export async function createCardSecuredFields(
         this.state.type = type;
     }
 
-    // So, is it a single branded card?
+    // So, is it a single branded card? i.e. a storedCard or a regular card that has just one brand set in its brands array
     this.isSingleBrandedCard = type !== 'card';
 
     // If single branded card field...

--- a/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/constants.ts
@@ -15,7 +15,7 @@ export const ENCRYPTED_SECURITY_CODE_4_DIGITS = 'encryptedSecurityCode4digits';
 
 export const GIFT_CARD = 'giftcard';
 
-export const SF_VERSION = '6.2.0';
+export const SF_VERSION = '6.2.1';
 
 export const DEFAULT_CARD_GROUP_TYPES = ['amex', 'mc', 'visa'];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Bumped securedFields to version `6.2.1`
This fixed a regression where securedFields had stopped allowing `ionic://` domains

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

