### PR TITLE
Updating deps to use mature versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "prettier": "3.9.4"
     },
     "resolutions": {
+        "shell-quote": "1.9.0",
         "tar-fs": "^3.0.9"
     },
     "packageManager": "yarn@4.17.0"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -27,7 +27,7 @@
         "css-loader": "^6.0.0",
         "dotenv": "17.2.3",
         "html-webpack-plugin": "5.6.4",
-        "postcss": "^8.5.12",
+        "postcss": "8.5.16",
         "postcss-loader": "^7.0.0",
         "sass-loader": "^10.2.0",
         "source-map-loader": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,7 +38,7 @@ __metadata:
     css-loader: "npm:^6.0.0"
     dotenv: "npm:17.2.3"
     html-webpack-plugin: "npm:5.6.4"
-    postcss: "npm:^8.5.12"
+    postcss: "npm:8.5.16"
     postcss-loader: "npm:^7.0.0"
     sass-loader: "npm:^10.2.0"
     source-map-loader: "npm:^1.1.3"
@@ -11743,15 +11743,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^5.1.7":
   version: 5.1.9
   resolution: "nanoid@npm:5.1.9"
@@ -13486,17 +13477,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.12":
-  version: 8.5.22
-  resolution: "postcss@npm:8.5.22"
-  dependencies:
-    nanoid: "npm:^3.3.16"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/9e143ee457988049d5f187116fd37f2750ae9d8d71cc99eae690b776e549e134b34086cbaa2f0360ecd1729b15d918227bd0fc3a2ffbe341f7212d0827080793
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.5.15":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
@@ -14811,17 +14791,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.4":
-  version: 1.8.4
-  resolution: "shell-quote@npm:1.8.4"
-  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.8.4":
-  version: 1.10.0
-  resolution: "shell-quote@npm:1.10.0"
-  checksum: 10c0/46ee59bfd972ce6a45500c44ed130dff2d0a7d6fbac9841e59d548518cad8060a06393c9a5dcbc0cede294ad80b2a2cd8c904679e09265f53efc0a0879f30961
+"shell-quote@npm:1.9.0":
+  version: 1.9.0
+  resolution: "shell-quote@npm:1.9.0"
+  checksum: 10c0/a39960107eb086b02394cfceb3c732bd3bf567b568719ff47101448fc3f1bf4a59ecfdd8960ff7ea564d749ef8bda70f2c82a768f22d8c7aeeabf2b64f53b7e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📝 Summary

#### Dependency changes
- Pins playground postcss to exact version 8.5.16, replacing ^8.5.12.
- Adds a root Yarn resolution pinning transitive shell-quote to 1.9.0.
- Updates yarn.lock accordingly: 
  - Both workspace PostCSS declarations resolve to 8.5.16.
  - Removes the obsolete PostCSS 8.5.22 and Nano ID 3.3.16 resolutions.
  - Replaces shell-quote versions 1.8.4 and 1.10.0 with a single 1.9.0 resolution.

---

## 🧪 Tested scenarios
Yarn install works


