### PR TITLE
Update snapshot release workflow to be triggered from a PR

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,28 +1,61 @@
-# Manually triggered by a maintainer to build a one off preview of a feature
-# branch, e.g. 6.43.0-alpha+{commit-hash}.
+# Triggered by adding the `release-snapshot` label to an approved pull request to
+# build a one off preview of the PR's source branch, e.g.
+# 6.43.0-alpha.{commit-hash}. The label is removed again when the run finishes,
+# whether it succeeded or failed, so it can be added again for a new build.
 #
 # It does NOT commit any version or changelog change back to the branch. It
 # creates a prerelease GitHub Release with the UMD build attached and a git tag
-# for the snapshot version. npm is NOT published here; trigger
-# .github/workflows/npm-publish.yml manually on the tag it creates.
+# for the snapshot version, then comments the release link on the PR. npm is NOT
+# published here; trigger .github/workflows/npm-publish.yml manually on the tag
+# it creates.
 #
 # Requires at least one changeset on the branch so the snapshot can be computed.
 name: Release | Snapshot
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+# One snapshot build per PR at a time. Runs are queued rather than cancelled: a
+# cancelled run can leave a pushed tag with no GitHub Release behind it. Builds
+# for different PRs are independent and may run in parallel.
+concurrency:
+  group: release-snapshot-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   release-snapshot:
-    if: github.repository == 'adyen/adyen-web'
+    if: github.repository == 'adyen/adyen-web' && github.event.label.name == 'release-snapshot'
     name: Build Snapshot
     runs-on: ubuntu-latest
     permissions:
       contents: write # create git tag and GitHub Release
+      pull-requests: write # comment the release link on the PR
     steps:
+      # An alpha build is published publicly, so require a human approval on the
+      # PR first. A review that was later dismissed or superseded by a newer
+      # review from the same person does not count.
+      - name: Require an approved pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          APPROVALS=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/reviews" --paginate \
+            --jq '[.[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")]
+                  | group_by(.user.login) | map(last)
+                  | map(select(.state == "APPROVED")) | length')
+          if [ "$APPROVALS" -eq 0 ]; then
+            echo "::error::PR #${PR_NUMBER} has no active approval. Get the PR approved before adding the release-snapshot label."
+            exit 1
+          fi
+
+      # Check out the PR's source branch head, not the merge commit, so the
+      # snapshot reflects exactly what is on the branch.
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v7
@@ -39,7 +72,8 @@ jobs:
       - name: Version snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn changeset version --snapshot alpha.${GITHUB_SHA::7}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: yarn changeset version --snapshot alpha.${HEAD_SHA::7}
 
       - name: Read SDK version
         id: sdk-version
@@ -73,11 +107,29 @@ jobs:
           git push origin "$TAG"
 
       - name: Create GitHub Prerelease
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "v${{ steps.sdk-version.outputs.version }}" \
             --title "${{ steps.sdk-version.outputs.version }}" \
-            --notes "Snapshot preview build from feature branch [${{ github.ref_name }}](${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }})." \
+            --notes "Snapshot preview build from pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})." \
             --prerelease \
             "/tmp/adyen-web-sdk-umd-and-translations-${{ steps.sdk-version.outputs.version }}.zip"
