### PR TITLE
feat(storybook): add SR panel debugger overlay

### DIFF
--- a/packages/lib/.storybook/preview.tsx
+++ b/packages/lib/.storybook/preview.tsx
@@ -1,5 +1,7 @@
 import './main.css';
+import { h, Fragment } from 'preact';
 import { Preview } from '@storybook/preact-vite';
+import { SRPanelDebugger } from '../storybook/components/SRPanelDebugger';
 import { DEFAULT_COUNTRY_CODE, DEFAULT_SHOPPER_LOCALE, DEFAULT_AMOUNT_VALUE, SHOPPER_LOCALES } from '../storybook/config/commonConfig';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { COUNTRY_CODES } from '../storybook/constants/countries';
@@ -20,6 +22,31 @@ if (!disableMsw) {
 }
 
 const preview: Preview = {
+    globalTypes: {
+        srPanelDebugger: {
+            description: 'Log every screen reader panel mutation and setMessages call on screen',
+            toolbar: {
+                title: 'SR panel debugger',
+                icon: 'accessibility',
+                items: [
+                    { value: false, title: 'SR debugger: off' },
+                    { value: true, title: 'SR debugger: on' }
+                ],
+                dynamicTitle: true
+            }
+        }
+    },
+    initialGlobals: {
+        srPanelDebugger: false
+    },
+    decorators: [
+        (Story, context) => (
+            <Fragment>
+                <Story />
+                {context.globals.srPanelDebugger && <SRPanelDebugger />}
+            </Fragment>
+        )
+    ],
     argTypes: {
         useSessions: {
             control: 'boolean'

--- a/packages/lib/storybook/components/SRPanelDebugger.tsx
+++ b/packages/lib/storybook/components/SRPanelDebugger.tsx
@@ -70,7 +70,7 @@ export const SRPanelDebugger = () => {
                         const later = mutations
                             .slice(i + 1)
                             .find(n => n.type === 'attributes' && n.attributeName === m.attributeName && n.target === m.target);
-                        const next = later ? later.oldValue : (m.target as HTMLElement).getAttribute(m.attributeName);
+                        const next = later ? later.oldValue : (m.target as HTMLElement).getAttribute(m.attributeName ?? '');
                         const changed = m.oldValue !== next;
                         push('ATTR', `${m.attributeName}: "${m.oldValue}" -> "${next}"${changed ? '' : '  (no-op write)'}`, changed);
                     } else if (m.type === 'characterData') {

--- a/packages/lib/storybook/components/SRPanelDebugger.tsx
+++ b/packages/lib/storybook/components/SRPanelDebugger.tsx
@@ -1,0 +1,151 @@
+import { h } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+/**
+ * Debugging aid for the screen reader panel. Toggle it from the Storybook toolbar
+ * ("SR panel debugger"); it is mounted globally by .storybook/preview.tsx.
+ *
+ * Watches the SR panel live region and prints every DOM mutation on screen, so announcements
+ * heard in a screen reader can be correlated against what actually changed in the DOM. A screen
+ * reader only announces an actual change to the region, which makes "nothing was announced" and
+ * "nothing changed" impossible to tell apart without a log like this.
+ *
+ * What to look for:
+ *  - ATTR rows in red  = the attribute VALUE really changed. Changing a live region's own
+ *                        attributes can make an AT re-register it and drop a queued announcement.
+ *  - ATTR rows in grey = setAttribute called with an identical value (no-op write).
+ *  - CHILD rows        = message text added/removed. No CHILD row means nothing was announced,
+ *                        because aria-live only fires on an actual content change.
+ *  - A message that is added and removed within a few milliseconds was very likely never read.
+ */
+
+const SR_PANEL_SELECTOR = '[class^="adyen-checkout-sr-panel"]';
+
+interface LogEntry {
+    id: number;
+    t: string;
+    kind: 'ATTR' | 'CHILD' | 'TEXT' | 'INFO';
+    text: string;
+    changed: boolean;
+}
+
+const COLORS: Record<LogEntry['kind'], string> = {
+    ATTR: '#d32f2f',
+    CHILD: '#2e7d32',
+    TEXT: '#1565c0',
+    INFO: '#777'
+};
+
+export const SRPanelDebugger = () => {
+    const [entries, setEntries] = useState<LogEntry[]>([]);
+    const idRef = useRef(0);
+    const listRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        let observer: MutationObserver;
+        let cancelled = false;
+        const start = performance.now();
+
+        const push = (kind: LogEntry['kind'], text: string, changed = false) => {
+            setEntries(prev =>
+                [...prev, { id: idRef.current++, t: ((performance.now() - start) / 1000).toFixed(2) + 's', kind, text, changed }].slice(-200)
+            );
+        };
+
+        // The SR panel is created by Core, so it may not exist on first paint.
+        const waitForPanel = () => {
+            if (cancelled) return;
+            const panel = document.querySelector(SR_PANEL_SELECTOR);
+            if (!panel) return void requestAnimationFrame(waitForPanel);
+
+            push('INFO', `observing ${panel.className} [aria-relevant="${panel.getAttribute('aria-relevant')}"]`);
+
+            observer = new MutationObserver(mutations => {
+                mutations.forEach((m, i) => {
+                    if (m.type === 'attributes') {
+                        // MutationObserver only reports oldValue, and records arrive batched, so
+                        // reading getAttribute() here returns the value AFTER the whole batch.
+                        // The true new value is the oldValue of the next record for this same
+                        // attribute/target, falling back to the current value for the last one.
+                        const later = mutations
+                            .slice(i + 1)
+                            .find(n => n.type === 'attributes' && n.attributeName === m.attributeName && n.target === m.target);
+                        const next = later ? later.oldValue : (m.target as HTMLElement).getAttribute(m.attributeName);
+                        const changed = m.oldValue !== next;
+                        push('ATTR', `${m.attributeName}: "${m.oldValue}" -> "${next}"${changed ? '' : '  (no-op write)'}`, changed);
+                    } else if (m.type === 'characterData') {
+                        push('TEXT', `"${m.oldValue}" -> "${m.target.textContent}"`, true);
+                    } else {
+                        m.removedNodes.forEach(n => push('CHILD', `- "${n.textContent}"`));
+                        m.addedNodes.forEach(n => push('CHILD', `+ "${n.textContent}"`));
+                    }
+                });
+            });
+
+            observer.observe(panel, {
+                attributes: true,
+                attributeOldValue: true,
+                childList: true,
+                subtree: true,
+                characterData: true,
+                characterDataOldValue: true
+            });
+        };
+
+        waitForPanel();
+
+        return () => {
+            cancelled = true;
+            observer?.disconnect();
+        };
+    }, []);
+
+    useEffect(() => {
+        if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
+    }, [entries]);
+
+    return (
+        <div
+            style={{
+                position: 'fixed',
+                right: '12px',
+                bottom: '12px',
+                width: '440px',
+                maxHeight: '45vh',
+                display: 'flex',
+                flexDirection: 'column',
+                background: '#fff',
+                border: '2px solid #333',
+                borderRadius: '6px',
+                fontFamily: 'monospace',
+                fontSize: '11px',
+                zIndex: 99999,
+                boxShadow: '0 4px 16px rgba(0,0,0,.25)'
+            }}
+        >
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '6px 8px',
+                    borderBottom: '1px solid #ddd',
+                    fontWeight: 'bold'
+                }}
+            >
+                <span>SR panel mutations ({entries.length})</span>
+                <button type="button" onClick={() => setEntries([])} style={{ fontFamily: 'monospace', fontSize: '11px', cursor: 'pointer' }}>
+                    clear
+                </button>
+            </div>
+            <div ref={listRef} style={{ overflowY: 'auto', padding: '4px 8px' }}>
+                {entries.length === 0 && <div style={{ color: '#999' }}>no mutations yet…</div>}
+                {entries.map(e => (
+                    <div key={e.id} style={{ color: COLORS[e.kind], fontWeight: e.changed ? 'bold' : 'normal', whiteSpace: 'pre-wrap' }}>
+                        {e.t} {e.kind} {e.text}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Dev-only Storybook overlay used to diagnose #4098. It attaches a `MutationObserver` to the SR live region (`[class^="adyen-checkout-sr-panel"]`) and prints every DOM mutation (attribute writes, text/child changes) with timestamps and colour coding, so announcements heard in a screen reader can be correlated against what actually changed in the DOM.

- New `SRPanelDebugger.tsx` component, mounted via a `preview.tsx` decorator.
- Registered as a `globalTypes` toolbar toggle ("SR panel debugger"), **off by default**.
- Storybook-only tooling — nothing ships in the published package, so no changeset is needed.

Note: the overlay only logs DOM mutations. Attributing each `setMessages` call to its caller was useful while debugging #4098, but that requires a dev-only event dispatched from `SRPanel.setMessages`, which was deliberately kept out of core for this PR. Could be added later if wanted.

---

## 🧪 Tested scenarios

- `npx tsc --noEmit -p tsconfig.json` — passes.
- `npx eslint storybook .storybook src` — passes.
- `yarn start:storybook` boots cleanly, "SR panel debugger" toolbar item appears, toggling it mounts/unmounts the overlay, and it logs live-region mutations correctly.

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**: 

---
