### PR TITLE
Fix/a11y announce resend countdown

### DIFF
--- a/.changeset/rare-mice-argue.md
+++ b/.changeset/rare-mice-argue.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: a11y announcements for resend OTP countdown in Click to Pay

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePassword.test.tsx
@@ -1,6 +1,8 @@
 import { h } from 'preact';
 import { render, screen } from '@testing-library/preact';
 import { CoreProvider } from '../../../../../core/Context/CoreProvider';
+import SRPanelProvider from '../../../../../core/Errors/SRPanelProvider';
+import { setupCoreMock } from '../../../../../../config/testMocks/setup-core-mock';
 import ClickToPayProvider from '../../context/ClickToPayProvider';
 import { IClickToPayService } from '../../services/types';
 import { mock } from 'jest-mock-extended';
@@ -8,19 +10,22 @@ import userEvent from '@testing-library/user-event';
 import CtPOneTimePassword from './CtPOneTimePassword';
 
 const customRender = (ui, { clickToPayService = mock<IClickToPayService>(), configuration = {} } = {}) => {
+    const core = setupCoreMock();
     return render(
         <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
-            <ClickToPayProvider
-                clickToPayService={clickToPayService}
-                isStandaloneComponent={true}
-                onSetStatus={jest.fn()}
-                configuration={configuration}
-                onError={jest.fn()}
-                onSubmit={jest.fn()}
-                setClickToPayRef={jest.fn()}
-            >
-                {ui}
-            </ClickToPayProvider>
+            <SRPanelProvider srPanel={core.modules.srPanel}>
+                <ClickToPayProvider
+                    clickToPayService={clickToPayService}
+                    isStandaloneComponent={true}
+                    onSetStatus={jest.fn()}
+                    configuration={configuration}
+                    onError={jest.fn()}
+                    onSubmit={jest.fn()}
+                    setClickToPayRef={jest.fn()}
+                >
+                    {ui}
+                </ClickToPayProvider>
+            </SRPanelProvider>
         </CoreProvider>
     );
 };

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.test.tsx
@@ -1,6 +1,8 @@
 import { h } from 'preact';
 import { render, screen, waitFor } from '@testing-library/preact';
 import { CoreProvider } from '../../../../../../core/Context/CoreProvider';
+import SRPanelProvider from '../../../../../../core/Errors/SRPanelProvider';
+import { setupCoreMock } from '../../../../../../../config/testMocks/setup-core-mock';
 import ClickToPayProvider from '../../../context/ClickToPayProvider';
 import { IClickToPayService } from '../../../services/types';
 import { mock } from 'jest-mock-extended';
@@ -8,19 +10,22 @@ import CtPOneTimePasswordInput from './CtPOneTimePasswordInput';
 import userEvent from '@testing-library/user-event';
 
 const customRender = (ui, { clickToPayService = mock<IClickToPayService>(), configuration = {} } = {}) => {
+    const core = setupCoreMock();
     return render(
         <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
-            <ClickToPayProvider
-                clickToPayService={clickToPayService}
-                isStandaloneComponent={true}
-                onSetStatus={jest.fn()}
-                configuration={configuration}
-                onError={jest.fn()}
-                onSubmit={jest.fn()}
-                setClickToPayRef={jest.fn()}
-            >
-                {ui}
-            </ClickToPayProvider>
+            <SRPanelProvider srPanel={core.modules.srPanel}>
+                <ClickToPayProvider
+                    clickToPayService={clickToPayService}
+                    isStandaloneComponent={true}
+                    onSetStatus={jest.fn()}
+                    configuration={configuration}
+                    onError={jest.fn()}
+                    onSubmit={jest.fn()}
+                    setClickToPayRef={jest.fn()}
+                >
+                    {ui}
+                </ClickToPayProvider>
+            </SRPanelProvider>
         </CoreProvider>
     );
 };

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
@@ -3,12 +3,14 @@ import { useCallback, useEffect, useState } from 'preact/hooks';
 import useClickToPayContext from '../../../context/useClickToPayContext';
 import classnames from 'classnames';
 import { useCoreContext } from '../../../../../../core/Context/CoreProvider';
+import { useA11yReporter } from '../../../../../../core/Errors/useA11yReporter';
 import Icon from '../../../../Icon';
 import { isSrciError } from '../../../services/utils';
 import { PREFIX } from '../../../../Icon/constants';
 import Button from '../../../../Button';
 
 const CONFIRMATION_SHOWING_TIME = 2000;
