### PR TITLE
Replace deprecated keypress event with keydown

### DIFF
--- a/.changeset/strict-news-flow.md
+++ b/.changeset/strict-news-flow.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Improved: replace deprecated keypress event with keydown event

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -348,7 +348,7 @@ export class CardElement extends UIElement<CardConfiguration> {
                 onSubmitAnalytics={this.submitAnalytics}
                 onChange={this.setState}
                 onSubmit={this.submit}
-                handleKeyPress={this.handleKeyPress}
+                handleKeyDown={this.handleKeyDown}
                 payButton={this.payButton}
                 onBrand={this.onBrand}
                 onBinValue={this.onBinValue}

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -128,7 +128,7 @@ export interface CardInputProps {
     onFocus?: (e) => void;
     onLoad?: (o: CardLoadData) => void;
     onSubmitAnalytics: (event: AbstractAnalyticsEvent) => void;
-    handleKeyPress?: (obj: KeyboardEvent) => void;
+    handleKeyDown?: (event: KeyboardEvent) => void;
     onAddressLookup?: OnAddressLookupType;
     onAddressSelected?: OnAddressSelectedType;
     addressSearchDebounceMs?: number;

--- a/packages/lib/src/components/Card/components/CardInput/utils.ts
+++ b/packages/lib/src/components/Card/components/CardInput/utils.ts
@@ -160,7 +160,7 @@ export const extractPropsForSFP = (props: CardInputProps): Pick<SFPProps, 'clien
         onAutoComplete: props.onAutoComplete,
         onBinValue: props.onBinValue,
         onConfigSuccess: props.onConfigSuccess,
-        handleKeyPress: props.handleKeyPress,
+        handleKeyDown: props.handleKeyDown,
         onError: props.onError,
         onFieldValid: props.onFieldValid,
         onLoad: props.onLoad,

--- a/packages/lib/src/components/ClickToPay/ClickToPay.test.ts
+++ b/packages/lib/src/components/ClickToPay/ClickToPay.test.ts
@@ -104,7 +104,7 @@ test('should reject isAvailable if shopper account is not found', async () => {
     await expect(element.isAvailable()).rejects.toBeFalsy();
 });
 
-describe('Click to Pay: ENTER keypress should perform an action only within the CtP Component and should not propagate the event up to UIElement', () => {
+describe('Click to Pay: ENTER keydown should perform an action only within the CtP Component and should not propagate the event up to UIElement', () => {
     test('[Login form] should trigger shopper email lookup when ENTER key is pressed', async () => {
         // It's not possible to wait for onChange because it's not called.
         // Hence, add some delay between individual keystrokes, which yields to the event loop and allows pending state updates to be processed.

--- a/packages/lib/src/components/CustomCard/CustomCard.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCard.tsx
@@ -140,7 +140,7 @@ export class CustomCard extends UIElement<CustomCardConfiguration> {
                 }}
                 {...this.props}
                 {...this.state}
-                handleKeyPress={this.handleKeyPress}
+                handleKeyDown={this.handleKeyDown}
                 rootNode={this._node}
                 onChange={this.setState}
                 onBinValue={this.onBinValue}

--- a/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
@@ -172,7 +172,6 @@ const extractPropsForSFP = (props: SecuredFieldsProps) => {
         brandsConfiguration: props.brandsConfiguration,
         clientKey: props.clientKey,
         forceCompat: props.forceCompat,
-        // countryCode: props.countryCode, // only used for korean cards when koreanAuthenticationRequired is true
         i18n: props.i18n,
         implementationType: props.implementationType,
         keypadFix: props.keypadFix,
@@ -185,14 +184,12 @@ const extractPropsForSFP = (props: SecuredFieldsProps) => {
         onAutoComplete: props.onAutoComplete,
         onBinValue: props.onBinValue,
         onBrand: props.onBrand,
-        // onChange // set directly
         onConfigSuccess: props.onConfigSuccess,
         handleKeyDown: props.handleKeyDown,
         onError: props.onError,
         onFieldValid: props.onFieldValid,
         onFocus: props.onFocus,
         onLoad: props.onLoad,
-        // render // set directly
         rootNode: props.rootNode,
         showWarnings: props.showWarnings,
         styles: props.styles,

--- a/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
@@ -34,7 +34,7 @@ interface SecuredFieldsProps {
     onConfigSuccess?: () => {};
     onChange: (data) => void;
     onSubmitAnalytics?: (event: AbstractAnalyticsEvent) => void;
-    handleKeyPress?: (obj: KeyboardEvent) => void;
+    handleKeyDown?: (event: KeyboardEvent) => void;
     onError?: () => {};
     onFieldValid?: () => {};
     onFocus?: (e) => {};
@@ -187,7 +187,7 @@ const extractPropsForSFP = (props: SecuredFieldsProps) => {
         onBrand: props.onBrand,
         // onChange // set directly
         onConfigSuccess: props.onConfigSuccess,
-        handleKeyPress: props.handleKeyPress,
+        handleKeyDown: props.handleKeyDown,
         onError: props.onError,
         onFieldValid: props.onFieldValid,
         onFocus: props.onFocus,

--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -429,7 +429,7 @@ describe('Dropin', () => {
             await waitFor(() => expect(screen.getByRole('button', { name: 'Continue to AliPay' })).toBeVisible());
 
             const alipayHeader = screen.getByText('AliPay');
-            fireEvent.keyPress(alipayHeader, { key: 'Enter', code: 'Enter', charCode: 13 });
+            fireEvent.keyDown(alipayHeader, { key: 'Enter', code: 'Enter', charCode: 13 });
 
             expect(onEnterKeyPressedMock).toHaveBeenCalledTimes(1);
         });

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, TargetedKeyboardEvent } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import defaultProps from './defaultProps';
 import DropinComponent from '../../components/Dropin/components/DropinComponent';
@@ -232,14 +232,14 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
         this.dropinRef.closeActivePaymentMethod();
     }
 
-    protected handleKeyPress(e: h.JSX.TargetedKeyboardEvent<HTMLInputElement> | KeyboardEvent) {
+    protected handleKeyDown(e: TargetedKeyboardEvent<HTMLInputElement> | KeyboardEvent) {
         if (e.key === 'Enter' || e.code === 'Enter') {
             // If the active element has role="radio", we're on a header in the PMList, in which case we don't want to validate the form, or, prevent the default behaviour
             const isPMHeader = document?.activeElement?.getAttribute('role') === 'radio';
             if (isPMHeader) {
                 return;
             }
-            super.handleKeyPress(e);
+            super.handleKeyDown(e);
         }
     }
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/DisableOneClickConfirmation.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/DisableOneClickConfirmation.tsx
@@ -28,7 +28,6 @@ const DisableOneClickConfirmation = ({ id, open, onDisable, onCancel }) => {
                         )}
                         disabled={!open}
                         onClick={onDisable}
-                        onKeyPress={stopPropagationForActionKeys}
                         onKeyDown={stopPropagationForActionKeys}
                     >
                         {i18n.get('storedPaymentMethod.disable.confirmButton')}
@@ -42,7 +41,6 @@ const DisableOneClickConfirmation = ({ id, open, onDisable, onCancel }) => {
                         )}
                         disabled={!open}
                         onClick={onCancel}
-                        onKeyPress={stopPropagationForActionKeys}
                         onKeyDown={stopPropagationForActionKeys}
                     >
                         {i18n.get('storedPaymentMethod.disable.cancelButton')}

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -58,7 +58,6 @@ export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLo
                                             : undefined
                                     }
                                     label={i18n.get('storedPaymentMethod.disable.button')}
-                                    onKeyPress={stopPropagationForActionKeys}
                                     onKeyDown={stopPropagationForActionKeys}
                                     onClick={() => {
                                         onOrderCancel({ order });

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodItem/PaymentMethodItem.tsx
@@ -128,7 +128,6 @@ class PaymentMethodItem extends Component<Readonly<PaymentMethodItemProps>> {
                             inline
                             variant="link"
                             onClick={this.toggleDisableConfirmation}
-                            onKeyPress={stopPropagationForActionKeys}
                             onKeyDown={stopPropagationForActionKeys}
                             ariaExpanded={this.state.showDisableStoredPaymentMethodConfirmation}
                             ariaControls={disableConfirmationId}

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -175,7 +175,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
                     this.componentRef = ref;
                 }}
                 {...this.props}
-                handleKeyPress={this.handleKeyPress}
+                handleKeyDown={this.handleKeyDown}
                 showPayButton={this.props.showPayButton}
                 onChange={this.setState}
                 makeBalanceCheck={() => this.onBalanceCheck()}

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -25,7 +25,7 @@ interface GiftcardComponentProps extends Partial<Pick<SFPProps, 'clientKey' | 'l
     expiryDateRequired?: boolean;
     fieldsLayoutComponent: FunctionComponent<GiftcardFieldsProps>;
     placeholders?: Placeholders;
-    handleKeyPress?: (o: KeyboardEvent) => void;
+    handleKeyDown?: (event: KeyboardEvent) => void;
     onSubmitAnalytics?: (event: AbstractAnalyticsEvent) => void;
 }
 

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -1,4 +1,4 @@
-import { ComponentChild, h, render } from 'preact';
+import { ComponentChild, h, render, TargetedKeyboardEvent } from 'preact';
 import uuid from '../../../utils/uuid';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import { NO_CHECKOUT_ATTEMPT_ID } from '../../../core/Analytics/constants';
@@ -47,7 +47,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
         this.core = checkout;
         this.buildElementProps(props);
 
-        this.handleKeyPress = this.handleKeyPress.bind(this);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
     }
 
     protected buildElementProps(componentProps?: P) {
@@ -70,13 +70,11 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
         return {};
     }
 
-    /* eslint-disable-next-line */
-    protected submitAnalytics(analyticsObj?: AbstractAnalyticsEvent) {
+    protected submitAnalytics(_analyticsObj?: AbstractAnalyticsEvent) {
         return null;
     }
 
-    /* eslint-disable-next-line */
-    protected handleKeyPress(e: h.JSX.TargetedKeyboardEvent<HTMLInputElement>) {
+    protected handleKeyDown(_e: TargetedKeyboardEvent<HTMLInputElement>) {
         return null;
     }
 
@@ -145,7 +143,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
         this._node = node;
 
         // Add listener for key press events, notably 'Enter' key presses
-        on(this._node, 'keypress', this.handleKeyPress, false);
+        on(this._node, 'keydown', this.handleKeyDown, false);
 
         this._component = this.render();
 
@@ -172,7 +170,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
      */
     public unmount(): this {
         // Remove listener
-        off(this._node, 'keypress', this.handleKeyPress);
+        off(this._node, 'keydown', this.handleKeyDown);
 
         if (this._node) {
             render(null, this._node);

--- a/packages/lib/src/components/internal/Button/Button.tsx
+++ b/packages/lib/src/components/internal/Button/Button.tsx
@@ -62,8 +62,7 @@ class Button extends Component<ButtonProps, ButtonState> {
             onMouseLeave,
             onFocus,
             onBlur,
-            onKeyDown,
-            onKeyPress
+            onKeyDown
         }: ButtonProps = this.props;
         const { completed } = this.state;
         const { i18n } = useCoreContext();
@@ -149,7 +148,6 @@ class Button extends Component<ButtonProps, ButtonState> {
                 onKeyDown={onKeyDown}
                 onFocus={onFocus}
                 onBlur={onBlur}
-                onKeyPress={onKeyPress}
             >
                 {buttonText}
                 {status !== 'loading' && status !== 'redirect' && this.props.children}

--- a/packages/lib/src/components/internal/Button/CopyButton.tsx
+++ b/packages/lib/src/components/internal/Button/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, TargetedMouseEvent } from 'preact';
 import { useCallback } from 'preact/hooks';
 import Button from './Button';
 import { ButtonProps } from './types';
@@ -14,7 +14,7 @@ export interface CopyButtonProps extends Omit<ButtonProps, 'variant' | 'onClickC
      */
     text: string;
     copiedLabel?: string;
-    onClick?: (e: h.JSX.TargetedMouseEvent<HTMLButtonElement>) => void;
+    onClick?: (e: TargetedMouseEvent<HTMLButtonElement>) => void;
 }
 
 const CopyButton = (props: Readonly<CopyButtonProps>) => {
@@ -36,7 +36,6 @@ const CopyButton = (props: Readonly<CopyButtonProps>) => {
             variant="action"
             onClick={onClick}
             // Workaround: See ADR-0001-uielement-keyboard-event-propagation-workaround
-            onKeyPress={stopPropagationForActionKeys}
             onKeyDown={stopPropagationForActionKeys}
             icon={props.icon ?? getImage({ imageFolder: 'components/' })(`${PREFIX}copy`)}
             label={props.label ?? i18n.get('button.copy')}

--- a/packages/lib/src/components/internal/Button/CopyIconButton.tsx
+++ b/packages/lib/src/components/internal/Button/CopyIconButton.tsx
@@ -5,8 +5,8 @@ import { ButtonProps } from './types';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import copyToClipboard from '../../../utils/clipboard';
 import { SingletonTooltipProvider, useTooltip } from '../Tooltip/SingletonTooltipProvider';
-import './CopyIconButton.scss';
 import { stopPropagationForActionKeys } from './stopPropagationForActionKeys';
+import './CopyIconButton.scss';
 
 export interface CopyIconButtonProps extends ButtonProps {
     /**
@@ -25,7 +25,6 @@ const CopyIconButton = (props: Readonly<CopyIconButtonProps>) => {
         showTooltip({ anchorRef, text: i18n.get('button.copied') });
     }, [props.text, i18n, showTooltip]);
 
-    // We need it because onKeyPress does not trigger for Esc key
     const onKeyDown = useCallback(
         (event: KeyboardEvent) => {
             stopPropagationForActionKeys(event);
@@ -53,8 +52,6 @@ const CopyIconButton = (props: Readonly<CopyIconButtonProps>) => {
             onFocus={handleShowTooltip}
             onBlur={hideTooltip}
             onClick={onClick}
-            // It's ok to have both, browsers will fire only one click event for enter/space key pressed.
-            onKeyPress={stopPropagationForActionKeys}
             onKeyDown={onKeyDown}
         >
             <svg

--- a/packages/lib/src/components/internal/Button/types.ts
+++ b/packages/lib/src/components/internal/Button/types.ts
@@ -27,7 +27,6 @@ export interface ButtonProps {
     rel?: string;
     onClick?: (e: TargetedMouseEvent<HTMLButtonElement | HTMLAnchorElement>, callbacks?: { complete?: () => void }) => void;
     onKeyDown?: (event: KeyboardEvent) => void;
-    onKeyPress?: (event: KeyboardEvent) => void;
     buttonRef?: Ref<HTMLButtonElement>;
     onMouseEnter?: (event: MouseEvent) => void;
     onMouseLeave?: (event: MouseEvent) => void;

--- a/packages/lib/src/components/internal/ClickToPay/ClickToPayComponent.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/ClickToPayComponent.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, TargetedKeyboardEvent } from 'preact';
 import { useCallback, useEffect } from 'preact/hooks';
 import { CtpState } from './services/ClickToPayService';
 import useClickToPayContext from './context/useClickToPayContext';
@@ -37,13 +37,13 @@ const ClickToPayComponent = ({ onDisplayCardComponent }: Readonly<ClickToPayComp
     }, [ctpState]);
 
     /**
-     * We capture the ENTER keypress within the ClickToPay component because we do not want to propagate the event up to the UIElement
+     * We capture the ENTER keydown within the ClickToPay component because we do not want to propagate the event up to the UIElement
      * UIElement would perform the payment flow (by calling .submit), which is not relevant/supported by Click to Pay
      */
-    const handleEnterKeyPress = useCallback((event: h.JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
+    const handleEnterKeyPress = useCallback((event: TargetedKeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'Enter') {
             event.preventDefault(); // Prevent <form> submission if Component is placed inside a form
-            event.stopPropagation(); // Prevent global BaseElement keypress event to be triggered
+            event.stopPropagation(); // Prevent global BaseElement keydown event to be triggered
         }
     }, []);
 

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPLogin/CtPLoginInput.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, TargetedKeyboardEvent } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import { loginValidationRules } from './validate';
 import { useCoreContext } from '../../../../../core/Context/CoreProvider';
@@ -58,8 +58,8 @@ const CtPLoginInput = (props: Readonly<CtPLoginInputProps>): h.JSX.Element => {
         props.onSetInputHandlers(loginInputHandlersRef.current);
     }, [validateInput, props.onSetInputHandlers]);
 
-    const handleOnKeyPress = useCallback(
-        (event: h.JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
+    const handleOnKeyDown = useCallback(
+        (event: TargetedKeyboardEvent<HTMLInputElement>) => {
             if (event.key === 'Enter') {
                 void props.onPressEnter();
             }
@@ -88,7 +88,7 @@ const CtPLoginInput = (props: Readonly<CtPLoginInputProps>): h.JSX.Element => {
                     disabled={props.disabled}
                     onInput={handleChangeFor('shopperLogin', 'input')}
                     onBlur={handleChangeFor('shopperLogin', 'blur')}
-                    onKeyPress={handleOnKeyPress}
+                    onKeyDown={handleOnKeyDown}
                     autocomplete={'email'}
                 />
             </Field>

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPOneTimePassword/CtPOneTimePasswordInput/CtPOneTimePasswordInput.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, TargetedKeyboardEvent } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import { otpValidationRules } from './validate';
 import CtPResendOtpLink from './CtPResendOtpLink';
@@ -96,8 +96,8 @@ const CtPOneTimePasswordInput = (props: Readonly<CtPOneTimePasswordInputProps>):
         [i18n]
     );
 
-    const handleOnKeyPress = useCallback(
-        (event: h.JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
+    const handleOnKeyDown = useCallback(
+        (event: TargetedKeyboardEvent<HTMLInputElement>) => {
             if (event.key === 'Enter') {
                 void props.onPressEnter();
             }
@@ -132,7 +132,7 @@ const CtPOneTimePasswordInput = (props: Readonly<CtPOneTimePasswordInputProps>):
                     disabled={props.disabled}
                     onInput={handleChangeFor('otp', 'input')}
                     onBlur={handleChangeFor('otp', 'blur')}
-                    onKeyPress={handleOnKeyPress}
+                    onKeyDown={handleOnKeyDown}
                     setRef={(ref: HTMLInputElement) => {
                         inputRef.current = ref;
                     }}

--- a/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPSection.tsx
+++ b/packages/lib/src/components/internal/ClickToPay/components/CtPSection/CtPSection.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, TargetedKeyboardEvent } from 'preact';
 import classnames from 'classnames';
 import CtPLogoutLink from './CtPLogoutLink';
 import { CtPBrand } from '../CtPBrand';
@@ -6,7 +6,7 @@ import useClickToPayContext from '../../context/useClickToPayContext';
 import './CtPSection.scss';
 
 interface CtPSectionProps {
-    onEnterKeyPress: (event: h.JSX.TargetedKeyboardEvent<HTMLInputElement>) => void;
+    onEnterKeyPress: (event: TargetedKeyboardEvent<HTMLInputElement>) => void;
     children?: h.JSX.Element[];
 }
 
@@ -17,7 +17,7 @@ const CtPSection = ({ children, onEnterKeyPress }: Readonly<CtPSectionProps>): h
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div
             className={classnames('adyen-checkout-ctp__section', { 'adyen-checkout-ctp__section--standalone': isStandaloneComponent })}
-            onKeyPress={onEnterKeyPress}
+            onKeyDown={onEnterKeyPress}
         >
             <div className="adyen-checkout-ctp__section-brand">
                 <CtPBrand />

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -65,23 +65,20 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
 
     /**
      *  Event is fired when a key that produces a character value is pressed down.
-     *  ENTER keypress also triggers this event.
-     *
-     *  TODO: 'keypress' event is deprecated
-     *  https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event
+     *  ENTER keydown also triggers this event.
      */
-    const handleKeyPress = useCallback(
+    const handleKeyDown = useCallback(
         (event: TargetedKeyboardEvent<HTMLInputElement>) => {
-            if (props?.onKeyPress) props.onKeyPress(event);
+            if (props?.onKeyDown) props.onKeyDown(event);
         },
-        [props?.onKeyPress]
+        [props?.onKeyDown]
     );
 
     /**
      * Event is fired when certain keys are pressed (keys that do not output characters):
      * Backspace, Arrow keys, Shift, Ctrl, Command, Option, Esc
      *
-     * Exception: ENTER keypress triggers 'onKeyPress' AND 'onKeyUp'
+     * Exception: ENTER keydown triggers 'onKeyDown' AND 'onKeyUp'
      */
     const handleKeyUp = useCallback(
         (event: TargetedKeyboardEvent<HTMLInputElement>) => {
@@ -156,7 +153,7 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
             onBlur={handleBlur}
             onFocus={handleFocus}
             onKeyUp={handleKeyUp}
-            onKeyPress={handleKeyPress}
+            onKeyDown={handleKeyDown}
             disabled={disabled}
             ref={setRef}
         />

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -70,6 +70,17 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
         [props?.onKeyDown]
     );
 
+    /**
+     * Event is fired when certain keys are pressed (keys that do not output characters):
+     * Backspace, Arrow keys, Shift, Ctrl, Command, Option, Esc
+     */
+    const handleKeyUp = useCallback(
+        (event: TargetedKeyboardEvent<HTMLInputElement>) => {
+            if (props?.onKeyUp) props.onKeyUp(event);
+        },
+        [props?.onKeyUp]
+    );
+
     const handleBlur = useCallback(
         (event: TargetedFocusEvent<HTMLInputElement>) => {
             props?.onBlurHandler?.(event); // From Field component
@@ -135,6 +146,7 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
             onInput={handleInput}
             onBlur={handleBlur}
             onFocus={handleFocus}
+            onKeyUp={handleKeyUp}
             onKeyDown={handleKeyDown}
             disabled={disabled}
             ref={setRef}

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -63,28 +63,11 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
         [props.onInput]
     );
 
-    /**
-     *  Event is fired when a key that produces a character value is pressed down.
-     *  ENTER keydown also triggers this event.
-     */
     const handleKeyDown = useCallback(
         (event: TargetedKeyboardEvent<HTMLInputElement>) => {
             if (props?.onKeyDown) props.onKeyDown(event);
         },
         [props?.onKeyDown]
-    );
-
-    /**
-     * Event is fired when certain keys are pressed (keys that do not output characters):
-     * Backspace, Arrow keys, Shift, Ctrl, Command, Option, Esc
-     *
-     * Exception: ENTER keydown triggers 'onKeyDown' AND 'onKeyUp'
-     */
-    const handleKeyUp = useCallback(
-        (event: TargetedKeyboardEvent<HTMLInputElement>) => {
-            if (props?.onKeyUp) props.onKeyUp(event);
-        },
-        [props?.onKeyUp]
     );
 
     const handleBlur = useCallback(
@@ -152,7 +135,6 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
             onInput={handleInput}
             onBlur={handleBlur}
             onFocus={handleFocus}
-            onKeyUp={handleKeyUp}
             onKeyDown={handleKeyDown}
             disabled={disabled}
             ref={setRef}

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -70,17 +70,6 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
         [props?.onKeyDown]
     );
 
-    /**
-     * Event is fired when certain keys are pressed (keys that do not output characters):
-     * Backspace, Arrow keys, Shift, Ctrl, Command, Option, Esc
-     */
-    const handleKeyUp = useCallback(
-        (event: TargetedKeyboardEvent<HTMLInputElement>) => {
-            if (props?.onKeyUp) props.onKeyUp(event);
-        },
-        [props?.onKeyUp]
-    );
-
     const handleBlur = useCallback(
         (event: TargetedFocusEvent<HTMLInputElement>) => {
             props?.onBlurHandler?.(event); // From Field component
@@ -146,7 +135,6 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
             onInput={handleInput}
             onBlur={handleBlur}
             onFocus={handleFocus}
-            onKeyUp={handleKeyUp}
             onKeyDown={handleKeyDown}
             disabled={disabled}
             ref={setRef}

--- a/packages/lib/src/components/internal/Modal/Modal.tsx
+++ b/packages/lib/src/components/internal/Modal/Modal.tsx
@@ -59,13 +59,13 @@ const Modal = ({
     useEffect(() => {
         if (!modalContainerRef.current) return;
 
-        const suppressKeyPress = (event: KeyboardEvent) => {
+        const suppressKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Enter' || event.code === 'Enter') event.stopPropagation();
         };
 
-        modalContainerRef.current.addEventListener('keypress', suppressKeyPress, { capture: true });
+        modalContainerRef.current.addEventListener('keydown', suppressKeyDown, { capture: true });
         return () => {
-            modalContainerRef.current.removeEventListener('keypress', suppressKeyPress);
+            modalContainerRef.current.removeEventListener('keydown', suppressKeyDown);
         };
     }, [modalContainerRef.current]);
 

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -14,7 +14,7 @@ import {
     CardAutoCompleteData,
     CardConfigSuccessData,
     CardLoadData,
-    SFKeyPressObj,
+    SFKeyDownObj,
     SFFieldType
 } from '../lib/types';
 import { CSFReturnObject, CSFSetupObject } from '../lib/CSF/types';
@@ -32,24 +32,24 @@ import { TxVariants } from '../../../tx-variants';
  */
 class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
     private csfLoadFailTimeout: number;
-    private csfLoadFailTimeoutMS: number;
-    private csfConfigFailTimeout: number;
-    private csfConfigFailTimeoutMS: number;
+    private readonly csfLoadFailTimeoutMS: number;
+    private readonly csfConfigFailTimeout: number;
+    private readonly csfConfigFailTimeoutMS: number;
     private numCharsInField: object;
     private rootNode: HTMLElement;
     private numDateFields: number;
     private csf: CSFReturnObject;
-    private handleOnLoad: (obj: CardLoadData) => void;
-    private handleOnConfigSuccess: (obj: CardConfigSuccessData) => void;
-    private handleOnFieldValid: (obj: CardFieldValidData) => void;
-    private handleOnAllValid: (obj: CardAllValidData) => void;
-    private handleOnBrand: (obj: CardBrandData) => void;
-    private handleFocus: (obj: CardFocusData) => void;
-    private handleOnError: (obj: CardErrorData, hasUnsupportedCard?: boolean) => void;
-    private handleOnAutoComplete: (obj: CardAutoCompleteData) => void;
-    private handleOnNoDataRequired: () => void;
-    private handleOnTouchstartIOS: (obj) => void;
-    private handleKeyPressed: (obj: SFKeyPressObj) => void;
+    private readonly handleOnLoad: (obj: CardLoadData) => void;
+    private readonly handleOnConfigSuccess: (obj: CardConfigSuccessData) => void;
+    private readonly handleOnFieldValid: (obj: CardFieldValidData) => void;
+    private readonly handleOnAllValid: (obj: CardAllValidData) => void;
+    private readonly handleOnBrand: (obj: CardBrandData) => void;
+    private readonly handleFocus: (obj: CardFocusData) => void;
+    private readonly handleOnError: (obj: CardErrorData, hasUnsupportedCard?: boolean) => void;
+    private readonly handleOnAutoComplete: (obj: CardAutoCompleteData) => void;
+    private readonly handleOnNoDataRequired: () => void;
+    private readonly handleOnTouchstartIOS: (obj) => void;
+    private readonly handleKeyDown: (obj: SFKeyDownObj) => void;
     public state: SFPState;
     public props: SFPProps;
     private issuingCountryCode: string;
@@ -89,7 +89,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
         this.handleOnNoDataRequired = handlers.handleOnNoDataRequired.bind(this);
         this.handleOnAutoComplete = handlers.handleOnAutoComplete.bind(this);
         this.handleOnTouchstartIOS = handlers.handleOnTouchstartIOS.bind(this); // Only called when iOS detected
-        this.handleKeyPressed = handlers.handleKeyPressed.bind(this);
+        this.handleKeyDown = handlers.handleKeyDown.bind(this);
 
         this.processBinLookupResponse = this.processBinLookupResponse.bind(this);
 
@@ -185,7 +185,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
                 onAdditionalSFConfig: this.props.onAdditionalSFConfig,
                 onAdditionalSFRemoved: this.props.onAdditionalSFRemoved,
                 onTouchstartIOS: this.handleOnTouchstartIOS,
-                onKeyPressed: this.handleKeyPressed
+                onKeyDown: this.handleKeyDown
             },
             isKCP: this.state.hasKoreanFields,
             legacyInputMode: this.props.legacyInputMode,

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProviderHandlers.ts
@@ -19,7 +19,7 @@ import {
     CardAutoCompleteData,
     CardConfigSuccessData,
     CardLoadData,
-    SFKeyPressObj
+    SFKeyDownObj
 } from '../lib/types';
 import { existy } from '../../../../utils/commonUtils';
 import AdyenCheckoutError from '../../../../core/Errors/AdyenCheckoutError';
@@ -222,15 +222,15 @@ function handleOnAutoComplete(cbObj: CardAutoCompleteData): void {
     this.props.onAutoComplete(cbObj);
 }
 
-function handleKeyPressed(obj: SFKeyPressObj): void {
+function handleKeyDown(obj: SFKeyDownObj): void {
     if (obj.action === 'enterKeyPressed') {
-        const kb = new KeyboardEvent('keypress', {
+        const kb = new KeyboardEvent('keydown', {
             bubbles: true,
             cancelable: true,
             key: 'Enter',
             code: 'Enter'
         });
-        this.props.handleKeyPress?.(kb);
+        this.props.handleKeyDown?.(kb);
     }
 }
 
@@ -253,5 +253,5 @@ export default {
     handleOnError,
     handleOnNoDataRequired,
     handleOnTouchstartIOS,
-    handleKeyPressed
+    handleKeyDown
 };

--- a/packages/lib/src/components/internal/SecuredFields/SFP/defaultProps.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/defaultProps.ts
@@ -21,7 +21,7 @@ export default {
     onBinValue: () => {},
     onFocus: () => {},
     onAutoComplete: () => {},
-    handleKeyPress: () => {},
+    handleKeyDown: () => {},
 
     // Customization
     styles: {}

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -61,7 +61,7 @@ export interface SFPProps {
     onLoad?: (cbObj: CardLoadData) => void;
     onStateUpdate?: (obj: SFPState) => void;
     onSubmitAnalytics?: (event: AbstractAnalyticsEvent) => void;
-    handleKeyPress?: (obj: KeyboardEvent) => void;
+    handleKeyDown?: (event: KeyboardEvent) => void;
     rootNode?: HTMLElement; // Specific to SecuredFieldsInput
     showWarnings?: boolean;
     styles?: StylesObject;

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/configureCallbacks.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/configureCallbacks.ts
@@ -28,5 +28,5 @@ export function configureCallbacks(callbacksObj: Partial<CSFCallbacksConfig> = {
 
     this.callbacks.onTouchstartIOS = callbacksObj.onTouchstartIOS ? callbacksObj.onTouchstartIOS : noop;
 
-    this.callbacks.onKeyPressed = callbacksObj.onKeyPressed ? callbacksObj.onKeyPressed : noop;
+    this.callbacks.onKeyDown = callbacksObj.onKeyDown ? callbacksObj.onKeyDown : noop;
 }

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.test.ts
@@ -21,7 +21,7 @@ const myCSF = {
     callbacks: {
         onLoad: jest.fn(() => {}),
         onTouchstartIOS: jest.fn(() => {}),
-        onKeyPressed: jest.fn(() => {})
+        onKeyDown: jest.fn(() => {})
     },
     createSecuredFields,
     setupSecuredField,
@@ -68,7 +68,7 @@ describe('Testing CSFs setupSecuredField functionality', () => {
             onEncryptionCallback: null,
             onValidationCallback: null,
             onAutoCompleteCallback: null,
-            onKeyPressedCallback: null,
+            onKeyDownCallback: null,
             onIframeLoaded: cbFn => {
                 MySecuredField.onIframeLoadedCallback = cbFn;
                 return MySecuredField;
@@ -105,8 +105,8 @@ describe('Testing CSFs setupSecuredField functionality', () => {
                 MySecuredField.onAutoCompleteCallback = cbFn;
                 return MySecuredField;
             },
-            onKeyPressed: cbFn => {
-                MySecuredField.onKeyPressedCallback = cbFn;
+            onKeyDown: cbFn => {
+                MySecuredField.onKeyDownCallback = cbFn;
                 return MySecuredField;
             }
         };
@@ -312,10 +312,10 @@ describe('Testing CSFs setupSecuredField functionality', () => {
         MySecuredField.onAutoCompleteCallback(dummyObj);
         expect(myCSF.processAutoComplete).toHaveBeenCalledWith(dummyObj);
 
-        // onKeyPressedCallback
-        expect(MySecuredField.onKeyPressedCallback).not.toEqual(null);
+        // onKeyDownCallback
+        expect(MySecuredField.onKeyDownCallback).not.toEqual(null);
 
-        MySecuredField.onKeyPressedCallback(dummyObjWithNumKey);
-        expect(myCSF.callbacks.onKeyPressed).toHaveBeenCalledWith(dummyObj); // checking that numKey prop gets removed
+        MySecuredField.onKeyDownCallback(dummyObjWithNumKey);
+        expect(myCSF.callbacks.onKeyDown).toHaveBeenCalledWith(dummyObj); // checking that numKey prop gets removed
     });
 });

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/extensions/createSecuredFields.ts
@@ -301,9 +301,9 @@ export function setupSecuredField(pItem: HTMLElement, cvcPolicy?: CVCPolicyType,
             .onAutoComplete((pFeedbackObj: SFFeedbackObj): void => {
                 this.processAutoComplete(pFeedbackObj);
             })
-            .onKeyPressed((pFeedbackObj: SFFeedbackObj): void => {
+            .onKeyDown((pFeedbackObj: SFFeedbackObj): void => {
                 const { numKey, ...rest } = pFeedbackObj;
-                this.callbacks.onKeyPressed(rest);
+                this.callbacks.onKeyDown(rest);
             });
 
         // Store reference to securedField in this.state (under fieldType)

--- a/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/CSF/types.ts
@@ -90,7 +90,7 @@ export interface CSFCallbacksConfig {
     onAdditionalSFConfig?: (callbackObj: object) => void;
     onAdditionalSFRemoved?: (callbackObj: object) => void;
     onTouchstartIOS?: (callbackObj: object) => void;
-    onKeyPressed?: (callbackObj: object) => void;
+    onKeyDown?: (callbackObj: object) => void;
 }
 
 export interface CSFStateObject {

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/AbstractSecuredField.ts
@@ -37,7 +37,7 @@ abstract class AbstractSecuredField {
     protected onTouchstartCallback: RtnType_callbackFn;
     protected onShiftTabCallback: RtnType_callbackFn;
     protected onAutoCompleteCallback: RtnType_callbackFn;
-    protected onKeyPressedCallback: RtnType_callbackFn;
+    protected onKeyDownCallback: RtnType_callbackFn;
 
     protected constructor() {
         this.sfConfig = {};

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.test.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.test.ts
@@ -540,7 +540,7 @@ describe('SecuredField handling placeholders from the placeholders config', () =
         });
 
         test('Check callback is called after "enterKeyPressed" action', () => {
-            card.onKeyPressed(myCallback);
+            card.onKeyDown(myCallback);
 
             // Set action
             data.action = 'enterKeyPressed';

--- a/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/securedField/SecuredField.ts
@@ -285,7 +285,7 @@ class SecuredField extends AbstractSecuredField {
                 break;
 
             case 'enterKeyPressed':
-                this.onKeyPressedCallback(feedbackObj);
+                this.onKeyDownCallback(feedbackObj);
                 break;
 
             case 'encryptionError': {
@@ -406,8 +406,8 @@ class SecuredField extends AbstractSecuredField {
         return this;
     }
 
-    onKeyPressed(callbackFn: RtnType_callbackFn): SecuredField {
-        this.onKeyPressedCallback = callbackFn;
+    onKeyDown(callbackFn: RtnType_callbackFn): SecuredField {
+        this.onKeyDownCallback = callbackFn;
         return this;
     }
     //------------------------------------

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -347,7 +347,7 @@ export interface SFPlaceholdersObject {
     [ENCRYPTED_PWD_FIELD]?: string;
 }
 
-export interface SFKeyPressObj {
+export interface SFKeyDownObj {
     fieldType: string;
     action: string;
 }

--- a/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.tsx
+++ b/packages/lib/src/components/internal/SegmentedControl/SegmentedControl.tsx
@@ -68,7 +68,6 @@ export const SegmentedControl = <T,>({
                     key={value}
                     onClick={(event: MouseEvent) => onChange(value, event)}
                     // Workaround: See ADR-0001-uielement-keyboard-event-propagation-workaround
-                    onKeyPress={stopPropagationForActionKeys}
                     onKeyDown={stopPropagationForActionKeys}
                     className={cx('adyen-checkout__segmented-control-segment', {
                         'adyen-checkout__segmented-control-segment--selected': selectedValue === value

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -524,7 +524,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         this.handleSuccessResult(response);
     }
 
-    protected handleKeyPress(e: h.JSX.TargetedKeyboardEvent<HTMLInputElement> | KeyboardEvent) {
+    protected handleKeyDown(e: h.JSX.TargetedKeyboardEvent<HTMLInputElement> | KeyboardEvent) {
         if (e.key === 'Enter' || e.code === 'Enter') {
             e.preventDefault(); // Prevent <form> submission if Component is placed inside a form
 
@@ -533,7 +533,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     }
 
     /**
-     * Handle Enter key pressed from a UIElement (called via handleKeyPress)
+     * Handle Enter key pressed from a UIElement (called via handleKeyDown)
      * @param obj
      */
     protected onEnterKeyPressed(activeElement: Element, component: UIElement) {

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -1,4 +1,4 @@
-import { createRef, h, RefObject } from 'preact';
+import { createRef, h, RefObject, TargetedKeyboardEvent } from 'preact';
 import { Resources } from '../../../core/Context/Resources';
 import AdyenCheckoutError, { NETWORK_ERROR } from '../../../core/Errors/AdyenCheckoutError';
 import { hasOwnProperty } from '../../../utils/hasOwnProperty';
@@ -524,7 +524,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         this.handleSuccessResult(response);
     }
 
-    protected handleKeyDown(e: h.JSX.TargetedKeyboardEvent<HTMLInputElement> | KeyboardEvent) {
+    protected handleKeyDown(e: TargetedKeyboardEvent<HTMLInputElement> | KeyboardEvent) {
         if (e.key === 'Enter' || e.code === 'Enter') {
             e.preventDefault(); // Prevent <form> submission if Component is placed inside a form
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

The [`keypress`](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event) event is deprecated, so this swaps it out for [`keydown` ](https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event) everywhere. Same behaviour, just no longer using a dead API. Also renamed the related handlers/props/types to match, and did a bit of cleanup along the way.

## What changed

- **Inputs** (`InputBase`): `onKeyPress`/`handleKeyPress` → `onKeyDown`/`handleKeyDown`
- - **Inputs** (`InputBase`): Remove `onKeyUp` handler as it is not being used and `onKeyDown` now covers the usecase for `onKeyUp`
- **Button**: dropped the redundant `onKeyPress` prop, kept `onKeyDown`
- **UIElement / Dropin**: `handleKeyPress` → `handleKeyDown` (Enter-to-submit still works the same)
- **SecuredFields**: renamed `onKeyPressed`/`handleKeyPressed`/`SFKeyPressObj` → `onKeyDown`/`handleKeyDown`/`SFKeyDownObj`
- Tidied up unused props and marked a few `SecuredFieldsProvider` fields `readonly`
- Added a `minor` changeset

## Testing

- [x] Unit tests pass
- [x] Enter still submits in Card / Custom Card / Giftcard
- [x] Enter on a Drop-in payment-method header doesn't submit


<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

- COSDK-520

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

