### PR TITLE
fix: US postal code validation

### DIFF
--- a/.changeset/fiery-lands-camp.md
+++ b/.changeset/fiery-lands-camp.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: US postal code validation

--- a/.changeset/fiery-lands-camp.md
+++ b/.changeset/fiery-lands-camp.md
@@ -1,5 +1,0 @@
----
-'@adyen/adyen-web': patch
----
-
-Fixed: US postal code validation

--- a/.changeset/olive-pandas-shave.md
+++ b/.changeset/olive-pandas-shave.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Fixed: Postal code not being formatted for the configured country in partial billing address mode
+Fixed: US postal code validation & postal code formatting for partial billing address mode

--- a/.changeset/olive-pandas-shave.md
+++ b/.changeset/olive-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Postal code not being formatted for the configured country in partial billing address mode

--- a/packages/lib/src/components/Card/Card.test.tsx
+++ b/packages/lib/src/components/Card/Card.test.tsx
@@ -9,6 +9,7 @@ import { CardFocusData } from '../internal/SecuredFields/lib/types';
 import { mock } from 'jest-mock-extended';
 import { AmountProvider } from '../../core/Context/AmountProvider';
 import { ICore } from '../../types';
+import { FALLBACK_VALUE } from '../internal/Address/constants';
 
 describe('Card', () => {
     describe('formatProps', function () {
@@ -319,6 +320,20 @@ describe('Card', () => {
             render(card.render());
             // we need to wait here for the screen to render / hook to trigger
             await waitFor(() => expect(card.formatData().paymentMethod.holderName).toContain(''));
+        });
+
+        test('should send stateOrProvince as "N/A" in the billingAddress when in partial address mode', async () => {
+            const core = setupCoreMock();
+
+            const card = new CardElement(core, {
+                ...props,
+                billingAddressRequired: true,
+                billingAddressMode: 'partial',
+                data: { billingAddress: { country: 'US', postalCode: '95014' } }
+            });
+            render(card.render());
+
+            await waitFor(() => expect(card.formatData().billingAddress?.stateOrProvince).toBe(FALLBACK_VALUE));
         });
     });
 

--- a/packages/lib/src/components/internal/Address/Address.test.tsx
+++ b/packages/lib/src/components/internal/Address/Address.test.tsx
@@ -3,7 +3,7 @@ import Address from './Address';
 import getDataset from '../../../core/Services/get-dataset';
 import { AddressSpecifications } from './types';
 import { AddressData } from '../../../types';
-import { FALLBACK_VALUE } from './constants';
+import { FALLBACK_VALUE, PARTIAL_ADDRESS_SCHEMA } from './constants';
 import { render, screen, waitFor } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
 import { CoreProvider } from '../../../core/Context/CoreProvider';
@@ -321,6 +321,46 @@ describe('Address', () => {
                 const postCode = await screen.findByRole('textbox', { name: /code/ });
                 expect(postCode).toHaveValue(expected);
             });
+        });
+
+        test('should regionalize the postal code label in partial address mode using the country from the merchant config', async () => {
+            const allowedCountries = Object.keys(countrySpecificFormatters);
+            customRender(
+                <Address
+                    data={{ country: 'US' }}
+                    specifications={PARTIAL_ADDRESS_SCHEMA}
+                    requiredFields={['postalCode']}
+                    allowedCountries={allowedCountries}
+                />
+            );
+
+            expect(await screen.findByRole('textbox', { name: /Zip code/ })).toBeInTheDocument();
+        });
+
+        describe.each`
+            countryCode | raw                | expected
+            ${'US'}     | ${'1234599999999'} | ${'12345'}
+            ${'BR'}     | ${'12345678999'}   | ${'12345678'}
+            ${'PL'}     | ${'99-99999999'}   | ${'99-999'}
+        `('Format post code in partial address mode', ({ countryCode, raw, expected }) => {
+            it(`should format the post code being typed for ${countryCode}, using the country from the merchant config`, async () => {
+                const user = userEvent.setup();
+                customRender(<Address data={{ country: countryCode }} specifications={PARTIAL_ADDRESS_SCHEMA} requiredFields={['postalCode']} />);
+
+                const postCode = await screen.findByRole('textbox', { name: /code/ });
+                await user.type(postCode, raw);
+                expect(postCode).toHaveValue(expected);
+            });
+        });
+
+        test('should regionalize the postal code label in partial address mode', async () => {
+            customRender(<Address data={{ country: 'us' }} specifications={PARTIAL_ADDRESS_SCHEMA} requiredFields={['postalCode']} />);
+            expect(await screen.findByRole('textbox', { name: /Zip code/ })).toBeInTheDocument();
+        });
+
+        test('should preselect the country in the country dropdown', async () => {
+            customRender(<Address data={{ country: 'us' }} allowedCountries={['US', 'CA']} onChange={jest.fn()} />);
+            expect(await screen.findByRole('combobox', { name: 'Country/Region' })).toHaveValue('United States');
         });
 
         test("should show proper 'Zip Code' label for US", async () => {

--- a/packages/lib/src/components/internal/Address/Address.test.tsx
+++ b/packages/lib/src/components/internal/Address/Address.test.tsx
@@ -342,6 +342,8 @@ describe('Address', () => {
             ${'US'}     | ${'1234599999999'} | ${'12345'}
             ${'BR'}     | ${'12345678999'}   | ${'12345678'}
             ${'PL'}     | ${'99-99999999'}   | ${'99-999'}
+            ${'us'}     | ${'1234599999999'} | ${'12345'}
+            ${'br'}     | ${'12345678999'}   | ${'12345678'}
         `('Format post code in partial address mode', ({ countryCode, raw, expected }) => {
             it(`should format the post code being typed for ${countryCode}, using the country from the merchant config`, async () => {
                 const user = userEvent.setup();
@@ -353,12 +355,22 @@ describe('Address', () => {
             });
         });
 
-        test('should regionalize the postal code label in partial address mode', async () => {
+        test('should regionalize the postal code label in partial address mode when the country is in lowercase', async () => {
             customRender(<Address data={{ country: 'us' }} specifications={PARTIAL_ADDRESS_SCHEMA} requiredFields={['postalCode']} />);
             expect(await screen.findByRole('textbox', { name: /Zip code/ })).toBeInTheDocument();
         });
 
-        test('should preselect the country in the country dropdown', async () => {
+        test('should emit an uppercased country when the merchant configures it in lowercase', async () => {
+            const onChangeMock = jest.fn();
+            customRender(
+                <Address data={{ country: 'us' }} specifications={PARTIAL_ADDRESS_SCHEMA} requiredFields={['postalCode']} onChange={onChangeMock} />
+            );
+            await waitFor(() =>
+                expect(onChangeMock).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ country: 'US' }) }))
+            );
+        });
+
+        test('should preselect the country in the country dropdown when the country is in lowercase', async () => {
             customRender(<Address data={{ country: 'us' }} allowedCountries={['US', 'CA']} onChange={jest.fn()} />);
             expect(await screen.findByRole('combobox', { name: 'Country/Region' })).toHaveValue('United States');
         });

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -9,7 +9,7 @@ import { AddressData } from '../../../types/global-types';
 import FieldContainer from './components/FieldContainer';
 import useForm from '../../../utils/useForm';
 import Specifications from './Specifications';
-import { ADDRESS_SCHEMA, FALLBACK_VALUE } from './constants';
+import { ADDRESS_SCHEMA, COUNTRY, FALLBACK_VALUE } from './constants';
 import { getMaxLengthByFieldAndCountry } from '../../../utils/validator-utils';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import AddressSearch from './components/AddressSearch';
@@ -46,19 +46,21 @@ export default function Address(props: Readonly<AddressProps>) {
 
     const showAddressFields = props.onAddressLookup ? hasSelectedAddress || useManualAddress : true;
 
+    // In partial address mode the country field is not rendered, so it is absent from the address schema.
+    // The country the merchant configured must still be part of the form data for country dependent rules to be applied.
+    const merchantCountry = (props.data as AddressData)?.country;
+    const formSchema = merchantCountry && !requiredFieldsSchema.includes(COUNTRY) ? [...requiredFieldsSchema, COUNTRY] : requiredFieldsSchema;
+
     const { data, errors, valid, isValid, handleChangeFor, triggerValidation, setData, mergeData } = useForm<AddressData>({
-        schema: requiredFieldsSchema,
+        schema: formSchema,
         defaultData: props.data,
         // Ensure any passed validation rules are merged with the default ones
         rules: { ...getAddressValidationRules(specifications), ...props.validationRules },
         formatters: addressFormatters
     });
 
-    // In partial address mode, country is not in the form schema but we need it for regionalized labels.
-    // Store the merchant's country config once at mount, then use it if form data doesn't have country.
-    const initialCountryRef = useRef<string | undefined>((props.data as AddressData)?.country);
-    const effectiveCountry = (data.country || initialCountryRef.current)?.toUpperCase();
-    const dataWithCountry = useMemo(() => ({ ...data, country: effectiveCountry }), [data, effectiveCountry]);
+    const formattedCountry = data.country?.toUpperCase();
+    const dataWithCountry = useMemo(() => ({ ...data, country: formattedCountry }), [data, formattedCountry]);
 
     const setSearchData = useCallback(
         (selectedAddress: AddressData) => {
@@ -147,16 +149,11 @@ export default function Address(props: Readonly<AddressProps>) {
             const newValue = data[cur];
             const initialValue = props.data[cur];
             // recover default data values which are not requiredFields, or prefill with 'N/A'
-            const fallbackValue = !isRequired && !newValue && !!initialValue ? initialValue : FALLBACK_VALUE;
+            const fallbackValue = !isRequired && initialValue ? initialValue : FALLBACK_VALUE;
             const value = (isOptional && !newValue) || !isRequired ? fallbackValue : newValue;
             if (value?.length) acc[cur] = value;
             return acc;
         }, {});
-
-        // In partial address mode, ensure country is included in output for regionalized labels/validation.
-        if (!(processedData as AddressData).country && initialCountryRef.current) {
-            (processedData as AddressData).country = initialCountryRef.current;
-        }
 
         props.onChange({ data: processedData, valid, errors, isValid });
     }, [data, valid, errors, isValid]);
@@ -180,7 +177,7 @@ export default function Address(props: Readonly<AddressProps>) {
                 onBlur={handleChangeFor(fieldName, 'blur')}
                 onDropdownChange={handleChangeFor(fieldName, 'blur')}
                 specifications={specifications}
-                maxLength={getMaxLengthByFieldAndCountry(countrySpecificFormatters, fieldName, effectiveCountry, true)}
+                maxLength={getMaxLengthByFieldAndCountry(countrySpecificFormatters, fieldName, formattedCountry, true)}
                 trimOnBlur={true}
                 disabled={!enabledFields.includes(fieldName)}
                 addressType={addressType}

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -50,17 +50,18 @@ export default function Address(props: Readonly<AddressProps>) {
     // The country the merchant configured must still be part of the form data for country dependent rules to be applied.
     const merchantCountry = (props.data as AddressData)?.country;
     const formSchema = merchantCountry && !requiredFieldsSchema.includes(COUNTRY) ? [...requiredFieldsSchema, COUNTRY] : requiredFieldsSchema;
+    const defaultData = useMemo<AddressData>(
+        () => (merchantCountry ? { ...props.data, country: merchantCountry.toUpperCase() } : (props.data)),
+        [props.data, merchantCountry]
+    );
 
     const { data, errors, valid, isValid, handleChangeFor, triggerValidation, setData, mergeData } = useForm<AddressData>({
         schema: formSchema,
-        defaultData: props.data,
+        defaultData,
         // Ensure any passed validation rules are merged with the default ones
         rules: { ...getAddressValidationRules(specifications), ...props.validationRules },
         formatters: addressFormatters
     });
-
-    const formattedCountry = data.country?.toUpperCase();
-    const dataWithCountry = useMemo(() => ({ ...data, country: formattedCountry }), [data, formattedCountry]);
 
     const setSearchData = useCallback(
         (selectedAddress: AddressData) => {
@@ -147,7 +148,7 @@ export default function Address(props: Readonly<AddressProps>) {
             const isOptional = optionalFields.includes(cur);
             const isRequired = requiredFields.includes(cur);
             const newValue = data[cur];
-            const initialValue = props.data[cur];
+            const initialValue = defaultData[cur];
             // recover default data values which are not requiredFields, or prefill with 'N/A'
             const fallbackValue = !isRequired && initialValue ? initialValue : FALLBACK_VALUE;
             const value = (isOptional && !newValue) || !isRequired ? fallbackValue : newValue;
@@ -169,7 +170,7 @@ export default function Address(props: Readonly<AddressProps>) {
                 key={fieldName}
                 allowedCountries={props.allowedCountries}
                 classNameModifiers={[...classNameModifiers, fieldName]}
-                data={dataWithCountry}
+                data={data}
                 errors={errors}
                 valid={valid}
                 fieldName={fieldName}
@@ -177,7 +178,7 @@ export default function Address(props: Readonly<AddressProps>) {
                 onBlur={handleChangeFor(fieldName, 'blur')}
                 onDropdownChange={handleChangeFor(fieldName, 'blur')}
                 specifications={specifications}
-                maxLength={getMaxLengthByFieldAndCountry(countrySpecificFormatters, fieldName, formattedCountry, true)}
+                maxLength={getMaxLengthByFieldAndCountry(countrySpecificFormatters, fieldName, data.country, true)}
                 trimOnBlur={true}
                 disabled={!enabledFields.includes(fieldName)}
                 addressType={addressType}

--- a/packages/lib/src/components/internal/Address/validate.formats.ts
+++ b/packages/lib/src/components/internal/Address/validate.formats.ts
@@ -1,3 +1,4 @@
+import { FormatterContext } from '../../../utils/Formatters/types';
 import { CountryFormatRules, FormatRules } from '../../../utils/Validator/types';
 import { Formatter } from '../../../utils/useForm/types';
 import { getFormattingRegEx, SPECIAL_CHARS } from '../../../utils/validator-utils';
@@ -19,7 +20,7 @@ const formattingFn = (val: string) => val.replace(specialCharsRegEx, '');
 
 export const addressFormatters: FormatRules = {
     postalCode: {
-        formatterFn: (val, context) => {
+        formatterFn: (val: string, context: FormatterContext) => {
             const country = context.state.data.country;
 
             // Country specific formatting rule

--- a/packages/lib/src/components/internal/Address/validate.test.ts
+++ b/packages/lib/src/components/internal/Address/validate.test.ts
@@ -63,11 +63,10 @@ describe('validatePostalCode', () => {
         expect(result).toBe(true);
     });
 
-    // It fails because createPatternByDigits actually just check if there's at least X amount of digits
-    // it('should return false for an invalid US postal code with more than 5 digits without a hyphen', () => {
-    //     const result = validatePostalCode('1234567', 'US', validatorRules);
-    //     expect(result).toBe(false);
-    // });
+    it('should return false for an invalid US postal code with more than 5 digits without a hyphen', () => {
+        const result = validatePostalCode('1234567', 'US', validatorRules);
+        expect(result).toBe(false);
+    });
 
     // General
     it('should return null if the postal code is empty', () => {

--- a/packages/lib/src/components/internal/Address/validate.test.ts
+++ b/packages/lib/src/components/internal/Address/validate.test.ts
@@ -68,6 +68,16 @@ describe('validatePostalCode', () => {
         expect(result).toBe(false);
     });
 
+    it('should return true for a valid 9-digit US postal code with a hyphen', () => {
+        const result = validatePostalCode('12345-6789', 'US', validatorRules);
+        expect(result).toBe(true);
+    });
+
+    it('should return false for an invalid 9-digit US postal code', () => {
+        const result = validatePostalCode('12345-678', 'US', validatorRules);
+        expect(result).toBe(false);
+    });
+
     // General
     it('should return null if the postal code is empty', () => {
         const result = validatePostalCode('', 'AT', validatorRules);

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -71,7 +71,7 @@ const postalCodePatterns = {
     SE: createPatternByDigits(5),
     SG: createPatternByDigits(6),
     SK: createPatternByDigits(5),
-    US: createPatternByDigits(5)
+    US: { pattern: /^\d{5}(?:[-\s]\d{4})?$/ }
 };
 
 /**

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -71,7 +71,7 @@ const postalCodePatterns = {
     SE: createPatternByDigits(5),
     SG: createPatternByDigits(6),
     SK: createPatternByDigits(5),
-    US: { pattern: /^\d{5}(?:[-\s]\d{4})?$/ }
+    US: { pattern: /^\d{5}(?:-\d{4})?$/ }
 };
 
 /**

--- a/packages/lib/src/utils/Formatters/types.ts
+++ b/packages/lib/src/utils/Formatters/types.ts
@@ -1,11 +1,10 @@
 // Context holds state data for the input field implementing this.
-export type FormatterFn = (
-    value: string,
-    context?: {
-        state: {
-            data: {
-                country?: string;
-            };
+export type FormatterFn = (value: string, context?: FormatterContext) => string;
+
+export type FormatterContext = {
+    state: {
+        data: {
+            country?: string;
         };
-    }
-) => string;
+    };
+};


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

**Align US postal code validation with the error message.**

**Issue:** 
`validate.formats.ts` states that the US postal code format is `99999 or 99999-9999`, but `validate.ts` uses
`US: createPatternByDigits(5)`, which builds `new RegExp('\d{5}')`. This means, that any value
containing five consecutive digits passes, so `1234567` and values with surrounding non-digit
characters are accepted despite the error message stating otherwise.

**Solution:**
Replace the `createPatternByDigits` helper for `US` with an explicit pattern that
matches what the error message actually advertises:
 
```diff
- US: createPatternByDigits(5)
+ US: { pattern: /^\d{5}(?:[-\s]\d{4})?$/ }
```

**Enable the address formatter for AVS**

**Issue**
- The formatter was not applied to the Address fields for AVS, since no country was inside the form. 
**Solution**
- Add an optional `fallbackCountry` parameter to `addressFormatters`, and pass the `props.data.country` inside the `Address.tsx`, enabling the formatter for partial address as well.
---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  #4076 

---

