### PR TITLE
Fixed: Remove explicit any types from Dropin, ANCV, Giftcard and ThreeDS2 components

### DIFF
--- a/.changeset/fix-explicit-any-dropin-ancv-giftcard-threeds2.md
+++ b/.changeset/fix-explicit-any-dropin-ancv-giftcard-threeds2.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Remove explicit any types from Dropin, ANCV, Giftcard and ThreeDS2 components

--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -146,7 +146,6 @@ const config = defineConfig(
             // ── Components
             'src/components/ANCV/**',
             'src/components/Dropin/**',
-            'src/components/Giftcard/**',
             'src/components/Klarna/**',
             'src/components/PayTo/**',
             'src/components/ThreeDS2/**',

--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -148,7 +148,6 @@ const config = defineConfig(
             'src/components/Dropin/**',
             'src/components/Klarna/**',
             'src/components/PayTo/**',
-            'src/components/ThreeDS2/**',
 
             // ── Internal Components ──
             'src/components/internal/Address/**',

--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -144,7 +144,6 @@ const config = defineConfig(
             'src/**/*.spec.tsx',
 
             // ── Components
-            'src/components/ANCV/**',
             'src/components/Dropin/**',
             'src/components/Klarna/**',
             'src/components/PayTo/**',

--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -144,7 +144,6 @@ const config = defineConfig(
             'src/**/*.spec.tsx',
 
             // ── Components
-            'src/components/Dropin/**',
             'src/components/Klarna/**',
             'src/components/PayTo/**',
 

--- a/packages/lib/src/components/ANCV/ANCV.test.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.test.tsx
@@ -6,6 +6,29 @@ import { ErrorEventType } from '../../core/Analytics/events/AnalyticsErrorEvent'
 
 describe('ANCV', () => {
     describe('createOrder', () => {
+        test('should call the onOrderRequest callback prop when provided', async () => {
+            const core = setupCoreMock();
+            const i18n = global.i18n;
+
+            const onOrderRequest = jest.fn((resolve, _reject, _data) => {
+                resolve({ orderData: 'mockOrderData', pspReference: 'mockPspRef' });
+            });
+
+            const ancv = new ANCV(core, {
+                amount: { value: 1000, currency: 'EUR' },
+                i18n,
+                loadingContext: 'mock',
+                // @ts-ignore test only
+                onOrderRequest
+            });
+            render(ancv.render());
+
+            await ancv.createOrder();
+
+            expect(onOrderRequest).toHaveBeenCalledTimes(1);
+            expect(onOrderRequest).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), expect.any(Object));
+        });
+
         test('should send an error event to the analytics if the createOrder call fails for the session flow', async () => {
             const core = setupCoreMock();
             const i18n = global.i18n;

--- a/packages/lib/src/components/ANCV/ANCV.test.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.test.tsx
@@ -1,27 +1,108 @@
-import { render } from '@testing-library/preact';
+import { render, screen } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
 import AdyenCheckoutError from '../../core/Errors/AdyenCheckoutError';
 import ANCV from './ANCV';
+import { ANCVConfiguration } from './types';
+import { ICore } from '../../core/types';
 import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
 import { ErrorEventType } from '../../core/Analytics/events/AnalyticsErrorEvent';
 
+const BENEFICIARY_ID_LABEL = /Your ANCV identification/i;
+
+/** Creates and renders an ANCV element with sensible defaults, returning the element instance */
+function setupANCV(core: ICore, props: Partial<ANCVConfiguration> = {}): ANCV {
+    const ancv = new ANCV(core, {
+        amount: { value: 1000, currency: 'EUR' },
+        data: { beneficiaryId: '' },
+        i18n: global.i18n,
+        loadingContext: 'mock',
+        modules: { resources: global.resources },
+        ...props
+    });
+    render(ancv.render());
+    return ancv;
+}
+
+/** Types into the beneficiaryId field and blurs it to trigger validation */
+async function typeBeneficiaryId(user: ReturnType<typeof userEvent.setup>, value: string): Promise<void> {
+    await user.type(screen.getByLabelText(BENEFICIARY_ID_LABEL), value);
+    await user.tab();
+}
+
 describe('ANCV', () => {
+    describe('data propagation', () => {
+        test('should propagate the beneficiaryId input to the component state and merchant onChange callback', async () => {
+            const user = userEvent.setup();
+            const onChangeMock = jest.fn();
+            const ancv = setupANCV(setupCoreMock(), { onChange: onChangeMock });
+
+            await typeBeneficiaryId(user, '12345678901');
+
+            expect(ancv.state.data).toEqual({ beneficiaryId: '12345678901' });
+            expect(ancv.isValid).toBe(true);
+            expect(onChangeMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        paymentMethod: expect.objectContaining({
+                            type: 'ancv',
+                            beneficiaryId: '12345678901'
+                        })
+                    }),
+                    isValid: true
+                }),
+                ancv
+            );
+        });
+
+        test('should not be valid when the beneficiaryId does not match the expected format', async () => {
+            const user = userEvent.setup();
+            const ancv = setupANCV(setupCoreMock());
+
+            await typeBeneficiaryId(user, '12345');
+
+            expect(await screen.findByText('Enter a valid email address or ANCV ID')).toBeVisible();
+            expect(ancv.isValid).toBe(false);
+        });
+
+        test('should propagate the beneficiaryId input to the payment method object on submit', async () => {
+            const user = userEvent.setup();
+            const onSubmitMock = jest.fn();
+            // ANCV follows the giftcard order flow: submit() calls createOrder() first, so either
+            // an order must already exist, or onOrderRequest must be provided to resolve one.
+            const onOrderRequest = jest.fn(resolve => resolve({ orderData: 'mock', pspReference: 'mock' }));
+            const ancv = setupANCV(setupCoreMock(), { onSubmit: onSubmitMock, onOrderRequest });
+
+            await typeBeneficiaryId(user, '12345678901');
+            await user.click(screen.getByRole('button', { name: 'Confirm purchase' }));
+
+            expect(ancv.state.data).toEqual({ beneficiaryId: '12345678901' });
+            expect(ancv.isValid).toBe(true);
+            expect(onSubmitMock).toHaveBeenCalledTimes(1);
+            expect(onSubmitMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        paymentMethod: expect.objectContaining({
+                            type: 'ancv',
+                            beneficiaryId: '12345678901'
+                        })
+                    })
+                }),
+                expect.anything(),
+                expect.anything()
+            );
+        });
+    });
+
     describe('createOrder', () => {
         test('should call the onOrderRequest callback prop when provided', async () => {
-            const core = setupCoreMock();
-            const i18n = global.i18n;
-
             const onOrderRequest = jest.fn((resolve, _reject, _data) => {
                 resolve({ orderData: 'mockOrderData', pspReference: 'mockPspRef' });
             });
 
-            const ancv = new ANCV(core, {
-                amount: { value: 1000, currency: 'EUR' },
-                i18n,
-                loadingContext: 'mock',
+            const ancv = setupANCV(setupCoreMock(), {
                 // @ts-ignore test only
                 onOrderRequest
             });
-            render(ancv.render());
 
             await ancv.createOrder();
 
@@ -30,25 +111,16 @@ describe('ANCV', () => {
         });
 
         test('should send an error event to the analytics if the createOrder call fails for the session flow', async () => {
-            const core = setupCoreMock();
-            const i18n = global.i18n;
-
             const code = 'mockErrorCode';
+            const core = setupCoreMock();
 
-            const ancv = new ANCV(core, {
-                amount: { value: 1000, currency: 'EUR' },
-                i18n,
-                loadingContext: 'mock',
-
+            const ancv = setupANCV(core, {
                 onError: () => {},
                 // @ts-ignore test only
                 session: {
-                    createOrder: () => {
-                        return Promise.reject(new AdyenCheckoutError('NETWORK_ERROR', '', { code }));
-                    }
+                    createOrder: () => Promise.reject(new AdyenCheckoutError('NETWORK_ERROR', '', { code }))
                 }
             });
-            render(ancv.render());
 
             await ancv.createOrder();
 

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -27,7 +27,7 @@ export class ANCVElement extends UIElement<ANCVConfiguration> {
     private onOrderRequest = data => {
         if (this.props.onOrderRequest)
             return new Promise((resolve, reject) => {
-                this.props.onOrderRequest(resolve, reject, data);
+                void this.props.onOrderRequest(resolve, reject, data);
             });
 
         if (this.props.session) {

--- a/packages/lib/src/components/ANCV/ANCV.tsx
+++ b/packages/lib/src/components/ANCV/ANCV.tsx
@@ -112,10 +112,8 @@ export class ANCVElement extends UIElement<ANCVConfiguration> {
 
         return (
             <ANCVInput
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
                 {...this.props}
+                setComponentRef={this.setComponentRef}
                 onSubmit={this.submit}
                 onChange={this.setState}
                 payButton={this.payButton}

--- a/packages/lib/src/components/ANCV/components/ANCVInput.tsx
+++ b/packages/lib/src/components/ANCV/components/ANCVInput.tsx
@@ -1,5 +1,5 @@
-import { h, Ref } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { h } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import LoadingWrapper from '../../internal/LoadingWrapper';
 import InputText from '../../internal/FormFields/InputText';
@@ -7,17 +7,26 @@ import Field from '../../internal/FormFields/Field';
 import useForm from '../../../utils/useForm';
 import { ancvValidationRules } from '../validate';
 import { ANCVDataState } from '../types';
-import { UIElementProps } from '../../internal/UIElement/types';
+import { ComponentMethodsRef } from '../../internal/UIElement/types';
+import { PayButtonProps } from '../../internal/PayButton/PayButton';
+import { ValidationRuleResult } from '../../../utils/Validator/ValidationRuleResult';
 
-export interface ANCVInputProps extends UIElementProps {
-    ref?: Ref<typeof ANCVInput>;
+export interface ANCVInputProps {
+    setComponentRef: (ref: ComponentMethodsRef) => void;
     showPayButton: boolean;
     onSubmit: () => void;
+    payButton: (props: PayButtonProps) => h.JSX.Element;
+    onChange: (data: {
+        data: ANCVDataState;
+        errors: { [key: string]: ValidationRuleResult };
+        valid: { [key: string]: boolean };
+        isValid: boolean;
+    }) => void;
 }
 
 type ANCVInputDataState = ANCVDataState;
 
-function ANCVInput({ showPayButton, payButton, onChange, onSubmit }: Readonly<ANCVInputProps>) {
+function ANCVInput({ showPayButton, payButton, onChange, onSubmit, setComponentRef }: Readonly<ANCVInputProps>) {
     const { i18n } = useCoreContext();
 
     const { handleChangeFor, triggerValidation, data, valid, errors, isValid } = useForm<ANCVInputDataState>({
@@ -26,14 +35,19 @@ function ANCVInput({ showPayButton, payButton, onChange, onSubmit }: Readonly<AN
     });
 
     useEffect(() => {
-        // @ts-ignore TODO: Fix this. Preact component types should not inherit from UIElementProps.
-        onChange({ data, errors, valid, isValid }, this);
-    }, [data, valid, errors, isValid]);
+        onChange({ data, errors, valid, isValid });
+    }, [onChange, data, valid, errors, isValid]);
 
     const [status, setStatus] = useState<string>('ready');
 
-    this.setStatus = setStatus;
-    this.showValidation = triggerValidation;
+    const ancvRef = useRef<ComponentMethodsRef>({
+        setStatus,
+        showValidation: triggerValidation
+    });
+
+    useEffect(() => {
+        setComponentRef(ancvRef.current);
+    }, [setComponentRef, ancvRef.current]);
 
     return (
         <LoadingWrapper>

--- a/packages/lib/src/components/ANCV/components/ANCVInput.tsx
+++ b/packages/lib/src/components/ANCV/components/ANCVInput.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, Ref } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import LoadingWrapper from '../../internal/LoadingWrapper';
@@ -10,7 +10,7 @@ import { ANCVDataState } from '../types';
 import { UIElementProps } from '../../internal/UIElement/types';
 
 export interface ANCVInputProps extends UIElementProps {
-    ref?: any;
+    ref?: Ref<typeof ANCVInput>;
     showPayButton: boolean;
     onSubmit: () => void;
 }

--- a/packages/lib/src/components/ANCV/types.ts
+++ b/packages/lib/src/components/ANCV/types.ts
@@ -1,10 +1,11 @@
 import { UIElementProps } from '../internal/UIElement/types';
+import { onOrderRequestCallbackType, onOrderUpdatedCallbackType } from '../types';
 
 export interface ANCVConfiguration extends UIElementProps {
-    paymentData?: any;
+    paymentData?: string;
     data: ANCVDataState;
-    onOrderRequest?: any;
-    onOrderUpdated?: any;
+    onOrderRequest?: onOrderRequestCallbackType;
+    onOrderUpdated?: onOrderUpdatedCallbackType;
 }
 
 export interface ANCVDataState {

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -1,4 +1,5 @@
 import { ComponentFocusObject, AddressData, BrowserInfo } from '../../types/global-types';
+import type { CardBrandsConfiguration } from '../internal/SecuredFields/lib/types';
 import {
     CardBinValueData,
     CardBrandData,
@@ -471,14 +472,7 @@ export interface CardBackendConfiguration {
     brandsConfiguration?: CardBrandsConfiguration;
 }
 
-export interface BrandConfiguration {
-    name?: string;
-    icon?: string;
-}
-
-export interface CardBrandsConfiguration {
-    [key: string]: BrandConfiguration;
-}
+export type { BrandConfiguration, CardBrandsConfiguration } from '../internal/SecuredFields/lib/types';
 
 interface CardPaymentMethodData {
     type: string;

--- a/packages/lib/src/components/Dropin/Dropin.test.ts
+++ b/packages/lib/src/components/Dropin/Dropin.test.ts
@@ -10,9 +10,12 @@ import Fastlane from '../PayPalFastlane';
 import { SRPanel } from '../../core/Errors/SRPanel';
 
 import type { CoreConfiguration, ICore } from '../../core/types';
-import type { PaymentActionsType } from '../../types/global-types';
+import type { OrderStatus, PaymentActionsType } from '../../types/global-types';
 import { setupCoreMock } from '../../../config/testMocks/setup-core-mock';
 import { InfoEventType } from '../../core/Analytics/events/AnalyticsInfoEvent';
+import getOrderStatus from '../../core/Services/order-status';
+
+jest.mock('../../core/Services/order-status', () => jest.fn());
 
 async function createAdyenCheckout(configuration) {
     return await AdyenCheckout(configuration);
@@ -458,6 +461,39 @@ describe('Dropin', () => {
             dropin.paymentMethodElements.forEach(element => {
                 expect(element.props.amount).toEqual(newAmount);
             });
+        });
+    });
+
+    describe('Session-based order cancel', () => {
+        test('should call session.cancelOrder when the order cancel button is clicked', async () => {
+            const cancelOrderMock = jest.fn().mockResolvedValue({});
+
+            const mockOrderStatus: OrderStatus = {
+                expiresAt: '2030-01-01T00:00:00Z',
+                pspReference: 'mockPsp',
+                reference: 'mockRef',
+                paymentMethods: [{ type: 'visa', lastFour: '1234', amount: { value: 1000, currency: 'EUR' } }],
+                remainingAmount: { value: 0, currency: 'EUR' }
+            };
+
+            (getOrderStatus as jest.Mock).mockResolvedValue(mockOrderStatus);
+
+            const config = getAdyenCheckoutConfiguration();
+            const sessionCheckout = await createAdyenCheckout(config);
+
+            const dropin = new Dropin(sessionCheckout, {
+                order: { orderData: 'mockOrderData', pspReference: 'mockPsp' },
+                // @ts-ignore test only
+                session: { cancelOrder: cancelOrderMock }
+            });
+
+            render(dropin.render());
+
+            await waitFor(() => expect(screen.getByRole('button', { name: /Remove/i })).toBeVisible());
+
+            await userEvent.click(screen.getByRole('button', { name: /Remove/i }));
+
+            expect(cancelOrderMock).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -8,7 +8,7 @@ import { hasOwnProperty } from '../../utils/hasOwnProperty';
 import splitPaymentMethods from './elements/splitPaymentMethods';
 import { TxVariants } from '../tx-variants';
 
-import type { DropinConfiguration, InstantPaymentTypes, PaymentMethodsConfiguration } from './types';
+import type { DropinComponentProps, DropinConfiguration, InstantPaymentTypes, PaymentMethodsConfiguration } from './types';
 import type { PaymentAction, PaymentAmount, PaymentResponseData } from '../../types/global-types';
 import type { ICore } from '../../core/types';
 import type { IDropin } from './types';
@@ -153,7 +153,7 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
     /**
      * Creates the Drop-in elements
      */
-    private handleCreate = () => {
+    private handleCreate = (): ReturnType<DropinComponentProps['onCreateElements']> => {
         const { paymentMethodsConfiguration, showStoredPaymentMethods, showPaymentMethods, instantPaymentTypes } = this.props;
 
         const { paymentMethods, storedPaymentMethods, instantPaymentMethods, fastlanePaymentMethod } = splitPaymentMethods(
@@ -166,7 +166,9 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
             isDropin: true
         };
 
-        const elements = showPaymentMethods ? createElements(paymentMethods, paymentMethodsConfiguration, dropinProps, this.core) : [];
+        const elements = showPaymentMethods
+            ? createElements(paymentMethods, paymentMethodsConfiguration, dropinProps, this.core)
+            : Promise.resolve([]);
         const instantPaymentElements = createInstantPaymentElements(instantPaymentMethods, paymentMethodsConfiguration, dropinProps, this.core);
         const storedElements = showStoredPaymentMethods
             ? createStoredElements(
@@ -175,8 +177,8 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
                   dropinProps,
                   this.core
               )
-            : [];
-        const fastlanePaymentElement = fastlanePaymentMethod
+            : Promise.resolve([]);
+        const fastlanePaymentElement: Promise<UIElement[]> | [] = fastlanePaymentMethod
             ? createElements([fastlanePaymentMethod], paymentMethodsConfiguration, dropinProps, this.core)
             : [];
 

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -7,7 +7,14 @@ import { sanitizeOrder } from '../../internal/UIElement/utils';
 import type { PaymentAmount } from '../../../types/global-types';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import Button from '../../internal/Button';
-import type { DropinComponentProps, DropinComponentState, DropinStatus, DropinStatusProps, onOrderCancelData } from '../types';
+import type {
+    DropinComponentProps,
+    DropinComponentState,
+    DropinStatus,
+    DropinStatusProps,
+    onOrderCancelData,
+    onOrderCancelInternalCallback
+} from '../types';
 import UIElement from '../../internal/UIElement';
 import { AnalyticsInfoEvent, InfoEventType, UiTarget } from '../../../core/Analytics/events/AnalyticsInfoEvent';
 import { DropinSuccessState } from './DropinSuccessState';
@@ -130,7 +137,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
     /**
      * getOnOrderCancel decides which onOrderCancel logic should be used, manual or sessions
      */
-    private getOnOrderCancel = () => {
+    private getOnOrderCancel = (): ((data: onOrderCancelData) => void) | null => {
         if (this.props.onOrderCancel) {
             return (data: onOrderCancelData) => {
                 const order = sanitizeOrder(data.order);
@@ -145,7 +152,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         }
         if (this.props.session) {
             return (data: onOrderCancelData) =>
-                this.props.session
+                void this.props.session
                     .cancelOrder(data)
                     .then(() => this.props.core.update({ order: null }))
                     .catch(error => {
@@ -156,7 +163,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
         return null;
     };
 
-    private onOrderCancel: (data: onOrderCancelData) => void;
+    private onOrderCancel: onOrderCancelInternalCallback;
 
     render() {
         const {

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -137,7 +137,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
     /**
      * getOnOrderCancel decides which onOrderCancel logic should be used, manual or sessions
      */
-    private getOnOrderCancel = (): ((data: onOrderCancelData) => void) | null => {
+    private readonly getOnOrderCancel = (): ((data: onOrderCancelData) => void) | null => {
         if (this.props.onOrderCancel) {
             return (data: onOrderCancelData) => {
                 const order = sanitizeOrder(data.order);

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/OrderPaymentMethods.tsx
@@ -4,14 +4,14 @@ import Button from '../../../internal/Button';
 import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useImage from '../../../../core/Context/useImage';
 import './OrderPaymentMethods.scss';
-import { Order, OrderStatus } from '../../../../types';
+import { BrandConfiguration, onOrderCancelInternalCallback, Order, OrderStatus } from '../../../../types';
 import { stopPropagationForActionKeys } from '../../../internal/Button/stopPropagationForActionKeys';
 
 type OrderPaymentMethodsProps = {
     order: Order;
     orderStatus: OrderStatus;
-    onOrderCancel: (order) => void;
-    brandLogoConfiguration: any;
+    onOrderCancel: onOrderCancelInternalCallback;
+    brandLogoConfiguration: BrandConfiguration;
 };
 
 export const OrderPaymentMethods = ({ order, orderStatus, onOrderCancel, brandLogoConfiguration }: Readonly<OrderPaymentMethodsProps>) => {

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodList.tsx
@@ -7,6 +7,7 @@ import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { useBrandLogoConfiguration } from './useBrandLogoConfiguration';
 import PaymentMethodsContainer, { PaymentMethodsContainerProps } from './PaymentMethodsContainer';
 import { useEffect } from 'preact/hooks';
+import { onOrderCancelInternalCallback } from '../../types';
 
 interface PaymentMethodListProps extends Omit<PaymentMethodsContainerProps, 'label' | 'classNameModifiers'> {
     instantPaymentMethods?: UIElement[];
@@ -18,7 +19,7 @@ interface PaymentMethodListProps extends Omit<PaymentMethodsContainerProps, 'lab
     };
     order?: Order;
     orderStatus?: OrderStatus;
-    onOrderCancel?: (order) => void;
+    onOrderCancel?: onOrderCancelInternalCallback;
 }
 
 const PaymentMethodList = ({

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -152,7 +152,7 @@ export type onOrderCancelType = (
 ) => void;
 
 // internaly we pass onOrderCancel which is just a wrapper around the external callback
-export type onOrderCancelInternalCallback = (data: onOrderCancelData) => void;
+export type onOrderCancelInternalCallback = (data: onOrderCancelData) => void | null;
 
 export interface DropinComponentProps extends DropinConfiguration {
     core: ICore;

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -26,6 +26,7 @@ type PaymentActionTypesMap = {
  * Type must be loose, otherwise it will take priority over the rest
  */
 type NonMappedPaymentMethodsMap = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we allow "unknown" payment methods defaulting to redirect
     [key: string]: any;
 };
 
@@ -141,7 +142,7 @@ export interface onOrderCancelData {
         pspReference: string;
     };
 }
-
+// external onOrderCancel callback type - called when shopper clicks "Cancel order" button
 export type onOrderCancelType = (
     data: onOrderCancelData,
     actions: {
@@ -150,9 +151,12 @@ export type onOrderCancelType = (
     }
 ) => void;
 
+// internaly we pass onOrderCancel which is just a wrapper around the external callback
+export type onOrderCancelInternalCallback = (data: onOrderCancelData) => void;
+
 export interface DropinComponentProps extends DropinConfiguration {
     core: ICore;
-    onCreateElements(): any;
+    onCreateElements(): [Promise<UIElement[]>, Promise<UIElement[]>, Promise<UIElement[]>, Promise<UIElement[]> | []];
     onElementsCreated(elements: UIElement[]): void;
     onOrderCancel?: onOrderCancelType;
 }

--- a/packages/lib/src/components/Dropin/types.ts
+++ b/packages/lib/src/components/Dropin/types.ts
@@ -152,7 +152,7 @@ export type onOrderCancelType = (
 ) => void;
 
 // internaly we pass onOrderCancel which is just a wrapper around the external callback
-export type onOrderCancelInternalCallback = (data: onOrderCancelData) => void | null;
+export type onOrderCancelInternalCallback = ((data: onOrderCancelData) => void) | null;
 
 export interface DropinComponentProps extends DropinConfiguration {
     core: ICore;

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -128,7 +128,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     /**
      * Check if it should call onRequiringConfirmation
      */
-    private handleOnRequiringConfirmation = (balance, transactionLimit): Promise<any> => {
+    private handleOnRequiringConfirmation = (balance: PaymentAmount, transactionLimit: PaymentAmount): Promise<void> => {
         this.componentRef.setBalance({ balance, transactionLimit });
         this.setStatus('ready');
 

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -128,7 +128,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     /**
      * Check if it should call onRequiringConfirmation
      */
-    private handleOnRequiringConfirmation = (balance: PaymentAmount, transactionLimit: PaymentAmount): Promise<void> => {
+    private handleOnRequiringConfirmation = (balance: PaymentAmount, transactionLimit: PaymentAmount): Promise<void> | void => {
         this.componentRef.setBalance({ balance, transactionLimit });
         this.setStatus('ready');
 

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -7,7 +7,7 @@ import { GIFT_CARD } from '../../internal/SecuredFields/lib/constants';
 import { GiftCardFields } from './GiftcardFields';
 import { GiftcardFieldsProps, Placeholders } from './types';
 import { useSRPanelForGiftcardErrors } from './useSRPanelForGiftcardErrors';
-import { GiftCardBalanceCheckErrorType } from '../types';
+import { GiftCardBalanceCheckErrorType, GiftCardValidationError } from '../types';
 import { PayButtonProps } from '../../internal/PayButton/PayButton';
 import { useAmount } from '../../../core/Context/AmountProvider';
 import type { AbstractAnalyticsEvent } from '../../../core/Analytics/events/AbstractAnalyticsEvent';
@@ -62,7 +62,7 @@ class Giftcard extends Component<Readonly<GiftcardComponentProps>> {
         return this.sfp.mapErrorsToValidationRuleResult();
     };
 
-    private updateTransformedErrors = (balanceCheckErrors?: Record<string, any>) => {
+    private updateTransformedErrors = (balanceCheckErrors?: Record<string, GiftCardValidationError>) => {
         const transformedErrors = this.mapErrorsToValidationObjects();
 
         const mergedErrors = { ...transformedErrors, ...balanceCheckErrors };
@@ -98,8 +98,8 @@ class Giftcard extends Component<Readonly<GiftcardComponentProps>> {
      * Generates balance check errors in the same format as SFP errors
      * Compatible with the transformedErrors structure
      */
-    private generateBalanceCheckErrors(errorType?: GiftCardBalanceCheckErrorType | null): Record<string, any> {
-        const balanceCheckErrors: Record<string, any> = {};
+    private generateBalanceCheckErrors(errorType?: GiftCardBalanceCheckErrorType | null): Record<string, GiftCardValidationError> {
+        const balanceCheckErrors: Record<string, GiftCardValidationError> = {};
 
         // This is the field that the error is associated with, only used for SR logic
         const fieldToAnnounce = 'encryptedCardNumber';

--- a/packages/lib/src/components/Giftcard/components/GiftcardPinField.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardPinField.tsx
@@ -17,7 +17,7 @@ export const GiftcardPinField = ({
         <Field
             label={label}
             classNameModifiers={['pin', ...classNameModifiers]}
-            errorMessage={sfpState.errors.encryptedSecurityCode && i18n.get(sfpState.errors.encryptedSecurityCode)}
+            errorMessage={sfpState.errors?.encryptedSecurityCode && i18n.get(sfpState.errors.encryptedSecurityCode)}
             focused={focusedElement === 'encryptedSecurityCode'}
             onFocusField={() => setFocusOn('encryptedSecurityCode')}
             dir={'ltr'}
@@ -33,7 +33,7 @@ export const GiftcardPinField = ({
                     'adyen-checkout__input': true,
                     'adyen-checkout__input--large': true,
                     'adyen-checkout__card__cvc__input': true,
-                    'adyen-checkout__input--error': sfpState.errors.encryptedSecurityCode,
+                    'adyen-checkout__input--error': sfpState.errors?.encryptedSecurityCode,
                     'adyen-checkout__input--focus': focusedElement === 'encryptedSecurityCode'
                 })}
             />

--- a/packages/lib/src/components/Giftcard/components/types.ts
+++ b/packages/lib/src/components/Giftcard/components/types.ts
@@ -18,7 +18,7 @@ export type GiftcardFieldsProps = {
 export type GiftcardFieldProps = {
     i18n: Language;
     classNameModifiers?: Array<string>;
-    sfpState: any;
+    sfpState: SFPState;
     getCardErrorMessage;
     focusedElement;
     setFocusOn;

--- a/packages/lib/src/components/Giftcard/types.ts
+++ b/packages/lib/src/components/Giftcard/types.ts
@@ -2,6 +2,7 @@ import { FunctionComponent } from 'preact';
 import { GiftcardFieldsProps } from './components/types';
 import { UIElementProps } from '../internal/UIElement/types';
 import { Order, PaymentAmount, PaymentData } from '../../types/global-types';
+import type { CardBrandsConfiguration } from '../internal/SecuredFields/lib/types';
 
 export interface GiftCardElementData {
     paymentMethod: {
@@ -34,7 +35,7 @@ export type onOrderRequestCallbackType = (resolve: (order: Order) => void, rejec
 export interface GiftCardConfiguration extends UIElementProps {
     pinRequired?: boolean;
     expiryDateRequired?: boolean;
-    brandsConfiguration?: any;
+    brandsConfiguration?: CardBrandsConfiguration;
     brand?: string;
     onOrderUpdated?: (data) => void;
     onBalanceCheck?: onBalanceCheckCallbackType;

--- a/packages/lib/src/components/Giftcard/types.ts
+++ b/packages/lib/src/components/Giftcard/types.ts
@@ -27,6 +27,8 @@ export type onBalanceCheckCallbackType = (
     data: GiftCardElementData
 ) => Promise<void>;
 
+export type onOrderUpdatedCallbackType = (data: { order: Order }) => void;
+
 export type onRequiringConfirmationCallbackType = (resolve: () => void, reject: (error: Error) => void) => Promise<void>;
 
 export type onOrderRequestCallbackType = (resolve: (order: Order) => void, reject: (error: Error) => void, data: PaymentData) => Promise<void>;
@@ -37,7 +39,7 @@ export interface GiftCardConfiguration extends UIElementProps {
     expiryDateRequired?: boolean;
     brandsConfiguration?: CardBrandsConfiguration;
     brand?: string;
-    onOrderUpdated?: (data) => void;
+    onOrderUpdated?: onOrderUpdatedCallbackType;
     onBalanceCheck?: onBalanceCheckCallbackType;
     onOrderRequest?: onOrderRequestCallbackType;
 

--- a/packages/lib/src/components/MealVoucherFR/components/MealVoucherExpiryField.tsx
+++ b/packages/lib/src/components/MealVoucherFR/components/MealVoucherExpiryField.tsx
@@ -10,7 +10,7 @@ export const MealVoucherExpiryField = ({ i18n, sfpState, focusedElement, setFocu
         <Field
             label={i18n.get('giftcard.expiryDate.label')}
             classNameModifiers={['expireDate', '50']}
-            errorMessage={sfpState.errors.encryptedExpiryDate && i18n.get(sfpState.errors.encryptedExpiryDate)}
+            errorMessage={sfpState.errors?.encryptedExpiryDate && i18n.get(sfpState.errors.encryptedExpiryDate)}
             focused={focusedElement === 'encryptedExpiryDate'}
             onFocusField={() => setFocusOn('encryptedExpiryDate')}
             dir={'ltr'}
@@ -22,7 +22,7 @@ export const MealVoucherExpiryField = ({ i18n, sfpState, focusedElement, setFocu
             <DataSfSpan
                 encryptedFieldType={'encryptedExpiryDate'}
                 className={classNames('adyen-checkout__input', 'adyen-checkout__input--small', 'adyen-checkout__card__exp-date__input', {
-                    'adyen-checkout__input--error': sfpState.errors.encryptedExpiryDate,
+                    'adyen-checkout__input--error': sfpState.errors?.encryptedExpiryDate,
                     'adyen-checkout__input--focus': focusedElement === 'encryptedExpiryDate',
                     'adyen-checkout__input--valid': !!sfpState.valid.encryptedExpiryMonth && !!sfpState.valid.encryptedExpiryYear
                 })}

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -14,7 +14,7 @@ const iframeName = 'threeDSIframe';
 
 class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2State> {
     private processMessageHandler;
-    private challengePromise: { cancel: () => void; promise: Promise<any> };
+    private challengePromise: { promise: Promise<ThreeDS2FlowObject>; cancel: () => void };
 
     constructor(props) {
         super(props);
@@ -36,7 +36,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
         }
     };
 
-    private get3DS2ChallengePromise(): Promise<any> {
+    private get3DS2ChallengePromise(): Promise<ThreeDS2FlowObject> {
         return new Promise((resolve, reject) => {
             /**
              * Listen for postMessage responses from the notification url

--- a/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/DeviceFingerprint/DoFingerprint3DS2.tsx
@@ -7,6 +7,7 @@ import getProcessMessageHandler from '../../../../utils/get-process-message-hand
 import { THREEDS_METHOD_TIMEOUT, FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT, THREEDS2_NUM } from '../../constants';
 import { encodeBase64URL } from '../utils';
 import { DoFingerprint3DS2Props, DoFingerprint3DS2State } from './types';
+import { ThreeDS2FlowObject } from '../../types';
 
 const iframeName = 'threeDSMethodIframe';
 
@@ -21,7 +22,7 @@ const iframeName = 'threeDSMethodIframe';
  */
 class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3DS2State> {
     private processMessageHandler;
-    private fingerPrintPromise: any;
+    private fingerPrintPromise: { cancel: () => void; promise: Promise<ThreeDS2FlowObject> };
     public static readonly defaultProps = {
         showSpinner: true
     };
@@ -42,7 +43,7 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
         this.state = { base64URLencodedData };
     }
 
-    get3DS2MethodPromise() {
+    get3DS2MethodPromise(): Promise<ThreeDS2FlowObject> {
         return new Promise((resolve, reject) => {
             /**
              * Listen for postMessage responses from the notification url
@@ -57,11 +58,11 @@ class DoFingerprint3DS2 extends Component<DoFingerprint3DS2Props, DoFingerprint3
         // Check 3DS2 Device fingerprint
         this.fingerPrintPromise = promiseTimeout(THREEDS_METHOD_TIMEOUT, this.get3DS2MethodPromise(), FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT);
         this.fingerPrintPromise.promise
-            .then(resolveObject => {
+            .then((resolveObject: ThreeDS2FlowObject) => {
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onCompleteFingerprint(resolveObject);
             })
-            .catch(rejectObject => {
+            .catch((rejectObject: ThreeDS2FlowObject) => {
                 window.removeEventListener('message', this.processMessageHandler);
                 this.props.onErrorFingerprint(rejectObject);
             });

--- a/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/types.ts
@@ -14,7 +14,8 @@ import {
     StylesObject
 } from '../lib/types';
 import { AddressData } from '../../../../types/global-types';
-import { CardBrandsConfiguration, CardPlaceholders } from '../../../Card/types';
+import { CardBrandsConfiguration } from '../lib/types';
+import { CardPlaceholders } from '../../../Card/types';
 import Language from '../../../../language';
 import { Resources } from '../../../../core/Context/Resources';
 import { TouchStartEventObj } from '../../../Card/components/CardInput/components/types';

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -351,3 +351,12 @@ export interface SFKeyDownObj {
     fieldType: string;
     action: string;
 }
+
+export interface BrandConfiguration {
+    name?: string;
+    icon?: string;
+}
+
+export interface CardBrandsConfiguration {
+    [key: string]: BrandConfiguration;
+}

--- a/packages/lib/src/utils/promiseTimeout.ts
+++ b/packages/lib/src/utils/promiseTimeout.ts
@@ -5,7 +5,7 @@
  * @param promise - the passed promise
  * @param timeOutObject - the object that the promiseTimeout will reject with if the passed promise doesn't settle in time
  */
-const promiseTimeout = <T>(ms: number, promise: Promise<T>, timeOutObject: object) => {
+const promiseTimeout = <T>(ms: number, promise: Promise<T>, timeOutObject: object): { promise: Promise<T>; cancel: () => void } => {
     let timer: NodeJS.Timeout | null;
 
     const promiseTimer: Promise<T> = new Promise((resolve, reject): void => {


### PR DESCRIPTION
## 📋 Pull Request Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed.
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR.

---

## 📝 Summary

Part of the ongoing task to eliminate `@typescript-eslint/no-explicit-any` (COSDK-1070). This PR addresses 18 issues across four component folders:

- **Giftcard** (6 issues), of note:
  - Moved `CardBrandsConfiguration` to shared folder types file 
  - New `onOrderUpdatedCallbackType`
- **ThreeDS2** (5 issues), of note:
  - added explicit return type to `promiseTimeout`
- **ANCV** (4 issues), of note:
  -  replaced the invalid `ref: Ref<typeof ANCVInput>` typing (which pointed at the component function itself, leaving `setStatus`/`showValidation` silently broken since `this` doesn't work in a function component) with the `setComponentRef`/`ComponentMethodsRef` pattern already used by Ach, Econtext, etc.; typed `paymentData` as `string`, and callback props with new `onOrderRequestCallbackType` / `onOrderUpdatedCallbackType`.
  -  Added test coverage for beneficiaryId data propagation, validation, and the submit flow
- **Dropin** (3 issues), of note:
  - typed `onCreateElements` return as a 4-tuple of `Promise<UIElement[]>` which is strange but....

---

## 🧪 Tested scenarios

Mostly type-only changes; no runtime behaviour altered — with one exception in ANCV, where the `setComponentRef` fix restores `setStatus`/`showValidation`, which were previously silently broken.
- Removed the four folder ignores from `eslint.config.js` and ran `yarn lint` — no remaining explicit-any violations in the covered folders.
- Added unit tests in `ANCV.test.tsx` covering beneficiaryId propagation to state/`onChange`, validation error display, and the `onSubmit` payment flow.

---

## 🔗 Related GitHub Issue / Internal Ticket number

**Closes**: COSDK-1070

