### PR TITLE
Fix/ignore merchant defined installments on sessions

### DIFF
--- a/.changeset/slimy-knives-hope.md
+++ b/.changeset/slimy-knives-hope.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Stop displaying installments defined at the component level when in a sessions integration, and put a warning message in the console. This installment configuration could end up in being shown in the UI, but was then always ignored by the backend.

--- a/.changeset/slimy-knives-hope.md
+++ b/.changeset/slimy-knives-hope.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Stop displaying installments defined at the component level when in a sessions integration, and put a warning message in the console. This installment configuration could end up in being shown in the UI, but was then always ignored by the backend.
+Fixed:Stop displaying installments defined at the component level when in a sessions integration, and put a warning message in the console. This installment configuration could end up in being shown in the UI, but was then always ignored by the backend.

--- a/packages/e2e-playwright/tests/ui/card/installments/card.installments.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/installments/card.installments.spec.ts
@@ -18,7 +18,7 @@ const componentConfig = {
         }
     }
 };
-const url = getStoryUrl({ baseUrl: URL_MAP.card, componentConfig });
+const url = getStoryUrl({ baseUrl: URL_MAP.cardWithAdvancedFlow, componentConfig });
 
 test.describe('Cards (Installments)', () => {
     test('#1 should not add installments property to payload if one-time payment is selected (default selection)', async ({ card, page }) => {

--- a/packages/lib/src/components/Card/Card.test.tsx
+++ b/packages/lib/src/components/Card/Card.test.tsx
@@ -39,6 +39,65 @@ describe('Card', () => {
             expect(card.props.enableStoreDetails).toEqual(true);
             expect(card.props.showStoreDetailsCheckbox).toEqual(false);
         });
+
+        describe('installmentOptions', () => {
+            let core: ICore;
+            let consoleWarnSpy: jest.SpyInstance;
+
+            const merchantInstallmentOptions = { mc: { values: [1, 2, 3] } };
+            const sessionInstallmentOptions = { visa: { values: [1, 2] } };
+
+            beforeEach(() => {
+                core = setupCoreMock();
+                consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            });
+
+            afterEach(() => {
+                consoleWarnSpy.mockRestore();
+            });
+
+            test('installments defined on the session, not on the component: no warning, uses the session value', () => {
+                const card = new CardElement(core, {
+                    // @ts-ignore it's just a test
+                    session: { configuration: { installmentOptions: sessionInstallmentOptions } }
+                });
+
+                expect(consoleWarnSpy).not.toHaveBeenCalled();
+                expect(card.props.installmentOptions).toEqual(sessionInstallmentOptions);
+            });
+
+            test('installments defined on the session, and on the component: warns, uses the session value', () => {
+                const card = new CardElement(core, {
+                    installmentOptions: merchantInstallmentOptions,
+                    // @ts-ignore it's just a test
+                    session: { configuration: { installmentOptions: sessionInstallmentOptions } }
+                });
+
+                expect(consoleWarnSpy).toHaveBeenCalled();
+                expect(card.props.installmentOptions).toEqual(sessionInstallmentOptions);
+            });
+
+            test('no installments defined on the session, but defined on the component: warns, resolves to null', () => {
+                const card = new CardElement(core, {
+                    installmentOptions: merchantInstallmentOptions,
+                    // @ts-ignore it's just a test
+                    session: { configuration: {} }
+                });
+
+                expect(consoleWarnSpy).toHaveBeenCalled();
+                expect(card.props.installmentOptions).toBeNull();
+            });
+
+            test('no installments defined on the session, and not defined on the component: no warning, resolves to null', () => {
+                const card = new CardElement(core, {
+                    // @ts-ignore it's just a test
+                    session: { configuration: {} }
+                });
+
+                expect(consoleWarnSpy).not.toHaveBeenCalled();
+                expect(card.props.installmentOptions).toBeNull();
+            });
+        });
     });
 
     describe('payButton', () => {

--- a/packages/lib/src/components/Card/Card.test.tsx
+++ b/packages/lib/src/components/Card/Card.test.tsx
@@ -77,7 +77,7 @@ describe('Card', () => {
                 expect(card.props.installmentOptions).toEqual(sessionInstallmentOptions);
             });
 
-            test('no installments defined on the session, but defined on the component: warns, resolves to null', () => {
+            test('no installments defined on the session, but defined on the component: warns, resolves to the default, empty, object', () => {
                 const card = new CardElement(core, {
                     installmentOptions: merchantInstallmentOptions,
                     // @ts-ignore it's just a test
@@ -85,17 +85,17 @@ describe('Card', () => {
                 });
 
                 expect(consoleWarnSpy).toHaveBeenCalled();
-                expect(card.props.installmentOptions).toBeNull();
+                expect(card.props.installmentOptions).toEqual({});
             });
 
-            test('no installments defined on the session, and not defined on the component: no warning, resolves to null', () => {
+            test('no installments defined on the session, and not defined on the component: no warning, resolves to the default, empty, object', () => {
                 const card = new CardElement(core, {
                     // @ts-ignore it's just a test
                     session: { configuration: {} }
                 });
 
                 expect(consoleWarnSpy).not.toHaveBeenCalled();
-                expect(card.props.installmentOptions).toBeNull();
+                expect(card.props.installmentOptions).toEqual({});
             });
 
             test('no session, installments defined on the component: no warning, uses the component value', () => {
@@ -107,11 +107,11 @@ describe('Card', () => {
                 expect(card.props.installmentOptions).toEqual(merchantInstallmentOptions);
             });
 
-            test('no session, no installments defined on the component: no warning, resolves to null', () => {
+            test('no session, no installments defined on the component: no warning, resolves to the default, empty, object', () => {
                 const card = new CardElement(core, {});
 
                 expect(consoleWarnSpy).not.toHaveBeenCalled();
-                expect(card.props.installmentOptions).toBeNull();
+                expect(card.props.installmentOptions).toEqual({});
             });
         });
     });

--- a/packages/lib/src/components/Card/Card.test.tsx
+++ b/packages/lib/src/components/Card/Card.test.tsx
@@ -97,6 +97,22 @@ describe('Card', () => {
                 expect(consoleWarnSpy).not.toHaveBeenCalled();
                 expect(card.props.installmentOptions).toBeNull();
             });
+
+            test('no session, installments defined on the component: no warning, uses the component value', () => {
+                const card = new CardElement(core, {
+                    installmentOptions: merchantInstallmentOptions
+                });
+
+                expect(consoleWarnSpy).not.toHaveBeenCalled();
+                expect(card.props.installmentOptions).toEqual(merchantInstallmentOptions);
+            });
+
+            test('no session, no installments defined on the component: no warning, resolves to null', () => {
+                const card = new CardElement(core, {});
+
+                expect(consoleWarnSpy).not.toHaveBeenCalled();
+                expect(card.props.installmentOptions).toBeNull();
+            });
         });
     });
 

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -99,6 +99,9 @@ export class CardElement extends UIElement<CardConfiguration> {
         }
 
         // Take the configuration set on the card component - which is either merchant defined or default (empty object)
+        // @ts-ignore 'installmentOptions' is optional on CardConfiguration (the merchant-facing type), but by this point
+        // UIElement.buildElementProps has already merged CardInputDefaultProps.installmentOptions ({}) into props
+        // before formatProps() is called, so the value is always defined here.
         const merchantInstallmentOptions: InstallmentOptions = props.installmentOptions;
 
         if (props.session && notFalsy(merchantInstallmentOptions)) {

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -99,22 +99,6 @@ export class CardElement extends UIElement<CardConfiguration> {
         }
 
         // If it's been defined by the merchant, take the configuration set on the card component
-        // let shownInstallmentOptions: InstallmentOptions = falsy(props.installmentOptions) ? null : props.installmentOptions;
-        // if (props.session) {
-        //     if (shownInstallmentOptions) {
-        //         console.warn(
-        //             'WARNING: You have defined installments configuration on the Card component, but you are using a /sessions integration.\nWith this integration, installments configuration must be defined when you create the session. Any configuration defined elsewhere will be ignored.\n\n'
-        //         );
-        //         shownInstallmentOptions = null; // If in a session scenario, ignore the merchant defined configuration
-        //     }
-        //
-        //     // In a session we will only accept installments configuration from the session itself
-        //     if (props.session?.configuration?.installmentOptions) {
-        //         shownInstallmentOptions = props.session?.configuration?.installmentOptions;
-        //     }
-        // }
-
-        // If it's been defined by the merchant, take the configuration set on the card component
         const merchantInstallmentOptions = falsy(props.installmentOptions) ? null : props.installmentOptions;
 
         if (props.session && merchantInstallmentOptions) {

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import { BinLookupResponse, CardElementData, CardConfiguration } from './types';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';
 import { CardBinLookupData, CardConfigSuccessData, CardFocusData } from '../internal/SecuredFields/lib/types';
 import { fieldTypeToSnakeCase, isSecuredField } from '../internal/SecuredFields/utils';
-import { falsy, reject } from '../../utils/commonUtils';
+import { notFalsy, reject } from '../../utils/commonUtils';
 import { shouldIncludeInstallmentsInPaymentData } from './components/CardInput/utils';
 import createClickToPayService from '../internal/ClickToPay/services/create-clicktopay-service';
 import { ClickToPayCheckoutPayload, IClickToPayService } from '../internal/ClickToPay/services/types';
@@ -98,10 +98,10 @@ export class CardElement extends UIElement<CardConfiguration> {
             );
         }
 
-        // If it's been defined by the merchant, take the configuration set on the card component
-        const merchantInstallmentOptions = falsy(props.installmentOptions) ? null : props.installmentOptions;
+        // Take the configuration set on the card component - which is either merchant defined or default
+        const merchantInstallmentOptions = props.installmentOptions;
 
-        if (props.session && merchantInstallmentOptions) {
+        if (props.session && notFalsy(merchantInstallmentOptions)) {
             console.warn(
                 'WARNING: You have defined installments configuration on the Card component, but you are using a /sessions integration.\nWith this integration, installments configuration must be defined when you create the session. Any configuration defined elsewhere will be ignored.\n\n'
             );
@@ -109,7 +109,7 @@ export class CardElement extends UIElement<CardConfiguration> {
 
         // In a session scenario, only the session's own installments configuration is used; otherwise fall back to the merchant configuration
         const shownInstallmentOptions: InstallmentOptions = props.session
-            ? (props.session?.configuration?.installmentOptions ?? null)
+            ? (props.session?.configuration?.installmentOptions ?? CardInputDefaultProps.installmentOptions)
             : merchantInstallmentOptions;
 
         return {
@@ -134,7 +134,7 @@ export class CardElement extends UIElement<CardConfiguration> {
             brandsConfiguration: props.brandsConfiguration || props.configuration?.brandsConfiguration || {},
             icon: props.icon || props.configuration?.icon,
             // installmentOptions of a session should be used before falling back to the merchant configuration
-            installmentOptions: shownInstallmentOptions, //props.session?.configuration?.installmentOptions || props.installmentOptions,
+            installmentOptions: shownInstallmentOptions,
             enableStoreDetails,
             showStoreDetailsCheckbox,
             /**

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -98,8 +98,8 @@ export class CardElement extends UIElement<CardConfiguration> {
             );
         }
 
-        // Take the configuration set on the card component - which is either merchant defined or default
-        const merchantInstallmentOptions = props.installmentOptions;
+        // Take the configuration set on the card component - which is either merchant defined or default (empty object)
+        const merchantInstallmentOptions: InstallmentOptions = props.installmentOptions;
 
         if (props.session && notFalsy(merchantInstallmentOptions)) {
             console.warn(
@@ -107,7 +107,7 @@ export class CardElement extends UIElement<CardConfiguration> {
             );
         }
 
-        // In a session scenario, only the session's own installments configuration is used; otherwise fall back to the merchant configuration
+        // In a session scenario, only the session's own installments configuration is used; otherwise fall back to the merchant configuration / default
         const shownInstallmentOptions: InstallmentOptions = props.session
             ? (props.session?.configuration?.installmentOptions ?? CardInputDefaultProps.installmentOptions)
             : merchantInstallmentOptions;
@@ -133,7 +133,6 @@ export class CardElement extends UIElement<CardConfiguration> {
             },
             brandsConfiguration: props.brandsConfiguration || props.configuration?.brandsConfiguration || {},
             icon: props.icon || props.configuration?.icon,
-            // installmentOptions of a session should be used before falling back to the merchant configuration
             installmentOptions: shownInstallmentOptions,
             enableStoreDetails,
             showStoreDetailsCheckbox,

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import { BinLookupResponse, CardElementData, CardConfiguration } from './types';
 import triggerBinLookUp from '../internal/SecuredFields/binLookup/triggerBinLookUp';
 import { CardBinLookupData, CardConfigSuccessData, CardFocusData } from '../internal/SecuredFields/lib/types';
 import { fieldTypeToSnakeCase, isSecuredField } from '../internal/SecuredFields/utils';
-import { reject } from '../../utils/commonUtils';
+import { falsy, reject } from '../../utils/commonUtils';
 import { shouldIncludeInstallmentsInPaymentData } from './components/CardInput/utils';
 import createClickToPayService from '../internal/ClickToPay/services/create-clicktopay-service';
 import { ClickToPayCheckoutPayload, IClickToPayService } from '../internal/ClickToPay/services/types';
@@ -20,6 +20,7 @@ import AdyenCheckoutError, { IMPLEMENTATION_ERROR } from '../../core/Errors/Adye
 import CardInputDefaultProps from './components/CardInput/defaultProps';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 import { AnalyticsInfoEvent, InfoEventType, UiTarget } from '../../core/Analytics/events/AnalyticsInfoEvent';
+import { InstallmentOptions } from './components/CardInput/components/Installments/Installments';
 
 export class CardElement extends UIElement<CardConfiguration> {
     public static readonly type: TxVariants = TxVariants.scheme;
@@ -97,6 +98,36 @@ export class CardElement extends UIElement<CardConfiguration> {
             );
         }
 
+        // If it's been defined by the merchant, take the configuration set on the card component
+        // let shownInstallmentOptions: InstallmentOptions = falsy(props.installmentOptions) ? null : props.installmentOptions;
+        // if (props.session) {
+        //     if (shownInstallmentOptions) {
+        //         console.warn(
+        //             'WARNING: You have defined installments configuration on the Card component, but you are using a /sessions integration.\nWith this integration, installments configuration must be defined when you create the session. Any configuration defined elsewhere will be ignored.\n\n'
+        //         );
+        //         shownInstallmentOptions = null; // If in a session scenario, ignore the merchant defined configuration
+        //     }
+        //
+        //     // In a session we will only accept installments configuration from the session itself
+        //     if (props.session?.configuration?.installmentOptions) {
+        //         shownInstallmentOptions = props.session?.configuration?.installmentOptions;
+        //     }
+        // }
+
+        // If it's been defined by the merchant, take the configuration set on the card component
+        const merchantInstallmentOptions = falsy(props.installmentOptions) ? null : props.installmentOptions;
+
+        if (props.session && merchantInstallmentOptions) {
+            console.warn(
+                'WARNING: You have defined installments configuration on the Card component, but you are using a /sessions integration.\nWith this integration, installments configuration must be defined when you create the session. Any configuration defined elsewhere will be ignored.\n\n'
+            );
+        }
+
+        // In a session scenario, only the session's own installments configuration is used; otherwise fall back to the merchant configuration
+        const shownInstallmentOptions: InstallmentOptions = props.session
+            ? (props.session?.configuration?.installmentOptions ?? null)
+            : merchantInstallmentOptions;
+
         return {
             ...props,
             // Mismatch between hasHolderName & holderNameRequired which can mean card can never be valid
@@ -119,7 +150,7 @@ export class CardElement extends UIElement<CardConfiguration> {
             brandsConfiguration: props.brandsConfiguration || props.configuration?.brandsConfiguration || {},
             icon: props.icon || props.configuration?.icon,
             // installmentOptions of a session should be used before falling back to the merchant configuration
-            installmentOptions: props.session?.configuration?.installmentOptions || props.installmentOptions,
+            installmentOptions: shownInstallmentOptions, //props.session?.configuration?.installmentOptions || props.installmentOptions,
             enableStoreDetails,
             showStoreDetailsCheckbox,
             /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

When a merchant is on a `/sessions` integration they should define `installmentOptions` for the Card component when they create the session.
However, a throwback from the Advanced flow, meant that these options could still be defined directly on the Card component. If this was done, and if no `installmentOptions` were defined on the session, then the component-level `installmentOptions` would show in the UI _but would be completely ignored by the backend._

Now we ignore these options if set at component level (on a sessions integration), don't display them in the UI, and place a warning message in the console:
> 'WARNING: You have defined installments configuration on the Card component, but you are using a /sessions integration. With this integration, installments configuration must be defined when you create the session. Any configuration defined elsewhere will be ignored.

---

## 🧪 Tested scenarios

Added unit tests

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

