### PR TITLE
Fixed: aria-checked missing in the Dropin payment method list if openFirstPaymentMethod set to false

### DIFF
--- a/.changeset/thin-spies-film.md
+++ b/.changeset/thin-spies-film.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: aria-checked missing in the Dropin payment method list if openFirstPaymentMethod set to false

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodsContainer.tsx
@@ -55,7 +55,7 @@ function PaymentMethodsContainer({
                 aria-label={standalone ? undefined : i18n.get('paymentMethodsList.aria.label')}
             >
                 {paymentMethods.map((paymentMethod, index, paymentMethodsCollection) => {
-                    const isSelected = activePaymentMethod && activePaymentMethod._id === paymentMethod._id;
+                    const isSelected: boolean = activePaymentMethod?._id === paymentMethod._id;
                     const isNextOneSelected =
                         activePaymentMethod &&
                         paymentMethodsCollection[index + 1] &&


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [x] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [x] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

This issue fixed #3824. The issue was reproducible when using `openFirstPaymentMethod` was set to false, in this case the `isSelected` condition would evaluate wrongly to null hiding the key from the element.

Fixed by swapping to optional chaining on the comparison.

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  #3824 


---

