### PR TITLE
Analytics - Reporting Core properties

### DIFF
--- a/.changeset/three-doors-cross.md
+++ b/.changeset/three-doors-cross.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Improved: Analytics for Checkout core configuration

--- a/packages/lib/src/components/Address/Address.test.tsx
+++ b/packages/lib/src/components/Address/Address.test.tsx
@@ -12,7 +12,7 @@ describe('Address standalone component', () => {
         expect(core.modules.analytics.sendAnalytics).toHaveBeenCalledWith({
             component: 'address',
             configData: {
-                onChange: 'function'
+                onChange: '<function>'
             },
             timestamp: expect.any(String),
             id: expect.any(String),

--- a/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.test.ts
+++ b/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.test.ts
@@ -32,6 +32,68 @@ describe('AnalyticsInfoEvent', () => {
             );
         });
 
+        test('should mask PII fields with <masked>', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    data: { name: 'John Doe' },
+                    holderName: 'John Doe',
+                    shopperEmail: 'john.doe@example.com',
+                    email: 'jane.doe@example.com',
+                    telephoneNumber: '+31612345678',
+                    clickToPayConfiguration: { shopperEmail: 'john.doe@example.com', telephoneNumber: '+31612345678' }
+                }
+            });
+
+            expect(event['configData']).toEqual({
+                data: '<masked>',
+                holderName: '<masked>',
+                shopperEmail: '<masked>',
+                email: '<masked>',
+                telephoneNumber: '<masked>',
+                clickToPayConfiguration: '<masked>'
+            });
+        });
+
+        test('should not leak PII values into the configData payload', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    holderName: 'John Doe',
+                    shopperEmail: 'john.doe@example.com',
+                    telephoneNumber: '+31612345678',
+                    data: { name: 'John Doe' }
+                }
+            });
+
+            const serialized = JSON.stringify(event['configData']);
+            expect(serialized).not.toContain('John Doe');
+            expect(serialized).not.toContain('john.doe@example.com');
+            expect(serialized).not.toContain('+31612345678');
+            expect(serialized).not.toContain('4111111111111111');
+            expect(serialized).not.toContain('737');
+        });
+
+        test('should mask PII fields regardless of their type (primitive, function, array, object)', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    holderName: 'John Doe',
+                    email: () => 'jane.doe@example.com',
+                    data: ['4111111111111111', '737']
+                }
+            });
+
+            expect(event['configData']).toEqual({
+                holderName: '<masked>',
+                email: '<masked>',
+                data: '<masked>'
+            });
+        });
+
         test('should replace functions with <function>', () => {
             const event = new AnalyticsInfoEvent({
                 type: InfoEventType.Initialized,
@@ -65,11 +127,11 @@ describe('AnalyticsInfoEvent', () => {
                     risk: { enabled: false },
                     longObject
                 }
-            }) as any;
+            });
 
-            expect(event.configData.amount).toBe('{"value":1000,"currency":"USD"}');
-            expect(event.configData.risk).toBe('{"enabled":false}');
-            expect(event.configData.longObject.length).toBe(128);
+            expect(event['configData']?.amount).toBe('{"value":1000,"currency":"USD"}');
+            expect(event['configData']?.risk).toBe('{"enabled":false}');
+            expect((event['configData']?.longObject as string).length).toBe(128);
         });
 
         test('should join arrays into a comma-separated string capped at 128 characters', () => {
@@ -79,9 +141,9 @@ describe('AnalyticsInfoEvent', () => {
                 configData: {
                     allowPaymentMethods: ['scheme', 'paypal', 'googlepay']
                 }
-            }) as any;
+            });
 
-            expect(event.configData.allowPaymentMethods).toBe('scheme, paypal, googlepay');
+            expect(event['configData']?.allowPaymentMethods).toBe('scheme, paypal, googlepay');
         });
 
         test('should keep primitive values as-is', () => {
@@ -94,9 +156,9 @@ describe('AnalyticsInfoEvent', () => {
                     countryCode: 'US',
                     showPayButton: true
                 }
-            }) as any;
+            });
 
