### PR TITLE
Fixed: focus moving to the wrong component when multiple OpenInvoice components

### DIFF
--- a/.changeset/fix-openinvoice-focus-multiple-instances.md
+++ b/.changeset/fix-openinvoice-focus-multiple-instances.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: focus moving to the wrong component when multiple OpenInvoice-based components (e.g. AfterPay, RatePay, FacilyPay, Atome) are rendered on the same page and a validation error occurs

--- a/packages/lib/src/components/AfterPay/AfterPay.test.ts
+++ b/packages/lib/src/components/AfterPay/AfterPay.test.ts
@@ -378,4 +378,38 @@ describe('AfterPay', () => {
         expect(screen.getByText('Enter the city')).toBeInTheDocument();
         expect(within(<HTMLElement>consentCheckboxContainer).getByAltText('Error')).toBeInTheDocument();
     });
+
+    test('should focus a field within the submitted instance (not another instance) when multiple OpenInvoice-based components are rendered on the same page', async () => {
+        const user = userEvent.setup();
+
+        const buildAfterPay = () =>
+            new AfterPay(setupCoreMock(), {
+                countryCode: 'NL',
+                modules: { resources: global.resources },
+                i18n: global.i18n,
+                onSubmit: jest.fn(),
+                loadingContext: 'https://checkoutshopper-live.adyen.com/checkoutshopper/'
+            });
+
+        // Render two independent AfterPay instances on the same page, as can happen when a merchant shows
+        // multiple OpenInvoice-based payment methods (AfterPay, RatePay, FacilyPay, Atome, ...) at once.
+        render(buildAfterPay().render());
+        render(buildAfterPay().render());
+
+        const payButtons = screen.getAllByRole('button', { name: 'Confirm purchase' });
+        expect(payButtons).toHaveLength(2);
+
+        // Submit the SECOND instance with an empty form, triggering validation errors on it
+        await user.click(payButtons[1]);
+
+        const firstNameInputs = screen.getAllByLabelText('First name');
+        expect(firstNameInputs).toHaveLength(2);
+
+        // Focus must move to the first invalid field of the instance that was actually submitted (the second
+        // one), not to the first instance rendered on the page.
+        await waitFor(() => {
+            expect(firstNameInputs[1]).toHaveFocus();
+        });
+        expect(firstNameInputs[0]).not.toHaveFocus();
+    });
 });

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -42,6 +42,7 @@ export default function OpenInvoice(props: Readonly<OpenInvoiceProps>) {
     }
 
     const isValidating = useRef(false);
+    const containerRef = useRef<HTMLDivElement>(null);
 
     const initialActiveFieldsets: OpenInvoiceActiveFieldsets = getInitialActiveFieldsets(visibility, props.data);
     const [activeFieldsets, setActiveFieldsets] = useState<OpenInvoiceActiveFieldsets>(initialActiveFieldsets);
@@ -82,7 +83,7 @@ export default function OpenInvoice(props: Readonly<OpenInvoiceProps>) {
 
     openInvoiceRef.current.setStatus = setStatus;
 
-    useSRPanelForOpenInvoiceErrors({ errors, data, props, isValidating });
+    useSRPanelForOpenInvoiceErrors({ errors, data, props, isValidating, containerRef });
 
     useEffect(() => {
         const fieldsetsAreValid: boolean = checkFieldsets();
@@ -113,6 +114,7 @@ export default function OpenInvoice(props: Readonly<OpenInvoiceProps>) {
     };
     return (
         <div
+            ref={containerRef}
             className={classNames({
                 'adyen-checkout__open-invoice': true,
                 'adyen-checkout__open-invoice--loading': status === 'loading'

--- a/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
@@ -18,9 +18,10 @@ interface UseSRPanelForErrorsProps {
     data: OpenInvoiceStateData;
     props: OpenInvoiceProps;
     isValidating: MutableRef<boolean>;
+    containerRef: MutableRef<HTMLDivElement>;
 }
 
-const useSRPanelForOpenInvoiceErrors = ({ errors, data, props, isValidating }: UseSRPanelForErrorsProps) => {
+const useSRPanelForOpenInvoiceErrors = ({ errors, data, props, isValidating, containerRef }: UseSRPanelForErrorsProps) => {
     // Relates to onBlur errors
     const [sortedErrorList, setSortedErrorList] = useState(null);
     // Get the previous value (Relates to onBlur errors)
@@ -126,7 +127,9 @@ const useSRPanelForOpenInvoiceErrors = ({ errors, data, props, isValidating }: U
                     }
 
                     // Focus first field in error, if required
-                    if (shouldMoveFocusSR) setFocusOnField('.adyen-checkout__open-invoice', fieldToFocus, focusContextSelector);
+                    // Use the component's own container ref (rather than a global class selector) so that, when multiple
+                    // OpenInvoice-based components are rendered on the same page, focus moves within the correct instance
+                    if (shouldMoveFocusSR && containerRef.current) setFocusOnField(containerRef.current, fieldToFocus, focusContextSelector);
                     // Remove 'showValidation' mode - allowing time for collation of all the fields in error whilst it is 'showValidation' mode (some errors come in a second render pass)
                     setTimeout(() => {
                         isValidating.current = false;

--- a/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/useSRPanelForOpenInvoiceErrors.ts
@@ -18,7 +18,7 @@ interface UseSRPanelForErrorsProps {
     data: OpenInvoiceStateData;
     props: OpenInvoiceProps;
     isValidating: MutableRef<boolean>;
-    containerRef: MutableRef<HTMLDivElement>;
+    containerRef: MutableRef<HTMLDivElement | null>;
 }
 
 const useSRPanelForOpenInvoiceErrors = ({ errors, data, props, isValidating, containerRef }: UseSRPanelForErrorsProps) => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

On OpenInvoice-based components (AfterPay, RatePay, FacilyPay, Atome, ...), pressing Pay with an invalid form moves focus to the first field in error. This focus call used a global CSS selector (`.adyen-checkout__open-invoice`) resolved via `document.querySelector`, which always returns the **first** matching element in the DOM.

When multiple OpenInvoice-based components are rendered on the same page, submitting any instance other than the first one moved focus into the **first** component's fields instead of the submitted component's own fields.

Fixed by scoping the focus lookup to the submitted component's own container, using a `containerRef` (the same pattern already used by `IssuerList` and the ClickToPay inputs) instead of a page-wide selector.

---

## 🧪 Tested scenarios

- Added a unit test in `AfterPay.test.ts` that renders two independent `AfterPay` instances on the same page, submits the second one with an empty form, and asserts focus lands on the second instance's field (not the first's).
- Verified the new test fails against the old code (reproducing the bug) and passes with the fix.
- Manually reproduced with a temporary debug Storybook story rendering two `AfterPay` components side by side (removed before opening this PR).

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number --> COSDK-1417


---
