### PR TITLE
Fix actions.resolve onSubmit bug for PayPal

### DIFF
--- a/.changeset/fresh-bugs-smoke.md
+++ b/.changeset/fresh-bugs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: actions.reject onSubmit bug for PayPal

--- a/packages/lib/src/components/PayPal/Paypal.test.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.test.tsx
@@ -1,6 +1,7 @@
 import Paypal from './Paypal';
 import { render, screen } from '@testing-library/preact';
 import { setupCoreMock, TEST_CHECKOUT_ATTEMPT_ID, TEST_RISK_DATA } from '../../../config/testMocks/setup-core-mock';
+import CancelError from '../../core/Errors/CancelError';
 
 const core = setupCoreMock();
 
@@ -85,267 +86,350 @@ describe('Paypal', () => {
         expect(props.isExpress).toBeFalsy();
         expect(props.userAction).toBe('pay');
     });
-});
 
-describe('Paypal configuration prop configures correctly', () => {
-    test('Paypal element has configuration object with default values', () => {
-        const paypal = new Paypal(core);
-        expect(paypal.props.configuration?.merchantId).toEqual(undefined);
-        expect(paypal.props.configuration?.intent).toEqual(undefined);
+    describe('configuration prop configures correctly', () => {
+        test('element has configuration object with default values', () => {
+            const paypal = new Paypal(core);
+            expect(paypal.props.configuration?.merchantId).toEqual(undefined);
+            expect(paypal.props.configuration?.intent).toEqual(undefined);
+        });
+
+        test('element has configuration object with values pulled from props.configuration', () => {
+            const paypal = new Paypal(core, { configuration: { merchantId: 'abcdef', intent: 'order' } });
+            expect(paypal.props.configuration?.merchantId).toEqual('abcdef');
+            expect(paypal.props.configuration?.intent).toEqual('order');
+        });
     });
 
-    test('Paypal element has configuration object with values pulled from props.configuration', () => {
-        const paypal = new Paypal(core, { configuration: { merchantId: 'abcdef', intent: 'order' } });
-        expect(paypal.props.configuration?.merchantId).toEqual('abcdef');
-        expect(paypal.props.configuration?.intent).toEqual('order');
-    });
-});
+    describe('formatProps', () => {
+        test('should set intent to tokenize and vault to true when amount is 0', () => {
+            const paypal = new Paypal(core, { amount: { value: 0, currency: 'USD' } });
+            expect(paypal.props.configuration?.intent).toBe('tokenize');
+            expect(paypal.props.vault).toBe(true);
+        });
 
-describe('Paypal formatProps', () => {
-    test('should set intent to tokenize and vault to true when amount is 0', () => {
-        const paypal = new Paypal(core, { amount: { value: 0, currency: 'USD' } });
-        expect(paypal.props.configuration?.intent).toBe('tokenize');
-        expect(paypal.props.vault).toBe(true);
-    });
+        test('should use intent from props over configuration intent', () => {
+            const paypal = new Paypal(core, { intent: 'capture', configuration: { intent: 'order' } });
+            expect(paypal.props.configuration?.intent).toBe('capture');
+        });
 
-    test('should use intent from props over configuration intent', () => {
-        const paypal = new Paypal(core, { intent: 'capture', configuration: { intent: 'order' } });
-        expect(paypal.props.configuration?.intent).toBe('capture');
-    });
+        test('should set commit to false when userAction is continue', () => {
+            const paypal = new Paypal(core, { userAction: 'continue' });
+            expect(paypal.props.commit).toBe(false);
+        });
 
-    test('should set commit to false when userAction is continue', () => {
-        const paypal = new Paypal(core, { userAction: 'continue' });
-        expect(paypal.props.commit).toBe(false);
-    });
+        test('should keep commit as true when userAction is pay', () => {
+            const paypal = new Paypal(core, { userAction: 'pay' });
+            expect(paypal.props.commit).toBe(true);
+        });
 
-    test('should keep commit as true when userAction is pay', () => {
-        const paypal = new Paypal(core, { userAction: 'pay' });
-        expect(paypal.props.commit).toBe(true);
-    });
+        test('should set vault to true when intent is tokenize', () => {
+            const paypal = new Paypal(core, { intent: 'tokenize' });
+            expect(paypal.props.vault).toBe(true);
+        });
 
-    test('should set vault to true when intent is tokenize', () => {
-        const paypal = new Paypal(core, { intent: 'tokenize' });
-        expect(paypal.props.vault).toBe(true);
-    });
-
-    test('should set vault based on props.vault when intent is not tokenize', () => {
-        const paypal = new Paypal(core, { vault: true, intent: 'capture' });
-        expect(paypal.props.vault).toBe(true);
-    });
-});
-
-describe('Paypal updatePaymentData', () => {
-    test('should update paymentData', () => {
-        const paypal = new Paypal(core);
-        paypal.updatePaymentData('test-payment-data');
-        expect(paypal.paymentData).toBe('test-payment-data');
+        test('should set vault based on props.vault when intent is not tokenize', () => {
+            const paypal = new Paypal(core, { vault: true, intent: 'capture' });
+            expect(paypal.props.vault).toBe(true);
+        });
     });
 
-    test('should warn when updating with falsy value', () => {
-        jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const paypal = new Paypal(core);
-        paypal.updatePaymentData('');
-        expect(console.warn).toHaveBeenCalledWith('PayPal - Updating payment data with an invalid value');
-    });
-});
+    describe('updatePaymentData', () => {
+        test('should update paymentData', () => {
+            const paypal = new Paypal(core);
+            paypal.updatePaymentData('test-payment-data');
+            expect(paypal.paymentData).toBe('test-payment-data');
+        });
 
-describe('Paypal updateWithAction', () => {
-    test('should throw if action paymentMethodType does not match', () => {
-        const paypal = new Paypal(core);
-        expect(() => paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'scheme' })).toThrow('Invalid Action');
-    });
-
-    test('should store paymentData from action', () => {
-        const paypal = new Paypal(core);
-        // Set up resolve/reject to avoid WRONG_INSTANCE error
-        // @ts-ignore accessing private
-        paypal.resolve = jest.fn();
-        paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', paymentData: 'pd-123', sdkData: { token: 'tok-abc' } });
-        expect(paypal.paymentData).toBe('pd-123');
+        test('should warn when updating with falsy value', () => {
+            jest.spyOn(console, 'warn').mockImplementation(() => {});
+            const paypal = new Paypal(core);
+            paypal.updatePaymentData('');
+            expect(console.warn).toHaveBeenCalledWith('PayPal - Updating payment data with an invalid value');
+        });
     });
 
-    test('should resolve with token when sdkData.token is provided', () => {
-        const paypal = new Paypal(core);
-        const resolveMock = jest.fn();
-        // @ts-ignore accessing private
-        paypal.resolve = resolveMock;
-        paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', sdkData: { token: 'test-token' } });
-        expect(resolveMock).toHaveBeenCalledWith('test-token');
+    describe('updateWithAction', () => {
+        test('should throw if action paymentMethodType does not match', () => {
+            const paypal = new Paypal(core);
+            expect(() => paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'scheme' })).toThrow('Invalid Action');
+        });
+
+        test('should store paymentData from action', () => {
+            const paypal = new Paypal(core);
+            // Set up resolve/reject to avoid WRONG_INSTANCE error
+            // @ts-ignore accessing private
+            paypal.resolve = jest.fn();
+            paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', paymentData: 'pd-123', sdkData: { token: 'tok-abc' } });
+            expect(paypal.paymentData).toBe('pd-123');
+        });
+
+        test('should resolve with token when sdkData.token is provided', () => {
+            const paypal = new Paypal(core);
+            const resolveMock = jest.fn();
+            // @ts-ignore accessing private
+            paypal.resolve = resolveMock;
+            paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', sdkData: { token: 'test-token' } });
+            expect(resolveMock).toHaveBeenCalledWith('test-token');
+        });
+
+        test('should reject when sdkData has no token', () => {
+            const paypal = new Paypal(core);
+            const rejectMock = jest.fn();
+            // @ts-ignore accessing private
+            paypal.reject = rejectMock;
+            paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', sdkData: {} });
+            expect(rejectMock).toHaveBeenCalledWith(expect.any(Error));
+        });
+
+        test('should call handleError when resolve is not set and token is provided', () => {
+            const onErrorMock = jest.fn();
+            const paypal = new Paypal(core, { onError: onErrorMock });
+            paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', sdkData: { token: 'test-token' } });
+            expect(onErrorMock).toHaveBeenCalled();
+        });
     });
 
-    test('should reject when sdkData has no token', () => {
-        const paypal = new Paypal(core);
-        const rejectMock = jest.fn();
-        // @ts-ignore accessing private
-        paypal.reject = rejectMock;
-        paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', sdkData: {} });
-        expect(rejectMock).toHaveBeenCalledWith(expect.any(Error));
+    describe('handleAction', () => {
+        test('should delegate to updateWithAction', () => {
+            const paypal = new Paypal(core);
+            const spy = jest.spyOn(paypal, 'updateWithAction');
+            // @ts-ignore accessing private
+            paypal.resolve = jest.fn();
+            const action = { type: 'sdk' as const, paymentMethodType: 'paypal', sdkData: { token: 'tok' } };
+            paypal.handleAction(action);
+            expect(spy).toHaveBeenCalledWith(action);
+        });
     });
 
-    test('should call handleError when resolve is not set and token is provided', () => {
-        const onErrorMock = jest.fn();
-        const paypal = new Paypal(core, { onError: onErrorMock });
-        paypal.updateWithAction({ type: 'sdk', paymentMethodType: 'paypal', sdkData: { token: 'test-token' } });
-        expect(onErrorMock).toHaveBeenCalled();
-    });
-});
+    describe('handleOnApprove', () => {
+        test('should call handleAdditionalDetails when onAuthorized is not provided', async () => {
+            const onAdditionalDetailsMock = jest.fn();
+            const paypal = new Paypal(core, { onAdditionalDetails: onAdditionalDetailsMock });
+            paypal.paymentData = 'pd-123';
 
-describe('Paypal handleAction', () => {
-    test('should delegate to updateWithAction', () => {
-        const paypal = new Paypal(core);
-        const spy = jest.spyOn(paypal, 'updateWithAction');
-        // @ts-ignore accessing private
-        paypal.resolve = jest.fn();
-        const action = { type: 'sdk' as const, paymentMethodType: 'paypal', sdkData: { token: 'tok' } };
-        paypal.handleAction(action);
-        expect(spy).toHaveBeenCalledWith(action);
-    });
-});
+            const data = { orderID: 'order-1' };
+            const actions = { order: { get: jest.fn() } };
 
-describe('Paypal handleOnApprove', () => {
-    test('should call handleAdditionalDetails when onAuthorized is not provided', async () => {
-        const onAdditionalDetailsMock = jest.fn();
-        const paypal = new Paypal(core, { onAdditionalDetails: onAdditionalDetailsMock });
-        paypal.paymentData = 'pd-123';
+            // @ts-ignore accessing private method
+            await paypal.handleOnApprove(data, actions);
 
-        const data = { orderID: 'order-1' };
-        const actions = { order: { get: jest.fn() } };
+            expect(onAdditionalDetailsMock).toHaveBeenCalled();
+        });
 
-        // @ts-ignore accessing private method
-        await paypal.handleOnApprove(data, actions);
+        test('should call handleError when onAuthorized is provided but actions.order is missing', async () => {
+            const onErrorMock = jest.fn();
+            const paypal = new Paypal(core, { onAuthorized: jest.fn(), onError: onErrorMock });
 
-        expect(onAdditionalDetailsMock).toHaveBeenCalled();
-    });
+            const data = { orderID: 'order-1' };
+            const actions = {};
 
-    test('should call handleError when onAuthorized is provided but actions.order is missing', async () => {
-        const onErrorMock = jest.fn();
-        const paypal = new Paypal(core, { onAuthorized: jest.fn(), onError: onErrorMock });
+            // @ts-ignore accessing private method
+            await paypal.handleOnApprove(data, actions);
 
-        const data = { orderID: 'order-1' };
-        const actions = {};
+            expect(onErrorMock).toHaveBeenCalledWith(
+                expect.objectContaining({ message: 'PayPal order actions are not available' }),
+                expect.anything()
+            );
+        });
 
-        // @ts-ignore accessing private method
-        await paypal.handleOnApprove(data, actions);
+        test('should get order details and call onAuthorized when provided', async () => {
+            const onAuthorizedMock = jest.fn().mockImplementation((_, { resolve }) => resolve());
+            const onAdditionalDetailsMock = jest.fn();
+            const paypal = new Paypal(core, { onAuthorized: onAuthorizedMock, onAdditionalDetails: onAdditionalDetailsMock });
+            paypal.paymentData = 'pd-456';
 
-        expect(onErrorMock).toHaveBeenCalledWith(expect.objectContaining({ message: 'PayPal order actions are not available' }), expect.anything());
-    });
+            const mockOrder = {
+                payer: { name: { given_name: 'John', surname: 'Doe' } },
+                purchase_units: [{ shipping: { name: { full_name: 'John Doe' } } }]
+            };
 
-    test('should get order details and call onAuthorized when provided', async () => {
-        const onAuthorizedMock = jest.fn().mockImplementation((_, { resolve }) => resolve());
-        const onAdditionalDetailsMock = jest.fn();
-        const paypal = new Paypal(core, { onAuthorized: onAuthorizedMock, onAdditionalDetails: onAdditionalDetailsMock });
-        paypal.paymentData = 'pd-456';
+            const data = { orderID: 'order-1' };
+            const actions = { order: { get: jest.fn().mockResolvedValue(mockOrder) } };
 
-        const mockOrder = {
-            payer: { name: { given_name: 'John', surname: 'Doe' } },
-            purchase_units: [{ shipping: { name: { full_name: 'John Doe' } } }]
-        };
+            // @ts-ignore accessing private method
+            await paypal.handleOnApprove(data, actions);
 
-        const data = { orderID: 'order-1' };
-        const actions = { order: { get: jest.fn().mockResolvedValue(mockOrder) } };
+            expect(actions.order.get).toHaveBeenCalled();
+            expect(onAuthorizedMock).toHaveBeenCalledWith(
+                expect.objectContaining({ authorizedEvent: mockOrder }),
+                expect.objectContaining({ resolve: expect.any(Function), reject: expect.any(Function) })
+            );
+            expect(onAdditionalDetailsMock).toHaveBeenCalled();
+        });
 
-        // @ts-ignore accessing private method
-        await paypal.handleOnApprove(data, actions);
+        test('should call handleError when order.get() fails', async () => {
+            const onErrorMock = jest.fn();
+            const onAuthorizedMock = jest.fn();
+            const paypal = new Paypal(core, { onAuthorized: onAuthorizedMock, onError: onErrorMock });
 
-        expect(actions.order.get).toHaveBeenCalled();
-        expect(onAuthorizedMock).toHaveBeenCalledWith(
-            expect.objectContaining({ authorizedEvent: mockOrder }),
-            expect.objectContaining({ resolve: expect.any(Function), reject: expect.any(Function) })
-        );
-        expect(onAdditionalDetailsMock).toHaveBeenCalled();
-    });
+            const data = { orderID: 'order-1' };
+            const actions = { order: { get: jest.fn().mockRejectedValue(new Error('Order fetch failed')) } };
 
-    test('should call handleError when order.get() fails', async () => {
-        const onErrorMock = jest.fn();
-        const onAuthorizedMock = jest.fn();
-        const paypal = new Paypal(core, { onAuthorized: onAuthorizedMock, onError: onErrorMock });
+            // @ts-ignore accessing private method
+            await paypal.handleOnApprove(data, actions);
 
-        const data = { orderID: 'order-1' };
-        const actions = { order: { get: jest.fn().mockRejectedValue(new Error('Order fetch failed')) } };
-
-        // @ts-ignore accessing private method
-        await paypal.handleOnApprove(data, actions);
-
-        expect(onErrorMock).toHaveBeenCalledWith(
-            expect.objectContaining({ message: 'Something went wrong while parsing PayPal Order' }),
-            expect.anything()
-        );
-    });
-});
-
-describe('Paypal handleReject', () => {
-    test('should call handleError when reject is not set', () => {
-        const onErrorMock = jest.fn();
-        const paypal = new Paypal(core, { onError: onErrorMock });
-        paypal.handleReject('some error');
-        expect(onErrorMock).toHaveBeenCalled();
-    });
-});
-
-describe('Paypal shipping change handlers', () => {
-    test('handleOnShippingAddressChange should call the merchant callback', async () => {
-        const onShippingAddressChangeMock = jest.fn().mockResolvedValue(undefined);
-        const paypal = new Paypal(core, { onShippingAddressChange: onShippingAddressChangeMock });
-
-        const data = { shippingAddress: { city: 'Amsterdam' } };
-        const actions = { reject: jest.fn() };
-
-        // @ts-ignore accessing private method
-        await paypal.handleOnShippingAddressChange(data, actions);
-
-        expect(onShippingAddressChangeMock).toHaveBeenCalledWith(data, actions, paypal);
+            expect(onErrorMock).toHaveBeenCalledWith(
+                expect.objectContaining({ message: 'Something went wrong while parsing PayPal Order' }),
+                expect.anything()
+            );
+        });
     });
 
-    test('handleOnShippingAddressChange should resolve when no callback provided', async () => {
-        const paypal = new Paypal(core);
-        // @ts-ignore accessing private method
-        const result = await paypal.handleOnShippingAddressChange({}, {});
-        expect(result).toBeUndefined();
+    describe('handleReject', () => {
+        test('should call handleError when reject is not set', () => {
+            const onErrorMock = jest.fn();
+            const paypal = new Paypal(core, { onError: onErrorMock });
+            paypal.handleReject('some error');
+            expect(onErrorMock).toHaveBeenCalled();
+        });
     });
 
-    test('handleOnShippingOptionsChange should call the merchant callback', async () => {
-        const onShippingOptionsChangeMock = jest.fn().mockResolvedValue(undefined);
-        const paypal = new Paypal(core, { onShippingOptionsChange: onShippingOptionsChangeMock });
+    describe('shipping change handlers', () => {
+        test('handleOnShippingAddressChange should call the merchant callback', async () => {
+            const onShippingAddressChangeMock = jest.fn().mockResolvedValue(undefined);
+            const paypal = new Paypal(core, { onShippingAddressChange: onShippingAddressChangeMock });
 
-        const data = { selectedShippingOption: { id: 'option-1' } };
-        const actions = { reject: jest.fn() };
+            const data = { shippingAddress: { city: 'Amsterdam' } };
+            const actions = { reject: jest.fn() };
 
-        // @ts-ignore accessing private method
-        await paypal.handleOnShippingOptionsChange(data, actions);
+            // @ts-ignore accessing private method
+            await paypal.handleOnShippingAddressChange(data, actions);
 
-        expect(onShippingOptionsChangeMock).toHaveBeenCalledWith(data, actions, paypal);
+            expect(onShippingAddressChangeMock).toHaveBeenCalledWith(data, actions, paypal);
+        });
+
+        test('handleOnShippingAddressChange should resolve when no callback provided', async () => {
+            const paypal = new Paypal(core);
+            // @ts-ignore accessing private method
+            const result = await paypal.handleOnShippingAddressChange({}, {});
+            expect(result).toBeUndefined();
+        });
+
+        test('handleOnShippingOptionsChange should call the merchant callback', async () => {
+            const onShippingOptionsChangeMock = jest.fn().mockResolvedValue(undefined);
+            const paypal = new Paypal(core, { onShippingOptionsChange: onShippingOptionsChangeMock });
+
+            const data = { selectedShippingOption: { id: 'option-1' } };
+            const actions = { reject: jest.fn() };
+
+            // @ts-ignore accessing private method
+            await paypal.handleOnShippingOptionsChange(data, actions);
+
+            expect(onShippingOptionsChangeMock).toHaveBeenCalledWith(data, actions, paypal);
+        });
+
+        test('handleOnShippingOptionsChange should resolve when no callback provided', async () => {
+            const paypal = new Paypal(core);
+            // @ts-ignore accessing private method
+            const result = await paypal.handleOnShippingOptionsChange({}, {});
+            expect(result).toBeUndefined();
+        });
     });
 
-    test('handleOnShippingOptionsChange should resolve when no callback provided', async () => {
-        const paypal = new Paypal(core);
-        // @ts-ignore accessing private method
-        const result = await paypal.handleOnShippingOptionsChange({}, {});
-        expect(result).toBeUndefined();
-    });
-});
+    describe('handleSubmit', () => {
+        test('should call onPaymentFailed and reject when makePaymentsCall fails with a non-cancel error', async () => {
+            const onPaymentFailedMock = jest.fn();
+            const failedResponse = { resultCode: 'Refused' };
 
-describe('Paypal componentToRender', () => {
-    test('should not render PayPal buttons when showPayButton is false', () => {
-        const paypal = new Paypal(core, { showPayButton: false });
-        render(paypal.render());
-        expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+            const onSubmitMock = jest.fn().mockImplementation((_data, _component, actions) => {
+                actions.resolve(failedResponse);
+            });
+
+            const paypal = new Paypal(core, { onSubmit: onSubmitMock, onPaymentFailed: onPaymentFailedMock });
+
+            // @ts-ignore accessing private method
+            const submitPromise = paypal.handleSubmit();
+
+            await new Promise(process.nextTick);
+
+            expect(onPaymentFailedMock).toHaveBeenCalledTimes(1);
+            expect(onPaymentFailedMock).toHaveBeenCalledWith({ resultCode: 'Refused' }, paypal);
+            await expect(submitPromise).rejects.toThrow('Something went wrong during PayPal payment: {"resultCode":"Refused"}');
+        });
+
+        test('should include the Error message in the rejection when makePaymentsCall rejects with an Error', async () => {
+            const onPaymentFailedMock = jest.fn();
+
+            const onSubmitMock = jest.fn().mockImplementation((_data, _component, actions) => {
+                actions.reject(new Error('Network timeout'));
+            });
+
+            const paypal = new Paypal(core, { onSubmit: onSubmitMock, onPaymentFailed: onPaymentFailedMock });
+
+            // @ts-ignore accessing private method
+            const submitPromise = paypal.handleSubmit();
+
+            await new Promise(process.nextTick);
+
+            await expect(submitPromise).rejects.toThrow('Something went wrong during PayPal payment: Network timeout');
+        });
+
+        test('should stringify non-Error values in the rejection message', async () => {
+            const onPaymentFailedMock = jest.fn();
+            const failedResponse = { resultCode: 'Refused' };
+
+            const onSubmitMock = jest.fn().mockImplementation((_data, _component, actions) => {
+                actions.resolve(failedResponse);
+            });
+
+            const paypal = new Paypal(core, { onSubmit: onSubmitMock, onPaymentFailed: onPaymentFailedMock });
+
+            // @ts-ignore accessing private method
+            const submitPromise = paypal.handleSubmit();
+
+            await new Promise(process.nextTick);
+
+            await expect(submitPromise).rejects.toThrow('Something went wrong during PayPal payment: {"resultCode":"Refused"}');
+        });
+
+        test('should set status to ready and not call onPaymentFailed when makePaymentsCall fails with CancelError', async () => {
+            const onPaymentFailedMock = jest.fn();
+
+            const onSubmitMock = jest.fn().mockImplementation((_data, _component, actions) => {
+                actions.reject(new CancelError('cancelled'));
+            });
+
+            const paypal = new Paypal(core, { onSubmit: onSubmitMock, onPaymentFailed: onPaymentFailedMock });
+            const setStatusSpy = jest.spyOn(paypal, 'setElementStatus');
+
+            // @ts-ignore accessing private method
+            const submitPromise = paypal.handleSubmit();
+
+            await new Promise(process.nextTick);
+
+            expect(setStatusSpy).toHaveBeenCalledWith('ready');
+            expect(onPaymentFailedMock).not.toHaveBeenCalled();
+
+            // Promise should remain pending (never resolved/rejected) for CancelError
+            const raceResult = await Promise.race([submitPromise.then(() => 'resolved').catch(() => 'rejected'), Promise.resolve('pending')]);
+            expect(raceResult).toBe('pending');
+        });
     });
 
-    test('should render component when showPayButton is true', () => {
-        const paypal = new Paypal(core, { showPayButton: true });
-        render(paypal.render());
-        expect(screen.getByTestId('spinner')).toBeInTheDocument();
-    });
+    describe('componentToRender', () => {
+        test('should not render PayPal buttons when showPayButton is false', () => {
+            const paypal = new Paypal(core, { showPayButton: false });
+            render(paypal.render());
+            expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+        });
 
-    test('should pass onShippingAddressChange handler when callback is provided', () => {
-        const paypal = new Paypal(core, { showPayButton: true, onShippingAddressChange: jest.fn() });
-        render(paypal.render());
-        expect(paypal.props.onShippingAddressChange).toBeDefined();
-    });
+        test('should render component when showPayButton is true', () => {
+            const paypal = new Paypal(core, { showPayButton: true });
+            render(paypal.render());
+            expect(screen.getByTestId('spinner')).toBeInTheDocument();
+        });
 
-    test('should pass onShippingOptionsChange handler when callback is provided', () => {
-        const paypal = new Paypal(core, { showPayButton: true, onShippingOptionsChange: jest.fn() });
-        render(paypal.render());
-        expect(paypal.props.onShippingOptionsChange).toBeDefined();
+        test('should pass onShippingAddressChange handler when callback is provided', () => {
+            const paypal = new Paypal(core, { showPayButton: true, onShippingAddressChange: jest.fn() });
+            render(paypal.render());
+            expect(paypal.props.onShippingAddressChange).toBeDefined();
+        });
+
+        test('should pass onShippingOptionsChange handler when callback is provided', () => {
+            const paypal = new Paypal(core, { showPayButton: true, onShippingOptionsChange: jest.fn() });
+            render(paypal.render());
+            expect(paypal.props.onShippingOptionsChange).toBeDefined();
+        });
     });
 });

--- a/packages/lib/src/components/PayPal/Paypal.tsx
+++ b/packages/lib/src/components/PayPal/Paypal.tsx
@@ -8,7 +8,7 @@ import { TxVariants } from '../tx-variants';
 import { formatPaypalOrderContactToAdyenFormat } from './utils/format-paypal-order-contact-to-adyen-format';
 
 import type { ICore } from '../../core/types';
-import type { PaymentAction } from '../../types/global-types';
+import type { PaymentAction, PaymentResponseData } from '../../types/global-types';
 import type { Intent, PayPalConfiguration } from './types';
 import type {
     PayPalOnApproveActions,
@@ -21,6 +21,8 @@ import type {
 } from './paypal-js-types';
 
 import { AnalyticsInfoEvent, InfoEventType } from '../../core/Analytics/events/AnalyticsInfoEvent';
+import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement/utils';
+import CancelError from '../../core/Errors/CancelError';
 import './Paypal.scss';
 
 class PaypalElement extends UIElement<PayPalConfiguration> {
@@ -184,11 +186,24 @@ class PaypalElement extends UIElement<PayPalConfiguration> {
     }
 
     private handleSubmit(): Promise<string> {
-        super.submit();
-
         return new Promise((resolve, reject) => {
             this.resolve = resolve;
             this.reject = reject;
+
+            this.makePaymentsCall()
+                .then(sanitizeResponse)
+                .then(verifyPaymentDidNotFail)
+                .then(this.handleResponse)
+                .catch((e: PaymentResponseData | Error) => {
+                    if (e instanceof CancelError) {
+                        this.setElementStatus('ready');
+                        return;
+                    }
+                    this.handleFailedResult(e as PaymentResponseData);
+                    const errorDetail = e instanceof Error ? e.message : JSON.stringify(e);
+                    const errorMessage = e ? `: ${errorDetail}` : '';
+                    this.handleReject(`${ERRORS.PAYMENT_FAILED}${errorMessage}`);
+                });
         });
     }
 

--- a/packages/lib/src/components/PayPal/constants.ts
+++ b/packages/lib/src/components/PayPal/constants.ts
@@ -3,5 +3,6 @@ export const ERRORS = {
     NO_TOKEN_PROVIDED: 'No token was provided',
     PAYPAL_OVERLAY_CLOSED: 'PayPal overlay closed',
     SUBMIT_NOT_SUPPORTED: 'Calling submit() is not supported for this payment method',
-    WRONG_INSTANCE: 'The instance of the PayPal component being used is not the same which started the payment'
+    WRONG_INSTANCE: 'The instance of the PayPal component being used is not the same which started the payment',
+    PAYMENT_FAILED: 'Something went wrong during PayPal payment'
 };

--- a/packages/lib/src/components/PayPal/stories/PayPal.stories.tsx
+++ b/packages/lib/src/components/PayPal/stories/PayPal.stories.tsx
@@ -26,10 +26,7 @@ export const Default: Story = {
             blockPayPalVenmoButton: false,
             onAuthorized: (data, actions) => {
                 console.log({ data });
-                // Simulate async action after authorization
-                setTimeout(() => {
-                    actions.resolve();
-                }, 3000);
+                actions.resolve();
             }
         }
     }

--- a/packages/lib/storybook/helpers/checkout-handlers.ts
+++ b/packages/lib/storybook/helpers/checkout-handlers.ts
@@ -27,7 +27,7 @@ export function displayResultMessage(isAuthorized: boolean, resultCode: string):
 
 export function handleFinalState(result: any, component: UIElement): void {
     const isDropin = component?.props?.isDropin;
-    const isAuthorized = result.resultCode === 'Authorised' || result.resultCode === 'Received';
+    const isAuthorized = result?.resultCode === 'Authorised' || result?.resultCode === 'Received';
 
     if (isDropin) {
         if (isAuthorized) {
@@ -38,10 +38,13 @@ export function handleFinalState(result: any, component: UIElement): void {
         return;
     }
 
-    if (component?.unmount) {
+    if (result?.resultCode && component?.unmount) {
         component.unmount();
     }
-    displayResultMessage(isAuthorized, result.resultCode);
+
+    if (result?.resultCode) {
+        displayResultMessage(isAuthorized, result.resultCode);
+    }
 
     return result;
 }

--- a/packages/lib/storybook/helpers/create-advanced-checkout.ts
+++ b/packages/lib/storybook/helpers/create-advanced-checkout.ts
@@ -96,13 +96,14 @@ async function createAdvancedFlowCheckout(
                 const { resultCode, action, order, donationToken } = await makeDetailsCall(state.data);
 
                 if (!resultCode) actions.reject();
-
-                actions.resolve({
-                    resultCode,
-                    action,
-                    order,
-                    donationToken
-                });
+                else {
+                    actions.resolve({
+                        resultCode,
+                        action,
+                        order,
+                        donationToken
+                    });
+                }
             } catch (error) {
                 console.error('## onAdditionalDetails - critical error', error);
                 actions.reject();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

When a merchant called `actions.reject()` inside the `onSubmit` callback for PayPal, the PayPal overlay would remain open instead of closing. This happened because PayPal's `handleSubmit` delegated to `super.submit()`, which resolves asynchronously via the `actions` callback pattern — but PayPal needs the rejection to propagate back into its own Promise chain so the PayPal SDK can close the modal.

### Changes

- **Rewrote `PaypalElement.handleSubmit()`** to call `this.makePaymentsCall()` directly (instead of `super.submit()`), piping the response through `sanitizeResponse` → `verifyPaymentDidNotFail` → `handleResponse`. This ensures that when a merchant calls `actions.reject()`, the rejection flows back into the Promise that the PayPal SDK is awaiting, allowing it to properly close the overlay.
- **Added a `PAYMENT_FAILED` error constant** for clearer error messaging when the PayPal payment flow fails.
- **Hardened storybook helpers** (`handleFinalState`, `createAdvancedFlowCheckout`) with optional chaining and guard clauses so they handle missing/undefined result gracefully — prevents runtime errors when `actions.reject()` is called without a response payload.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

- COSDK-1221

**Closes**:  <!-- #-prefixed issue number -->

---