+          echo "url=${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.sdk-version.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment release link on the pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "Alpha release [\`${{ steps.sdk-version.outputs.version }}\`](${{ steps.release.outputs.url }}) is ready."
+
+      # Always drop the label, whether the run succeeded or failed, so the label
+      # can be added again to trigger another build.
+      - name: Remove the release-snapshot label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label release-snapshot

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -71,10 +71,10 @@ For a new major version on a `next-v*` branch with changeset pre mode enabled. S
 
 For a one off alpha preview build of a pull request. Does not change the branch.
 
-The only trigger is the **`release-alpha` label** on a pull request. Adding the label starts a build from the PR's source branch head (not the merge commit); the workflow cannot be started manually. The label is **removed automatically when the run finishes**, whether it succeeded or failed, so adding it again is all that is needed for another build.
+The only trigger is the **`release-snapshot` label** on a pull request. Adding the label starts a build from the PR's source branch head (not the merge commit); the workflow cannot be started manually. The label is **removed automatically when the run finishes**, whether it succeeded or failed, so adding it again is all that is needed for another build.
 
 ```text
-  Maintainer adds the `release-alpha` label to a PR
+  Maintainer adds the `release-snapshot` label to a PR
        │
        ▼
 ┌─────────────────────────────────────┐
@@ -113,4 +113,4 @@ Requirements and caveats:
 | `check-release-build.yml` | `.github/workflows` | Push to `main` or `next-v*` | Checks commit message for `[ci] release main` or `[ci] release next-v{version}` and triggers `gh-release.yml` |
 | `gh-release.yml` | `.github/workflows` | `workflow_dispatch` / `workflow_call` | Builds UMD + translations, parses CHANGELOG, creates a git tag and GitHub Release (`--latest` or `--prerelease`) with the UMD bundle attached |
 | `npm-publish.yml` | `.github/workflows` | `workflow_dispatch` (run from the release tag) | Builds and publishes the package to npm via OIDC |
-| `release-snapshot.yml` | `.github/workflows` | `release-alpha` label added to an approved PR | Builds a snapshot (`6.43.0-alpha.{commit-hash}`) from the PR's source branch, tags it, creates a prerelease GitHub Release with the UMD build linking the PR, comments the release link on the PR, and removes the label again. The branch is not changed |
+| `release-snapshot.yml` | `.github/workflows` | `release-snapshot` label added to an approved PR | Builds a snapshot (`6.43.0-alpha.{commit-hash}`) from the PR's source branch, tags it, creates a prerelease GitHub Release with the UMD build linking the PR, comments the release link on the PR, and removes the label again. The branch is not changed |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,7 +6,7 @@ The release process creates a **GitHub Release** (with the UMD build attached) a
 
 - **Main branch** releases for stable versions.
 - **Next version branch** (`next-v*`) for `alpha` / `beta` / `rc` builds of a new major version.
-- **Feature branch** point (snapshot) builds for previewing a single feature.
+- **Pull request** point (snapshot) builds for previewing a single feature.
 
 Every flow ends the same way: a GitHub Release is created, and npm publishing is a separate step run from the tag.
 
@@ -67,28 +67,39 @@ For a new major version on a `next-v*` branch with changeset pre mode enabled. S
 
 ---
 
-## Snapshot release flow (`snapshot-release.yml`)
+## Snapshot release flow (`release-snapshot.yml`)
 
-For a one off preview build of a feature branch. Does not change the branch.
+For a one off alpha preview build of a pull request. Does not change the branch.
+
+The only trigger is the **`release-alpha` label** on a pull request. Adding the label starts a build from the PR's source branch head (not the merge commit); the workflow cannot be started manually. The label is **removed automatically when the run finishes**, whether it succeeded or failed, so adding it again is all that is needed for another build.
 
 ```text
-  Maintainer runs snapshot-release.yml
-  (workflow_dispatch on the feature branch)
+  Maintainer adds the `release-alpha` label to a PR
        │
        ▼
-┌────────────────────────────────────┐
+┌─────────────────────────────────────┐
+│  - Fail unless the PR is approved   │
+│  - Checkout PR head (source branch) │
 │  - changeset version --snapshot     │
-│    (e.g. 6.43.0-alpha+{commit-hash})│
+│    (e.g. 6.43.0-alpha.{commit-hash})│
 │  - Build UMD + translations         │
 │  - Tag the snapshot version         │
 │    (branch is NOT updated)          │
 │  - Create GH Release (--prerelease) │
-│    with UMD zip                     │
-└────────────────────────────────────┘
+│    with UMD zip, notes link the PR  │
+│  - Comment the release link on PR   │
+│  - Remove the label (always)        │
+└─────────────────────────────────────┘
 
   ── Manual npm publish ──
   Maintainer runs npm-publish.yml from the snapshot tag
 ```
+
+Requirements and caveats:
+
+- The PR needs **an active approving review**. The workflow fails immediately if there is none, or if the approver's latest review is "changes requested" or their approval was dismissed.
+- The branch needs **at least one changeset**, otherwise the snapshot version cannot be computed.
+- Only works for PRs from branches in this repository. Fork PRs get a read-only token, so tagging and commenting fail.
 
 ---
 > **Important:** When triggering `npm-publish.yml`, the maintainer **must select the git tag of the version they intend to publish** in the "Use workflow from" dropdown. Running it against a branch can publish a different version than the one the release created. Tags are created automatically by each release workflow.
@@ -102,4 +113,4 @@ For a one off preview build of a feature branch. Does not change the branch.
 | `check-release-build.yml` | `.github/workflows` | Push to `main` or `next-v*` | Checks commit message for `[ci] release main` or `[ci] release next-v{version}` and triggers `gh-release.yml` |
 | `gh-release.yml` | `.github/workflows` | `workflow_dispatch` / `workflow_call` | Builds UMD + translations, parses CHANGELOG, creates a git tag and GitHub Release (`--latest` or `--prerelease`) with the UMD bundle attached |
 | `npm-publish.yml` | `.github/workflows` | `workflow_dispatch` (run from the release tag) | Builds and publishes the package to npm via OIDC |
-| `snapshot-release.yml` | `.github/workflows` | `workflow_dispatch` | Builds a snapshot (`6.43.0-alpha+{commit-hash}`), tags it, and creates a prerelease GitHub Release with the UMD build. The branch is not changed |
+| `release-snapshot.yml` | `.github/workflows` | `release-alpha` label added to an approved PR | Builds a snapshot (`6.43.0-alpha.{commit-hash}`) from the PR's source branch, tags it, creates a prerelease GitHub Release with the UMD build linking the PR, comments the release link on the PR, and removes the label again. The branch is not changed |


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary


Snapshot (alpha) preview builds are now requested from the pull request itself instead of being manually dispatched on a branch. Adding the `release-snapshot` label to an approved PR builds a preview from that PR's source branch and reports the result back on the PR, so the request, the review, and the resulting artifact all live in one place.

## Key changes

- Replaced the `workflow_dispatch` trigger with a `release-snapshot` label on a pull request; the label is removed again once the run finishes (success or failure) so it can simply be re-added for a new build.
- The build checks out the PR's head commit rather than the merge commit, and that commit's SHA is used for the snapshot version suffix, so the artifact matches exactly what is on the branch.
- Added a gate that fails the run unless the PR has an active approving review.
- The prerelease notes now link back to the pull request instead of the branch, and a comment with the release link is posted on the PR.
- Added a per-PR concurrency group so one PR cannot build two snapshots at once, queueing rather than cancelling to avoid leaving a pushed tag without a release.
- Updated the release process docs to describe the label-triggered flow, its requirements, and the corrected version format.

## Notes

- Only works for pull requests from branches in this repository; fork PRs receive a read-only token and cannot tag or comment.
- The branch still needs at least one changeset for the snapshot version to be computed, and npm publishing remains a separate manual step run from the created tag.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

