### PR TITLE
fix: prefer exact locale match so zh-TW and pt-PT load correct CDN translations

### DIFF
--- a/packages/lib/src/language/LanguageService.test.ts
+++ b/packages/lib/src/language/LanguageService.test.ts
@@ -92,6 +92,14 @@ describe('LanguageService', () => {
                     })
                 );
             });
+
+            test('should request the exact translation file for zh-TW (not zh-CN)', async () => {
+                mockHttpGet.mockResolvedValueOnce({});
+                await service.fetchTranslationsFromCdn('zh-TW');
+                expect(mockHttpGet).toHaveBeenCalledWith(
+                    expect.objectContaining({ path: `sdk/${sdkVersion}/translations/zh-TW.json` })
+                );
+            });
         });
 
         describe('fallback behavior', () => {

--- a/packages/lib/src/language/utils.test.ts
+++ b/packages/lib/src/language/utils.test.ts
@@ -51,17 +51,21 @@ describe('matchLocale()', () => {
         expect(matchLocale('en-CA', localesWithDuplicates)).toBe('en-US');
     });
 
-    test('should prefer the exact locale over a same-language sibling for zh-TW', () => {
+    test.only('should prefer the exact locale over a same-language sibling for zh-TW', () => {
         expect(matchLocale('zh-TW', CDN_SUPPORTED_LOCALES)).toBe('zh-TW');
+        expect(matchLocale('zh-tw', CDN_SUPPORTED_LOCALES)).toBe('zh-TW');
     });
 
-    test('should prefer the exact locale over a same-language sibling for pt-PT', () => {
+    test.only('should prefer the exact locale over a same-language sibling for pt-PT', () => {
         expect(matchLocale('pt-PT', CDN_SUPPORTED_LOCALES)).toBe('pt-PT');
+        expect(matchLocale('pt-pt', CDN_SUPPORTED_LOCALES)).toBe('pt-PT');
     });
 
-    test('should still resolve the unambiguous siblings correctly', () => {
+    test.only('should still resolve the unambiguous siblings correctly', () => {
         expect(matchLocale('zh-CN', CDN_SUPPORTED_LOCALES)).toBe('zh-CN');
         expect(matchLocale('pt-BR', CDN_SUPPORTED_LOCALES)).toBe('pt-BR');
+        expect(matchLocale('zh-cn', CDN_SUPPORTED_LOCALES)).toBe('zh-CN');
+        expect(matchLocale('pt-br', CDN_SUPPORTED_LOCALES)).toBe('pt-BR');
     });
 });
 

--- a/packages/lib/src/language/utils.test.ts
+++ b/packages/lib/src/language/utils.test.ts
@@ -1,6 +1,6 @@
 import { formatCustomTranslations, formatLocaleToLanguageCountryLocale, getTranslation, interpolateElement, matchLocale, parseLocale } from './utils';
 import { createElement } from 'preact';
-import { DEFAULT_LOCALE } from './constants';
+import { CDN_SUPPORTED_LOCALES, DEFAULT_LOCALE } from './constants';
 
 describe('matchLocale()', () => {
     const supportedLocales = ['en-US', 'es-ES', 'fr-FR', 'de-DE', 'nl-NL'];
@@ -49,6 +49,19 @@ describe('matchLocale()', () => {
     test('should match first occurrence when multiple locales share language code', () => {
         const localesWithDuplicates = ['en-US', 'en-GB', 'es-ES'];
         expect(matchLocale('en-CA', localesWithDuplicates)).toBe('en-US');
+    });
+
+    test('should prefer the exact locale over a same-language sibling for zh-TW', () => {
+        expect(matchLocale('zh-TW', CDN_SUPPORTED_LOCALES)).toBe('zh-TW');
+    });
+
+    test('should prefer the exact locale over a same-language sibling for pt-PT', () => {
+        expect(matchLocale('pt-PT', CDN_SUPPORTED_LOCALES)).toBe('pt-PT');
+    });
+
+    test('should still resolve the unambiguous siblings correctly', () => {
+        expect(matchLocale('zh-CN', CDN_SUPPORTED_LOCALES)).toBe('zh-CN');
+        expect(matchLocale('pt-BR', CDN_SUPPORTED_LOCALES)).toBe('pt-BR');
     });
 });
 

--- a/packages/lib/src/language/utils.ts
+++ b/packages/lib/src/language/utils.ts
@@ -27,6 +27,7 @@ const isLocaleLenghtValid = (locale: string): boolean =>
  */
 export function matchLocale(locale: string, supportedLocales: readonly string[]): string | null {
     if (!locale || typeof locale !== 'string') return null;
+    if (supportedLocales.includes(locale)) return locale;
     return supportedLocales.find(supLoc => toTwoLetterCode(supLoc) === toTwoLetterCode(locale)) || null;
 }
 

--- a/packages/lib/src/language/utils.ts
+++ b/packages/lib/src/language/utils.ts
@@ -27,7 +27,8 @@ const isLocaleLenghtValid = (locale: string): boolean =>
  */
 export function matchLocale(locale: string, supportedLocales: readonly string[]): string | null {
     if (!locale || typeof locale !== 'string') return null;
-    if (supportedLocales.includes(locale)) return locale;
+    const exactMatch = supportedLocales.find(supLoc => supLoc.toLowerCase() === locale.toLowerCase());
+    if (exactMatch) return exactMatch;
     return supportedLocales.find(supLoc => toTwoLetterCode(supLoc) === toTwoLetterCode(locale)) || null;
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed.
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR.
---

## 📝 Summary

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

`locale: "zh-TW"` was loading the `zh-CN.json` translations from the CDN, so the UI showed up in Simplified Chinese for a Traditional Chinese shopper. `pt-PT` had the same problem and loaded `pt-BR.json`.

The internal locale was set correctly (amounts and dates were fine), only the translations file was wrong. The cause is in `matchLocale`: it compares just the first two letters of the locale and returns the first match in the list. `zh-CN` comes before `zh-TW` (and `pt-BR` before `pt-PT`), so the exact locale never got picked. `fetchTranslationsFromCdn` calls `matchLocale` directly without an exact-match check first, unlike `parseLocale` which already guards for it.

The fix adds an exact-match check at the start of `matchLocale`. If the requested locale is in the supported list, return it as is, otherwise fall back to the existing two-letter match. This keeps the fuzzy fallback working (`fr-CH` still resolves to `fr-FR`) and covers any other caller of `matchLocale`.

These are the only two locales affected, since they are the only pairs in `CDN_SUPPORTED_LOCALES` that share a language code.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

- `matchLocale('zh-TW', CDN_SUPPORTED_LOCALES)` returns `zh-TW` (was `zh-CN`)
- `matchLocale('pt-PT', CDN_SUPPORTED_LOCALES)` returns `pt-PT` (was `pt-BR`)
- `matchLocale('zh-CN', ...)` and `matchLocale('pt-BR', ...)` still return themselves
- `fetchTranslationsFromCdn('zh-TW')` requests `translations/zh-TW.json`
- Fuzzy fallback still works (`fr-CH` resolves to `fr-FR`)
- Unknown locales still return `null` / fall back to the default
- Verified manually in the browser: with `locale: "zh-TW"` the network request now goes to `zh-TW.json` and the Drop-in renders in Traditional Chinese.

Unit tests added in `src/language/utils.test.ts` and `src/language/LanguageService.test.ts`.

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  #4050 

---
