### PR TITLE
Affirm UK support

### DIFF
--- a/.changeset/fifty-doors-show.md
+++ b/.changeset/fifty-doors-show.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: countryCode & allowedCountries mismatch issue for Affirm

--- a/.changeset/moody-otters-design.md
+++ b/.changeset/moody-otters-design.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Improved: UK support for Affirm

--- a/packages/lib/src/components/Affirm/Affirm.stories.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.stories.tsx
@@ -18,7 +18,10 @@ const render = ({ componentConfiguration, ...checkoutConfig }: PaymentMethodStor
 export const Default: AffirmStory = {
     render,
     args: {
-        countryCode: 'US'
+        countryCode: 'US',
+        componentConfiguration: {
+            allowedCountries: ['CA', 'US']
+        }
     }
 };
 

--- a/packages/lib/src/components/Affirm/Affirm.stories.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.stories.tsx
@@ -3,15 +3,15 @@ import { MetaConfiguration, PaymentMethodStoryProps, StoryConfiguration } from '
 import { ComponentContainer } from '../../../storybook/components/ComponentContainer';
 import { Checkout } from '../../../storybook/components/Checkout';
 import Affirm from './Affirm';
-import { OpenInvoiceConfiguration } from '../types';
+import type { AffirmConfiguration } from './types';
 
-type AffirmStory = StoryConfiguration<OpenInvoiceConfiguration>;
+type AffirmStory = StoryConfiguration<AffirmConfiguration>;
 
-const meta: MetaConfiguration<OpenInvoiceConfiguration> = {
+const meta: MetaConfiguration<AffirmConfiguration> = {
     title: 'Components/Affirm'
 };
 
-const render = ({ componentConfiguration, ...checkoutConfig }: PaymentMethodStoryProps<OpenInvoiceConfiguration>) => (
+const render = ({ componentConfiguration, ...checkoutConfig }: PaymentMethodStoryProps<AffirmConfiguration>) => (
     <Checkout checkoutConfig={checkoutConfig}>{checkout => <ComponentContainer element={new Affirm(checkout, componentConfiguration)} />}</Checkout>
 );
 

--- a/packages/lib/src/components/Affirm/Affirm.test.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.test.tsx
@@ -18,4 +18,25 @@ describe('Affirm', () => {
         const affirm = new Affirm(core);
         expect(affirm.data.paymentMethod.type).toBe('affirm');
     });
+
+    test('uses countryCode as-is when it is in allowedCountries', () => {
+        const affirm = new Affirm(core, { countryCode: 'US', allowedCountries: ['US', 'GB'] });
+        expect(affirm.props.countryCode).toBe('US');
+        expect(affirm.props.allowedCountries).toEqual(['US', 'GB']);
+    });
+
+    test('defaults to the first allowed country when countryCode is not in allowedCountries', () => {
+        const affirm = new Affirm(core, { countryCode: 'US', allowedCountries: ['GB'] });
+        expect(affirm.props.countryCode).toBe('GB');
+    });
+
+    test('defaults allowedCountries to CA and US when not provided', () => {
+        const affirm = new Affirm(core, { countryCode: 'US' });
+        expect(affirm.props.allowedCountries).toEqual(['CA', 'US']);
+    });
+
+    test('filters out unsupported countries from allowedCountries', () => {
+        const affirm = new Affirm(core, { allowedCountries: ['US', 'FR'] });
+        expect(affirm.props.allowedCountries).toEqual(['US']);
+    });
 });

--- a/packages/lib/src/components/Affirm/Affirm.test.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.test.tsx
@@ -39,4 +39,9 @@ describe('Affirm', () => {
         const affirm = new Affirm(core, { allowedCountries: ['US', 'FR'] });
         expect(affirm.props.allowedCountries).toEqual(['US']);
     });
+
+    test('falls back to DEFAULT_COUNTRIES when all allowedCountries are unsupported', () => {
+        const affirm = new Affirm(core, { allowedCountries: ['FR'] });
+        expect(affirm.props.allowedCountries).toEqual(['CA', 'US']);
+    });
 });

