### PR TITLE
Use "next" dist-tag for prerelease npm publishes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,30 @@ jobs:
       # Copy LICENSE to adyen-web package
       - run: cp LICENSE packages/lib/
 
+      # Determine the npm dist-tag from the git ref this workflow runs from:
+      #   - prerelease ref (alpha / beta / rc) -> use "next"
+      #   - otherwise                          -> use "latest"
+      - name: Determine npm dist-tag
+        id: dist-tag
+        run: |
+          REF_NAME="${GITHUB_REF_NAME}"
+          echo "Publishing from ref: ${REF_NAME}"
+
+          if [[ "${REF_NAME}" == *alpha* || "${REF_NAME}" == *beta* || "${REF_NAME}" == *rc* ]]; then
+            DIST_TAG="next"
+          else
+            DIST_TAG="latest"
+          fi
+
+          echo "Resolved dist-tag: ${DIST_TAG}"
+          echo "dist_tag=${DIST_TAG}" >> "${GITHUB_OUTPUT}"
+
       # Build and publish to npm
       - name: Build and release
-        run: cd packages/lib && npm publish --access public --tag latest
+        env:
+          DIST_TAG: ${{ steps.dist-tag.outputs.dist_tag }}
+        run: |
+          cd packages/lib
+          echo "Publishing with dist-tag: ${DIST_TAG}"
+          npm publish --access public --tag "${DIST_TAG}"
  


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

- Dynamically resolve the npm dist-tag in the publish workflow instead of hardcoding latest.
- Prerelease refs (containing alpha, beta, or rc) publish under the next tag; all other refs publish under latest.
- This prevents prerelease builds from overwriting the latest tag that default npm install adyen-web resolves to.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

