### PR TITLE
chore: remove explicit `any` from Giftcard, ThreeDS2, ANCV, and Dropin

### DIFF
--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -144,12 +144,8 @@ const config = defineConfig(
             'src/**/*.spec.tsx',
 
             // ── Components
-            'src/components/ANCV/**',
-            'src/components/Dropin/**',
-            'src/components/Giftcard/**',
             'src/components/Klarna/**',
             'src/components/PayTo/**',
-            'src/components/ThreeDS2/**',
 
             // ── Internal Components ──
             'src/components/internal/Address/**',

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -27,7 +27,7 @@ export class ANCVElement extends UIElement<ANCVConfiguration> {
     private onOrderRequest = data => {
         if (this.props.onOrderRequest)
             return new Promise((resolve, reject) => {
-                this.props.onOrderRequest(resolve, reject, data);
+                void this.props.onOrderRequest(resolve, reject, data);
             });
 
         if (this.props.session) {

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -8,6 +8,7 @@ import PayButton from '../internal/PayButton';
 import { ANCVConfiguration } from './types';
 import { sanitizeResponse, verifyPaymentDidNotFail } from '../internal/UIElement/utils';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
+import { Order, PaymentData } from '../../types/global-types';
 
 export class ANCVElement extends UIElement<ANCVConfiguration> {
     public static readonly type = 'ancv';
@@ -24,15 +25,17 @@ export class ANCVElement extends UIElement<ANCVConfiguration> {
         };
     }
 
-    private onOrderRequest = data => {
+    private onOrderRequest = (data: PaymentData): Promise<Order> => {
         if (this.props.onOrderRequest)
-            return new Promise((resolve, reject) => {
+            return new Promise<Order>((resolve, reject) => {
                 void this.props.onOrderRequest(resolve, reject, data);
             });
 
         if (this.props.session) {
             return this.props.session.createOrder();
         }
+
+        return Promise.reject(new AdyenCheckoutError('IMPLEMENTATION_ERROR', 'onOrderRequest or session must be provided'));
     };
 
     /**

--- a/packages/lib/src/components/ANCV/components/ANCVInput.tsx
+++ b/packages/lib/src/components/ANCV/components/ANCVInput.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, Ref } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import LoadingWrapper from '../../internal/LoadingWrapper';
@@ -10,7 +10,7 @@ import { ANCVDataState } from '../types';
 import { UIElementProps } from '../../internal/UIElement/types';
 
 export interface ANCVInputProps extends UIElementProps {
-    ref?: any;
+    ref?: Ref<unknown>;
     showPayButton: boolean;
     onSubmit: () => void;
 }

--- a/packages/lib/src/components/ANCV/types.ts
+++ b/packages/lib/src/components/ANCV/types.ts
@@ -1,10 +1,11 @@
 import { UIElementProps } from '../internal/UIElement/types';
+import { onOrderRequestCallbackType, onOrderUpdatedCallbackType } from '../Giftcard/types';
 
 export interface ANCVConfiguration extends UIElementProps {
-    paymentData?: any;
+    paymentData?: string;
     data: ANCVDataState;
-    onOrderRequest?: any;
-    onOrderUpdated?: any;
+    onOrderRequest?: onOrderRequestCallbackType;
+    onOrderUpdated?: onOrderUpdatedCallbackType;
 }
 
 export interface ANCVDataState {

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -13,6 +13,9 @@ import { CVCPolicyType, DatePolicyType, CardAllValidData } from '../internal/Sec
 import { ClickToPayProps } from '../internal/ClickToPay/types';
 import { DisclaimerMsgObject } from '../internal/DisclaimerMessage/DisclaimerMessage';
 import { UIElementProps } from '../internal/UIElement/types';
+import { BrandConfiguration, CardBrandsConfiguration } from '../internal/types';
+
+export { BrandConfiguration, CardBrandsConfiguration };
 import type { OnAddressLookupType, OnAddressSelectedType } from '../internal/Address/components/AddressSearch';
 import type { FastlaneSignupConfiguration } from '../PayPalFastlane/types';
 import type { ChallengeWindowSize } from '../ThreeDS2/types';
@@ -469,15 +472,6 @@ export interface CardBackendConfiguration {
     // Remove?
     icon?: string;
     brandsConfiguration?: CardBrandsConfiguration;
-}
-
-export interface BrandConfiguration {
-    name?: string;
-    icon?: string;
-}
-
-export interface CardBrandsConfiguration {
-    [key: string]: BrandConfiguration;
 }
 
 interface CardPaymentMethodData {

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -8,7 +8,7 @@ import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import splitPaymentMethods from './elements/splitPaymentMethods';
 import { TxVariants } from '../tx-variants';
 
-import type { DropinConfiguration, InstantPaymentTypes, PaymentMethodsConfiguration } from './types';
+import type { DropinConfiguration, DropinCreateElementsReturn, InstantPaymentTypes, PaymentMethodsConfiguration } from './types';
 import type { PaymentAction, PaymentAmount, PaymentResponseData } from '../../types/global-types';
 import type { ICore } from '../../core/types';
 import type { IDropin } from './types';
@@ -153,7 +153,7 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
     /**
      * Creates the Drop-in elements
      */
-    private handleCreate = () => {
+    private handleCreate = (): DropinCreateElementsReturn => {
         const { paymentMethodsConfiguration, showStoredPaymentMethods, showPaymentMethods, instantPaymentTypes } = this.props;
 
         const { paymentMethods, storedPaymentMethods, instantPaymentMethods, fastlanePaymentMethod } = splitPaymentMethods(

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -6,12 +6,13 @@ import useImage from '../../../../core/Context/useImage';
 import './OrderPaymentMethods.scss';
 import { Order, OrderStatus } from '../../../../types';
 import { stopPropagationForActionKeys } from '../../../internal/Button/stopPropagationForActionKeys';
+import { BrandLogoConfiguration } from './useBrandLogoConfiguration';
 
 type OrderPaymentMethodsProps = {
     order: Order;
     orderStatus: OrderStatus;
     onOrderCancel: (order) => void;
-    brandLogoConfiguration: any;
+    brandLogoConfiguration: BrandLogoConfiguration;
 };
 
 export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLogoConfiguration }: Readonly<OrderPaymentMethodsProps>) => {

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -4,14 +4,14 @@ import Button from '../../../internal/Button';
 import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useImage from '../../../../core/Context/useImage';
 import './OrderPaymentMethods.scss';
-import { Order, OrderStatus } from '../../../../types';
+import type { Order, OrderStatus } from '../../../../types';
 import { stopPropagationForActionKeys } from '../../../internal/Button/stopPropagationForActionKeys';
 import { BrandLogoConfiguration } from './useBrandLogoConfiguration';
 
 type OrderPaymentMethodsProps = {
     order: Order;
     orderStatus: OrderStatus;
-    onOrderCancel: (order) => void;
+    onOrderCancel: (order: { order: Order }) => void;
     brandLogoConfiguration: BrandLogoConfiguration;
 };
 

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/useBrandLogoConfiguration.ts
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/useBrandLogoConfiguration.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import UIElement from '../../../internal/UIElement/UIElement';
 
-type BrandLogoConfiguration = {
+export type BrandLogoConfiguration = {
     [key: string]: string;
 };
 

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -26,6 +26,7 @@ type PaymentActionTypesMap = {
  * Type must be loose, otherwise it will take priority over the rest
  */
 type NonMappedPaymentMethodsMap = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Intentionally loose to avoid taking priority over the rest of the intersection type
     [key: string]: any;
 };
 
@@ -150,9 +151,16 @@ export type onOrderCancelType = (
     }
 ) => void;
 
+export type DropinCreateElementsReturn = [
+    Promise<UIElement[]> | UIElement[],
+    Promise<UIElement[]> | UIElement[],
+    Promise<UIElement[]> | UIElement[],
+    Promise<UIElement[]> | UIElement[]
+];
+
 export interface DropinComponentProps extends DropinConfiguration {
     core: ICore;
-    onCreateElements(): any;
+    onCreateElements(): DropinCreateElementsReturn;
     onElementsCreated(elements: UIElement[]): void;
     onOrderCancel?: onOrderCancelType;
 }

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -128,7 +128,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     /**
      * Check if it should call onRequiringConfirmation
      */
-    private handleOnRequiringConfirmation = (balance, transactionLimit): Promise<any> => {
+    private handleOnRequiringConfirmation = (balance, transactionLimit): void | Promise<void> => {
         this.componentRef.setBalance({ balance, transactionLimit });
         this.setStatus('ready');
 

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -128,8 +128,8 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     /**
      * Check if it should call onRequiringConfirmation
      */
-    private handleOnRequiringConfirmation = (balance, transactionLimit): void | Promise<void> => {
-        this.componentRef.setBalance({ balance, transactionLimit });
+    private handleOnRequiringConfirmation = (balance: PaymentAmount, transactionLimit: PaymentAmount): void | Promise<void> => {
+        this.componentRef?.setBalance({ balance, transactionLimit });
         this.setStatus('ready');
 
         // 1. if we show pay button we don't need to ask for confirmation

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -7,7 +7,7 @@ import { GIFT_CARD } from '../../internal/SecuredFields/lib/constants';
 import { GiftCardFields } from './GiftcardFields';
 import { GiftcardFieldsProps, Placeholders } from './types';
 import { useSRPanelForGiftcardErrors } from './useSRPanelForGiftcardErrors';
-import { GiftCardBalanceCheckErrorType } from '../types';
+import { GiftCardBalanceCheckErrorType, GiftCardValidationError } from '../types';
 import { PayButtonProps } from '../../internal/PayButton/PayButton';
 import { useAmount } from '../../../core/Context/AmountProvider';
 import type { AbstractAnalyticsEvent } from '../../../core/Analytics/events/AbstractAnalyticsEvent';
@@ -62,7 +62,7 @@ class Giftcard extends Component<Readonly<GiftcardComponentProps>> {
         return this.sfp.mapErrorsToValidationRuleResult();
     };
 
-    private updateTransformedErrors = (balanceCheckErrors?: Record<string, any>) => {
+    private updateTransformedErrors = (balanceCheckErrors?: Record<string, GiftCardValidationError>) => {
         const transformedErrors = this.mapErrorsToValidationObjects();
 
         const mergedErrors = { ...transformedErrors, ...balanceCheckErrors };
@@ -98,8 +98,8 @@ class Giftcard extends Component<Readonly<GiftcardComponentProps>> {
      * Generates balance check errors in the same format as SFP errors
      * Compatible with the transformedErrors structure
      */
-    private generateBalanceCheckErrors(errorType?: GiftCardBalanceCheckErrorType | null): Record<string, any> {
-        const balanceCheckErrors: Record<string, any> = {};
+    private generateBalanceCheckErrors(errorType?: GiftCardBalanceCheckErrorType | null): Record<string, GiftCardValidationError> {
+        const balanceCheckErrors: Record<string, GiftCardValidationError> = {};
 
         // This is the field that the error is associated with, only used for SR logic
         const fieldToAnnounce = 'encryptedCardNumber';

--- a/packages/lib/src/components/Giftcard/components/GiftcardPinField.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardPinField.tsx
@@ -17,7 +17,7 @@ export const GiftcardPinField = ({
         <Field
             label={label}
             classNameModifiers={['pin', ...classNameModifiers]}
-            errorMessage={sfpState.errors.encryptedSecurityCode && i18n.get(sfpState.errors.encryptedSecurityCode)}
+            errorMessage={sfpState.errors?.encryptedSecurityCode && i18n.get(sfpState.errors.encryptedSecurityCode)}
             focused={focusedElement === 'encryptedSecurityCode'}
             onFocusField={() => setFocusOn('encryptedSecurityCode')}
             dir={'ltr'}
@@ -33,7 +33,7 @@ export const GiftcardPinField = ({
                     'adyen-checkout__input': true,
                     'adyen-checkout__input--large': true,
                     'adyen-checkout__card__cvc__input': true,
-                    'adyen-checkout__input--error': sfpState.errors.encryptedSecurityCode,
+                    'adyen-checkout__input--error': sfpState.errors?.encryptedSecurityCode,
                     'adyen-checkout__input--focus': focusedElement === 'encryptedSecurityCode'
                 })}
             />

--- a/packages/lib/src/components/Giftcard/components/types.ts
+++ b/packages/lib/src/components/Giftcard/components/types.ts
@@ -18,7 +18,7 @@ export type GiftcardFieldsProps = {
 export type GiftcardFieldProps = {
     i18n: Language;
     classNameModifiers?: Array<string>;
-    sfpState: any;
+    sfpState: SFPState;
     getCardErrorMessage;
     focusedElement;
     setFocusOn;

--- a/packages/lib/src/components/Giftcard/types.ts
+++ b/packages/lib/src/components/Giftcard/types.ts
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'preact';
 import { GiftcardFieldsProps } from './components/types';
 import { UIElementProps } from '../internal/UIElement/types';
+import { CardBrandsConfiguration } from '../internal/types';
 import { Order, PaymentAmount, PaymentData } from '../../types/global-types';
 
 export interface GiftCardElementData {
@@ -30,13 +31,15 @@ export type onRequiringConfirmationCallbackType = (resolve: () => void, reject: 
 
 export type onOrderRequestCallbackType = (resolve: (order: Order) => void, reject: (error: Error) => void, data: PaymentData) => Promise<void>;
 
+export type onOrderUpdatedCallbackType = (data: { order: Order }) => void;
+
 // TODO: Fix these types
 export interface GiftCardConfiguration extends UIElementProps {
     pinRequired?: boolean;
     expiryDateRequired?: boolean;
-    brandsConfiguration?: any;
+    brandsConfiguration?: CardBrandsConfiguration;
     brand?: string;
-    onOrderUpdated?: (data) => void;
+    onOrderUpdated?: onOrderUpdatedCallbackType;
     onBalanceCheck?: onBalanceCheckCallbackType;
     onOrderRequest?: onOrderRequestCallbackType;
 

--- a/packages/lib/src/components/MealVoucherFR/components/MealVoucherExpiryField.tsx
+++ b/packages/lib/src/components/MealVoucherFR/components/MealVoucherExpiryField.tsx
@@ -10,7 +10,7 @@ export const MealVoucherExpiryField = ({ i18n, sfpState, focusedElement, setFocu
         <Field
             label={i18n.get('giftcard.expiryDate.label')}
             classNameModifiers={['expireDate', '50']}
-            errorMessage={sfpState.errors.encryptedExpiryDate && i18n.get(sfpState.errors.encryptedExpiryDate)}
+            errorMessage={sfpState.errors?.encryptedExpiryDate && i18n.get(sfpState.errors.encryptedExpiryDate)}
             focused={focusedElement === 'encryptedExpiryDate'}
             onFocusField={() => setFocusOn('encryptedExpiryDate')}
             dir={'ltr'}
@@ -22,7 +22,7 @@ export const MealVoucherExpiryField = ({ i18n, sfpState, focusedElement, setFocu
             <DataSfSpan
                 encryptedFieldType={'encryptedExpiryDate'}
                 className={classNames('adyen-checkout__input', 'adyen-checkout__input--small', 'adyen-checkout__card__exp-date__input', {
-                    'adyen-checkout__input--error': sfpState.errors.encryptedExpiryDate,
+                    'adyen-checkout__input--error': sfpState.errors?.encryptedExpiryDate,
                     'adyen-checkout__input--focus': focusedElement === 'encryptedExpiryDate',
                     'adyen-checkout__input--valid': !!sfpState.valid.encryptedExpiryMonth && !!sfpState.valid.encryptedExpiryYear
                 })}

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -14,7 +14,7 @@ const iframeName = 'threeDSIframe';
 
 class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2State> {
     private processMessageHandler;
-    private challengePromise: { cancel: () => void; promise: Promise<any> };
+    private challengePromise: { cancel: () => void; promise: Promise<ThreeDS2FlowObject> };
 
     constructor(props) {
         super(props);
@@ -36,7 +36,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
         }
     };
 
-    private get3DS2ChallengePromise(): Promise<any> {
+    private get3DS2ChallengePromise(): Promise<ThreeDS2FlowObject> {
         return new Promise((resolve, reject) => {
             /**
              * Listen for postMessage responses from the notification url

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -7,6 +7,7 @@ import getProcessMessageHandler from '../../../../utils/get-process-message-hand
 import { THREEDS_METHOD_TIMEOUT, FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT, THREEDS2_NUM } from '../../constants';
 import { encodeBase64URL } from '../utils';
 import { DoFingerprint3DS2Props, DoFingerprint3DS2State } from './types';
+import { ThreeDS2FlowObject } from '../../types';
 
 const iframeName = 'threeDSMethodIframe';
 
@@ -21,7 +22,7 @@ const iframeName = 'threeDSMethodIframe';
  */
 class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3DS2State> {
     private processMessageHandler;
-    private fingerPrintPromise: any;
+    private fingerPrintPromise: { cancel: () => void; promise: Promise<ThreeDS2FlowObject> };
     public static readonly defaultProps = {
         showSpinner: true
     };
@@ -42,8 +43,8 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
         this.state = { base64URLencodedData };
     }
 
-    get3DS2MethodPromise() {
-        return new Promise((resolve, reject) => {
+    get3DS2MethodPromise(): Promise<ThreeDS2FlowObject> {
+        return new Promise<ThreeDS2FlowObject>((resolve, reject) => {
             /**
              * Listen for postMessage responses from the notification url
              */

--- a/packages/lib/src/components/internal/types.ts
+++ b/packages/lib/src/components/internal/types.ts
@@ -1,0 +1,8 @@
+export interface BrandConfiguration {
+    name?: string;
+    icon?: string;
+}
+
+export interface CardBrandsConfiguration {
+    [key: string]: BrandConfiguration;
+}


### PR DESCRIPTION
## Summary

- Replaces all `any` types in the ANCV, ThreeDS2, Giftcard, and Dropin components with proper types
- Removes these four folders from the `@typescript-eslint/no-explicit-any` ESLint ignore list in `packages/lib/eslint.config.js`
- Extracts `BrandConfiguration`/`CardBrandsConfiguration` to a shared `components/internal/types.ts` (re-exported from `Card/types.ts` for backward compatibility) to avoid a Giftcard -> Card dependency
- Adds a new `onOrderUpdatedCallbackType` in `Giftcard/types.ts`, reused by both `ANCVConfiguration` and `GiftCardConfiguration`
- Exports `BrandLogoConfiguration` from `useBrandLogoConfiguration.ts` and reuses it in `OrderPaymentMethods`
- Types `Dropin.onCreateElements` return as a 4-element tuple
- Suppresses `any` on the intentionally loose `NonMappedPaymentMethodsMap` with a justification comment (changing it would break the intersection type behavior with `PaymentMethodsConfigurationMap`)

Implements [task-6-remove-explicit-any.md](https://github.com/Adyen/adyen-checkout-sdk-meta/blob/develop/docs/tech-debt/task-6-remove-explicit-any.md).

#### Test plan

- [x] `yarn lint` — zero `no-explicit-any` errors for the four folders
- [x] `yarn type-check` (`tsc --noEmit`) — passes
- [x] Unit tests for ANCV, ThreeDS2, Giftcard, and Dropin — 132 tests pass (19 suites)
- [x] `yarn build` — passes

Generated with [Devin](https://devin.ai)