+const RESEND_OTP_COUNTDOWN_SECONDS = 60;
 
 interface CtPResendOtpLinkProps {
     onError(errorCode: string): void;
@@ -21,6 +23,13 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: Readonly<CtPResen
     const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
     const { i18n } = useCoreContext();
     const { startIdentityValidation } = useClickToPayContext();
+    const announcementPoints = [RESEND_OTP_COUNTDOWN_SECONDS, 0];
+    const resendStatusMessage = announcementPoints.includes(counter)
+        ? counter > 0
+            ? `${i18n.get('ctp.otp.resendCode')} - ${counter}s`
+            : i18n.get('ctp.otp.resendCode')
+        : null;
+    useA11yReporter(resendStatusMessage);
 
     useEffect(() => {
         let timeout = null;
@@ -36,7 +45,7 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: Readonly<CtPResen
         if (showConfirmation) {
             timeout = setTimeout(() => {
                 setShowConfirmation(false);
-                setCounter(60);
+                setCounter(RESEND_OTP_COUNTDOWN_SECONDS);
             }, CONFIRMATION_SHOWING_TIME);
         }
         return () => clearTimeout(timeout);

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
@@ -23,18 +23,18 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: Readonly<CtPResen
     const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
     const { i18n } = useCoreContext();
     const { startIdentityValidation } = useClickToPayContext();
-    const announcementPoints = [RESEND_OTP_COUNTDOWN_SECONDS, 0];
-    const resendStatusMessage = announcementPoints.includes(counter)
-        ? counter > 0
-            ? `${i18n.get('ctp.otp.resendCode')} - ${counter}s`
-            : i18n.get('ctp.otp.resendCode')
-        : null;
+    const [resendStatusMessage, setResendStatusMessage] = useState<string>(null);
     useA11yReporter(resendStatusMessage);
 
     useEffect(() => {
         let timeout = null;
         if (counter > 0) {
             timeout = setTimeout(() => setCounter(counter - 1), 1000);
+        }
+        if (counter === RESEND_OTP_COUNTDOWN_SECONDS) {
+            setResendStatusMessage(`${i18n.get('ctp.otp.resendCode')} - ${counter}s`);
+        } else if (counter === 0) {
+            setResendStatusMessage(i18n.get('ctp.otp.resendCode'));
         }
         return () => clearTimeout(timeout);
     }, [counter]);

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPResendOtpLink.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, TargetedMouseEvent } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 import useClickToPayContext from '../../../context/useClickToPayContext';
 import classnames from 'classnames';
@@ -19,15 +19,15 @@ interface CtPResendOtpLinkProps {
 }
 
 const CtPResendOtpLink = ({ onError, onResendCode, disabled }: Readonly<CtPResendOtpLinkProps>): h.JSX.Element => {
-    const [counter, setCounter] = useState<number>(null);
+    const [counter, setCounter] = useState<number | null>(null);
     const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
     const { i18n } = useCoreContext();
     const { startIdentityValidation } = useClickToPayContext();
-    const [resendStatusMessage, setResendStatusMessage] = useState<string>(null);
+    const [resendStatusMessage, setResendStatusMessage] = useState<string | null>(null);
     useA11yReporter(resendStatusMessage);
 
     useEffect(() => {
-        let timeout = null;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
         if (counter > 0) {
             timeout = setTimeout(() => setCounter(counter - 1), 1000);
         }
@@ -40,7 +40,7 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: Readonly<CtPResen
     }, [counter]);
 
     useEffect(() => {
-        let timeout = null;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
 
         if (showConfirmation) {
             timeout = setTimeout(() => {
@@ -52,7 +52,7 @@ const CtPResendOtpLink = ({ onError, onResendCode, disabled }: Readonly<CtPResen
     }, [showConfirmation]);
 
     const handleResendCodeClick = useCallback(
-        async event => {
+        async (event: TargetedMouseEvent<HTMLButtonElement>) => {
             event.preventDefault();
 
             try {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

The OTP resend flow in Click to Pay had no screen reader announcements for the countdown timer or the resend button becoming available again.

Reason:
- The countdown timer (role="timer") was rendered visually but never communicated to screen readers, thus users had no indication about the waiting time. When the cooldown ended and the resend button reappeared, screen readers received no notification as well.

Fix:
- Used the existing `useA11yReporter` hook to announce via the SR panel at two points:
  -When the countdown starts: "Resend code - 60s"
  -When the countdown ends and the button is available: "Resend code"

The timer div still has the `role="timer"` for semantics (by default role="timer" has aria-live="off" ) but the SR announcements are handled through the global SR panel, preventing duplicate announcements.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->
COSDK-748
---

