### PR TITLE
Fixed: Removes incorrect presentation role on card fields

### DIFF
--- a/.changeset/dull-pillows-heal.md
+++ b/.changeset/dull-pillows-heal.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Removes incorrect presentation role on card fields

--- a/packages/lib/src/components/Card/components/CardInput/a11y.docs.mdx
+++ b/packages/lib/src/components/Card/components/CardInput/a11y.docs.mdx
@@ -1,0 +1,36 @@
+{/* a11y.docs.mdx */}
+
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Components/Cards/a11y" />
+
+# Card Component — Accessibility Notes
+
+## Overview
+
+This document outlines accessibility improvements and considerations for the Card component and Secure Fields.
+
+## Secure Fields iframes `role="presentation"` removed
+
+Secure field inputs (card number, expiry date, CVC) are rendered inside iframes via the `createIframe` utility. A previous iteration of this code set `role="presentation"` on those iframes following earlier guidance from LevelAccess (COSDK-189). That attribute has since been removed.
+
+### Why it was removed
+
+`role="presentation"` on an element containing focusable or interactive content conflicts with the ARIA specification and is a documented [WCAG Failure F92](https://www.w3.org/WAI/WCAG21/Techniques/failures/F92) (Failure of Success Criterion 1.3.1 due to the use of `role="presentation"` on content which conveys relationships that are important).
+
+Its behaviour on iframes is also inconsistent across screen reader and browser combinations:
+
+- Some screen readers ignore it, making the original "fix" ineffective.
+- Others remove the entire iframe content from the accessibility tree which is a significantly worse outcome than a slightly verbose announcement.
+
+The apparent "working" behaviour observed during earlier testing was screen readers applying their own conflict resolution logic, which is not reliable to build on.
+
+This change addresses [WCAG SC 4.1.2 — Name, Role, Value](https://www.w3.org/TR/WCAG22/#name-role-value), which requires that the role of every UI component can be programmatically determined.
+
+## Decorative images hidden from assistive technology
+
+The CVC hint, the expiry date hint, and the placeholder brand icon images were purely decorative — the information they represented was already conveyed through field labels. Exposing them to screen readers caused redundant announcements.
+
+The CVC hint SVGs are now `aria-hidden`. The expiry date hint and the placeholder brand icon now have `alt=""`. Real detected brand icons retain their full brand name as `alt` text.
+
+This follows [WCAG SC 1.1.1 Non-text Content](https://www.w3.org/TR/WCAG22/#non-text-content): decorative images must have an empty text alternative so they are ignored by assistive technology.

--- a/packages/lib/src/components/Card/components/CardInput/a11y.md
+++ b/packages/lib/src/components/Card/components/CardInput/a11y.md
@@ -1,9 +1,0 @@
-# CardInput Component — Accessibility Notes
-
-## Decorative images hidden from assistive technology
-
-The CVC hint, the expiry date hint, and the placeholder brand icon images were purely decorative — the information they represented was already conveyed through field labels. Exposing them to screen readers caused redundant announcements.
-
-The CVC hint SVGs are now `aria-hidden`. The expiry date hint and the placeholder brand icon now have `alt=""`. Real detected brand icons retain their full brand name as `alt` text.
-
-This follows [WCAG SC 1.1.1 Non-text Content](https://www.w3.org/TR/WCAG22/#non-text-content): decorative images must have an empty text alternative so they are ignored by assistive technology.

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/createIframe.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/utils/createIframe.ts
@@ -3,9 +3,6 @@ export default function createIframe({ src, title = 'iframe element', policy = '
     iframeEl.setAttribute('src', src);
     iframeEl.classList.add('js-iframe');
 
-    // Following a11y advice from LevelAccess, we always set the iframe to be role=presentation
-    iframeEl.setAttribute('role', 'presentation');
-
     if (title !== '' && title.trim().length > 0) {
         iframeEl.setAttribute('title', title);
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

> [!IMPORTANT]
> This also fixes a bug preventing correct tabbing on card fields while Voice Over is enabled.  COSDK-1305

Removes role="presentation" from the secure field iframes.

This attribute was added in a previous ticket (COSDK-189) based on earlier LevelAccess guidance. Updated guidance from LevelAccess reverses that recommendation for the following reasons:

- `role="presentation"` on an element containing focusable or interactive content is a documented WCAG Failure F92 and conflicts with the ARIA specification.
- Its behaviour on iframes is inconsistent across screen reader / browser combinations: some ignore it (making the fix ineffective), while others remove the entire iframe content from the accessibility tree which is a significantly worse outcome.

Note: iframe title attributes remain in place. Improving those titles to be distinct from internal input labels is a lower-priority usability improvement tracked in a separate follow-up ticket.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

Verified secure fields (card number, expiry date, CVC) are announced correctly by screen reader after removal.

We can see in the screenshot with role presentation the input is actually not showing in the a11y tree on Chrome which is a major issue.

<img width="426" height="196" alt="Screenshot 2026-06-17 at 20 08 54" src="https://github.com/user-attachments/assets/85e744c7-140d-467c-81a2-0537fa3f08a3" />
<img width="807" height="331" alt="Screenshot 2026-06-17 at 20 09 13" src="https://github.com/user-attachments/assets/c477c419-cddc-49d7-8fb5-a1d65e2b2a78" />


---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number --> COSDK-1298 COSDK-1305

---

