### PR TITLE
Move `@paypal/paypal-js` from devDependencies to dependencies

### DIFF
--- a/.changeset/eleven-files-hope.md
+++ b/.changeset/eleven-files-hope.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Moved paypal js to dependencies from dev dependencies

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -84,7 +84,6 @@
     "devDependencies": {
         "@adyen/bento-design-tokens": "1.10.0",
         "@eslint/js": "10.0.1",
-        "@paypal/paypal-js": "9.7.0",
         "@preact/preset-vite": "2.10.5",
         "@rollup/plugin-commonjs": "29.0.2",
         "@rollup/plugin-eslint": "9.2.0",
@@ -138,6 +137,7 @@
         "whatwg-fetch": "3.6.20"
     },
     "dependencies": {
+        "@paypal/paypal-js": "9.7.0",
         "@types/applepayjs": "14.0.9",
         "@types/googlepay": "0.7.10",
         "classnames": "2.5.1",

--- a/packages/lib/src/components/PayPal/paypal-js-types.ts
+++ b/packages/lib/src/components/PayPal/paypal-js-types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     OrderResponseBody,
     OnApproveData,
     OnApproveActions,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary
Consumers of `@adyen/adyen-web` that rely on the published type declarations need the PayPal types to be resolvable at their end. Since `paypal-js-types.ts`  re-exports types from `@paypal/paypal-js`, the package must be a production dependency so its types ship alongside the library's `.d.ts` output.

### Changes

- **Moved `@paypal/paypal-js`** from `devDependencies` to `dependencies` in the lib `package.json`
- **Switched to `import type`** in `paypal-js-types.ts` to ensure no runtime code is emitted from the PayPal import

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