-            expect(event.configData).toEqual({
+            expect(event['configData']).toEqual({
                 environment: 'test',
                 locale: 'en-US',
                 countryCode: 'US',
@@ -105,8 +167,8 @@ describe('AnalyticsInfoEvent', () => {
         });
 
         test('should not include configData when none is provided', () => {
-            const event = new AnalyticsInfoEvent({ type: InfoEventType.Initialized, component: 'fastlane' }) as any;
-            expect(event.configData).toBeUndefined();
+            const event = new AnalyticsInfoEvent({ type: InfoEventType.Initialized, component: 'fastlane' });
+            expect(event['configData']).toBeUndefined();
         });
 
         test('should process configData for rendered events', () => {
@@ -114,9 +176,9 @@ describe('AnalyticsInfoEvent', () => {
                 type: InfoEventType.rendered,
                 component: 'scheme',
                 configData: { showPayButton: true, onChange: () => true }
-            }) as any;
+            });
 
-            expect(event.configData).toEqual({ showPayButton: true, onChange: '<function>' });
+            expect(event['configData']).toEqual({ showPayButton: true, onChange: '<function>' });
         });
     });
 });

--- a/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.test.ts
+++ b/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.test.ts
@@ -1,0 +1,122 @@
+import { AnalyticsInfoEvent, InfoEventType } from './AnalyticsInfoEvent';
+import { AnalyticsEventCategory } from './AbstractAnalyticsEvent';
+
+describe('AnalyticsInfoEvent', () => {
+    test('should be categorized as an info event', () => {
+        const event = new AnalyticsInfoEvent({ type: InfoEventType.rendered, component: 'scheme' });
+        expect(event.getEventCategory()).toBe(AnalyticsEventCategory.info);
+    });
+
+    describe('configData transformation', () => {
+        test('should mask sensitive fields with <masked>', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    clientKey: 'test_ABC123XYZ789DEF456',
+                    session: { id: 'CS1234567890ABCDEF', sessionData: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' },
+                    paymentMethodsResponse: { paymentMethods: [{ type: 'scheme' }] },
+                    translations: { 'en-US': { pay: 'Pay!' } }
+                }
+            });
+
+            expect(event).toEqual(
+                expect.objectContaining({
+                    configData: {
+                        clientKey: '<masked>',
+                        session: '<masked>',
+                        paymentMethodsResponse: '<masked>',
+                        translations: '<masked>'
+                    }
+                })
+            );
+        });
+
+        test('should replace functions with <function>', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    onSubmit: () => true,
+                    onPaymentCompleted: function () {
+                        return true;
+                    }
+                }
+            });
+
+            expect(event).toEqual(
+                expect.objectContaining({
+                    configData: {
+                        onSubmit: '<function>',
+                        onPaymentCompleted: '<function>'
+                    }
+                })
+            );
+        });
+
+        test('should stringify objects and cap them at 128 characters', () => {
+            const longObject = { data: 'a'.repeat(200) };
+
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    amount: { value: 1000, currency: 'USD' },
+                    risk: { enabled: false },
+                    longObject
+                }
+            }) as any;
+
+            expect(event.configData.amount).toBe('{"value":1000,"currency":"USD"}');
+            expect(event.configData.risk).toBe('{"enabled":false}');
+            expect(event.configData.longObject.length).toBe(128);
+        });
+
+        test('should join arrays into a comma-separated string capped at 128 characters', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    allowPaymentMethods: ['scheme', 'paypal', 'googlepay']
+                }
+            }) as any;
+
+            expect(event.configData.allowPaymentMethods).toBe('scheme, paypal, googlepay');
+        });
+
+        test('should keep primitive values as-is', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.Initialized,
+                component: 'checkout',
+                configData: {
+                    environment: 'test',
+                    locale: 'en-US',
+                    countryCode: 'US',
+                    showPayButton: true
+                }
+            }) as any;
+
+            expect(event.configData).toEqual({
+                environment: 'test',
+                locale: 'en-US',
+                countryCode: 'US',
+                showPayButton: true
+            });
+        });
+
+        test('should not include configData when none is provided', () => {
+            const event = new AnalyticsInfoEvent({ type: InfoEventType.Initialized, component: 'fastlane' }) as any;
+            expect(event.configData).toBeUndefined();
+        });
+
+        test('should process configData for rendered events', () => {
+            const event = new AnalyticsInfoEvent({
+                type: InfoEventType.rendered,
+                component: 'scheme',
+                configData: { showPayButton: true, onChange: () => true }
+            }) as any;
+
+            expect(event.configData).toEqual({ showPayButton: true, onChange: '<function>' });
+        });
+    });
+});

