### PR TITLE
feat: propagate healthcare field to onBinLookup

### DIFF
--- a/.changeset/shaky-wolves-watch.md
+++ b/.changeset/shaky-wolves-watch.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Improved: Propagate `healthcare` field to the `onBinLookup` callback

--- a/packages/e2e-playwright/tests/ui/card/binLookup/onBinLookup/onBinLookup.healthcare.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/binLookup/onBinLookup/onBinLookup.healthcare.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '../../../../../fixtures/card.fixture';
+import { CARD_WITH_HEALTHCARE, REGULAR_TEST_CARD } from '../../../../utils/constants';
+import { URL_MAP } from '../../../../../fixtures/URL_MAP';
+
+test.describe('Card - onBinLookup healthcare field', () => {
+    test.beforeEach(async ({ card, page }) => {
+        await card.goto(URL_MAP.card);
+        await page.evaluate(() => {
+            const w = window as unknown as { component: { onBinLookup: (obj: unknown) => void }; binLookupResult: any };
+            const original = w.component.onBinLookup.bind(w.component);
+            w.component.onBinLookup = (obj: unknown) => {
+                w.binLookupResult = obj;
+                original(obj);
+            };
+        });
+    });
+
+    test('should include healthcare in onBinLookup callback when the card is a healthcare card', async ({ card, page }) => {
+        await card.typeCardNumber(CARD_WITH_HEALTHCARE);
+        await page.waitForFunction('window.binLookupResult');
+        const binLookupResult: any = await page.evaluate('window.binLookupResult');
+        expect(Array.isArray(binLookupResult.healthcare)).toBe(true);
+        expect(binLookupResult.healthcare.some((entry: Record<string, boolean | undefined>) => Object.values(entry)[0] === true)).toBe(true);
+    });
+
+    test('should not include healthcare in onBinLookup callback for a regular card', async ({ card, page }) => {
+        await card.typeCardNumber(REGULAR_TEST_CARD);
+        await page.waitForFunction('window.binLookupResult');
+        const binLookupResult: any = await page.evaluate('window.binLookupResult');
+        expect(binLookupResult.healthcare).toBeUndefined();
+    });
+});

--- a/packages/e2e-playwright/tests/utils/constants.ts
+++ b/packages/e2e-playwright/tests/utils/constants.ts
@@ -13,7 +13,7 @@ export const BCMC_DUAL_BRANDED_VISA = '4871049999999910'; // dual branded visa &
 export const BCMC_DUAL_BRANDED_MC = '5127880999999990'; // dual branded mc & bcmc
 export const DUAL_BRANDED_CARD_EXCLUDED = '4001230000000004'; // dual branded visa/star
 export const CARD_WITH_PAN_LENGTH = '4000620000000007';
