### PR TITLE
feat: add usePasskeyIFrameAttributes for Visa Passkey iframe support

### DIFF
--- a/.changeset/cool-toes-watch.md
+++ b/.changeset/cool-toes-watch.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': minor
 ---
 
-Improved the 3DS2 iframe to add attributes which enable WebAuthn and SPC challenges.
+Improved: the 3DS2 iframe to add attributes which enable WebAuthn and SPC challenges.

--- a/.changeset/cool-toes-watch.md
+++ b/.changeset/cool-toes-watch.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': minor
+---
+
+Improved the 3DS2 iframe to add attributes which enable WebAuthn and SPC challenges.

--- a/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
+++ b/packages/lib/src/components/ThreeDS2/callSubmit3DS2Fingerprint.ts
@@ -100,7 +100,7 @@ export default function callSubmit3DS2Fingerprint({ data }): void {
              */
             if (resData.action?.type === 'threeDS2') {
                 // Ensure challengeWindowSize is propagated if there was a (merchant defined) handleAction call proceeding this one that had it set as an option
-                return actionHandler.handleAction(resData.action, pick('challengeWindowSize').from(this.props));
+                return actionHandler.handleAction(resData.action, pick('challengeWindowSize', 'usePasskeyIFrameAttributes').from(this.props));
             }
 
             /**

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.test.tsx
@@ -1,0 +1,60 @@
+import { h } from 'preact';
+import { render } from '@testing-library/preact';
+import DoChallenge3DS2 from './DoChallenge3DS2';
+import { PASSKEY_3DS2_IFRAME_ALLOW, PASSKEY_VISA_IFRAME_ALLOW, PASSKEY_VISA_IFRAME_SANDBOX } from '../../constants';
+
+let mockIframeProps: any = {};
+
+jest.mock('../../../internal/IFrame', () => ({
+    __esModule: true,
+    default: function MockIframe(props: Record<string, unknown>) {
+        mockIframeProps = props;
+        return null;
+    }
+}));
+
+const defaultProps = {
+    acsURL: 'https://pal-test.adyen.com/threeds2simulator/acs/challenge.shtml',
+    cReqData: {
+        acsTransID: '4bc7960d',
+        messageVersion: '2.1.0',
+        threeDSServerTransID: '3fc4ead',
+        messageType: 'CReq',
+        challengeWindowSize: '02'
+    },
+    iframeSizeArr: ['390px', '400px'],
+    postMessageDomain: 'https://checkoutshopper-test.adyen.com',
+    onCompleteChallenge: jest.fn(),
+    onErrorChallenge: jest.fn(),
+    onActionHandled: jest.fn(),
+    onFormSubmit: jest.fn()
+};
+
+describe('DoChallenge3DS2', () => {
+    describe('Passkey iframe attributes', () => {
+        beforeEach(() => {
+            mockIframeProps = {};
+        });
+
+        test('should set default allow attribute and no sandbox when usePasskeyIFrameAttributes is not set', () => {
+            render(<DoChallenge3DS2 {...defaultProps} />);
+
+            expect(mockIframeProps.allow).toBe(PASSKEY_3DS2_IFRAME_ALLOW);
+            expect(mockIframeProps.sandbox).toBeUndefined();
+        });
+
+        test('should set default allow attribute and no sandbox when usePasskeyIFrameAttributes is false', () => {
+            render(<DoChallenge3DS2 {...defaultProps} usePasskeyIFrameAttributes={false} />);
+
+            expect(mockIframeProps.allow).toBe(PASSKEY_3DS2_IFRAME_ALLOW);
+            expect(mockIframeProps.sandbox).toBeUndefined();
+        });
+
+        test('should set Visa passkey allow and sandbox attributes when usePasskeyIFrameAttributes is true', () => {
+            render(<DoChallenge3DS2 {...defaultProps} usePasskeyIFrameAttributes={true} />);
+
+            expect(mockIframeProps.allow).toBe(PASSKEY_VISA_IFRAME_ALLOW);
+            expect(mockIframeProps.sandbox).toBe(PASSKEY_VISA_IFRAME_SANDBOX);
+        });
+    });
+});

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/DoChallenge3DS2.tsx
@@ -6,7 +6,7 @@ import ThreeDS2Form from '../Form';
 import getProcessMessageHandler from '../../../../utils/get-process-message-handler';
 import { encodeBase64URL } from '../utils';
 import promiseTimeout from '../../../../utils/promiseTimeout';
-import { CHALLENGE_TIMEOUT, CHALLENGE_TIMEOUT_REJECT_OBJECT, THREEDS2_NUM } from '../../constants';
+import { CHALLENGE_TIMEOUT, CHALLENGE_TIMEOUT_REJECT_OBJECT, THREEDS2_NUM, PASSKEY_VISA_IFRAME_ALLOW, PASSKEY_3DS2_IFRAME_ALLOW, PASSKEY_VISA_IFRAME_SANDBOX } from '../../constants';
 import { DoChallenge3DS2Props, DoChallenge3DS2State } from './types';
 import { ThreeDS2FlowObject } from '../../types';
 
@@ -67,7 +67,7 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
         window.removeEventListener('message', this.processMessageHandler);
     }
 
-    render({ acsURL, cReqData, iframeSizeArr, onFormSubmit }: DoChallenge3DS2Props, { base64URLencodedData, status }: DoChallenge3DS2State) {
+    render({ acsURL, cReqData, iframeSizeArr, onFormSubmit, usePasskeyIFrameAttributes }: DoChallenge3DS2Props, { base64URLencodedData, status }: DoChallenge3DS2State) {
         const [width, height] = iframeSizeArr;
 
         return (
@@ -79,7 +79,14 @@ class DoChallenge3DS2 extends Component<DoChallenge3DS2Props, DoChallenge3DS2Sta
             >
                 {status !== 'iframeLoaded' && <Spinner />}
 
-                <Iframe name={iframeName} width={width} height={height} callback={this.iframeCallback} />
+                <Iframe
+                    name={iframeName}
+                    width={width}
+                    height={height}
+                    callback={this.iframeCallback}
+                    allow={usePasskeyIFrameAttributes ? PASSKEY_VISA_IFRAME_ALLOW : PASSKEY_3DS2_IFRAME_ALLOW}
+                    sandbox={usePasskeyIFrameAttributes ? PASSKEY_VISA_IFRAME_SANDBOX : undefined}
+                />
                 <ThreeDS2Form
                     name={'cReqForm'}
                     action={acsURL}

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.test.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.test.tsx
@@ -44,9 +44,12 @@ const completeFunction = jest.fn();
 
 let mockCallbacks: any = {};
 
+let mockDoChallengeProps: any = {};
+
 jest.mock('./DoChallenge3DS2', () => ({
     __esModule: true,
     default: function MockDoChallenge(props) {
+        mockDoChallengeProps = props;
         mockCallbacks = {
             onCompleteChallenge: props.onCompleteChallenge,
             onErrorChallenge: props.onErrorChallenge
@@ -70,6 +73,7 @@ describe('PrepareChallenge3DS2 - Happy flow', () => {
         onError = jest.fn();
         onSubmitAnalytics = jest.fn();
         mockCallbacks = {};
+        mockDoChallengeProps = {};
     });
 
     test('should not throw an error when passing correct properties', () => {
@@ -116,6 +120,7 @@ describe('PrepareChallenge3DS2 - flow completes with errors that are considered 
         onError = jest.fn();
         onSubmitAnalytics = jest.fn();
         mockCallbacks = {};
+        mockDoChallengeProps = {};
     });
 
     test('should fire timeout analytics when challenge times out', async () => {
@@ -195,6 +200,7 @@ describe('PrepareChallenge3DS2 - unhappy flows', () => {
         });
 
         onSubmitAnalytics = jest.fn(() => {});
+        mockDoChallengeProps = {};
     });
 
     test('should call onError and onSubmitAnalytics when token is missing from props', () => {
@@ -348,5 +354,38 @@ describe('PrepareChallenge3DS2 - unhappy flows', () => {
         expect(onSubmitAnalytics).toHaveBeenCalledWith(analyticsError);
 
         expect(onSubmitAnalytics).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('PrepareChallenge3DS2 - usePasskeyIFrameAttributes', () => {
+    beforeEach(() => {
+        onError = jest.fn();
+        onSubmitAnalytics = jest.fn();
+        mockCallbacks = {};
+        mockDoChallengeProps = {};
+    });
+
+    test('should pass usePasskeyIFrameAttributes to DoChallenge3DS2 when set to true', () => {
+        prepareProps();
+
+        renderPrepareChallenge({ ...propsMaster, usePasskeyIFrameAttributes: true });
+
+        expect(mockDoChallengeProps.usePasskeyIFrameAttributes).toBe(true);
+    });
+
+    test('should pass usePasskeyIFrameAttributes to DoChallenge3DS2 when set to false', () => {
+        prepareProps();
+
+        renderPrepareChallenge({ ...propsMaster, usePasskeyIFrameAttributes: false });
+
+        expect(mockDoChallengeProps.usePasskeyIFrameAttributes).toBe(false);
+    });
+
+    test('should not pass usePasskeyIFrameAttributes to DoChallenge3DS2 when not set', () => {
+        prepareProps();
+
+        renderPrepareChallenge(propsMaster);
+
+        expect(mockDoChallengeProps.usePasskeyIFrameAttributes).toBeUndefined();
     });
 });

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/PrepareChallenge3DS2.tsx
@@ -350,6 +350,7 @@ class PrepareChallenge3DS2 extends Component<PrepareChallenge3DS2Props, PrepareC
                     {...challengeData}
                     onActionHandled={this.props.onActionHandled}
                     onFormSubmit={this.onFormSubmit}
+                    usePasskeyIFrameAttributes={this.props.usePasskeyIFrameAttributes}
                 />
             );
         }

--- a/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
+++ b/packages/lib/src/components/ThreeDS2/components/Challenge/types.ts
@@ -8,6 +8,7 @@ export interface DoChallenge3DS2Props extends ChallengeData {
     onErrorChallenge: (rejectObject: ThreeDS2FlowObject) => void;
     onActionHandled: (rtnObj: ActionHandledReturnObject) => void;
     onFormSubmit: (msg: string) => void;
+    usePasskeyIFrameAttributes?: boolean;
 }
 
 export interface DoChallenge3DS2State {

--- a/packages/lib/src/components/ThreeDS2/constants.ts
+++ b/packages/lib/src/components/ThreeDS2/constants.ts
@@ -42,6 +42,10 @@ export const FAILED_METHOD_STATUS_RESOLVE_OBJECT_TIMEOUT: ThreeDS2FlowObject = {
     errorCode: TIMEOUT
 };
 
+export const PASSKEY_3DS2_IFRAME_ALLOW = 'payment *; publickey-credentials-get *';
+export const PASSKEY_VISA_IFRAME_ALLOW = 'payment *; publickey-credentials-get *; publickey-credentials-create *';
+export const PASSKEY_VISA_IFRAME_SANDBOX = 'allow-forms allow-same-origin allow-scripts allow-pointer-lock allow-popups';
+
 // Re. EMV 3-D Specification: EMVCo_3DS_Spec_210_1017.pdf
 export const CHALLENGE_WINDOW_SIZES = {
     '01': ['250px', '400px'],

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -38,6 +38,12 @@ interface ThreeDS2Configuration extends UIElementProps {
     token?: string;
     type?: string;
     challengeWindowSize?: ChallengeWindowSize;
+    /**
+     * @internal Visa Passkey only. Requires isMDFlow.
+     * When true, adds sandbox and allow attributes to the challenge iframe
+     * for WebAuthn credential creation/retrieval.
+     */
+    usePasskeyIFrameAttributes?: boolean;
 }
 
 export interface ThreeDS2DeviceFingerprintConfiguration extends ThreeDS2Configuration {
@@ -174,6 +180,12 @@ export type ThreeDS2ConfigProps = {
     readonly clientKey: string;
     readonly paymentMethodType: string;
     readonly challengeWindowSize?: ChallengeWindowSize;
+    /**
+     * @internal Visa Passkey only. Requires isMDFlow.
+     * When true, adds sandbox and allow attributes to the challenge iframe
+     * for WebAuthn credential creation/retrieval.
+     */
+    readonly usePasskeyIFrameAttributes?: boolean;
     readonly isMDFlow?: boolean;
     readonly modules?: {
         readonly analytics?: IAnalytics;
@@ -187,4 +199,4 @@ export type ThreeDS2ConfigProps = {
     readonly i18n?: Language;
 };
 
-export type ThreeDS2ActionProps = CardConfiguration & Pick<ThreeDS2ConfigProps, 'isMDFlow' | 'on3DS2RedirectFlowComplete'>;
+export type ThreeDS2ActionProps = CardConfiguration & Pick<ThreeDS2ConfigProps, 'isMDFlow' | 'on3DS2RedirectFlowComplete' | 'usePasskeyIFrameAttributes'>;

--- a/packages/lib/src/components/internal/IFrame/Iframe.tsx
+++ b/packages/lib/src/components/internal/IFrame/Iframe.tsx
@@ -12,6 +12,7 @@ interface IframeProps {
     allow?: string;
     name?: string;
     title?: string;
+    sandbox?: string;
     classNameModifiers?: string[];
     callback?: (contentWindow) => void;
 }
@@ -58,7 +59,7 @@ class Iframe extends Component<Readonly<IframeProps>> {
         }
     }
 
-    render({ name, src, width, height, minWidth, minHeight, allow, title, classNameModifiers }: IframeProps) {
+    render({ name, src, width, height, minWidth, minHeight, allow, title, sandbox, classNameModifiers }: IframeProps) {
         const validClassNameModifiers = classNameModifiers.filter(m => !!m);
 
         return (
@@ -82,6 +83,7 @@ class Iframe extends Component<Readonly<IframeProps>> {
                 referrerpolicy="origin"
                 min-width={minWidth}
                 min-height={minHeight}
+                sandbox={sandbox}
                 /* eslint-enable react/no-unknown-property */
             />
         );

--- a/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
+++ b/packages/lib/src/core/ProcessResponse/PaymentAction/actionTypes.ts
@@ -67,6 +67,7 @@ const actionTypes = {
             clientKey: props.clientKey,
             paymentMethodType: props.paymentMethodType,
             challengeWindowSize: props.challengeWindowSize, // always pass challengeWindowSize in case it's been set directly in the handleAction config object
+            usePasskeyIFrameAttributes: props.usePasskeyIFrameAttributes,
             isMDFlow: props.isMDFlow,
             modules: {
                 analytics: props.modules?.analytics,


### PR DESCRIPTION
## 📋 Pull Request Checklist

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Default allow attribute (all 3DS2 flows):

The iframe now always includes allow="payment *; publickey-credentials-get *". These permissions enable:

payment * — Allows the Payment Request API within the iframe, required for Secure Payment Confirmation (SPC) flows.
publickey-credentials-get * — Allows WebAuthn credential retrieval within the iframe, enabling FIDO-based authentication as defined in EMVCo SB-214v3.
These have no effect unless the ACS actually initiates an SPC or WebAuthn authentication flow.

Additional attributes when usePasskeyIFrameAttributes: true:

publickey-credentials-create * — Additionally allows WebAuthn credential creation (enrollment) within the iframe, for integrations that require passkey registration during the 3DS2 challenge.
sandbox — Restricts the iframe to a defined set of capabilities (allow-forms, allow-same-origin, allow-scripts, allow-pointer-lock, allow-popups).
These are opt-in via configuration for MDFlow to maintain EMVCo compliance for standard 3DS2 flows.

## 🔗 Related GitHub Issue / Internal Ticket number

**Closes**: <!-- #-prefixed issue number or internal ticket -->