### PR TITLE
fix(a11y): add alt text to UPI and Iris brand logo images

### DIFF
--- a/.changeset/fix-upi-iris-brand-logo-alt-text.md
+++ b/.changeset/fix-upi-iris-brand-logo-alt-text.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: UPI and Iris brand logo images missing alt text for screen readers

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -98,6 +98,7 @@ export class ANCVElement extends UIElement<ANCVConfiguration> {
                     onError={this.props.onError}
                     onComplete={this.onComplete}
                     brandLogo={this.icon}
+                    brandName={this.displayName}
                     type={this.constructor['type']}
                     messageText={this.props.i18n.get('ancv.confirmPayment')}
                     awaitText={this.props.i18n.get('await.waitForConfirmation')}

--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -65,6 +65,7 @@ class BlikElement extends UIElement<AwaitConfiguration> {
                     onError={this.handleError}
                     onComplete={this.onComplete}
                     brandLogo={this.icon}
+                    brandName={this.displayName}
                     type={config.type}
                     messageText={this.props.i18n.get(config.messageTextId)}
                     awaitText={this.props.i18n.get(config.awaitTextId)}

--- a/packages/lib/src/components/Iris/Iris.tsx
+++ b/packages/lib/src/components/Iris/Iris.tsx
@@ -61,6 +61,7 @@ export class Iris extends IssuerListContainer<IrisConfiguration, IrisData> {
                 <QRLoader
                     type={TxVariants.iris}
                     brandLogo={this.icon}
+                    brandName={this.displayName}
                     clientKey={this.props.clientKey}
                     qrCodeData={this.props.qrCodeData ? encodeURIComponent(this.props.qrCodeData) : undefined}
                     countdownTime={this.props.countdownTime}

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -53,6 +53,7 @@ export class MBWayElement extends UIElement<AwaitConfiguration> {
                     onError={this.props.onError}
                     onComplete={this.onComplete}
                     brandLogo={this.icon}
+                    brandName={this.displayName}
                     type={config.type}
                     messageText={this.props.i18n.get(config.messageTextId)}
                     awaitText={this.props.i18n.get(config.awaitTextId)}

--- a/packages/lib/src/components/PayTo/PayTo.tsx
+++ b/packages/lib/src/components/PayTo/PayTo.tsx
@@ -134,6 +134,7 @@ export class PayToElement extends UIElement<PayToConfiguration> {
                     onError={this.props.onError}
                     onComplete={this.onComplete}
                     brandLogo={this.icon}
+                    brandName={this.displayName}
                     type={this.constructor['type']}
                     messageText={this.props.i18n.get('payto.confirmPayment')}
                     awaitText={this.props.i18n.get('payto.await.waitForConfirmation')}

--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -121,6 +121,7 @@ class UPI extends UIElement<UPIConfiguration> {
                         awaitText={this.props.i18n?.get('await.waitForConfirmation') ?? ''}
                         onComplete={this.onComplete}
                         brandLogo={this.icon}
+                        brandName={this.displayName}
                     />
                 );
             default:

--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -96,6 +96,7 @@ class UPI extends UIElement<UPIConfiguration> {
                         qrCodeData={this.props.qrCodeData ? encodeURIComponent(this.props.qrCodeData) : undefined}
                         type={TxVariants.upi_qr}
                         brandLogo={this.props.brandLogo || this.icon}
+                        brandName={this.props.name}
                         onComplete={this.onComplete}
                         introduction={this.props.i18n?.get('upi.qrCodeWaitingMessage') ?? ''}
                         countdownTime={this.props.countdownTime}

--- a/packages/lib/src/components/UPI/UPI.tsx
+++ b/packages/lib/src/components/UPI/UPI.tsx
@@ -96,7 +96,7 @@ class UPI extends UIElement<UPIConfiguration> {
                         qrCodeData={this.props.qrCodeData ? encodeURIComponent(this.props.qrCodeData) : undefined}
                         type={TxVariants.upi_qr}
                         brandLogo={this.props.brandLogo || this.icon}
-                        brandName={this.props.name}
+                        brandName={this.displayName}
                         onComplete={this.onComplete}
                         introduction={this.props.i18n?.get('upi.qrCodeWaitingMessage') ?? ''}
                         countdownTime={this.props.countdownTime}

--- a/packages/lib/src/components/internal/Await/Await.test.tsx
+++ b/packages/lib/src/components/internal/Await/Await.test.tsx
@@ -38,6 +38,8 @@ const renderAwait = ({
 describe('Await', () => {
     const assignSpy = jest.fn();
 
+    const brandName = 'MBWay';
+
     const defaultProps: AwaitComponentProps = {
         countdownTime: 0,
         onActionHandled: jest.fn(),
@@ -47,7 +49,7 @@ describe('Await', () => {
         throttleInterval: 0,
         throttleTime: 0,
         brandLogo: 'https://example.com',
-        brandName: 'MBWay',
+        brandName,
         clientKey: 'test_client_key',
         messageText: 'test',
         paymentData: 'dummy',
@@ -80,7 +82,7 @@ describe('Await', () => {
 
         test('should show brand logo', async () => {
             renderAwait({ awaitProps: defaultProps, amountProviderProps });
-            const image = await screen.findByAltText(defaultProps.brandName);
+            const image = await screen.findByAltText(brandName);
             // @ts-ignore src is part of img
             expect(image.src).toContain(defaultProps.brandLogo);
         });
@@ -208,7 +210,7 @@ describe('Await', () => {
         test('should show brand logo', async () => {
             renderAwait({ awaitProps: defaultProps, amountProviderProps });
 
-            const image = await screen.findByAltText(defaultProps.brandName);
+            const image = await screen.findByAltText(brandName);
             // @ts-ignore src is part of img
             expect(image.src).toContain(defaultProps.brandLogo);
         });

--- a/packages/lib/src/components/internal/Await/Await.test.tsx
+++ b/packages/lib/src/components/internal/Await/Await.test.tsx
@@ -47,6 +47,7 @@ describe('Await', () => {
         throttleInterval: 0,
         throttleTime: 0,
         brandLogo: 'https://example.com',
+        brandName: 'MBWay',
         clientKey: 'test_client_key',
         messageText: 'test',
         paymentData: 'dummy',
@@ -79,7 +80,7 @@ describe('Await', () => {
 
         test('should show brand logo', async () => {
             renderAwait({ awaitProps: defaultProps, amountProviderProps });
-            const image = await screen.findByAltText(defaultProps.type);
+            const image = await screen.findByAltText(defaultProps.brandName);
             // @ts-ignore src is part of img
             expect(image.src).toContain(defaultProps.brandLogo);
         });
@@ -207,7 +208,7 @@ describe('Await', () => {
         test('should show brand logo', async () => {
             renderAwait({ awaitProps: defaultProps, amountProviderProps });
 
-            const image = await screen.findByAltText(defaultProps.type);
+            const image = await screen.findByAltText(defaultProps.brandName);
             // @ts-ignore src is part of img
             expect(image.src).toContain(defaultProps.brandLogo);
         });

--- a/packages/lib/src/components/internal/Await/Await.tsx
+++ b/packages/lib/src/components/internal/Await/Await.tsx
@@ -59,7 +59,7 @@ export function Await(props: Readonly<AwaitComponentProps>) {
     if (loading) {
         return (
             <div className="adyen-checkout__await">
-                {props.brandLogo && <img src={props.brandLogo} alt={props.type} className="adyen-checkout__await__brand-logo" />}
+                {props.brandLogo && <img src={props.brandLogo} alt={props.brandName ?? props.type} className="adyen-checkout__await__brand-logo" />}
                 <Spinner inline={false} size="large" />
             </div>
         );
@@ -75,7 +75,7 @@ export function Await(props: Readonly<AwaitComponentProps>) {
                 props.classNameModifiers.map(m => `adyen-checkout__await--${m}`)
             )}
         >
-            {props.brandLogo && <img src={props.brandLogo} alt={props.type} className="adyen-checkout__await__brand-logo" />}
+            {props.brandLogo && <img src={props.brandLogo} alt={props.brandName ?? props.type} className="adyen-checkout__await__brand-logo" />}
 
             {/* Everything is wrapped in !! so we evaluate the result as boolean,
              otherwise we might just print the value or object as mistake */}

--- a/packages/lib/src/components/internal/Await/types.ts
+++ b/packages/lib/src/components/internal/Await/types.ts
@@ -18,6 +18,7 @@ export interface AwaitComponentProps {
     onError: (error: AdyenCheckoutError) => void;
     onComplete: (status: AdditionalDetailsData) => void;
     brandLogo?: string;
+    brandName?: string;
     messageText?: string;
     awaitText: string;
     onActionHandled?: (rtnObj: ActionHandledReturnObject) => void;

--- a/packages/lib/src/components/internal/QRLoader/QRLoader.test.tsx
+++ b/packages/lib/src/components/internal/QRLoader/QRLoader.test.tsx
@@ -23,6 +23,8 @@ const renderQRLoader = ({
     const srPanel = new SRPanel(global.core);
     const defaultProps: QRLoaderProps = {
         type: 'pix',
+        brandLogo: 'logo.png',
+        brandName: 'Pix',
         onComplete: jest.fn(),
         onError: jest.fn(),
         paymentData: 'initial-payment-data',

--- a/packages/lib/src/components/internal/QRLoader/types.ts
+++ b/packages/lib/src/components/internal/QRLoader/types.ts
@@ -16,8 +16,8 @@ export type QRLoaderProps = Pick<
     showAmount?: boolean;
     i18n?: Language;
     classNameModifiers?: string[];
-    brandLogo?: string;
-    brandName?: string;
+    brandLogo: string;
+    brandName: string;
     buttonLabel?: string;
     redirectIntroduction?: string;
     timeToPay?: string;


### PR DESCRIPTION
## 📋 Pull Request Checklist

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events

---

## 📝 Summary

The UPI and Iris brand logo images rendered inside `QRLoader` had no `alt` text, making them inaccessible to screen readers. Flagged by Adobe's accessibility team (COSDK-803).

- Made `brandName` a required prop on `QRLoaderProps` (alongside the existing `brandLogo`)
- Pass `this.props.name` as `brandName` in `UPI.tsx` and `this.displayName` in `Iris.tsx`
- Updated `QRLoader.test.tsx` default props to include both `brandLogo` and `brandName`

---

## 🧪 Tested scenarios

- Unit tests pass with the new required props
- Verified `alt` attribute is rendered on the brand logo `<img>` in QR await screens

---

## 🔗 Related GitHub Issue / Internal Ticket number

**Closes**: COSDK-803
