### PR TITLE
Also add translated error message to error object for non-SF errors

### DIFF
--- a/.changeset/seven-shirts-sell.md
+++ b/.changeset/seven-shirts-sell.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+New: Also add translated error message to error object for non-SF errors

--- a/packages/lib/src/components/PayTo/components/validate.test.ts
+++ b/packages/lib/src/components/PayTo/components/validate.test.ts
@@ -1,8 +1,11 @@
 import Validator from '../../../utils/Validator';
 import { payIdValidationRules } from './validate';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
 
 describe('Test payIdValidationRules', () => {
-    const validator = new Validator(payIdValidationRules);
+    const core = setupCoreMock();
+    const { i18n } = core.modules;
+    const validator = new Validator(payIdValidationRules, i18n);
 
     // Email tests
     test('Test success email', () => {

--- a/packages/lib/src/utils/Validator/ValidationRuleResult.ts
+++ b/packages/lib/src/utils/Validator/ValidationRuleResult.ts
@@ -1,4 +1,5 @@
-import { ErrorMessageObject, ValidatorRule, ValidatorMode } from './types';
+import { ErrorMessageObject, ValidatorRule, ValidatorMode, FieldContext } from './types';
+import Language from '../../language';
 
 /**
  * Holds the result of a validation
@@ -7,11 +8,13 @@ export class ValidationRuleResult {
     private readonly shouldValidate: boolean;
     public isValid: boolean;
     public errorMessage: string | ErrorMessageObject;
+    public errorI18n: string;
 
-    constructor(rule: ValidatorRule, value: string, mode: ValidatorMode, context) {
+    constructor(rule: ValidatorRule, value: string, mode: ValidatorMode, context: FieldContext, i18n: Language) {
         this.shouldValidate = rule.modes.includes(mode);
         this.isValid = rule.validate(value, context);
         this.errorMessage = rule.errorMessage;
+        this.errorI18n = i18n.get(rule.errorMessage as string);
     }
 
     /**

--- a/packages/lib/src/utils/Validator/ValidationRuleResult.ts
+++ b/packages/lib/src/utils/Validator/ValidationRuleResult.ts
@@ -14,7 +14,12 @@ export class ValidationRuleResult {
         this.shouldValidate = rule.modes.includes(mode);
         this.isValid = rule.validate(value, context);
         this.errorMessage = rule.errorMessage;
-        this.errorI18n = i18n.get(rule.errorMessage as string);
+
+        if (typeof rule.errorMessage === 'string') {
+            this.errorI18n = i18n.get(rule.errorMessage);
+        } else {
+            this.errorI18n = i18n.get(rule.errorMessage.translationKey, rule.errorMessage.translationObject);
+        }
     }
 
     /**

--- a/packages/lib/src/utils/Validator/ValidationRuleResult.ts
+++ b/packages/lib/src/utils/Validator/ValidationRuleResult.ts
@@ -7,7 +7,7 @@ import Language from '../../language';
 export class ValidationRuleResult {
     private readonly shouldValidate: boolean;
     public isValid: boolean;
-    public errorMessage: string | ErrorMessageObject;
+    public errorMessage: string | ErrorMessageObject | undefined;
     public errorI18n: string;
 
     constructor(rule: ValidatorRule, value: string, mode: ValidatorMode, context: FieldContext, i18n: Language) {
@@ -17,7 +17,7 @@ export class ValidationRuleResult {
 
         if (typeof rule.errorMessage === 'string') {
             this.errorI18n = i18n.get(rule.errorMessage);
-        } else {
+        } else if (rule.errorMessage) {
             this.errorI18n = i18n.get(rule.errorMessage.translationKey, rule.errorMessage.translationObject);
         }
     }

--- a/packages/lib/src/utils/Validator/Validator.test.ts
+++ b/packages/lib/src/utils/Validator/Validator.test.ts
@@ -3,6 +3,10 @@ import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
 
 const mockRules = {};
 
+import enUS from '../../../../server/translations/en-US.json';
+
+const translatedErrorMsg = enUS['field.invalid'];
+
 describe('Validator', () => {
     const core = setupCoreMock();
     const { i18n } = core.modules;
@@ -39,5 +43,68 @@ describe('Validator', () => {
         expect(validator.validate({ key: 'aNewField', value: '123' }).hasError()).toBe(false);
         expect(validator.validate({ key: 'aNewField', value: null }).hasError()).toBe(false);
         expect(validator.validate({ key: 'shopperEmail', value: 'test@test.com' }).hasError()).toBe(false);
+    });
+
+    describe('errorI18n', () => {
+        test('should set errorI18n from string errorMessage', () => {
+            const validator = new Validator(
+                {
+                    testField: {
+                        validate: () => false,
+                        errorMessage: 'field.invalid',
+                        modes: ['blur']
+                    }
+                },
+                i18n
+            );
+
+            const result = validator.validate({ key: 'testField', value: 'invalid' });
+            const error = result.getError();
+
+            expect(error.errorMessage).toBe('field.invalid');
+            expect(error.errorI18n).toBe(translatedErrorMsg);
+        });
+
+        test('should set errorI18n from ErrorMessageObject with translationKey and translationObject', () => {
+            const errorMessageObject = {
+                translationKey: 'field.invalid',
+                translationObject: { values: { fieldName: 'Test Field' } }
+            };
+
+            const validator = new Validator(
+                {
+                    testField: {
+                        validate: () => false,
+                        errorMessage: errorMessageObject,
+                        modes: ['blur']
+                    }
+                },
+                i18n
+            );
+
+            const result = validator.validate({ key: 'testField', value: 'invalid' });
+            const error = result.getError();
+
+            expect(error.errorMessage).toEqual(errorMessageObject);
+            expect(error.errorI18n).toBe(translatedErrorMsg);
+        });
+
+        test('should leave errorI18n undefined when errorMessage is undefined', () => {
+            const validator = new Validator(
+                {
+                    testField: {
+                        validate: () => false,
+                        modes: ['blur']
+                    }
+                },
+                i18n
+            );
+
+            const result = validator.validate({ key: 'testField', value: 'invalid' });
+            const error = result.getError();
+
+            expect(error.errorMessage).toBeUndefined();
+            expect(error.errorI18n).toBeUndefined();
+        });
     });
 });

--- a/packages/lib/src/utils/Validator/Validator.test.ts
+++ b/packages/lib/src/utils/Validator/Validator.test.ts
@@ -1,10 +1,14 @@
 import Validator from './Validator';
+import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
 
 const mockRules = {};
 
 describe('Validator', () => {
+    const core = setupCoreMock();
+    const { i18n } = core.modules;
+
     test('Fields are valid by default', () => {
-        const validator = new Validator(mockRules);
+        const validator = new Validator(mockRules, i18n);
 
         // defaults validation for unknown fields
         expect(validator.validate({ key: 'aNewField', value: '123' }).hasError()).toBe(false);
@@ -12,13 +16,16 @@ describe('Validator', () => {
     });
 
     test('Set custom rules', () => {
-        const validator = new Validator({
-            aNewField: {
-                validate: () => false,
-                errorMessage: 'test',
-                modes: ['blur']
-            }
-        });
+        const validator = new Validator(
+            {
+                aNewField: {
+                    validate: () => false,
+                    errorMessage: 'test',
+                    modes: ['blur']
+                }
+            },
+            i18n
+        );
 
         expect(validator.validate({ key: 'aNewField', value: '123' }).hasError()).toBe(true);
 
@@ -27,7 +34,7 @@ describe('Validator', () => {
     });
 
     test('Has default rules', () => {
-        const validator = new Validator({});
+        const validator = new Validator({}, i18n);
 
         expect(validator.validate({ key: 'aNewField', value: '123' }).hasError()).toBe(false);
         expect(validator.validate({ key: 'aNewField', value: null }).hasError()).toBe(false);

--- a/packages/lib/src/utils/Validator/Validator.test.ts
+++ b/packages/lib/src/utils/Validator/Validator.test.ts
@@ -59,8 +59,8 @@ describe('Validator', () => {
             const result = validator.validate({ key: 'testField', value: 'invalid' });
             const error = result.getError();
 
-            expect(error.errorMessage).toBe('field.invalid');
-            expect(error.errorI18n).toBe(translatedErrorMsg);
+            expect(error?.errorMessage).toBe('field.invalid');
+            expect(error?.errorI18n).toBe(translatedErrorMsg);
         });
 
         test('should set errorI18n from ErrorMessageObject with translationKey and translationObject', () => {
@@ -83,8 +83,8 @@ describe('Validator', () => {
             const result = validator.validate({ key: 'testField', value: 'invalid' });
             const error = result.getError();
 
-            expect(error.errorMessage).toEqual(errorMessageObject);
-            expect(error.errorI18n).toBe(translatedErrorMsg);
+            expect(error?.errorMessage).toEqual(errorMessageObject);
+            expect(error?.errorI18n).toBe(translatedErrorMsg);
         });
 
         test('should leave errorI18n undefined when errorMessage is undefined', () => {
@@ -101,8 +101,8 @@ describe('Validator', () => {
             const result = validator.validate({ key: 'testField', value: 'invalid' });
             const error = result.getError();
 
-            expect(error.errorMessage).toBeUndefined();
-            expect(error.errorI18n).toBeUndefined();
+            expect(error?.errorMessage).toBeUndefined();
+            expect(error?.errorI18n).toBeUndefined();
         });
     });
 });

--- a/packages/lib/src/utils/Validator/Validator.test.ts
+++ b/packages/lib/src/utils/Validator/Validator.test.ts
@@ -1,10 +1,8 @@
 import Validator from './Validator';
 import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
-
-const mockRules = {};
-
 import enUS from '../../../../server/translations/en-US.json';
 
+const mockRules = {};
 const translatedErrorMsg = enUS['field.invalid'];
 
 describe('Validator', () => {

--- a/packages/lib/src/utils/Validator/Validator.ts
+++ b/packages/lib/src/utils/Validator/Validator.ts
@@ -1,5 +1,6 @@
 import { ValidatorRules, ValidatorRule, FieldContext, FieldData } from './types';
 import { ValidationRuleResult } from './ValidationRuleResult';
+import type Language from '../../language';
 
 class ValidationResult {
     private validationResults: ValidationRuleResult[];
@@ -37,8 +38,11 @@ class Validator {
         }
     };
 
-    constructor(rules) {
+    private readonly i18n: Language;
+
+    constructor(rules, i18n: Language) {
         this.setRules(rules);
+        this.i18n = i18n;
     }
 
     setRules(newRules) {
@@ -70,7 +74,7 @@ class Validator {
         // validate is called in the constructor of ValidationRuleResult
         // line rule.validate(value, context);
         //
-        const validationRulesResult = fieldRules.map(rule => new ValidationRuleResult(rule, value, mode, context));
+        const validationRulesResult = fieldRules.map(rule => new ValidationRuleResult(rule, value, mode, context, this.i18n));
 
         return new ValidationResult(validationRulesResult);
     }

--- a/packages/lib/src/utils/Validator/Validator.ts
+++ b/packages/lib/src/utils/Validator/Validator.ts
@@ -40,7 +40,7 @@ class Validator {
 
     private readonly i18n: Language;
 
-    constructor(rules, i18n: Language) {
+    constructor(rules: ValidatorRules, i18n: Language) {
         this.setRules(rules);
         this.i18n = i18n;
     }

--- a/packages/lib/src/utils/useForm/useForm.test.tsx
+++ b/packages/lib/src/utils/useForm/useForm.test.tsx
@@ -1,6 +1,17 @@
+import { h } from 'preact';
 import useForm from './useForm';
 import { renderHook, act } from '@testing-library/preact-hooks';
 import { Form } from './types';
+import { CoreProvider } from '../../core/Context/CoreProvider';
+import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
+
+const core = setupCoreMock();
+
+const wrapper = ({ children }) => (
+    <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
+        {children}
+    </CoreProvider>
+);
 
 describe('useForm', () => {
     const defaultSchema = ['firstName', 'lastName'];
@@ -14,7 +25,7 @@ describe('useForm', () => {
         let useFormHook;
 
         it('should set a default schema', () => {
-            const { result } = renderHook(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook(() => useForm({ schema: defaultSchema }), { wrapper });
             useFormHook = result;
 
             expect(useFormHook.current.schema).toEqual(defaultSchema);
@@ -27,7 +38,7 @@ describe('useForm', () => {
         });
 
         it('should update the schema', () => {
-            const { result } = renderHook(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook(() => useForm({ schema: defaultSchema }), { wrapper });
             useFormHook = result;
 
             void act(() => {
@@ -43,14 +54,14 @@ describe('useForm', () => {
 
     describe('defaultData', () => {
         it('should set defaultData', () => {
-            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema, defaultData }));
+            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema, defaultData }), { wrapper });
 
             expect(result.current.data.firstName).toEqual(defaultData.firstName);
             expect(result.current.data.lastName).toEqual(null);
         });
 
         it('should set default data after changing the schema', () => {
-            const { result } = renderHook(() => useForm({ schema: defaultSchema, defaultData }));
+            const { result } = renderHook(() => useForm({ schema: defaultSchema, defaultData }), { wrapper });
 
             void act(() => {
                 result.current.setSchema(['email']);
@@ -74,7 +85,7 @@ describe('useForm', () => {
         const firstNameValue = 'John';
 
         it('should handle changes for a field', () => {
-            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }), { wrapper });
 
             void act(() => {
                 result.current.handleChangeFor('firstName')(firstNameValue);
@@ -87,7 +98,7 @@ describe('useForm', () => {
 
         it('should format the value of a field using formatters', () => {
             const formatterMock = jest.fn();
-            const { result } = renderHook(() => useForm({ schema: defaultSchema, formatters: { firstName: formatterMock } }));
+            const { result } = renderHook(() => useForm({ schema: defaultSchema, formatters: { firstName: formatterMock } }), { wrapper });
 
             void act(() => {
                 result.current.handleChangeFor('firstName')(firstNameValue);
@@ -119,7 +130,7 @@ describe('useForm', () => {
         });
 
         it('should set the value of a checkbox', () => {
-            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }));
+            const { result } = renderHook<unknown, Form<defaultSchemaType>>(() => useForm({ schema: defaultSchema }), { wrapper });
             const mockEvent = { target: { type: 'checkbox' } };
 
             // call once to set to "checked"

--- a/packages/lib/src/utils/useForm/useForm.test.tsx
+++ b/packages/lib/src/utils/useForm/useForm.test.tsx
@@ -7,7 +7,7 @@ import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
 
 const core = setupCoreMock();
 
-const wrapper = ({ children }) => (
+const wrapper = ({ children }: { children: any }) => (
     <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
         {children}
     </CoreProvider>

--- a/packages/lib/src/utils/useForm/useForm.ts
+++ b/packages/lib/src/utils/useForm/useForm.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer } from 'preact/hooks';
 import Validator from '../Validator';
 import { getReducer, init } from './reducer';
 import { Form, FormState, FormProps, Formatter } from './types';
+import { useCoreContext } from '../../core/Context/CoreProvider';
 
 function isFormatterObject(formatter: Formatter | Function): formatter is Formatter {
     return formatter && 'formatterFn' in formatter;
@@ -10,7 +11,9 @@ function isFormatterObject(formatter: Formatter | Function): formatter is Format
 function useForm<FormSchema>(props: FormProps): Form<FormSchema> {
     const { rules = {}, formatters = {}, defaultData = {}, fieldProblems = {}, schema = [] } = props;
 
-    const validator = useMemo(() => new Validator(rules), [rules]);
+    const { i18n } = useCoreContext();
+
+    const validator = useMemo(() => new Validator(rules, i18n), [rules]);
 
     /** Formats and validates a field */
     const processField = ({ key, value, mode }, fieldContext) => {

--- a/packages/lib/src/utils/useForm/useFormWithA11y.test.tsx
+++ b/packages/lib/src/utils/useForm/useFormWithA11y.test.tsx
@@ -1,7 +1,18 @@
+import { h } from 'preact';
 import { renderHook, act } from '@testing-library/preact-hooks';
 import useFormWithA11y from './useFormWithA11y';
 import { setFocusOnField } from '../setFocus';
 import { ValidatorMode } from '../Validator/types';
+import { CoreProvider } from '../../core/Context/CoreProvider';
+import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
+
+const core = setupCoreMock();
+
+const wrapper = ({ children }: { children: any }) => (
+    <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
+        {children}
+    </CoreProvider>
+);
 
 jest.mock('../setFocus', () => ({
     setFocusOnField: jest.fn()
@@ -41,7 +52,7 @@ describe('useFormWithA11y', () => {
 
     it('does NOT focus any field when triggerValidation is NOT called (blur-time field change)', () => {
         const holder = document.createElement('div');
-        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder }));
+        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder }), { wrapper });
 
         void act(() => {
             getHookResult(result).handleChangeFor('email', 'blur')({ target: { value: '' } });
@@ -52,7 +63,7 @@ describe('useFormWithA11y', () => {
 
     it('focuses the first error field after triggerValidation is called', () => {
         const holder = document.createElement('div');
-        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder }));
+        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder }), { wrapper });
 
         void act(() => {
             getHookResult(result).triggerValidation();
@@ -64,8 +75,9 @@ describe('useFormWithA11y', () => {
 
     it('focuses the correct first error field when only later schema fields are invalid', () => {
         const holder = document.createElement('div');
-        const { result } = renderHook(() =>
-            useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder, defaultData: { email: 'valid@email.com', name: '' } })
+        const { result } = renderHook(
+            () => useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder, defaultData: { email: 'valid@email.com', name: '' } }),
+            { wrapper }
         );
 
         void act(() => {
@@ -77,13 +89,15 @@ describe('useFormWithA11y', () => {
 
     it('does NOT focus any field after triggerValidation when the form is fully valid', () => {
         const holder = document.createElement('div');
-        const { result } = renderHook(() =>
-            useFormWithA11y<FormSchema>({
-                schema,
-                rules,
-                formHolder: holder,
-                defaultData: { email: 'valid@email.com', name: 'John' }
-            })
+        const { result } = renderHook(
+            () =>
+                useFormWithA11y<FormSchema>({
+                    schema,
+                    rules,
+                    formHolder: holder,
+                    defaultData: { email: 'valid@email.com', name: 'John' }
+                }),
+            { wrapper }
         );
 
         void act(() => {
@@ -95,7 +109,7 @@ describe('useFormWithA11y', () => {
 
     it('uses the current schema at the time triggerValidation is called (no stale closure)', () => {
         const holder = document.createElement('div');
-        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema: ['email'], rules, formHolder: holder }));
+        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema: ['email'], rules, formHolder: holder }), { wrapper });
 
         void act(() => {
             getHookResult(result).setSchema(['name']);
@@ -111,7 +125,7 @@ describe('useFormWithA11y', () => {
 
     it('returns all Form interface methods from the underlying useForm', () => {
         const holder = document.createElement('div');
-        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder }));
+        const { result } = renderHook(() => useFormWithA11y<FormSchema>({ schema, rules, formHolder: holder }), { wrapper });
         const form = getHookResult(result);
 
         expect(typeof form.handleChangeFor).toBe('function');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

For the error objects created for SecuredField related fields (PAN, expiryDate, cvc) we add an `errorI18n` prop. This is the translated text of the error message i.e. the text that is actually shown in the UI.

This PR adds this same property to the error objects created for non-SecuredFields (of type `ValidationRuleResult`)

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  #4011

---