--- a/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.ts
+++ b/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.ts
@@ -1,6 +1,9 @@
 import { AbstractAnalyticsEvent, AnalyticsEventCategory } from './AbstractAnalyticsEvent';
 import { mapErrorCodesForAnalytics } from '../utils';
 
+import type { CoreConfiguration } from '../../types';
+import type { DropinConfiguration } from '../../../components/Dropin/types';
+
 type AnalyticsInfoEventProps = {
     type: InfoEventType;
     component: string;
@@ -80,10 +83,10 @@ export class AnalyticsInfoEvent extends AbstractAnalyticsEvent {
     private readonly type: InfoEventType;
 
     /**
-     * Component config data set by the merchant. Sent only in 'rendered' events
+     * Component config data set by the merchant. Sent on 'rendered' events or 'initialized' events
      * @private
      */
-    private readonly configData?: Record<string, string | boolean>;
+    private readonly configData?: Record<string, string | boolean | number | null>;
     private readonly target?: UiTarget;
     private readonly issuer?: string;
     private readonly isExpress?: boolean;
@@ -116,7 +119,8 @@ export class AnalyticsInfoEvent extends AbstractAnalyticsEvent {
         if (props.validationErrorCode) this.validationErrorCode = props.validationErrorCode;
         if (props.validationErrorMessage) this.validationErrorMessage = props.validationErrorMessage;
         if (props.presentedValues) this.presentedValues = props.presentedValues;
-        if (this.type === InfoEventType.rendered) {
+
+        if (this.type === InfoEventType.rendered || (this.type === InfoEventType.Initialized && props.configData)) {
             this.configData = this.createAnalyticsConfigData(props?.configData);
         }
 
@@ -130,8 +134,11 @@ export class AnalyticsInfoEvent extends AbstractAnalyticsEvent {
      * Set of properties that must not be included when creating the configData for Analytics
      * @private
      */
-    private get configDataExcludedFields() {
-        const DROPIN_FIELDS = ['paymentMethodsConfiguration'];
+    private get configDataExcludedFields(): string[] {
+        const DROPIN_FIELDS = ['paymentMethodsConfiguration', 'paymentMethodComponents'] satisfies Array<keyof DropinConfiguration>;
+
+        const CORE_INTERNAL_FIELDS = ['_environmentUrls', 'loadingContext'] satisfies Array<keyof CoreConfiguration>;
+
         const FIELDS_INJECTED_BY_DROPIN = [
             'elementRef',
             'isDropin',
@@ -140,8 +147,7 @@ export class AnalyticsInfoEvent extends AbstractAnalyticsEvent {
             'paymentMethodId',
             'isInstantPayment',
             'type'
-        ];
-        const PII_FIELDS = ['data', 'holderName', 'shopperEmail', 'email', 'telephoneNumber', 'clickToPayConfiguration'];
+        ] satisfies Array<keyof DropinConfiguration>;
 
         /**
          * TODO: Many unit tests are passing 'modules' as props, which leads to circular structure issue
@@ -149,31 +155,49 @@ export class AnalyticsInfoEvent extends AbstractAnalyticsEvent {
          */
         const UNIT_TEST_FIELDS = ['modules', 'i18n'];
 
-        return [...DROPIN_FIELDS, ...FIELDS_INJECTED_BY_DROPIN, ...PII_FIELDS, ...UNIT_TEST_FIELDS];
+        return [...DROPIN_FIELDS, ...CORE_INTERNAL_FIELDS, ...FIELDS_INJECTED_BY_DROPIN, ...UNIT_TEST_FIELDS];
+    }
+
+    /**
+     * Set of fields whose value must be masked (replaced with '<masked>') when creating the configData.
+     * These fields either contain merchant credentials, shopper PII, or large objects that would
+     * pollute the analytics payload without adding value.
+     * @private
+     */
+    private get configDataMaskedFields(): string[] {
+        const PII_FIELDS = ['data', 'holderName', 'shopperEmail', 'email', 'telephoneNumber', 'clickToPayConfiguration'];
+        const CORE_FIELDS = ['clientKey', 'session', 'paymentMethodsResponse', 'translations', 'order'] satisfies Array<keyof CoreConfiguration>;
+
+        return [...PII_FIELDS, ...CORE_FIELDS];
     }
 
     /**
      * Creates a serializable analytics payload from the given config object.
-     * Functions are replaced with 'function', and objects/arrays are stringified.
+     * Sensitive fields are masked with '<masked>', functions are replaced with '<function>',
+     * and objects/arrays are stringified (capped at 128 characters).
      */
     private createAnalyticsConfigData(config: Record<string, any>) {
         if (!config) return {};
 
         const MAX_STRING_LENGTH = 128;
-        const result: Record<string, string> = {};
+        const result: Record<string, string | boolean> = {};
 
         try {
             for (const [key, value] of Object.entries(config)) {
-                if (!this.configDataExcludedFields.includes(key)) {
-                    if (typeof value === 'function') {
-                        result[key] = 'function';
-                    } else if (Array.isArray(value)) {
-                        result[key] = value.join(', ').substring(0, MAX_STRING_LENGTH);
-                    } else if (typeof value === 'object' && value !== null) {
-                        result[key] = JSON.stringify(value).substring(0, MAX_STRING_LENGTH);
-                    } else {
-                        result[key] = value;
-                    }
+                if (this.configDataExcludedFields.includes(key)) {
+                    continue;
+                }
+
+                if (this.configDataMaskedFields.includes(key)) {
+                    result[key] = '<masked>';
+                } else if (typeof value === 'function') {
+                    result[key] = '<function>';
+                } else if (Array.isArray(value)) {
+                    result[key] = value.join(', ').substring(0, MAX_STRING_LENGTH);
+                } else if (typeof value === 'object' && value !== null) {
+                    result[key] = JSON.stringify(value).substring(0, MAX_STRING_LENGTH);
+                } else {
+                    result[key] = value;
                 }
             }
 

--- a/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.ts
+++ b/packages/lib/src/core/Analytics/events/AnalyticsInfoEvent.ts
@@ -179,33 +179,39 @@ export class AnalyticsInfoEvent extends AbstractAnalyticsEvent {
     private createAnalyticsConfigData(config: Record<string, any>) {
         if (!config) return {};
 
-        const MAX_STRING_LENGTH = 128;
         const result: Record<string, string | boolean> = {};
 
         try {
             for (const [key, value] of Object.entries(config)) {
-                if (this.configDataExcludedFields.includes(key)) {
-                    continue;
-                }
-
-                if (this.configDataMaskedFields.includes(key)) {
-                    result[key] = '<masked>';
-                } else if (typeof value === 'function') {
-                    result[key] = '<function>';
-                } else if (Array.isArray(value)) {
-                    result[key] = value.join(', ').substring(0, MAX_STRING_LENGTH);
-                } else if (typeof value === 'object' && value !== null) {
-                    result[key] = JSON.stringify(value).substring(0, MAX_STRING_LENGTH);
-                } else {
-                    result[key] = value;
-                }
+                if (this.configDataExcludedFields.includes(key)) continue;
+                result[key] = this.serializeConfigValue(key, value);
             }
-
-            return result;
         } catch (error: unknown) {
             if (process.env.NODE_ENV === 'development') console.warn('AnalyticsInfoEvent: Error when creating configData\n', error);
-            return result;
         }
+
+        return result;
+    }
+
+    /**
+     * Serializes a single config value into an analytics-safe representation.
+     * Sensitive fields are masked, functions are replaced with '<function>',
+     * and objects/arrays are stringified (capped at 128 characters).
+     */
+    private serializeConfigValue(key: string, value: unknown): string | boolean {
+        const MAX_STRING_LENGTH = 128;
+
+        if (this.configDataMaskedFields.includes(key)) return '<masked>';
+        if (typeof value === 'function') return '<function>';
+        if (Array.isArray(value)) return value.join(', ').substring(0, MAX_STRING_LENGTH);
+        if (typeof value === 'object' && value !== null) {
+            try {
+                return JSON.stringify(value).substring(0, MAX_STRING_LENGTH);
+            } catch {
+                return '[object]';
+            }
+        }
+        return value as string | boolean;
     }
 
     public getEventCategory(): AnalyticsEventCategory {

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -227,6 +227,24 @@ describe('Core', () => {
             );
         });
 
+        test('should report the raw merchant configuration and not the defaults applied internally', async () => {
+            const checkout = new AdyenCheckout({
+                countryCode: 'US',
+                environment: 'test',
+                clientKey: 'test_123456'
+            });
+
+            await checkout.initialize();
+
+            const initializedEvent = sendAnalyticsSpy.mock.calls
+                .map(([event]) => event)
+                .find(event => event.component === 'checkout' && event.type === 'initialized');
+
+            // showPayButton and exposeLibraryMetadata are applied via defaultProps, not set by the merchant
+            expect(initializedEvent.configData).not.toHaveProperty('showPayButton');
+            expect(initializedEvent.configData).not.toHaveProperty('exposeLibraryMetadata');
+        });
+
         test('should send the checkout "initialized" event only once', async () => {
             const checkout = new AdyenCheckout({ countryCode: 'US', environment: 'test', clientKey: 'test_123456' });
             await checkout.initialize();

--- a/packages/lib/src/core/core.test.ts
+++ b/packages/lib/src/core/core.test.ts
@@ -190,6 +190,62 @@ describe('Core', () => {
         });
     });
 
+    describe('Checkout configuration analytics', () => {
+        let sendAnalyticsSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            sendAnalyticsSpy = jest.spyOn(Analytics.prototype, 'sendAnalytics').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            sendAnalyticsSpy.mockRestore();
+        });
+
+        test('should send an "initialized" info event for the checkout with obfuscated config', async () => {
+            const checkout = new AdyenCheckout({
+                countryCode: 'US',
+                environment: 'test',
+                clientKey: 'test_123456',
+                translations: { 'en-US': { pay: 'Pay!' } },
+                onSubmit: jest.fn()
+            });
+
+            await checkout.initialize();
+
+            expect(sendAnalyticsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    component: 'checkout',
+                    type: 'initialized',
+                    configData: expect.objectContaining({
+                        environment: 'test',
+                        countryCode: 'US',
+                        clientKey: '<masked>',
+                        translations: '<masked>',
+                        onSubmit: '<function>'
+                    })
+                })
+            );
+        });
+
+        test('should send the checkout "initialized" event only once', async () => {
+            const checkout = new AdyenCheckout({ countryCode: 'US', environment: 'test', clientKey: 'test_123456' });
+            await checkout.initialize();
+
+            const initializedEvents = sendAnalyticsSpy.mock.calls.filter(([event]) => event.component === 'checkout' && event.type === 'initialized');
+            expect(initializedEvents).toHaveLength(1);
+        });
+
+        test('should not send the checkout "initialized" event again on update()', async () => {
+            const checkout = new AdyenCheckout({ countryCode: 'US', environment: 'test', clientKey: 'test_123456' });
+            await checkout.initialize();
+
+            await checkout.update({ countryCode: 'NL' });
+
+            const initializedEvents = sendAnalyticsSpy.mock.calls.filter(([event]) => event.component === 'checkout' && event.type === 'initialized');
+            expect(initializedEvents).toHaveLength(1);
+        });
+    });
+
     describe('Creating modules', () => {
         test('should create the modules when initializing on Advanced Flow', async () => {
             const checkout = new AdyenCheckout({ countryCode: 'US', environment: 'test', clientKey: 'test_123456' });

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -42,6 +42,13 @@ class Core implements ICore {
     private components: UIElement[] = [];
 
     /**
+     * Raw configuration received by the constructor, before defaults are applied and values are
+     * normalized/merged (e.g. via setOptions or the session setup). Used to report the actual
+     * configuration set by the merchant to analytics.
+     */
+    private readonly initialConfiguration: CoreConfiguration;
+
+    /**
      * Ensures the checkout configuration analytics event is only reported once per checkout instance,
      * and not again when the configuration is updated via update().
      */
@@ -76,6 +83,8 @@ class Core implements ICore {
 
     constructor(props: CoreConfiguration) {
         assertConfigurationPropertiesAreValid(props);
+
+        this.initialConfiguration = { ...props };
 
         this.createFromAction = this.createFromAction.bind(this);
         this.update = this.update.bind(this);
@@ -124,7 +133,8 @@ class Core implements ICore {
     }
 
     /**
-     * Sends an analytics 'initialized' event capturing the global checkout configuration.
+     * Sends an analytics 'initialized' event capturing the raw checkout configuration set by the merchant
+     * (before defaults are applied and values are normalized/merged).
      * Sensitive fields are obfuscated before being sent. The event is dispatched only once per
      * checkout instance (not on subsequent configuration updates) and is queued until the Analytics
      * module has retrieved a checkoutAttemptId.
@@ -138,7 +148,7 @@ class Core implements ICore {
         const event = new AnalyticsInfoEvent({
             type: InfoEventType.Initialized,
             component: 'checkout',
-            configData: this.options
+            configData: this.initialConfiguration
         });
         this.modules.analytics.sendAnalytics(event);
     }
@@ -148,10 +158,9 @@ class Core implements ICore {
             return this.session
                 .setupSession(this.options)
                 .then(sessionResponse => {
-                    const { amount, shopperLocale, countryCode, paymentMethods, ...rest } = sessionResponse;
+                    const { amount, shopperLocale, countryCode, paymentMethods } = sessionResponse;
 
                     this.setOptions({
-                        ...rest,
                         amount: this.options.order ? this.options.order.remainingAmount : amount,
                         locale: this.options.locale || shopperLocale,
                         countryCode: this.options.countryCode || countryCode
@@ -367,7 +376,7 @@ class Core implements ICore {
      * @internal
      * Create or update the config object passed when AdyenCheckout is initialised (environment, clientKey, etc...)
      */
-    private setOptions = (options: CoreConfiguration): void => {
+    private readonly setOptions = (options: CoreConfiguration): void => {
         this.options = {
             ...this.options,
             ...options,

--- a/packages/lib/src/core/core.ts
+++ b/packages/lib/src/core/core.ts
@@ -21,6 +21,7 @@ import type { PaymentAction, PaymentAmount, PaymentResponseData } from '../types
 import type { CoreConfiguration, ICore, AdditionalDetailsData, CoreModules } from './types';
 import type { UIElementProps } from '../components/internal/UIElement/types';
 import { AnalyticsLogEvent, LogEventType } from './Analytics/events/AnalyticsLogEvent';
+import { AnalyticsInfoEvent, InfoEventType } from './Analytics/events/AnalyticsInfoEvent';
 import CancelError from './Errors/CancelError';
 import { AnalyticsService } from './Analytics/AnalyticsService';
 import { AnalyticsEventQueue } from './Analytics/AnalyticsEventQueue';
@@ -39,6 +40,12 @@ class Core implements ICore {
     public cdnTranslationsUrl: string;
 
     private components: UIElement[] = [];
+
+    /**
+     * Ensures the checkout configuration analytics event is only reported once per checkout instance,
+     * and not again when the configuration is updated via update().
+     */
+    private hasReportedCheckoutConfiguration = false;
 
     public static readonly metadata: { version: string; bundleType: string } = {
         version: LIBRARY_VERSION,
@@ -111,8 +118,29 @@ class Core implements ICore {
         this.createCoreModules();
         this.assignLocaleToCore();
         void this.requestAnalyticsAttemptId();
+        this.reportCheckoutConfiguration();
         await this.requestTranslations();
         return this;
+    }
+
+    /**
+     * Sends an analytics 'initialized' event capturing the global checkout configuration.
+     * Sensitive fields are obfuscated before being sent. The event is dispatched only once per
+     * checkout instance (not on subsequent configuration updates) and is queued until the Analytics
+     * module has retrieved a checkoutAttemptId.
+     */
+    private reportCheckoutConfiguration(): void {
+        if (this.hasReportedCheckoutConfiguration) {
+            return;
+        }
+        this.hasReportedCheckoutConfiguration = true;
+
+        const event = new AnalyticsInfoEvent({
+            type: InfoEventType.Initialized,
+            component: 'checkout',
+            configData: this.options
+        });
+        this.modules.analytics.sendAnalytics(event);
     }
 
     private async initializeCore(): Promise<this> {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [x] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Adds a one-time analytics event that captures the global checkout configuration the merchant passes when initializing the SDK. Previously we only tracked configuration for individual payment method components, not the checkout-level setup (environment, locale, amount, callbacks, etc.).

This enables data-driven insights into how merchants configure the SDK globally, helps detect misconfigurations, and improves SDK defaults/documentation — while obfuscating sensitive data before transmission.

### What changed
- New "initialized" checkout event: On AdyenCheckout.initialize(), an Info event is sent with component: 'checkout' and type: 'initialized', carrying the merchant configuration as configData.
- Sent once per instance: Guarded by a flag so it is not re-sent when update() re-runs initialization. The event is queued and dispatched once the Analytics module has a checkoutAttemptId; it is skipped entirely when analytics is disabled.
- Reports the raw merchant props, not the internal this.options (which has defaults applied and is normalized/merged with session data). This reflects what the merchant actually set. Captured as a shallow copy at construction time.
- Field obfuscation in the shared AnalyticsInfoEvent config transformer:
  - Masked with `<masked>`: clientKey, session, paymentMethodsResponse, translations
  - Functions → `<function>`
  - Arrays → comma-joined string, objects → JSON stringified (both capped at 128 chars)
  - Primitives kept as-is
  - Excluded entirely: internal fields (`_environmentUrls`, `loadingContext`), Drop-in-specific fields (`paymentMethodsConfiguration`, `paymentMethodComponents`, `order`), injected props, and PII fields
  - Type-safety: excluded/masked field lists now use satisfies Array<keyof CoreConfiguration | keyof DropinConfiguration> so typos/renames fail compilation.
---

## 🧪 Tested scenarios
- Manual test (advanced flow and sessions flow) inspecting the new Analytics event being sent
- Added unit tests