-
+export const CARD_WITH_HEALTHCARE = '2292240000000005';
 export const DUAL_BRANDED_EFTPOS = '4687380100010006';
 
 export const THREEDS2_FRICTIONLESS_CARD = '5201281505129736';

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -507,6 +507,7 @@ export interface BrandObject {
     brandImageUrl?: string;
     panLength?: number;
     paymentMethodVariant?: string;
+    healthcare?: boolean;
 }
 
 export interface BinLookupResponseRaw {

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.test.tsx
@@ -203,7 +203,7 @@ describe('triggerBinLookUp', () => {
                         lookUpBin(bin);
                         await new Promise(process.nextTick);
 
-                        expect(mockOnBinLookup).toHaveBeenCalledWith(expect.objectContaining({ healthcare: [true] }));
+                        expect(mockOnBinLookup).toHaveBeenCalledWith(expect.objectContaining({ healthcare: [{ visa: true }] }));
                     });
 
                     test('should omit the healthcare field from the UIElement onBinLookup when not present in the response', async () => {
@@ -221,6 +221,7 @@ describe('triggerBinLookUp', () => {
                         lookUpBin(bin);
                         await new Promise(process.nextTick);
 
+                        expect(mockOnBinLookup).toHaveBeenCalledTimes(1);
                         const callArg = mockOnBinLookup.mock.calls[0][0];
                         expect(callArg).not.toHaveProperty('healthcare');
                     });

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.test.tsx
@@ -226,6 +226,29 @@ describe('triggerBinLookUp', () => {
                         expect(callArg).not.toHaveProperty('healthcare');
                     });
                 });
+
+                describe('BinLookup returns detected but unsupported brands', () => {
+                    test('should call the UIElement onBinLookup with healthcare when the unsupported brand has healthcare', async () => {
+                        const requestId = '123456789';
+                        httpPostMock.mockImplementation(
+                            jest.fn(() => Promise.resolve({ requestId, brands: [{ brand: visa, supported: false, healthcare: true }] }))
+                        );
+
+                        const mockUIElement = new MockUIElement(global.core, {
+                            clientKey,
+                            loadingContext,
+                            // @ts-ignore test
+                            brands: ['mc']
+                        });
+                        const bin = { binValue: '', type: '', encryptedBin: 'xxx-xxx', uuid: requestId };
+                        const lookUpBin = triggerBinLookUp(mockUIElement);
+                        lookUpBin(bin);
+                        await new Promise(process.nextTick);
+
+                        expect(mockHandleUnsupportedCard).toHaveBeenCalled();
+                        expect(mockOnBinLookup).toHaveBeenCalledWith(expect.objectContaining({ healthcare: [{ visa: true }] }));
+                    });
+                });
             });
         });
     });

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.test.tsx
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.test.tsx
@@ -185,6 +185,45 @@ describe('triggerBinLookUp', () => {
                             expect.objectContaining({ supportedBrands: [{ brand: visa, supported: true }], showSocialSecurityNumber: true })
                         );
                     });
