### PR TITLE
fix: slack release notifications issues

### DIFF
--- a/.github/workflows/release-notifications.yml
+++ b/.github/workflows/release-notifications.yml
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/slack-channel-message.yml
     with:
       channel: ${{ vars.CHECKOUT_WEB_CHANNEL_ID }}
-      message: "Release ${{ needs.resolve-version.outputs.version }} has been successfully published to npm!"
+      message: "Release ${{ needs.resolve-version.outputs.version }} has been successfully published to npm! You can find it here: https://www.npmjs.com/package/@adyen/adyen-web/v/${{ needs.resolve-version.outputs.version }}"
       thread_ts: ${{ needs.load-thread-ts.outputs.thread_ts }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-notifications.yml
+++ b/.github/workflows/release-notifications.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - '**/CHANGELOG.md'
   workflow_run:
-    workflows: ["GitHub Release", "Publish Package"]
+    workflows: ["GitHub Release", "Publish Package", "Check Commit Message"]
     types: [completed]
 
 jobs:
@@ -100,7 +100,7 @@ jobs:
 
   removed-from-queue:
     needs: [resolve-version, load-thread-ts]
-    if: github.event.action == 'dequeued' && contains(github.head_ref, 'changeset-release')
+    if: github.event.action == 'dequeued' && github.event.reason != 'MERGE' && github.event.reason != 'ALREADY_MERGED' && contains(github.head_ref, 'changeset-release')
     uses: ./.github/workflows/slack-channel-message.yml
     with:
       channel: ${{ vars.CHECKOUT_WEB_CHANNEL_ID }}
@@ -122,7 +122,7 @@ jobs:
 
   gh-release:
     needs: [resolve-version, load-thread-ts]
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'GitHub Release' && github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.name == 'GitHub Release' || (github.event.workflow_run.name == 'Check Commit Message' && contains(github.event.workflow_run.head_commit.message, '[ci] release')))
     uses: ./.github/workflows/slack-channel-message.yml
     with:
       channel: ${{ vars.CHECKOUT_WEB_CHANNEL_ID }}
@@ -133,7 +133,7 @@ jobs:
 
   gh-release-failed:
     needs: [resolve-version, load-thread-ts]
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'GitHub Release' && github.event.workflow_run.conclusion != 'success'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' && (github.event.workflow_run.name == 'GitHub Release' || (github.event.workflow_run.name == 'Check Commit Message' && contains(github.event.workflow_run.head_commit.message, '[ci] release')))
     uses: ./.github/workflows/slack-channel-message.yml
     with:
       channel: ${{ vars.CHECKOUT_WEB_CHANNEL_ID }}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

This PR fixes the issues identified during the last release with the slack bot.
- Triggers `removed-from-queue` job only when it is due to failed status
- Triggers `gh-release` job both when `gh-release` action is triggered directly and when `gh-release` gets triggered through `check-release-build`
- Updated `npm-publish` message to include link to npm

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

