### PR TITLE
Fixed: Components crashing when `null` data was passed

### DIFF
--- a/.changeset/hot-papers-fly.md
+++ b/.changeset/hot-papers-fly.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Fixed: Card component crashing when `billingAddress` is `null`
+Fixed: Components crashing when `null` data was passed

--- a/.changeset/hot-papers-fly.md
+++ b/.changeset/hot-papers-fly.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Fixes: Card component crashing on empty billing address object
+Fixed: Card component crashing on empty billing address object

--- a/.changeset/hot-papers-fly.md
+++ b/.changeset/hot-papers-fly.md
@@ -2,4 +2,4 @@
 '@adyen/adyen-web': patch
 ---
 
-Fixed: Card component crashing on empty billing address object
+Fixed: Card component crashing when `billingAddress` is `null`

--- a/.changeset/hot-papers-fly.md
+++ b/.changeset/hot-papers-fly.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixes: Card component crashing on empty billing address object

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -1,7 +1,7 @@
 import { createRef, h } from 'preact';
 import { render, screen, fireEvent, act } from '@testing-library/preact';
 import CardInput from './CardInput';
-import { CardInputDataState, CardInputValidState } from './types';
+import { AddressModeOptions, CardInputDataState, CardInputValidState } from './types';
 import { CoreProvider } from '../../../../core/Context/CoreProvider';
 import { AmountProvider } from '../../../../core/Context/AmountProvider';
 