+
+                    test('should call the UIElement onBinLookup with the healthcare value when present in the response', async () => {
+                        const requestId = '123456789';
+                        httpPostMock.mockImplementation(
+                            jest.fn(() => Promise.resolve({ requestId, brands: [{ brand: visa, supported: true, healthcare: true }] }))
+                        );
+
+                        const mockUIElement = new MockUIElement(global.core, {
+                            clientKey,
+                            loadingContext,
+                            // @ts-ignore test
+                            brands: [visa, 'mc']
+                        });
+                        const bin = { binValue: '', type: '', encryptedBin: 'xxx-xxx', uuid: requestId };
+                        const lookUpBin = triggerBinLookUp(mockUIElement);
+                        lookUpBin(bin);
+                        await new Promise(process.nextTick);
+
+                        expect(mockOnBinLookup).toHaveBeenCalledWith(expect.objectContaining({ healthcare: [true] }));
+                    });
+
+                    test('should omit the healthcare field from the UIElement onBinLookup when not present in the response', async () => {
+                        const requestId = '123456789';
+                        httpPostMock.mockImplementation(jest.fn(() => Promise.resolve({ requestId, brands: [{ brand: visa, supported: true }] })));
+
+                        const mockUIElement = new MockUIElement(global.core, {
+                            clientKey,
+                            loadingContext,
+                            // @ts-ignore test
+                            brands: [visa, 'mc']
+                        });
+                        const bin = { binValue: '', type: '', encryptedBin: 'xxx-xxx', uuid: requestId };
+                        const lookUpBin = triggerBinLookUp(mockUIElement);
+                        lookUpBin(bin);
+                        await new Promise(process.nextTick);
+
+                        const callArg = mockOnBinLookup.mock.calls[0][0];
+                        expect(callArg).not.toHaveProperty('healthcare');
+                    });
                 });
             });
         });

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
@@ -89,8 +89,10 @@ export default parent => {
                                 acc.detectedBrands.push(item.brand);
                                 // Also add the paymentMethodVariants (more granular description of the txvariant)
                                 acc.paymentMethodVariants.push(item.paymentMethodVariant);
-                                // Add healthcare to the healthcare array
-                                acc.healthcare.push(item.healthcare);
+                                // Add healthcare to the healthcare array, keyed by brand (only when the field is present)
+                                if (item.healthcare !== undefined) {
+                                    acc.healthcare.push({ [item.brand]: item.healthcare });
+                                }
 
                                 // Add supported brand objects to the supportedBrands array
                                 if (item.supported === true) {
@@ -104,11 +106,11 @@ export default parent => {
                                 supportedBrands: [] as BrandObject[],
                                 detectedBrands: [] as string[],
                                 paymentMethodVariants: [] as (string | undefined)[],
-                                healthcare: [] as (boolean | undefined)[]
+                                healthcare: [] as Record<string, boolean>[]
                             }
                         );
 
-                        const hasHealthcare = mappedResponse.healthcare.some(healthcareValue => healthcareValue !== undefined);
+                        const hasHealthcareData = mappedResponse.healthcare.length > 0;
 
                         /**
                          * supportedBrands = merchant supports this brand(s); we have detected the card number to be of this brand(s); carry on!
@@ -131,7 +133,7 @@ export default parent => {
                                 supportedBrandsRaw: mappedResponse.supportedBrands, // full supportedBrands data (for customCard comp)
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES,
                                 issuingCountryCode: data.issuingCountryCode,
-                                ...(hasHealthcare && { healthcare: mappedResponse.healthcare })
+                                ...(hasHealthcareData && { healthcare: mappedResponse.healthcare })
                             });
 
                             return;
@@ -156,7 +158,7 @@ export default parent => {
                                 detectedBrands: mappedResponse.detectedBrands,
                                 supportedBrands: null,
                                 paymentMethodVariants: mappedResponse.paymentMethodVariants,
-                                ...(hasHealthcare && { healthcare: mappedResponse.healthcare }),
+                                ...(hasHealthcareData && { healthcare: mappedResponse.healthcare }),
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES
                             });
 

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
@@ -51,7 +51,8 @@ export default parent => {
                                             // showExpiryDate: true, // deprecated in /binLookup v3
                                             expiryDatePolicy: 'optional',
                                             // panLength: 16,
-                                            supported: true
+                                            supported: true,
+                                            healthcare: true
                                         }
                                     ];
                                     // data.issuingCountryCode = 'KR'; // needed to mock korean_local_card
@@ -69,7 +70,8 @@ export default parent => {
                                             enableLuhnCheck: true,
                                             showExpiryDate: true,
                                             supported: true,
-                                            showSocialSecurityNumber: false
+                                            showSocialSecurityNumber: false,
+                                            healthcare: false
                                             // panLength: 16
                                         }
                                     ];
@@ -87,6 +89,8 @@ export default parent => {
                                 acc.detectedBrands.push(item.brand);
                                 // Also add the paymentMethodVariants (more granular description of the txvariant)
                                 acc.paymentMethodVariants.push(item.paymentMethodVariant);
+                                // Add healthcare to the healthcare array
+                                acc.healthcare.push(item.healthcare);
 
                                 // Add supported brand objects to the supportedBrands array
                                 if (item.supported === true) {
@@ -96,7 +100,7 @@ export default parent => {
 
                                 return acc;
                             },
-                            { supportedBrands: [], detectedBrands: [], paymentMethodVariants: [] }
+                            { supportedBrands: [], detectedBrands: [], paymentMethodVariants: [], healthcare: [] }
                         );
 
                         /**
@@ -119,7 +123,10 @@ export default parent => {
                                 paymentMethodVariants: mappedResponse.paymentMethodVariants,
                                 supportedBrandsRaw: mappedResponse.supportedBrands, // full supportedBrands data (for customCard comp)
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES,
-                                issuingCountryCode: data.issuingCountryCode
+                                issuingCountryCode: data.issuingCountryCode,
+                                ...(mappedResponse.healthcare.some(healthcareValue => healthcareValue !== undefined) && {
+                                    healthcare: mappedResponse.healthcare
+                                })
                             });
 
                             return;
@@ -144,6 +151,9 @@ export default parent => {
                                 detectedBrands: mappedResponse.detectedBrands,
                                 supportedBrands: null,
                                 paymentMethodVariants: mappedResponse.paymentMethodVariants,
+                                ...(mappedResponse.healthcare.some(healthcareValue => healthcareValue !== undefined) && {
+                                    healthcare: mappedResponse.healthcare
+                                }),
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES
                             });
 

--- a/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
+++ b/packages/lib/src/components/internal/SecuredFields/binLookup/triggerBinLookUp.ts
@@ -2,14 +2,14 @@ import { httpPost } from '../../../../core/Services/http';
 import { CardBinValueData, CardErrorData } from '../lib/types';
 import { DEFAULT_CARD_GROUP_TYPES } from '../lib/constants';
 import { SF_ErrorCodes } from '../../../../core/Errors/constants';
-import { BinLookupResponseRaw } from '../../../Card/types';
+import { BinLookupResponseRaw, BrandObject } from '../../../Card/types';
 
 if (process.env.NODE_ENV === 'development') {
     window.mockBinCount = 0; // Set to 0 to turn off mocking, 1 to turn it on
 }
 
 export default parent => {
-    let currentRequestId = null;
+    let currentRequestId: string | null = null;
 
     return (callbackObj: CardBinValueData) => {
         // Allow way for merchant to disallow binLookup by specifically setting the prop to false
@@ -100,8 +100,15 @@ export default parent => {
 
                                 return acc;
                             },
-                            { supportedBrands: [], detectedBrands: [], paymentMethodVariants: [], healthcare: [] }
+                            {
+                                supportedBrands: [] as BrandObject[],
+                                detectedBrands: [] as string[],
+                                paymentMethodVariants: [] as (string | undefined)[],
+                                healthcare: [] as (boolean | undefined)[]
+                            }
                         );
+
+                        const hasHealthcare = mappedResponse.healthcare.some(healthcareValue => healthcareValue !== undefined);
 
                         /**
                          * supportedBrands = merchant supports this brand(s); we have detected the card number to be of this brand(s); carry on!
@@ -124,9 +131,7 @@ export default parent => {
                                 supportedBrandsRaw: mappedResponse.supportedBrands, // full supportedBrands data (for customCard comp)
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES,
                                 issuingCountryCode: data.issuingCountryCode,
-                                ...(mappedResponse.healthcare.some(healthcareValue => healthcareValue !== undefined) && {
-                                    healthcare: mappedResponse.healthcare
-                                })
+                                ...(hasHealthcare && { healthcare: mappedResponse.healthcare })
                             });
 
                             return;
@@ -151,9 +156,7 @@ export default parent => {
                                 detectedBrands: mappedResponse.detectedBrands,
                                 supportedBrands: null,
                                 paymentMethodVariants: mappedResponse.paymentMethodVariants,
-                                ...(mappedResponse.healthcare.some(healthcareValue => healthcareValue !== undefined) && {
-                                    healthcare: mappedResponse.healthcare
-                                }),
+                                ...(hasHealthcare && { healthcare: mappedResponse.healthcare }),
                                 brands: parent.props.brands || DEFAULT_CARD_GROUP_TYPES
                             });
 

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -124,7 +124,7 @@ export interface CardBinLookupData {
     supportedBrands?: string[];
     brands?: string[];
     issuingCountryCode?: string;
-    healthcare?: (boolean | undefined)[];
+    healthcare?: Record<string, boolean>[];
     // New for CustomCard
     supportedBrandsRaw?: BrandObject[];
     rootNode?: HTMLElement;

--- a/packages/lib/src/components/internal/SecuredFields/lib/types.ts
+++ b/packages/lib/src/components/internal/SecuredFields/lib/types.ts
@@ -124,6 +124,7 @@ export interface CardBinLookupData {
     supportedBrands?: string[];
     brands?: string[];
     issuingCountryCode?: string;
+    healthcare?: (boolean | undefined)[];
     // New for CustomCard
     supportedBrandsRaw?: BrandObject[];
     rootNode?: HTMLElement;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [X] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [X] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

The BE is adding a healthcare boolean field at the brand level to the `/binLookup` response. Since the SDK re-maps the binLookup response before exposing it to merchants via `onBinLookup`, we will explicitly pass the field through.

The field is only included in the callback when the BE returns it, it is never defaulted to false when absent.
When at least one brand has the healthcare field (true/false), the healthcare array is returned inside the `onBinLookup`. In any other case the field gets omitted.

---

## 🧪 Tested scenarios

- healthcare: true in at least one brand returned by BE → included in onBinLookup callback
- healthcare absent from all brands from BE response → field omitted entirely from onBinLookup callback
- healthcare: false in at least one brand returned by BE → included in onBinLookup callback

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

COSDK-1266
---

