### PR TITLE
fix: duplicate characters issue in address input fields

### DIFF
--- a/.changeset/ninety-boats-open.md
+++ b/.changeset/ninety-boats-open.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Duplicate characters when typing in address fields using an IME

--- a/packages/e2e-playwright/tests/automated/visual/visual.spec.ts
+++ b/packages/e2e-playwright/tests/automated/visual/visual.spec.ts
@@ -2,7 +2,6 @@ import { test } from '../../../fixtures/base-fixture';
 import fs from 'node:fs';
 import { Automated } from '../../../models/automated';
 import { toHaveScreenshot } from '../../utils/assertions';
-import { waitForImageLoaded } from '../../utils/image';
 import { StorybookIndex } from '../types';
 
 // This is relative to playwright root: adyen-web/lib/e2e-playwright/
@@ -28,8 +27,6 @@ test.describe('Automated visual testing', () => {
         test(testTitle, async ({ page, browserName }) => {
             const automatedModel = new Automated(page);
             await automatedModel.gotoStory(storyId);
-
-            await waitForImageLoaded(page);
 
             await toHaveScreenshot(page.getByTestId('checkout-component'), browserName, `${storyId}.png`, {
                 mask: [page.getByRole('timer'), page.getByTestId('stored-card-info')]

--- a/packages/e2e-playwright/tests/e2e/dropin/sessions/iris.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/dropin/sessions/iris.spec.ts
@@ -24,7 +24,7 @@ test.describe('Dropin - Sessions - IRIS', () => {
 
                 await iris.pay();
 
-                await toHaveScreenshot(upiPaymentMethod.rootElement, browserName, 'iris-bank-list-pay-button-clicked.png');
+                await toHaveScreenshot(upiPaymentMethod.rootElement, browserName, 'iris-bank-list-pay-button-clicked.png', { skipWaitForImages: true });
             }
         );
     });

--- a/packages/e2e-playwright/tests/e2e/dropin/sessions/upi.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/dropin/sessions/upi.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '../../../../fixtures/dropin.fixture';
 import { MOBILE_USER_AGENT, SMALL_MOBILE_VIEWPORT, TAGS } from '../../../utils/constants';
 import { URL_MAP } from '../../../../fixtures/URL_MAP';
 import { toHaveScreenshot } from '../../../utils/assertions';
-import { waitForImageLoaded } from '../../../utils/image';
 import { UPI } from '../../../../models/upi';
 
 test.describe('Dropin - Sessions - UPI', () => {

--- a/packages/e2e-playwright/tests/e2e/upi/upi.spec.ts
+++ b/packages/e2e-playwright/tests/e2e/upi/upi.spec.ts
@@ -3,7 +3,6 @@ import { UPI } from '../../../models/upi';
 import { URL_MAP } from '../../../fixtures/URL_MAP';
 import { MOBILE_USER_AGENT, SMALL_MOBILE_VIEWPORT } from '../../utils/constants';
 import { toHaveScreenshot } from '../../utils/assertions';
-import { waitForImageLoaded } from '../../utils/image';
 import { TAGS } from '../../utils/constants';
 
 type Fixture = {
@@ -27,7 +26,6 @@ test.describe('UPI - QR Code Flow (Desktop)', () => {
             await expect(upiPage.appList).not.toBeVisible();
             await expect(upiPage.qrCodeArea).toBeVisible();
 
-            await waitForImageLoaded(upiPage.page);
             await toHaveScreenshot(upiPage.qrCodeArea, browserName, 'upi-qr-code-initial.png');
             await upiPage.pay({ name: /generate qr code/i });
 
@@ -55,7 +53,6 @@ test.describe('UPI - Intent Flow (Mobile)', () => {
             await upiPage.pay({ name: /continue/i });
             await expect(upiPage.errorAlert).toBeVisible();
 
-            await waitForImageLoaded(upiPage.page);
             await toHaveScreenshot(upiPage.intentArea, browserName, 'upi-intent-error-alert.png');
 
             // selected from priority list
@@ -74,7 +71,6 @@ test.describe('UPI - Intent Flow (Mobile)', () => {
             await expect(upiPage.intentArea).toBeVisible();
             await expect(upiPage.appList).toBeVisible();
             await expect(upiPage.appDropdown).toBeVisible();
-            await waitForImageLoaded(upiPage.page);
             await toHaveScreenshot(upiPage.intentArea, browserName, 'upi-intent-list-not-selected.png');
 
             await upiPage.selectAppFromDropdown(/.+/);

--- a/packages/e2e-playwright/tests/ui/card/bcmc/dualBranding.reset.spec.ts
+++ b/packages/e2e-playwright/tests/ui/card/bcmc/dualBranding.reset.spec.ts
@@ -18,7 +18,7 @@ test.describe('Testing Bancontact, with dual branded cards, how UI resets', () =
             await bcmc.deleteCardNumber();
 
             // Now only a single brand
-            await expect(bcmc.isDualBrandSelectionVisible()).resolves.toBe(false);
+            await expect(bcmc.dualBrandSelector).toBeHidden();
             await expect(bcmc.brandingIcon).toHaveAttribute('alt', 'Bancontact card');
         }
     );

--- a/packages/e2e-playwright/tests/utils/assertions.ts
+++ b/packages/e2e-playwright/tests/utils/assertions.ts
@@ -1,14 +1,21 @@
 import { Locator, expect } from '@playwright/test';
 import * as os from 'os';
+import { waitForImageLoaded } from './image';
 
 const isCI = process.env.CI === 'true';
 const isLinux = os.platform() === 'linux';
 
-export const toHaveScreenshot = (
+export const toHaveScreenshot = async (
     locator: Locator,
     browserName: 'chromium' | 'firefox' | 'webkit',
     name: string | ReadonlyArray<string>,
     options?: {
+        /**
+         * When true, skips waiting for images to load before taking the screenshot.
+         * Use this when the screenshot intentionally captures a transient state right after an action.
+         */
+        skipWaitForImages?: boolean;
+
         /**
          * When set to `"disabled"`, stops CSS animations, CSS transitions and Web Animations. Animations get different
          * treatment depending on their duration:
@@ -91,5 +98,11 @@ export const toHaveScreenshot = (
         return;
     }
 
-    return expect(locator).toHaveScreenshot(name, { ...options });
+    const { skipWaitForImages, ...screenshotOptions } = options ?? {};
+
+    if (!skipWaitForImages) {
+        await waitForImageLoaded(locator);
+    }
+
+    return expect(locator).toHaveScreenshot(name, { ...screenshotOptions });
 };

--- a/packages/lib/src/components/internal/Address/Address.test.tsx
+++ b/packages/lib/src/components/internal/Address/Address.test.tsx
@@ -76,6 +76,20 @@ describe('Address', () => {
         expect(await screen.findByLabelText('Country/Region')).toBeInTheDocument();
     });
 
+    test('should maintain spaces while typing but trim and collapse them on blur', async () => {
+        const user = userEvent.setup();
+        const requiredFields = ['street', 'houseNumberOrName', 'postalCode', 'country'];
+
+        customRender(<Address specifications={addressSpecificationsMock} requiredFields={requiredFields} />);
+
+        const street = screen.getByLabelText('Street');
+        await user.type(street, '  Simon   Carmiggeltstraat  ');
+        expect(street).toHaveValue('  Simon   Carmiggeltstraat  ');
+
+        await user.tab();
+        await waitFor(() => expect(street).toHaveValue('Simon Carmiggeltstraat'));
+    });
+
     test('should show the address as readOnly', () => {
         const requiredFields = ['street', 'houseNumberOrName', 'postalCode', 'country'];
 

--- a/packages/lib/src/components/internal/Address/validate.formats.test.ts
+++ b/packages/lib/src/components/internal/Address/validate.formats.test.ts
@@ -5,15 +5,15 @@ describe('addressFormatters', () => {
         const format = addressFormatters[field].formatterFn;
 
         test('should not trim trailing or leading spaces', () => {
-            expect(format('  Main Road  ')).toBe('  Main Road  ');
+            expect(format?.('  Main Road  ')).toBe('  Main Road  ');
         });
 
         test('should not collapse consecutive spaces', () => {
-            expect(format('Main   Road')).toBe('Main   Road');
+            expect(format?.('Main   Road')).toBe('Main   Road');
         });
 
         test('should strip special characters without touching spaces', () => {
-            expect(format('  Main@ Ro#ad  ')).toBe('  Main Road  ');
+            expect(format?.('  Main@ Ro#ad  ')).toBe('  Main Road  ');
         });
     });
 });

--- a/packages/lib/src/components/internal/Address/validate.formats.test.ts
+++ b/packages/lib/src/components/internal/Address/validate.formats.test.ts
@@ -1,4 +1,22 @@
-import { countrySpecificFormatters } from './validate.formats';
+import { addressFormatters, countrySpecificFormatters } from './validate.formats';
+
+describe('addressFormatters', () => {
+    describe.each(['street', 'houseNumberOrName', 'city'])('%s formatterFn', field => {
+        const format = addressFormatters[field].formatterFn;
+
+        test('should not trim trailing or leading spaces', () => {
+            expect(format('  Main Road  ')).toBe('  Main Road  ');
+        });
+
+        test('should not collapse consecutive spaces', () => {
+            expect(format('Main   Road')).toBe('Main   Road');
+        });
+
+        test('should strip special characters without touching spaces', () => {
+            expect(format('  Main@ Ro#ad  ')).toBe('  Main Road  ');
+        });
+    });
+});
 
 describe('countrySpecificFormatters', () => {
     describe('BR postalCode formatterFn', () => {

--- a/packages/lib/src/components/internal/Address/validate.formats.ts
+++ b/packages/lib/src/components/internal/Address/validate.formats.ts
@@ -1,6 +1,6 @@
 import { CountryFormatRules, FormatRules } from '../../../utils/Validator/types';
 import { Formatter } from '../../../utils/useForm/types';
-import { getFormattingRegEx, SPECIAL_CHARS, trimValWithOneSpace } from '../../../utils/validator-utils';
+import { getFormattingRegEx, SPECIAL_CHARS } from '../../../utils/validator-utils';
 
 const asCountryFormatRules = <T extends CountryFormatRules>(rules: T): T & CountryFormatRules => rules;
 
@@ -15,7 +15,7 @@ const createFormatByDigits = (digits: number): Formatter => {
 };
 
 const specialCharsRegEx = getFormattingRegEx(SPECIAL_CHARS);
-const formattingFn = val => trimValWithOneSpace(val).replace(specialCharsRegEx, '');
+const formattingFn = (val: string) => val.replace(specialCharsRegEx, '');
 
 export const addressFormatters: FormatRules = {
     postalCode: {

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -58,7 +58,7 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
 
     const handleInput = useCallback(
         (event: TargetedInputEvent<HTMLInputElement>) => {
-            props.onInput(event);
+            props.onInput?.(event);
         },
         [props.onInput]
     );
@@ -98,7 +98,7 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
             'adyen-checkout__input--invalid': isInvalid,
             'adyen-checkout__input--valid': isValid
         },
-        classNameModifiers.map(m => `adyen-checkout__input--${m}`)
+        (classNameModifiers ?? []).map(m => `adyen-checkout__input--${m}`)
     );
 
     // Don't spread classNameModifiers etc to input element (it ends up as an attribute on the element itself)

--- a/packages/lib/src/components/internal/FormFields/InputBase.tsx
+++ b/packages/lib/src/components/internal/FormFields/InputBase.tsx
@@ -11,6 +11,7 @@ import {
 import { useCallback } from 'preact/hooks';
 import classNames from 'classnames';
 import { ARIA_CONTEXT_SUFFIX, ARIA_ERROR_SUFFIX } from '../../../core/Errors/constants';
+import { trimValWithOneSpace } from '../../../utils/validator-utils';
 import Language from '../../../language';
 import { AutocompleteValue } from './types';
 import './FormFields.scss';
@@ -75,7 +76,8 @@ export default function InputBase({ setRef, ...props }: Readonly<InputBaseProps>
             props?.onBlurHandler?.(event); // From Field component
 
             if (props.trimOnBlur) {
-                (event.target as HTMLInputElement).value = (event.target as HTMLInputElement).value.trim(); // needed to trim trailing spaces in field (leading spaces can be done via formatting)
+                const input = event.target as HTMLInputElement;
+                input.value = trimValWithOneSpace(input.value);
             }
 
             props?.onBlur?.(event);

--- a/packages/lib/src/utils/validator-utils.ts
+++ b/packages/lib/src/utils/validator-utils.ts
@@ -51,5 +51,5 @@ export const validateForSpecialChars = (name: string) => {
     return CHARACTER_PATTERNS.noSpecialChars.test(name) || hasNoLength;
 };
 
-// Trim start and never allow more than 1 space on the end
-export const trimValWithOneSpace = (val: string) => val.trimStart().replace(/\s+/g, ' ');
+// Trim both ends and never allow more than 1 space in between
+export const trimValWithOneSpace = (val: string) => val.trim().replace(/\s+/g, ' ');


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

This PR fixes a bug where address input fields would produce duplicate characters when typing with an IME (used for Chinese, Japanese, Korean, and other languages with composing input systems)

**Root cause**: The formattingFn applied to address fields and specifically `trimValWithOneSpace`, which was modifying the input value mid-composition (removing spaces from the start and end of the input). This interfered with the browser's IME composition lifecycle and caused the composed text to be appended again after the `compositionend` event fired, resulting in duplicate characters.

**Fix**: Removed trimValWithOneSpace from the address formattingFn. The formatter now only strips special characters, handling the space characters `onBlur` only now

E2E fix for flaky screenshot tests was included in this PR.

---

## 🧪 Tested scenarios

- on iPhone 16 in Chrome, Safari and Firefox
  - Typing with an IME (Zhuyin keyboard) in Street, House Number and City fields no longer produces duplicate characters.
  - The above address fields with special characters are still correctly stripped.

---

## 🔗 Related GitHub Issue / Internal Ticket number



**Closes**:  #4083 

---