@@ -53,6 +53,21 @@ describe('CardInput', () => {
     test('Has HolderName element', () => {
         renderCardInput(<CardInput {...cardInputRequiredProps} hasHolderName={true} />);
         expect(screen.getByText('Name on card')).toBeVisible();
+    });
+});
+
+describe('CardInput - partial billing address', () => {
+    test.each([undefined, null])('should render when billingAddress is %s', billingAddress => {
+        expect(() =>
+            renderCardInput(
+                <CardInput
+                    {...cardInputRequiredProps}
+                    billingAddressMode={AddressModeOptions.partial}
+                    billingAddressRequired={true}
+                    data={{ billingAddress }}
+                />
+            )
+        ).not.toThrow();
     });
 });
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -57,17 +57,17 @@ describe('CardInput', () => {
 });
 
 describe('CardInput - partial billing address', () => {
-    test.each([undefined, null])('should render when billingAddress is %s', billingAddress => {
-        expect(() =>
-            renderCardInput(
-                <CardInput
-                    {...cardInputRequiredProps}
-                    billingAddressMode={AddressModeOptions.partial}
-                    billingAddressRequired={true}
-                    data={{ billingAddress }}
-                />
-            )
-        ).not.toThrow();
+    test.each([undefined, null])('should render with an empty postal code field when billingAddress is %s', billingAddress => {
+        renderCardInput(
+            <CardInput
+                {...cardInputRequiredProps}
+                billingAddressMode={AddressModeOptions.partial}
+                billingAddressRequired={true}
+                data={{ billingAddress }}
+            />
+        );
+
+        expect(screen.getByLabelText('Postal code')).toHaveValue('');
     });
 });
 

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.test.tsx
@@ -69,6 +69,21 @@ describe('CardInput - partial billing address', () => {
 
         expect(screen.getByLabelText('Postal code')).toHaveValue('');
     });
+
+    test('should validate the postal code when the initial country is lowercase', () => {
+        renderCardInput(
+            <CardInput
+                {...cardInputRequiredProps}
+                billingAddressMode={AddressModeOptions.partial}
+                billingAddressRequired={true}
+                data={{ billingAddress: { country: 'us' } }}
+            />
+        );
+
+        fireEvent.blur(screen.getByLabelText('Zip code'), { target: { value: '1' } });
+
+        expect(screen.getByText('Invalid format. Expected format: 99999 or 99999-9999')).toBeInTheDocument();
+    });
 });
 
 describe('CardInput - Brands beneath Card Number field', () => {

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -94,11 +94,13 @@ const CardInput = (props: Readonly<CardInputProps>) => {
     const showBillingAddress = props.billingAddressMode !== AddressModeOptions.none && props.billingAddressRequired;
 
     const partialAddressSchema = handlePartialAddressMode(props.billingAddressMode);
+    const initialBillingAddress = props.data?.billingAddress ?? null;
+
     // Keeps the value of the country set initially by the merchant, before the Address Component mutates it
-    const partialAddressCountry = useRef<string>(partialAddressSchema && props.data?.billingAddress?.country);
+    const partialAddressCountry = useRef<string | null>(partialAddressSchema ? (initialBillingAddress?.country ?? null) : null);
 
     const [storePaymentMethod, setStorePaymentMethod] = useState(false);
-    const [billingAddress, setBillingAddress] = useState<AddressData>(showBillingAddress ? (props.data?.billingAddress ?? null) : null);
+    const [billingAddress, setBillingAddress] = useState<AddressData | null>(showBillingAddress ? initialBillingAddress : null);
     const [showSocialSecurityNumber, setShowSocialSecurityNumber] = useState(false);
     const [socialSecurityNumber, setSocialSecurityNumber] = useState('');
     const [installments, setInstallments] = useState<InstallmentsState>({ value: null });

--- a/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
+++ b/packages/lib/src/components/Card/components/CardInput/CardInput.tsx
@@ -97,7 +97,7 @@ const CardInput = (props: Readonly<CardInputProps>) => {
     const initialBillingAddress = props.data?.billingAddress ?? null;
 
     // Keeps the value of the country set initially by the merchant, before the Address Component mutates it
-    const partialAddressCountry = useRef<string | null>(partialAddressSchema ? (initialBillingAddress?.country ?? null) : null);
+    const partialAddressCountry = useRef<string | null>(partialAddressSchema ? (initialBillingAddress?.country?.toUpperCase() ?? null) : null);
 
     const [storePaymentMethod, setStorePaymentMethod] = useState(false);
     const [billingAddress, setBillingAddress] = useState<AddressData | null>(showBillingAddress ? initialBillingAddress : null);

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -64,7 +64,7 @@ export interface CardInputErrorState {
 
 export interface CardInputDataState {
     holderName?: string;
-    billingAddress?: AddressData;
+    billingAddress?: AddressData | null;
     socialSecurityNumber?: string;
     taxNumber?: string;
 }

--- a/packages/lib/src/components/internal/Address/Address.test.tsx
+++ b/packages/lib/src/components/internal/Address/Address.test.tsx
@@ -76,10 +76,15 @@ describe('Address', () => {
         expect(await screen.findByLabelText('Country/Region')).toBeInTheDocument();
     });
 
-    test('should render when data is null', () => {
+    test('should render with empty fields and no preselected country when data is null', async () => {
         const requiredFields = ['street', 'houseNumberOrName', 'postalCode', 'country'];
 
-        expect(() => customRender(<Address data={null} specifications={addressSpecificationsMock} requiredFields={requiredFields} />)).not.toThrow();
+        customRender(<Address data={null} specifications={addressSpecificationsMock} requiredFields={requiredFields} />);
+
+        expect(screen.getByLabelText('Street')).toHaveValue('');
+        expect(screen.getByLabelText('House number')).toHaveValue('');
+        expect(screen.getByLabelText('Postal code')).toHaveValue('');
+        expect(await screen.findByLabelText('Country/Region')).toHaveValue('');
     });
 
     test('should maintain spaces while typing but trim and collapse them on blur', async () => {

--- a/packages/lib/src/components/internal/Address/Address.test.tsx
+++ b/packages/lib/src/components/internal/Address/Address.test.tsx
@@ -76,6 +76,12 @@ describe('Address', () => {
         expect(await screen.findByLabelText('Country/Region')).toBeInTheDocument();
     });
 
+    test('should render when data is null', () => {
+        const requiredFields = ['street', 'houseNumberOrName', 'postalCode', 'country'];
+
+        expect(() => customRender(<Address data={null} specifications={addressSpecificationsMock} requiredFields={requiredFields} />)).not.toThrow();
+    });
+
     test('should maintain spaces while typing but trim and collapse them on blur', async () => {
         const user = userEvent.setup();
         const requiredFields = ['street', 'houseNumberOrName', 'postalCode', 'country'];

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -17,6 +17,8 @@ import { ComponentMethodsRef } from '../UIElement/types';
 import './Address.scss';
 import { getAddressTypeFromLabel } from './utils';
 
+const EMPTY_ADDRESS_DATA: AddressData = {};
+
 export default function Address(props: Readonly<AddressProps>) {
     const { i18n } = useCoreContext();
 
@@ -48,11 +50,12 @@ export default function Address(props: Readonly<AddressProps>) {
 
     // In partial address mode the country field is not rendered, so it is absent from the address schema.
     // The country the merchant configured must still be part of the form data for country dependent rules to be applied.
-    const merchantCountry = (props.data as AddressData)?.country;
+    const addressData = props.data ?? EMPTY_ADDRESS_DATA;
+    const merchantCountry = addressData.country;
     const formSchema = merchantCountry && !requiredFieldsSchema.includes(COUNTRY) ? [...requiredFieldsSchema, COUNTRY] : requiredFieldsSchema;
     const defaultData = useMemo<AddressData>(
-        () => (merchantCountry ? { ...props.data, country: merchantCountry.toUpperCase() } : (props.data)),
-        [props.data, merchantCountry]
+        () => (merchantCountry ? { ...addressData, country: merchantCountry.toUpperCase() } : addressData),
+        [addressData, merchantCountry]
     );
 
     const { data, errors, valid, isValid, handleChangeFor, triggerValidation, setData, mergeData } = useForm<AddressData>({

--- a/packages/lib/src/components/internal/Address/Address.tsx
+++ b/packages/lib/src/components/internal/Address/Address.tsx
@@ -17,7 +17,7 @@ import { ComponentMethodsRef } from '../UIElement/types';
 import './Address.scss';
 import { getAddressTypeFromLabel } from './utils';
 
-const EMPTY_ADDRESS_DATA: AddressData = {};
+const EMPTY_ADDRESS_DATA: Readonly<AddressData> = {};
 
 export default function Address(props: Readonly<AddressProps>) {
     const { i18n } = useCoreContext();

--- a/packages/lib/src/components/internal/Address/types.ts
+++ b/packages/lib/src/components/internal/Address/types.ts
@@ -16,7 +16,7 @@ export interface AddressProps {
     addressType?: AddressType;
     allowedCountries?: string[];
     countryCode?: string;
-    data?: object;
+    data?: AddressData | null;
     label?: string;
     onChange: (newState) => void;
     onAddressLookup?: OnAddressLookupType;

--- a/packages/lib/src/components/internal/Address/validate.ts
+++ b/packages/lib/src/components/internal/Address/validate.ts
@@ -9,7 +9,7 @@ const createPatternByDigits = (digits: number) => {
     };
 };
 
-export const validatePostalCode = (val: string, countryCode: string, validatorRules: ValidatorRules) => {
+export const validatePostalCode = (val: string, countryCode: string | null, validatorRules: ValidatorRules) => {
     if (countryCode) {
         // If there is no value, we display the 'required' error message
         if (isEmpty(val)) return null;
@@ -80,7 +80,7 @@ const postalCodePatterns = {
  *
  * @param country - Country that will be used to validate postal code
  */
-export const getPartialAddressValidationRules = (country: string): ValidatorRules => {
+export const getPartialAddressValidationRules = (country: string | null): ValidatorRules => {
     const validationRules: ValidatorRules = {
         postalCode: {
             modes: ['blur'],

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.test.tsx
@@ -41,6 +41,15 @@ const renderOpenInvoice = (props: Partial<OpenInvoiceProps> = {}) => {
 };
 
 describe('OpenInvoice', () => {
+    test('should render empty personal details fields when personalDetails is null', () => {
+        renderOpenInvoice({
+            data: { personalDetails: null, billingAddress: {}, deliveryAddress: {} }
+        });
+
+        expect(screen.getByLabelText(/first name/i)).toHaveValue('');
+        expect(screen.getByLabelText(/last name/i)).toHaveValue('');
+    });
+
     test('should not display fieldsets set to hidden', () => {
         renderOpenInvoice({ visibility: { personalDetails: 'hidden' } });
         expect(screen.queryByLabelText(/first name/i)).not.toBeInTheDocument();

--- a/packages/lib/src/components/internal/OpenInvoice/types.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/types.ts
@@ -27,7 +27,7 @@ export interface OpenInvoiceProps extends UIElementProps {
     countryCode?: string;
     data: {
         companyDetails?: CompanyDetailsSchema;
-        personalDetails?: PersonalDetailsSchema;
+        personalDetails?: PersonalDetailsSchema | null;
         billingAddress?: AddressData;
         deliveryAddress?: AddressData;
         bankAccount?: BankDetailsSchema;

--- a/packages/lib/src/components/internal/PersonalDetails/types.ts
+++ b/packages/lib/src/components/internal/PersonalDetails/types.ts
@@ -11,7 +11,7 @@ export interface PersonalDetailsProps {
     namePrefix?: string;
     requiredFields?: string[];
     visibility?: FieldsetVisibility;
-    data: PersonalDetailsSchema;
+    data: PersonalDetailsSchema | null;
     onChange: (newState: object) => void;
     placeholders?: PersonalDetailsPlaceholders;
     readonly?: boolean;

--- a/packages/lib/src/utils/useForm/types.ts
+++ b/packages/lib/src/utils/useForm/types.ts
@@ -23,11 +23,11 @@ export interface Formatter {
 }
 
 export type FormProps = {
-    schema: string[];
-    rules?: ValidatorRules;
+    schema: string[] | null;
+    rules?: ValidatorRules | null;
     formatters?: {
         [key: string]: Formatter | Function;
-    };
+    } | null;
     [key: string]: any;
 };
 

--- a/packages/lib/src/utils/useForm/useForm.test.tsx
+++ b/packages/lib/src/utils/useForm/useForm.test.tsx
@@ -60,6 +60,28 @@ describe('useForm', () => {
             expect(result.current.data.lastName).toEqual(null);
         });
 
+        test('should initialize fields when defaultData is null', () => {
+            const { result } = renderHook(() => useForm({ schema: defaultSchema, defaultData: null }), { wrapper });
+
+            expect(result.current.schema).toEqual(defaultSchema);
+            expect(result.current.data).toEqual({ firstName: null, lastName: null });
+            expect(result.current.valid).toEqual({ firstName: false, lastName: false });
+            expect(result.current.errors).toEqual({ firstName: null, lastName: null });
+        });
+
+        test('should normalize null configuration values', () => {
+            const { result } = renderHook(() => useForm({ schema: null, rules: null, formatters: null, defaultData: null, fieldProblems: null }), {
+                wrapper
+            });
+
+            expect(result.current.schema).toEqual([]);
+            expect(result.current.data).toEqual({});
+            expect(result.current.valid).toEqual({});
+            expect(result.current.errors).toEqual({});
+            expect(result.current.fieldProblems).toEqual({});
+            expect(result.current.isValid).toBe(true);
+        });
+
         it('should set default data after changing the schema', () => {
             const { result } = renderHook(() => useForm({ schema: defaultSchema, defaultData }), { wrapper });
 

--- a/packages/lib/src/utils/useForm/useForm.test.tsx
+++ b/packages/lib/src/utils/useForm/useForm.test.tsx
@@ -13,6 +13,11 @@ const wrapper = ({ children }: { children: any }) => (
     </CoreProvider>
 );
 
+function getHookResult<T>(result: { current: T | undefined }): T {
+    if (!result.current) throw new Error('Hook result is undefined');
+    return result.current;
+}
+
 describe('useForm', () => {
     const defaultSchema = ['firstName', 'lastName'];
     type defaultSchemaType = {
@@ -61,25 +66,31 @@ describe('useForm', () => {
         });
 
         test('should initialize fields when defaultData is null', () => {
-            const { result } = renderHook(() => useForm({ schema: defaultSchema, defaultData: null }), { wrapper });
+            const { result } = renderHook<unknown, Form<defaultSchemaType>>(
+                () => useForm<defaultSchemaType>({ schema: defaultSchema, defaultData: null }),
+                { wrapper }
+            );
+            const form = getHookResult(result);
 
-            expect(result.current.schema).toEqual(defaultSchema);
-            expect(result.current.data).toEqual({ firstName: null, lastName: null });
-            expect(result.current.valid).toEqual({ firstName: false, lastName: false });
-            expect(result.current.errors).toEqual({ firstName: null, lastName: null });
+            expect(form.schema).toEqual(defaultSchema);
+            expect(form.data).toEqual({ firstName: null, lastName: null });
+            expect(form.valid).toEqual({ firstName: false, lastName: false });
+            expect(form.errors).toEqual({ firstName: null, lastName: null });
         });
 
         test('should normalize null configuration values', () => {
-            const { result } = renderHook(() => useForm({ schema: null, rules: null, formatters: null, defaultData: null, fieldProblems: null }), {
-                wrapper
-            });
+            const { result } = renderHook<unknown, Form<Record<string, unknown>>>(
+                () => useForm<Record<string, unknown>>({ schema: null, rules: null, formatters: null, defaultData: null, fieldProblems: null }),
+                { wrapper }
+            );
+            const form = getHookResult(result);
 
-            expect(result.current.schema).toEqual([]);
-            expect(result.current.data).toEqual({});
-            expect(result.current.valid).toEqual({});
-            expect(result.current.errors).toEqual({});
-            expect(result.current.fieldProblems).toEqual({});
-            expect(result.current.isValid).toBe(true);
+            expect(form.schema).toEqual([]);
+            expect(form.data).toEqual({});
+            expect(form.valid).toEqual({});
+            expect(form.errors).toEqual({});
+            expect(form.fieldProblems).toEqual({});
+            expect(form.isValid).toBe(true);
         });
 
         it('should set default data after changing the schema', () => {

--- a/packages/lib/src/utils/useForm/useForm.ts
+++ b/packages/lib/src/utils/useForm/useForm.ts
@@ -9,7 +9,19 @@ function isFormatterObject(formatter: Formatter | Function): formatter is Format
 }
 
 function useForm<FormSchema>(props: FormProps): Form<FormSchema> {
-    const { rules = {}, formatters = {}, defaultData = {}, fieldProblems = {}, schema = [] } = props;
+    // Normalize null values to empty objects/arrays to avoid type errors
+    const {
+        rules: providedRules,
+        formatters: providedFormatters,
+        defaultData: providedDefaultData,
+        fieldProblems: providedFieldProblems,
+        schema: providedSchema
+    } = props;
+    const rules = providedRules ?? {};
+    const formatters = providedFormatters ?? {};
+    const defaultData = providedDefaultData ?? {};
+    const fieldProblems = providedFieldProblems ?? {};
+    const schema = providedSchema ?? [];
 
     const { i18n } = useCoreContext();
 
@@ -28,7 +40,7 @@ function useForm<FormSchema>(props: FormProps): Form<FormSchema> {
 
     const [state, dispatch] = useReducer<FormState<FormSchema>, any, any>(
         getReducer(processField),
-        { defaultData, schema: schema ?? [], processField, fieldProblems },
+        { defaultData, schema, processField, fieldProblems },
         init
     );
     const isValid = useMemo(() => state.schema.reduce((acc, val) => acc && state.valid[val], true), [state.schema, state.valid]);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [x] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [x] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary
 
- Prevent `Address` from crashing when it receives a null billing address.
- Preserve nullable billing address handling in `CardInput`.
- Make `useForm` resilient to null configuration values, including `defaultData`, `schema`, `rules`, `formatters`, and `fieldProblems`.

---
## 🧪 Tested scenarios
 
- Rendering `Address` with `data={null}`.
- Rendering `CardInput` with missing and null billing addresses in partial address mode.
- Rendering `OpenInvoice` with `personalDetails: null`.
- Initializing `useForm` with null configuration values.
- Validating partial billing addresses with lowercase country codes.
- Focused unit tests, ESLint, regular TypeScript checks, and strict TypeScript regression checks pass.

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

