### PR TITLE
fix: improve Select keyboard navigation and ARIA compliance

### DIFF
--- a/.changeset/stale-icons-talk.md
+++ b/.changeset/stale-icons-talk.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: a11y keyboard navigation inside Select list

--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
@@ -44,7 +44,7 @@ describe('Installments', () => {
     test('should render the installments dropdown by default', () => {
         renderInstallments();
         expect(screen.getByText('Number of installments')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /Number of installments/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /Number of installments/i })).toBeInTheDocument();
     });
 
     test('should not render if the passed amount is 0', () => {
@@ -62,7 +62,7 @@ describe('Installments', () => {
             card: { values: [3] }
         };
         renderInstallments({ installmentsProps: { installmentOptions } });
-        expect(screen.getByRole('button')).toBeDisabled();
+        expect(screen.getByRole('combobox')).toHaveAttribute('aria-disabled', 'true');
     });
 
     test('should preselect the value from "preselectedValue"', async () => {
@@ -70,17 +70,17 @@ describe('Installments', () => {
             card: { values: [1, 2], preselectedValue: 2 }
         };
         renderInstallments({ installmentsProps: { installmentOptions, type: 'amount' } });
-        expect(await screen.findByRole('button')).toHaveTextContent('2x $150.00');
+        expect(await screen.findByRole('combobox')).toHaveTextContent('2x $150.00');
     });
 
     test('should preselect the first value if "preselectedValue" is not provided', async () => {
         renderInstallments({ installmentsProps: { type: 'amount' } });
-        expect(await screen.findByRole('button')).toHaveTextContent('1x $300.00');
+        expect(await screen.findByRole('combobox')).toHaveTextContent('1x $300.00');
     });
 
     test('should render the correct number of installment options for each brand', async () => {
         const { rerender } = renderInstallments({ installmentsProps: { brand: 'card' } });
-        await user.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('combobox'));
         expect(await screen.findAllByRole('option')).toHaveLength(2);
 
         rerender(
@@ -90,7 +90,7 @@ describe('Installments', () => {
                 </AmountProvider>
             </CoreProvider>
         );
-        await user.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('combobox'));
         expect(await screen.findAllByRole('option')).toHaveLength(3);
 
         rerender(
@@ -100,7 +100,7 @@ describe('Installments', () => {
                 </AmountProvider>
             </CoreProvider>
         );
-        await user.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('combobox'));
         expect(await screen.findAllByRole('option')).toHaveLength(4);
     });
 
@@ -112,7 +112,7 @@ describe('Installments', () => {
             };
 
             const { rerender } = renderInstallments({ installmentsProps: { installmentOptions, brand: 'card', type: 'amount' } });
-            expect(await screen.findByRole('button')).toHaveTextContent('2x $150.00');
+            expect(await screen.findByRole('combobox')).toHaveTextContent('2x $150.00');
 
             // Rerender with a new brand
             rerender(
@@ -123,7 +123,7 @@ describe('Installments', () => {
                 </CoreProvider>
             );
 
-            expect(await screen.findByRole('button')).toHaveTextContent('2x $150.00');
+            expect(await screen.findByRole('combobox')).toHaveTextContent('2x $150.00');
         });
 
         test('should use the new brands "preselectedValue" if the old value is not supported', async () => {
@@ -133,7 +133,7 @@ describe('Installments', () => {
             };
             const { rerender } = renderInstallments({ installmentsProps: { installmentOptions, brand: 'card', type: 'amount' } });
 
-            expect(await screen.findByRole('button')).toHaveTextContent('4x $75.00');
+            expect(await screen.findByRole('combobox')).toHaveTextContent('4x $75.00');
 
             rerender(
                 <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
@@ -143,7 +143,7 @@ describe('Installments', () => {
                 </CoreProvider>
             );
 
-            expect(await screen.findByRole('button')).toHaveTextContent('2x $150.00');
+            expect(await screen.findByRole('combobox')).toHaveTextContent('2x $150.00');
         });
 
         test('should default to the first option if the old value and "preselectedValue" are not supported', async () => {
@@ -153,7 +153,7 @@ describe('Installments', () => {
             };
             const { rerender } = renderInstallments({ installmentsProps: { installmentOptions, brand: 'card', type: 'amount' } });
 
-            expect(await screen.findByRole('button')).toHaveTextContent('4x $75.00');
+            expect(await screen.findByRole('combobox')).toHaveTextContent('4x $75.00');
 
             rerender(
                 <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
@@ -163,7 +163,7 @@ describe('Installments', () => {
                 </CoreProvider>
             );
 
-            expect(await screen.findByRole('button')).toHaveTextContent('1x $300.00');
+            expect(await screen.findByRole('combobox')).toHaveTextContent('1x $300.00');
         });
     });
 

--- a/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/components/Installments/Installments.test.tsx
@@ -62,7 +62,7 @@ describe('Installments', () => {
             card: { values: [3] }
         };
         renderInstallments({ installmentsProps: { installmentOptions } });
-        expect(screen.getByRole('combobox')).toHaveAttribute('aria-disabled', 'true');
+        expect(screen.getByRole('combobox')).toBeDisabled();
     });
 
     test('should preselect the value from "preselectedValue"', async () => {

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.test.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPCards/CtPCards.test.tsx
@@ -76,7 +76,7 @@ test('should pre selected available card', async () => {
 
     expect(screen.getByRole('button', { name: 'Pay €20.00 with •••• 3456' })).toBeEnabled();
 
-    const selectButton = screen.getByRole('button', { name: /Select a card to use\./ });
+    const selectButton = screen.getByRole('combobox', { name: /Select a card to use\./ });
     expect(selectButton.textContent).toBe('Mastercard •••• 3456 ');
 
     await user.click(selectButton);
@@ -183,7 +183,7 @@ test('should not be able to checkout with expired card (card list)', async () =>
 
     expect(screen.getByRole('button', { name: 'Pay €20.00 with •••• 3456' })).toBeDisabled();
 
-    const selectButton = screen.getByRole('button', { name: /Select a card to use\./ });
+    const selectButton = screen.getByRole('combobox', { name: /Select a card to use\./ });
 
     expect(selectButton.textContent).toBe('Mastercard •••• 3456 Expired');
 
@@ -259,7 +259,7 @@ test('should be able to checkout (card list)', async () => {
     expect(screen.getByRole('button', { name: 'Pay €20.00 with •••• 8902' })).toBeTruthy();
 
     // Shows available cards by clicking in the Select
-    await user.click(screen.getByRole('button', { name: /Select a card to use\./ }));
+    await user.click(screen.getByRole('combobox', { name: /Select a card to use\./ }));
     expect(screen.getAllByRole('option').length).toBe(2);
 
     // Selects Mastercard, then pay button label gets updated

--- a/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.test.tsx
@@ -33,7 +33,7 @@ describe('Select', () => {
             onChange: onChangeCb
         });
 
-        await user.click(screen.getByRole('button'));
+        await user.click(screen.getByRole('combobox'));
 
         await user.click(screen.getByText('Issuer 3'));
 
@@ -43,7 +43,7 @@ describe('Select', () => {
         expect(onChangeCb.mock.calls[0][0]).toStrictEqual(callbackData);
 
         // Test keyboard interaction - focus the button first with user event
-        const button = screen.getByRole('button');
+        const button = screen.getByRole('combobox');
         await user.click(button); // Open dropdown
 
         await user.keyboard('[ArrowDown][Enter]');
@@ -141,10 +141,10 @@ describe('Select', () => {
             onChange: jest.fn()
         });
 
-        const button = screen.getByRole('button');
+        const combobox = screen.getByRole('combobox');
 
         // Focus should not open the dropdown
-        await user.tab(); // Focus the button using tab navigation
+        await user.tab(); // Focus the combobox using tab navigation
 
         // Debug visibility
         const option1 = screen.getByText('Option 1');
@@ -155,7 +155,7 @@ describe('Select', () => {
         expect(option2.offsetParent).toBeNull();
 
         // Click should open the dropdown
-        await user.click(button);
+        await user.click(combobox);
         expect(screen.getByText('Option 1')).toBeVisible();
         expect(screen.getByText('Option 2')).toBeVisible();
     });
@@ -230,29 +230,29 @@ describe('Select', () => {
     describe('select-only (filterable=false)', () => {
         test('aria-expanded is false initially and true when open', async () => {
             renderSelect({ filterable: false });
-            const button = screen.getByRole('button');
-            expect(button).toHaveAttribute('aria-expanded', 'false');
-            await user.click(button);
-            expect(button).toHaveAttribute('aria-expanded', 'true');
+            const combobox = screen.getByRole('combobox');
+            expect(combobox).toHaveAttribute('aria-expanded', 'false');
+            await user.click(combobox);
+            expect(combobox).toHaveAttribute('aria-expanded', 'true');
         });
 
         test('button has aria-haspopup="listbox"', () => {
             renderSelect({ filterable: false });
-            expect(screen.getByRole('button')).toHaveAttribute('aria-haspopup', 'listbox');
+            expect(screen.getByRole('combobox')).toHaveAttribute('aria-haspopup', 'listbox');
         });
 
         test('button has aria-controls pointing to the listbox', () => {
             renderSelect({ filterable: false });
-            const button = screen.getByRole('button');
+            const combobox = screen.getByRole('combobox');
             const listbox = screen.getByRole('listbox');
-            expect(button).toHaveAttribute('aria-controls', listbox.id);
+            expect(combobox).toHaveAttribute('aria-controls', listbox.id);
         });
 
         test('button has aria-labelledby combining label and selected value when uniqueId is provided', () => {
             renderSelect({ filterable: false, uniqueId: 'test-select', selectedValue: '1', items: [{ id: '1', name: 'Mobile' }] });
-            const button = screen.getByRole('button');
-            expect(button).toHaveAttribute('aria-labelledby', 'test-select-label test-select-value');
-            expect(within(button).getByText('Mobile')).toBeInTheDocument();
+            const combobox = screen.getByRole('combobox');
+            expect(combobox).toHaveAttribute('aria-labelledby', 'test-select-label test-select-value');
+            expect(within(combobox).getByText('Mobile')).toBeInTheDocument();
         });
     });
 });

--- a/packages/lib/src/components/internal/FormFields/Select/Select.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.tsx
@@ -57,7 +57,7 @@ function Select({
 
     const setNextActive = () => {
         if (!filteredItems || filteredItems.length < 1) return;
-        const possibleNextIndex = filteredItems.findIndex(listItem => listItem === activeOption) + 1;
+        const possibleNextIndex = filteredItems.findIndex(listItem => listItem.id === activeOption.id) + 1;
         const nextIndex = possibleNextIndex < filteredItems.length ? possibleNextIndex : 0;
         const nextItem = filteredItems[nextIndex];
         scrollToItem(nextItem);
@@ -66,7 +66,7 @@ function Select({
 
     const setPreviousActive = () => {
         if (!filteredItems || filteredItems.length < 1) return;
-        const possibleNextIndex = filteredItems.findIndex(listItem => listItem === activeOption) - 1;
+        const possibleNextIndex = filteredItems.findIndex(listItem => listItem.id === activeOption.id) - 1;
         const nextIndex = possibleNextIndex < 0 ? filteredItems.length - 1 : possibleNextIndex;
         const nextItem = filteredItems[nextIndex];
         scrollToItem(nextItem);

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -65,7 +65,7 @@ function SelectButton(props: Readonly<SelectButtonProps>) {
     // 1. If readonly we ignore the click action
     // 2. If filterable we want to show the list and focus on the input
     // 3. Otherwise we just toggle the list
-    const onClickHandler = readonly || props.disabled ? null : props.filterable ? setFocus : props.toggleList;
+    const onClickHandler = readonly ? null : props.filterable ? setFocus : props.toggleList;
 
     // check COWEB-1301 [Investigate] Drop-in Accessibility - ADA Compliance questions
     const currentSelectedItemId = active.id ? `listItem-${active.id}` : '';
@@ -83,12 +83,12 @@ function SelectButton(props: Readonly<SelectButtonProps>) {
             disabled={props.disabled}
             filterable={props.filterable}
             onClick={onClickHandler}
-            onKeyDown={!readonly && !props.disabled ? props.onButtonKeyDown : null}
+            onKeyDown={!readonly ? props.onButtonKeyDown : null}
             toggleButtonRef={props.toggleButtonRef}
             id={props.id}
             showList={showList}
             selectListId={props.selectListId}
-            aria-activedescendant={!props.filterable ? currentSelectedItemId || undefined : undefined}
+            aria-activedescendant={!props.filterable && showList ? currentSelectedItemId || undefined : undefined}
         >
             {!props.filterable ? (
                 <Fragment>

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -13,18 +13,24 @@ function SelectButtonElement({ filterable, toggleButtonRef, showList, selectList
     }
 
     return (
-        <button
+        <div
+            role="combobox"
+            tabIndex={props.disabled ? -1 : 0}
             id={props.id}
+            className={props.className}
             aria-haspopup="listbox"
             aria-expanded={showList}
             aria-controls={selectListId}
-            aria-disabled={props.readonly}
+            aria-activedescendant={props['aria-activedescendant'] || undefined}
+            aria-disabled={props.disabled || props.readonly}
             aria-describedby={props.ariaDescribedBy}
             aria-labelledby={props.id ? `${props.id}-label ${props.id}-value` : undefined}
-            type={'button'}
-            {...props}
+            onClick={props.onClick}
+            onKeyDown={props.onKeyDown}
             ref={toggleButtonRef}
-        />
+        >
+            {props.children}
+        </div>
     );
 }
 
@@ -58,7 +64,7 @@ function SelectButton(props: Readonly<SelectButtonProps>) {
     // 1. If readonly we ignore the click action
     // 2. If filterable we want to show the list and focus on the input
     // 3. Otherwise we just toggle the list
-    const onClickHandler = readonly ? null : props.filterable ? setFocus : props.toggleList;
+    const onClickHandler = readonly || props.disabled ? null : props.filterable ? setFocus : props.toggleList;
 
     // check COWEB-1301 [Investigate] Drop-in Accessibility - ADA Compliance questions
     const currentSelectedItemId = active.id ? `listItem-${active.id}` : '';
@@ -76,11 +82,12 @@ function SelectButton(props: Readonly<SelectButtonProps>) {
             disabled={props.disabled}
             filterable={props.filterable}
             onClick={onClickHandler}
-            onKeyDown={!readonly ? props.onButtonKeyDown : null}
+            onKeyDown={!readonly && !props.disabled ? props.onButtonKeyDown : null}
             toggleButtonRef={props.toggleButtonRef}
             id={props.id}
             showList={showList}
             selectListId={props.selectListId}
+            aria-activedescendant={!props.filterable ? currentSelectedItemId || undefined : undefined}
         >
             {!props.filterable ? (
                 <Fragment>

--- a/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
+++ b/packages/lib/src/components/internal/FormFields/Select/components/SelectButton.tsx
@@ -13,16 +13,17 @@ function SelectButtonElement({ filterable, toggleButtonRef, showList, selectList
     }
 
     return (
-        <div
+        <button
             role="combobox"
-            tabIndex={props.disabled ? -1 : 0}
+            type="button"
             id={props.id}
             className={props.className}
             aria-haspopup="listbox"
             aria-expanded={showList}
             aria-controls={selectListId}
             aria-activedescendant={props['aria-activedescendant'] || undefined}
-            aria-disabled={props.disabled || props.readonly}
+            disabled={props.disabled}
+            aria-disabled={props.readonly}
             aria-describedby={props.ariaDescribedBy}
             aria-labelledby={props.id ? `${props.id}-label ${props.id}-value` : undefined}
             onClick={props.onClick}
@@ -30,7 +31,7 @@ function SelectButtonElement({ filterable, toggleButtonRef, showList, selectList
             ref={toggleButtonRef}
         >
             {props.children}
-        </div>
+        </button>
     );
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Ensure keyboard navigation in the Select component in non filterable mode

- Add role="combobox" to the non-filterable <button>, so SRs understand that the button controls a listbox and pass the arrow keys directly to the component rather than use them for virtual cursor navigation. 
- Add aria-activedescendant conditionally, when the dropdown is open, so screen readers don't announce a stale active option when the list is collapsed.
- Fix a bug in keyboard navigation (setNextActive / setPreviousActive) where items were compared by object reference instead of the `id`, causing navigation to silently break when the item reference wasn't identical.
---

## 🧪 Tested scenarios

PayID: Tab into the identifier Select -> Enter the list -> Navigate using the keyboard arrow keys
ClickToPay: Tab into the Cards Select -> Enter the list -> Navigate using the keyboard arrow keys
Ach: Tab into the Account Type Select -> Enter the list -> Navigate using the keyboard arrow keys
Card with Installments: Enter the card details -> Tab into the Installments Select -> Enter the list -> Navigate using the keyboard arrow keys

- Attached screen recordings to the ticket
---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->
COSDK-744
---