--- a/packages/lib/src/components/Affirm/Affirm.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.tsx
@@ -7,7 +7,8 @@ export default class Affirm extends OpenInvoiceContainer {
     public static readonly type = TxVariants.affirm;
 
     formatProps(props: AffirmConfiguration) {
-        const allowedCountries = props.allowedCountries?.filter(country => ALLOWED_COUNTRIES.includes(country)) || DEFAULT_COUNTRIES;
+        const filteredCountries = props.allowedCountries?.filter(country => ALLOWED_COUNTRIES.includes(country));
+        const allowedCountries = filteredCountries?.length ? filteredCountries : DEFAULT_COUNTRIES;
         const countryCode = allowedCountries.some(country => country === props.countryCode) ? props.countryCode : allowedCountries[0];
 
         return {

--- a/packages/lib/src/components/Affirm/Affirm.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.tsx
@@ -8,7 +8,8 @@ export default class Affirm extends OpenInvoiceContainer {
 
     formatProps(props: AffirmConfiguration) {
         const allowedCountries = props.allowedCountries?.filter(country => ALLOWED_COUNTRIES.includes(country)) || DEFAULT_COUNTRIES;
-        const countryCode = allowedCountries.includes(props.countryCode) ? props.countryCode : allowedCountries[0];
+        const countryCode = allowedCountries.some(country => country === props.countryCode) ? props.countryCode : allowedCountries[0];
+
         return {
             ...super.formatProps({ ...props, countryCode }),
             allowedCountries,

--- a/packages/lib/src/components/Affirm/Affirm.tsx
+++ b/packages/lib/src/components/Affirm/Affirm.tsx
@@ -1,15 +1,17 @@
 import OpenInvoiceContainer from '../helpers/OpenInvoiceContainer';
-import { ALLOWED_COUNTRIES } from './config';
+import { ALLOWED_COUNTRIES, DEFAULT_COUNTRIES } from './config';
 import { TxVariants } from '../tx-variants';
-import type { OpenInvoiceConfiguration } from '../types';
+import type { AffirmConfiguration } from './types';
 
 export default class Affirm extends OpenInvoiceContainer {
     public static readonly type = TxVariants.affirm;
 
-    formatProps(props: OpenInvoiceConfiguration) {
+    formatProps(props: AffirmConfiguration) {
+        const allowedCountries = props.allowedCountries?.filter(country => ALLOWED_COUNTRIES.includes(country)) || DEFAULT_COUNTRIES;
+        const countryCode = allowedCountries.includes(props.countryCode) ? props.countryCode : allowedCountries[0];
         return {
-            ...super.formatProps(props),
-            allowedCountries: ALLOWED_COUNTRIES,
+            ...super.formatProps({ ...props, countryCode }),
+            allowedCountries,
             personalDetailsRequiredFields: ['firstName', 'lastName', 'telephoneNumber', 'shopperEmail']
         };
     }

--- a/packages/lib/src/components/Affirm/config.ts
+++ b/packages/lib/src/components/Affirm/config.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_COUNTRIES = ['CA', 'US'];
-export const ALLOWED_COUNTRIES = ['CA', 'US', 'GB'];
+export const ALLOWED_COUNTRIES = ['CA', 'US', 'GB'] as const;
+export const DEFAULT_COUNTRIES: (typeof ALLOWED_COUNTRIES)[number][] = ['CA', 'US'];

--- a/packages/lib/src/components/Affirm/config.ts
+++ b/packages/lib/src/components/Affirm/config.ts
@@ -1,1 +1,2 @@
-export const ALLOWED_COUNTRIES = ['CA', 'US'];
+export const DEFAULT_COUNTRIES = ['CA', 'US'];
+export const ALLOWED_COUNTRIES = ['CA', 'US', 'GB'];

--- a/packages/lib/src/components/Affirm/types.ts
+++ b/packages/lib/src/components/Affirm/types.ts
@@ -1,5 +1,6 @@
 import { OpenInvoiceConfiguration } from '../helpers/OpenInvoiceContainer/types';
+import type { ALLOWED_COUNTRIES } from './config';
 
 export interface AffirmConfiguration extends OpenInvoiceConfiguration {
-    allowedCountries?: string[];
+    allowedCountries?: (typeof ALLOWED_COUNTRIES)[number][];
 }

--- a/packages/lib/src/components/Affirm/types.ts
+++ b/packages/lib/src/components/Affirm/types.ts
@@ -1,0 +1,5 @@
+import { OpenInvoiceConfiguration } from '../helpers/OpenInvoiceContainer/types';
+
+export interface AffirmConfiguration extends OpenInvoiceConfiguration {
+    allowedCountries?: string[];
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Affirm is now supported in the United Kingdom (GB), but the address form only showed US and CA as the allowed countries. Merchants operating in GB couldn't allow shoppers to select a GB billing address.
Changes:
- Expose an `allowedCountries` prop on AffirmConfiguration that lets merchants customize the country dropdown in the billing/delivery address form.
- Keep US, CA as the default allowed countries, to avoid creating a breaking change for merchants already using Affirm.
- Fix mismatch between countryCode and allowedCountries: when the countryCode is not present in the merchant-configured `allowedCountries` list, the address form was pre-populated with a country not available in the dropdown. This caused two failure modes:
  - Single allowed country: the field became read-only with an invalid pre-selected value, blocking payment completion entirely.
  - Multiple allowed countries: the dropdown rendered with no valid pre-selection and no indication that the shopper needed to make a choice.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->
COSDK-1281, COSDK-1283
---

