### PR TITLE
fix: guard ApplePaySession.abort() in onvalidatemerchant so onError is always called

### DIFF
--- a/.changeset/applepay-guard-session-abort.md
+++ b/.changeset/applepay-guard-session-abort.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed an issue where `ApplePaySession.abort()` throwing `InvalidAccessError` in the `onvalidatemerchant` catch handler (when Safari has already terminated the session, e.g. after the merchant validation deadline) prevented `onError` from being called, leaving the integration without any error callback.

--- a/packages/lib/src/components/ApplePay/services/ApplePayService.ts
+++ b/packages/lib/src/components/ApplePay/services/ApplePayService.ts
@@ -85,7 +85,12 @@ class ApplePayService {
             })
             .catch(error => {
                 console.error(error);
-                this.session.abort();
+                try {
+                    this.session.abort();
+                } catch (abortError) {
+                    // Safari throws InvalidAccessError if the session is no longer active (e.g. merchant
+                    // validation exceeded its deadline) - onError must still be called
+                }
                 this.options.onError(error);
             });
     }


### PR DESCRIPTION
## Summary

`ApplePayService.onvalidatemerchant`'s catch handler calls `this.session.abort()` before `this.options.onError(error)`:

```ts
.catch(error => {
    console.error(error);
    this.session.abort();
    this.options.onError(error);
});
```

Per [Apple's documentation](https://developer.apple.com/documentation/applepayontheweb/applepaysession/abort()), `ApplePaySession.abort()` throws `InvalidAccessError` when the session is no longer active. That is exactly the state the session is in when this catch handler runs in several real-world cases:

- merchant validation exceeded Safari's ~30s deadline (slow or failed `onValidateMerchant` implementation),
- the user closed the payment sheet while validation was in flight.

When `abort()` throws, the catch handler dies mid-way and **`onError` is never called**. The merchant integration gets no callback at all — the payment UI silently dies with no way to show an error or offer a retry. The throw itself surfaces only as an unhandled promise rejection (`InvalidAccessError: The object does not support the operation or argument.` with `[native code] abort` on top of the stack).

We (Vilgain) traced multiple customer-reported "dead payment page" incidents — which led to duplicate orders — to this exact mechanism in production, and currently work around it with a patch-package patch of this file.

## Fix

Wrap the `abort()` call in try/catch so `onError` is always reached. Aborting an already-terminated session has nothing left to abort, so swallowing the `InvalidAccessError` is safe.

## Tested

Verified against v6.32.0 in production traffic (patched via patch-package): the previously-dead flow now invokes `onError`, letting the integration render its error/retry UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
