### PR TITLE
Fix: remove implicit and explicit any from BaseElement and UIElement

### DIFF
--- a/.changeset/thick-books-stand.md
+++ b/.changeset/thick-books-stand.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Internal TS explicit and implicit anys of BaseElement and UIElement

--- a/packages/lib/eslint-rules/strict-null-checks.js
+++ b/packages/lib/eslint-rules/strict-null-checks.js
@@ -199,7 +199,6 @@ const STRICT_NULL_CHECKS_BACKLOG = [
     'src/components/GooglePay/requests.ts',
 
     // ── Ticket 9: Amazon Pay, PayPal and Cash App Pay (79 errors) ──
-    'src/components/AmazonPay/AmazonPay.tsx',
     'src/components/AmazonPay/components/AmazonPayButton.tsx',
     'src/components/AmazonPay/components/AmazonPayComponent.tsx',
     'src/components/AmazonPay/components/OrderButton.tsx',
@@ -244,14 +243,12 @@ const STRICT_NULL_CHECKS_BACKLOG = [
     'src/components/ANCV/ANCV.tsx',
     'src/components/ANCV/components/ANCVInput.tsx',
     // src/components/BacsDD (5 errors)
-    'src/components/BacsDD/components/BacsInput.tsx',
     // src/components/BankTransfer (6 errors)
     'src/components/BankTransfer/BankTransfer.tsx',
     'src/components/BankTransfer/components/BankTransferInput/BankTransferInput.tsx',
     'src/components/BankTransfer/components/BankTransferResult/BankTransferResult.tsx',
     // src/components/Blik (9 errors)
     'src/components/Blik/Blik.tsx',
-    'src/components/Blik/components/BlikInput.tsx',
     // src/components/Boleto (3 errors)
     'src/components/Boleto/components/BoletoInput/BoletoInput.tsx',
     // src/components/Doku (4 errors)

--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -155,13 +155,11 @@ const config = defineConfig(
 
             // ── Internal Components ──
             'src/components/internal/Address/**',
-            'src/components/internal/BaseElement/**',
             'src/components/internal/ClickToPay/**',
             'src/components/internal/FormFields/**',
             'src/components/internal/IbanInput/**',
             'src/components/internal/IssuerList/**',
             'src/components/internal/OpenInvoice/**',
-            'src/components/internal/UIElement/**',
 
             // ── Utils ──
             'src/utils/useForm/**',

--- a/packages/lib/src/components/Ach/Ach.tsx
+++ b/packages/lib/src/components/Ach/Ach.tsx
@@ -63,9 +63,7 @@ export class AchElement extends UIElement<AchConfiguration> {
                 name={this.displayName}
                 payButton={this.payButton}
                 onSubmit={this.submit}
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
+                setComponentRef={this.setComponentRef}
             />
         ) : (
             <AchComponent

--- a/packages/lib/src/components/AmazonPay/AmazonPay.test.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.test.tsx
@@ -52,7 +52,7 @@ describe('AmazonPay', () => {
             const amazonPay = getElement(props);
             expect(amazonPay.props.environment).toBe('TEST');
             expect(amazonPay.props.locale).toBe('en_US');
-            expect(amazonPay.props.configuration.region).toBe('EU');
+            expect(amazonPay.props.configuration?.region).toBe('EU');
         });
 
         test('sets checkoutMode to ProcessOrder when isDropin is true', () => {
@@ -129,11 +129,11 @@ describe('AmazonPay', () => {
             expect(mockSubmitFn).toHaveBeenCalled();
         });
 
-        test('falls back to makePaymentsCall when getSubmitFunction returns null', () => {
+        test('falls back to makePaymentsCall when getSubmitFunction returns nothing', () => {
             const amazonPay = getElement();
             // @ts-ignore setting componentRef for testing
             amazonPay.componentRef = {
-                getSubmitFunction: () => null
+                getSubmitFunction: jest.fn()
             };
             // @ts-ignore accessing protected method for testing
             const makePaymentsCallSpy = jest.spyOn(amazonPay, 'makePaymentsCall').mockResolvedValue({ resultCode: 'Authorised' });

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import UIElement from '../internal/UIElement/UIElement';
 import collectBrowserInfo from '../../utils/browserInfo';
 import AmazonPayComponent from './components/AmazonPayComponent';
-import { AmazonPayElementData, AmazonPayConfiguration, CheckoutDetailsRequest } from './types';
+import { AmazonPayElementData, AmazonPayConfiguration, CheckoutDetailsRequest, AmazonPayComponentRef } from './types';
 import defaultProps from './defaultProps';
 import { getCheckoutDetails } from './services';
 import { TxVariants } from '../tx-variants';
@@ -15,6 +15,8 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
     public static readonly type = TxVariants.amazonpay;
 
     protected static readonly defaultProps = defaultProps;
+
+    protected componentRef: AmazonPayComponentRef | undefined;
 
     formatProps(props) {
         return {
@@ -83,7 +85,7 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
                 window.location.assign(response.declineFlowUrl);
             })
             .catch(error => {
-                if (this.props.onError) this.props.onError(error, this.componentRef);
+                if (this.props.onError) this.props.onError(error, this.componentRef as unknown as UIElement);
             });
     }
 

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -18,12 +18,12 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
 
     protected componentRef: AmazonPayComponentRef | undefined;
 
-    formatProps(props) {
+    formatProps(props: AmazonPayConfiguration): AmazonPayConfiguration {
         return {
             ...props,
             checkoutMode: props.isDropin ? 'ProcessOrder' : props.checkoutMode,
-            environment: props.environment.toUpperCase(),
-            locale: props.locale.replace('-', '_'),
+            environment: props.environment?.toUpperCase(),
+            locale: props.locale?.replace('-', '_'),
             productType: props.isDropin && !props.addressDetails ? 'PayOnly' : props.productType
         };
     }
@@ -61,11 +61,11 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
         const request: CheckoutDetailsRequest = {
             checkoutSessionId: amazonCheckoutSessionId,
             getDeliveryAddress: true,
-            publicKeyId: configuration.publicKeyId,
+            publicKeyId: configuration?.publicKeyId || '',
             region: configuration.region
         };
 
-        return getCheckoutDetails(loadingContext, clientKey, request);
+        return getCheckoutDetails(loadingContext ?? '', clientKey ?? '', request);
     }
 
     public handleDeclineFlow() {
@@ -75,11 +75,11 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
         const request: CheckoutDetailsRequest = {
             checkoutSessionId: amazonCheckoutSessionId,
             getDeclineFlowUrl: true,
-            publicKeyId: configuration.publicKeyId,
+            publicKeyId: configuration.publicKeyId ?? '',
             region: configuration.region
         };
 
-        getCheckoutDetails(loadingContext, clientKey, request)
+        getCheckoutDetails(loadingContext ?? '', clientKey ?? '', request)
             .then((response = {}) => {
                 if (!response?.declineFlowUrl) throw response;
                 window.location.assign(response.declineFlowUrl);
@@ -98,7 +98,7 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
     }
 
     public submit(): void {
-        const amazonComponentSubmitFunction = this.componentRef?.getSubmitFunction() || null;
+        const amazonComponentSubmitFunction = this.componentRef?.getSubmitFunction?.() || null;
         if (amazonComponentSubmitFunction) {
             return amazonComponentSubmitFunction();
         }

--- a/packages/lib/src/components/AmazonPay/AmazonPay.tsx
+++ b/packages/lib/src/components/AmazonPay/AmazonPay.tsx
@@ -85,7 +85,7 @@ export class AmazonPayElement extends UIElement<AmazonPayConfiguration> {
                 window.location.assign(response.declineFlowUrl);
             })
             .catch(error => {
-                if (this.props.onError) this.props.onError(error, this.componentRef as unknown as UIElement);
+                if (this.props.onError) this.props.onError(error, this);
             });
     }
 

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -96,12 +96,14 @@ export interface AmazonPayConfiguration extends UIElementProps {
     isExpress?: boolean;
 }
 
+export type AmazonPayComponentRef = ComponentMethodsRef & { getSubmitFunction?: () => () => void };
+
 export interface AmazonPayComponentProps extends AmazonPayConfiguration {
     showSignOutButton?: boolean;
     amazonCheckoutSessionId?: string;
     showOrderButton?: boolean;
     showChangePaymentDetailsButton?: boolean;
-    setComponentRef: (ref: ComponentMethodsRef & { getSubmitFunction?: () => () => void }) => void;
+    setComponentRef: (ref: AmazonPayComponentRef) => void;
 }
 
 export interface AmazonPayButtonProps {

--- a/packages/lib/src/components/AmazonPay/types.ts
+++ b/packages/lib/src/components/AmazonPay/types.ts
@@ -54,6 +54,7 @@ export interface AmazonPayConfiguration extends UIElementProps {
     buttonColor?: ButtonColor;
     cancelUrl?: string;
     chargePermissionType?: ChargePermissionType;
+    checkoutMode?: string;
     clientKey?: string;
     configuration?: AmazonPayBackendConfiguration;
     currency?: Currency;
@@ -252,7 +253,7 @@ export interface CheckoutDetailsRequest {
     getDeliveryAddress?: boolean;
     getDeclineFlowUrl?: boolean;
     publicKeyId: string;
-    region: Region;
+    region?: Region;
 }
 
 export interface UpdateAmazonCheckoutSessionRequest {

--- a/packages/lib/src/components/BacsDD/BacsDD.test.ts
+++ b/packages/lib/src/components/BacsDD/BacsDD.test.ts
@@ -10,8 +10,8 @@ describe('Bacs Direct Debit', () => {
         const core = setupCoreMock();
 
         const bacs = new BacsDD(core, {
-            modules: { resources: global.resources },
-            i18n: global.i18n,
+            modules: { resources: core.modules.resources },
+            i18n: core.modules.i18n,
             onSubmit: onSubmitMock,
             loadingContext: 'https://checkoutshopper-live.adyen.com/checkoutshopper/'
         });
@@ -71,8 +71,8 @@ describe('Bacs Direct Debit', () => {
         const onSubmitMock = jest.fn();
 
         const bacs = new BacsDD(core, {
-            modules: { resources: global.resources },
-            i18n: global.i18n,
+            modules: { resources: core.modules.resources },
+            i18n: core.modules.i18n,
             onSubmit: onSubmitMock,
             loadingContext: 'https://checkoutshopper-live.adyen.com/checkoutshopper/'
         });
@@ -107,8 +107,8 @@ describe('Bacs Direct Debit', () => {
         const onSubmitMock = jest.fn();
 
         const bacs = new BacsDD(core, {
-            modules: { analytics: global.analytics, resources: global.resources },
-            i18n: global.i18n,
+            modules: { analytics: core.modules.analytics, resources: core.modules.resources },
+            i18n: core.modules.i18n,
             onSubmit: onSubmitMock,
             loadingContext: 'https://checkoutshopper-live.adyen.com/checkoutshopper/'
         });
@@ -190,8 +190,8 @@ describe('Bacs Direct Debit', () => {
         const core = setupCoreMock();
 
         const bacs = new BacsDD(core, {
-            modules: { analytics: global.analytics, resources: global.resources },
-            i18n: global.i18n,
+            modules: { analytics: core.modules.analytics, resources: core.modules.resources },
+            i18n: core.modules.i18n,
             loadingContext: 'https://checkoutshopper-live.adyen.com/checkoutshopper/',
             url: 'https://test.adyen.com/hpp/generateDdi.shtml?pdfFields=%2BjXS7Uo2RhBavkz'
         });

--- a/packages/lib/src/components/BacsDD/BacsDD.tsx
+++ b/packages/lib/src/components/BacsDD/BacsDD.tsx
@@ -34,22 +34,15 @@ class BacsElement extends UIElement<VoucherConfiguration> {
     protected override componentToRender(): h.JSX.Element {
         return this.props.url ? (
             <BacsResult
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
                 icon={this.icon}
                 url={this.props.url}
                 paymentMethodType={this.props.paymentMethodType}
                 onActionHandled={this.onActionHandled}
-                // originalAction={this.props.originalAction}
             />
         ) : (
             <BacsInput
-                // @ts-ignore ref is internal from the Component
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
                 {...this.props}
+                setComponentRef={this.setComponentRef}
                 onChange={this.setState}
                 payButton={this.payButton}
                 onSubmit={this.submit}

--- a/packages/lib/src/components/BacsDD/components/BacsInput.test.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.test.tsx
@@ -3,19 +3,21 @@ import { render, screen, act } from '@testing-library/preact';
 import BacsInput from './BacsInput';
 import { CoreProvider } from '../../../core/Context/CoreProvider';
 import { AmountProvider } from '../../../core/Context/AmountProvider';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
 
 const defaultProps = {
-    onChange: () => {},
-    onSubmit: () => {}
+    onChange: jest.fn(),
+    onSubmit: jest.fn()
 };
+
+const core = setupCoreMock();
 
 const renderBacsInput = (props = {}) => {
     const bacsRef = createRef();
     render(
-        <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
             <AmountProvider amount={{ currency: 'EUR', value: 1234 }} providerRef={createRef()}>
-                {/* @ts-ignore ref is internal from the Component */}
-                <BacsInput ref={bacsRef} {...defaultProps} {...props} />
+                <BacsInput {...defaultProps} {...props} setComponentRef={ref => (bacsRef.current = ref)} />
             </AmountProvider>
         </CoreProvider>
     );

--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -16,7 +16,7 @@ import FormInstruction from '../../internal/FormInstruction';
 import { getErrorMessage } from '../../../utils/getErrorMessage';
 import { PREFIX } from '../../internal/Icon/constants';
 import { useAmount } from '../../../core/Context/AmountProvider';
-import { ComponentMethodsRef } from '../../types';
+import { ComponentMethodsRef, UIElementStatus } from '../../types';
 
 const ENTER_STATE = 'enter-data';
 const CONFIRM_STATE = 'confirm-data';
@@ -36,7 +36,7 @@ function BacsInput(props: Readonly<BacsInputProps>) {
     const [status, setStatus] = useState(ENTER_STATE);
 
     const bacsInputRef = useRef<ComponentMethodsRef>({
-        setStatus: setStatus,
+        setStatus,
         showValidation: () => {
             triggerValidation();
         }
@@ -47,17 +47,17 @@ function BacsInput(props: Readonly<BacsInputProps>) {
     }, [props.setComponentRef]);
 
     const handlePayButton = () => {
-        if (!isValid) return this.showValidation();
+        if (!isValid) return bacsInputRef.current.showValidation();
 
         if (status === ENTER_STATE) {
-            return this.setStatus(CONFIRM_STATE);
+            return bacsInputRef.current.setStatus(CONFIRM_STATE as UIElementStatus);
         } else if (status === CONFIRM_STATE) {
             return props.onSubmit();
         }
     };
 
     const handleEdit = () => {
-        return this.setStatus(ENTER_STATE);
+        return bacsInputRef.current.setStatus(ENTER_STATE as UIElementStatus);
     };
 
     useEffect(() => {

--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import classNames from 'classnames';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Field from '../../internal/FormFields/Field';
@@ -16,6 +16,7 @@ import FormInstruction from '../../internal/FormInstruction';
 import { getErrorMessage } from '../../../utils/getErrorMessage';
 import { PREFIX } from '../../internal/Icon/constants';
 import { useAmount } from '../../../core/Context/AmountProvider';
+import { ComponentMethodsRef } from '../../types';
 
 const ENTER_STATE = 'enter-data';
 const CONFIRM_STATE = 'confirm-data';
@@ -33,8 +34,17 @@ function BacsInput(props: Readonly<BacsInputProps>) {
     });
 
     const [status, setStatus] = useState(ENTER_STATE);
-    this.setStatus = setStatus;
-    this.showValidation = triggerValidation;
+
+    const bacsInputRef = useRef<ComponentMethodsRef>({
+        setStatus: setStatus,
+        showValidation: () => {
+            triggerValidation();
+        }
+    });
+
+    useEffect(() => {
+        props.setComponentRef(bacsInputRef.current);
+    }, [props.setComponentRef]);
 
     const handlePayButton = () => {
         if (!isValid) return this.showValidation();

--- a/packages/lib/src/components/BacsDD/components/BacsInput.tsx
+++ b/packages/lib/src/components/BacsDD/components/BacsInput.tsx
@@ -47,17 +47,17 @@ function BacsInput(props: Readonly<BacsInputProps>) {
     }, [props.setComponentRef]);
 
     const handlePayButton = () => {
-        if (!isValid) return bacsInputRef.current.showValidation();
+        if (!isValid) return bacsInputRef.current?.showValidation?.();
 
         if (status === ENTER_STATE) {
-            return bacsInputRef.current.setStatus(CONFIRM_STATE as UIElementStatus);
+            return bacsInputRef.current?.setStatus?.(CONFIRM_STATE as UIElementStatus);
         } else if (status === CONFIRM_STATE) {
             return props.onSubmit();
         }
     };
 
     const handleEdit = () => {
-        return bacsInputRef.current.setStatus(ENTER_STATE as UIElementStatus);
+        return bacsInputRef.current?.setStatus?.(ENTER_STATE as UIElementStatus);
     };
 
     useEffect(() => {
@@ -106,7 +106,7 @@ function BacsInput(props: Readonly<BacsInputProps>) {
                 <InputText
                     name={'bacs.accountHolderName'}
                     className={'adyen-checkout__bacs-input--holder-name'}
-                    placeholder={props.placeholders.holderName}
+                    placeholder={props.placeholders?.holderName}
                     value={data.holderName}
                     aria-invalid={!valid.holderName}
                     aria-label={i18n.get('bacs.accountHolderName')}
@@ -136,7 +136,7 @@ function BacsInput(props: Readonly<BacsInputProps>) {
                     <InputText
                         value={data.bankAccountNumber}
                         className={'adyen-checkout__bacs-input--bank-account-number'}
-                        placeholder={props.placeholders.bankAccountNumber}
+                        placeholder={props.placeholders?.bankAccountNumber}
                         aria-invalid={!valid.bankAccountNumber}
                         aria-label={i18n.get('bacs.accountNumber')}
                         aria-required={'true'}
@@ -164,7 +164,7 @@ function BacsInput(props: Readonly<BacsInputProps>) {
                     <InputText
                         value={data.bankLocationId}
                         className={'adyen-checkout__bacs-input--bank-location-id'}
-                        placeholder={props.placeholders.bankLocationId}
+                        placeholder={props.placeholders?.bankLocationId}
                         aria-invalid={!valid.bankLocationId}
                         aria-label={i18n.get('bacs.bankLocationId')}
                         aria-required={'true'}
@@ -194,7 +194,7 @@ function BacsInput(props: Readonly<BacsInputProps>) {
                     name={'shopperEmail'}
                     className={'adyen-checkout__bacs-input--shopper-email'}
                     classNameModifiers={['large']}
-                    placeholder={props.placeholders.shopperEmail}
+                    placeholder={props.placeholders?.shopperEmail}
                     spellcheck={false}
                     aria-invalid={!valid.shopperEmail}
                     aria-label={i18n.get('shopperEmail')}
@@ -231,7 +231,7 @@ function BacsInput(props: Readonly<BacsInputProps>) {
             )}
 
             {props.showPayButton &&
-                props.payButton({
+                props.payButton?.({
                     status,
                     label:
                         status === ENTER_STATE

--- a/packages/lib/src/components/BacsDD/components/types.ts
+++ b/packages/lib/src/components/BacsDD/components/types.ts
@@ -1,4 +1,4 @@
-import { UIElementProps } from '../../internal/UIElement/types';
+import { ComponentMethodsRef, UIElementProps } from '../../internal/UIElement/types';
 
 export interface BacsInputData {
     holderName?: string;
@@ -12,7 +12,7 @@ export interface BacsInputProps extends UIElementProps {
     placeholders?: BacsInputData;
     onChange: (state) => void;
     onSubmit: () => void;
-    onEdit: (e, revertToEnter) => void;
+    setComponentRef: (ref: ComponentMethodsRef) => void;
 }
 
 export interface BacsDataState {

--- a/packages/lib/src/components/BankTransfer/BankTransfer.tsx
+++ b/packages/lib/src/components/BankTransfer/BankTransfer.tsx
@@ -80,6 +80,7 @@ export class BankTransferElement extends UIElement<BankTransferConfiguration> {
                 {this.props.showEmailAddress && <BankTransferInput setComponentRef={this.setComponentRef} {...this.props} onChange={this.setState} />}
                 <RedirectButton
                     {...this.props}
+                    setComponentRef={this.setComponentRef}
                     showPayButton={this.props.showPayButton}
                     name={this.displayName}
                     onSubmit={this.submit}

--- a/packages/lib/src/components/Blik/Blik.tsx
+++ b/packages/lib/src/components/Blik/Blik.tsx
@@ -85,17 +85,12 @@ class BlikElement extends UIElement<AwaitConfiguration> {
                 name={this.displayName}
                 payButton={this.payButton}
                 onSubmit={this.submit}
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
+                setComponentRef={this.setComponentRef}
             />
         ) : (
             <BlikInput
-                // @ts-ignore Ref is used by preact component
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
                 {...this.props}
+                setComponentRef={this.setComponentRef}
                 onChange={this.setState}
                 onSubmit={this.submit}
                 payButton={this.payButton}

--- a/packages/lib/src/components/Blik/components/BlikInput.tsx
+++ b/packages/lib/src/components/Blik/components/BlikInput.tsx
@@ -39,7 +39,7 @@ function BlikInput(props: Readonly<BlikInputProps>) {
     });
 
     useEffect(() => {
-        props.onChange({ data: data as unknown as PaymentData, errors, valid, isValid }, this);
+        props.onChange?.({ data: data as unknown as PaymentData, errors, valid, isValid: Boolean(isValid) }, this);
     }, [data, valid, errors, isValid]);
 
     const [status, setStatus] = useState('ready');
@@ -82,7 +82,7 @@ function BlikInput(props: Readonly<BlikInputProps>) {
             </Field>
 
             {props.showPayButton &&
-                props.payButton({
+                props.payButton?.({
                     status,
                     icon: getImage({ imageFolder: 'components/' })(`${PREFIX}lock`)
                 })}

--- a/packages/lib/src/components/Blik/components/BlikInput.tsx
+++ b/packages/lib/src/components/Blik/components/BlikInput.tsx
@@ -9,6 +9,7 @@ import useImage from '../../../core/Context/useImage';
 import InputText from '../../internal/FormFields/InputText';
 import { ComponentMethodsRef, UIElementProps } from '../../internal/UIElement/types';
 import { PREFIX } from '../../internal/Icon/constants';
+import { PaymentData } from '../../../types';
 
 interface BlikInputProps extends UIElementProps {
     data?: BlikInputDataState;
@@ -38,7 +39,7 @@ function BlikInput(props: Readonly<BlikInputProps>) {
     });
 
     useEffect(() => {
-        props.onChange({ data, errors, valid, isValid }, this);
+        props.onChange({ data: data as unknown as PaymentData, errors, valid, isValid }, this);
     }, [data, valid, errors, isValid]);
 
     const [status, setStatus] = useState('ready');

--- a/packages/lib/src/components/Blik/components/BlikInput.tsx
+++ b/packages/lib/src/components/Blik/components/BlikInput.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import Field from '../../internal/FormFields/Field';
 import './BlikInput.scss';
@@ -7,12 +7,13 @@ import useForm from '../../../utils/useForm';
 import { digitsOnlyFormatter } from '../../../utils/Formatters/formatters';
 import useImage from '../../../core/Context/useImage';
 import InputText from '../../internal/FormFields/InputText';
-import { UIElementProps } from '../../internal/UIElement/types';
+import { ComponentMethodsRef, UIElementProps } from '../../internal/UIElement/types';
 import { PREFIX } from '../../internal/Icon/constants';
 
 interface BlikInputProps extends UIElementProps {
     data?: BlikInputDataState;
     placeholders?: BlikInputDataState;
+    setComponentRef: (ref: ComponentMethodsRef) => void;
 }
 
 interface BlikInputDataState {
@@ -37,13 +38,21 @@ function BlikInput(props: Readonly<BlikInputProps>) {
     });
 
     useEffect(() => {
-        // @ts-ignore TODO: Fix this. Preact component types should not inherit from UIElementProps.
         props.onChange({ data, errors, valid, isValid }, this);
     }, [data, valid, errors, isValid]);
 
     const [status, setStatus] = useState('ready');
-    this.setStatus = setStatus;
-    this.showValidation = triggerValidation;
+
+    const blikComponentRef = useRef<ComponentMethodsRef>({
+        setStatus: setStatus,
+        showValidation: () => {
+            triggerValidation();
+        }
+    });
+
+    useEffect(() => {
+        props.setComponentRef(blikComponentRef.current);
+    }, [props.setComponentRef]);
 
     return (
         <div className="adyen-checkout__blik">

--- a/packages/lib/src/components/Card/Card.tsx
+++ b/packages/lib/src/components/Card/Card.tsx
@@ -3,7 +3,14 @@ import CardInput from './components/CardInput';
 import collectBrowserInfo from '../../utils/browserInfo';
 import { BinLookupResponse, CardElementData, CardConfiguration } from './types';
 import { triggerBinLookUp } from '../internal/SecuredFields/binLookup/triggerBinLookUp';
-import { CardBinLookupData, CardConfigSuccessData, CardFocusData } from '../internal/SecuredFields/lib/types';
+import {
+    CardBinLookupData,
+    CardBrandData,
+    CardConfigSuccessData,
+    CardErrorData,
+    CardFocusData,
+    StylesObject
+} from '../internal/SecuredFields/lib/types';
 import { fieldTypeToSnakeCase, isSecuredField } from '../internal/SecuredFields/utils';
 import { notFalsy, reject } from '../../utils/commonUtils';
 import { shouldIncludeInstallmentsInPaymentData } from './components/CardInput/utils';
@@ -21,11 +28,14 @@ import CardInputDefaultProps from './components/CardInput/defaultProps';
 import { PayButtonProps } from '../internal/PayButton/PayButton';
 import { AnalyticsInfoEvent, InfoEventType, UiTarget } from '../../core/Analytics/events/AnalyticsInfoEvent';
 import { InstallmentOptions } from './components/CardInput/components/Installments/Installments';
+import { AddressModeOptions, CardInputRef } from './components/CardInput/types';
 
 export class CardElement extends UIElement<CardConfiguration> {
     public static readonly type: TxVariants = TxVariants.scheme;
 
     private readonly clickToPayService: IClickToPayService | null;
+
+    protected componentRef: CardInputRef | undefined;
 
     /**
      * Reference to the 'ClickToPayComponent'
@@ -55,9 +65,9 @@ export class CardElement extends UIElement<CardConfiguration> {
         ...reject(['type', 'setComponentRef']).from(CardInputDefaultProps)
     };
 
-    public setStatus(status: UIElementStatus, props?): this {
+    public setStatus(status: UIElementStatus): this {
         if (this.componentRef?.setStatus) {
-            this.componentRef.setStatus(status, props);
+            this.componentRef.setStatus(status);
         }
         if (this.clickToPayRef?.setStatus) {
             this.clickToPayRef.setStatus(status);
@@ -206,17 +216,17 @@ export class CardElement extends UIElement<CardConfiguration> {
         this.analytics.sendAnalytics(event);
     }
 
-    updateStyles(stylesObj) {
+    updateStyles(stylesObj: StylesObject) {
         if (this.componentRef?.updateStyles) this.componentRef.updateStyles(stylesObj);
         return this;
     }
 
-    setFocusOn(fieldName) {
+    setFocusOn(fieldName: string) {
         if (this.componentRef?.setFocusOn) this.componentRef.setFocusOn(fieldName);
         return this;
     }
 
-    public onBrand = event => {
+    public onBrand = (event: CardBrandData) => {
         this.props.onBrand?.(event);
     };
 
@@ -225,7 +235,7 @@ export class CardElement extends UIElement<CardConfiguration> {
         return this;
     }
 
-    handleUnsupportedCard(errObj) {
+    handleUnsupportedCard(errObj: CardErrorData) {
         if (this.componentRef?.handleUnsupportedCard) this.componentRef.handleUnsupportedCard(errObj);
         return this;
     }
@@ -369,6 +379,7 @@ export class CardElement extends UIElement<CardConfiguration> {
                 setComponentRef={this.setComponentRef}
                 {...this.props}
                 {...this.state}
+                billingAddressMode={this.props.billingAddressMode as AddressModeOptions}
                 onSubmitAnalytics={this.submitAnalytics}
                 onChange={this.setState}
                 onSubmit={this.submit}

--- a/packages/lib/src/components/Card/components/CardInput/types.ts
+++ b/packages/lib/src/components/Card/components/CardInput/types.ts
@@ -38,6 +38,7 @@ import { h } from 'preact';
 import { InstallmentOptions } from './components/Installments/Installments';
 import type { Form } from '../../../../utils/useForm/types';
 import type { SecuredFieldsProviderRef } from '../../../internal/SecuredFields/SFP/types';
+import { AdyenCheckoutError } from '../../../../types';
 
 export interface CardInputValidState {
     holderName?: boolean;
@@ -84,7 +85,7 @@ export interface CardInputProps {
     brands?: string[];
     brandsConfiguration?: CardBrandsConfiguration;
     brandsIcons: Array<BrandConfiguration>;
-    clientKey: string;
+    clientKey?: string;
     configuration: CardBackendConfiguration;
     countryCode?: string;
     cvcPolicy?: CVCPolicyType;
@@ -105,14 +106,14 @@ export interface CardInputProps {
     installmentOptions?: InstallmentOptions;
     keypadFix?: boolean;
     lastFour?: string;
-    loadingContext: string;
+    loadingContext?: string;
     legacyInputMode?: boolean;
     minimumExpiryDate?: string;
     modules?: {
-        srPanel: SRPanel;
-        analytics: IAnalytics;
-        risk: RiskElement;
-        resources: Resources;
+        srPanel?: SRPanel;
+        analytics?: IAnalytics;
+        risk?: RiskElement;
+        resources?: Resources;
     };
     onAdditionalSFConfig?: () => void;
     onAdditionalSFRemoved?: () => void;
@@ -123,7 +124,7 @@ export interface CardInputProps {
     onBrand?: (o: CardBrandData) => void;
     onConfigSuccess?: (O: CardConfigSuccessData) => void;
     onChange: (state) => void;
-    onError?: () => void;
+    onError?: (e: AdyenCheckoutError) => void;
     onFieldValid?: (o: CardFieldValidData) => void;
     onFocus?: (e) => void;
     onLoad?: (o: CardLoadData) => void;
@@ -131,6 +132,7 @@ export interface CardInputProps {
     handleKeyDown?: (event: KeyboardEvent) => void;
     onAddressLookup?: OnAddressLookupType;
     onAddressSelected?: OnAddressSelectedType;
+    onSubmit?: () => void;
     addressSearchDebounceMs?: number;
     payButton?: (props: PayButtonProps) => h.JSX.Element;
     placeholders?: CardPlaceholders;
@@ -139,7 +141,7 @@ export interface CardInputProps {
     setComponentRef?: (ref) => void;
     showBrandIcon?: boolean;
     showInstallmentAmounts?: boolean;
-    showPayButton: boolean;
+    showPayButton?: boolean;
     showStoreDetailsCheckbox?: boolean;
     showWarnings?: boolean;
     showContextualElement?: boolean;
@@ -173,7 +175,7 @@ export interface CardInputState {
 // An interface for the members exposed by CardInput to its parent Card/UIElement
 export interface CardInputRef extends ComponentMethodsRef {
     sfp?: SecuredFieldsProviderRef;
-    setFocusOn?: (who) => void;
+    setFocusOn?: (field: string) => void;
     processBinLookupResponse?: (binLookupResponse: BinLookupResponse, isReset: boolean) => void;
     updateStyles?: (stylesObj: StylesObject) => void;
     handleUnsupportedCard?: (errObj: CardErrorData) => boolean;

--- a/packages/lib/src/components/Card/types.ts
+++ b/packages/lib/src/components/Card/types.ts
@@ -18,16 +18,10 @@ import type { OnAddressLookupType, OnAddressSelectedType } from '../internal/Add
 import type { FastlaneSignupConfiguration } from '../PayPalFastlane/types';
 import type { ChallengeWindowSize } from '../ThreeDS2/types';
 import { InstallmentOptions } from './components/CardInput/components/Installments/Installments';
+import { AddressModeOptions } from './components/CardInput/types';
 
 type PlaceholderKeys =
-    | 'holderName'
-    | 'cardNumber'
-    | 'expiryDate'
-    | 'expiryMonth'
-    | 'expiryYear'
-    | 'securityCodeThreeDigits'
-    | 'securityCodeFourDigits'
-    | 'password';
+    'holderName' | 'cardNumber' | 'expiryDate' | 'expiryMonth' | 'expiryYear' | 'securityCodeThreeDigits' | 'securityCodeFourDigits' | 'password';
 
 export type FundingSourceKeys = 'credit' | 'debit' | 'prepaid';
 
@@ -55,7 +49,7 @@ export interface CardConfiguration extends UIElementProps {
      *
      * - merchant set config option
      */
-    billingAddressMode?: 'full' | 'partial' | 'none';
+    billingAddressMode?: `${AddressModeOptions}`;
 
     /**
      * Show Address fields

--- a/packages/lib/src/components/CashAppPay/CashAppPay.tsx
+++ b/packages/lib/src/components/CashAppPay/CashAppPay.tsx
@@ -152,9 +152,7 @@ export class CashAppPay extends UIElement<CashAppPayConfiguration> {
                 name={this.displayName}
                 payButton={this.payButton}
                 onSubmit={this.submit}
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
+                setComponentRef={this.setComponentRef}
             />
         ) : (
             <CashAppComponent

--- a/packages/lib/src/components/CustomCard/CustomCard.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCard.tsx
@@ -10,6 +10,7 @@ import { TxVariants } from '../tx-variants';
 import { CustomCardConfiguration } from './types';
 import { AnalyticsInfoEvent, InfoEventType, UiTarget } from '../../core/Analytics/events/AnalyticsInfoEvent';
 import { DUAL_BRANDS_THAT_NEED_SELECTION_MECHANISM } from '../Card/constants';
+import type { CustomCardInputRef } from './CustomCardInput';
 
 const SELECTABLE_DUAL_BRANDED_SCENARIO = 'Dual Branded (Selectable): Regulation mandates that you must provide a brand selection mechanism';
 const DISPLAY_ONLY_DUAL_BRANDED_SCENARIO = 'Dual Branded (Display-only): No selection mechanism required';
@@ -17,12 +18,14 @@ const DISPLAY_ONLY_DUAL_BRANDED_SCENARIO = 'Dual Branded (Display-only): No sele
 export class CustomCard extends UIElement<CustomCardConfiguration> {
     public static readonly type = TxVariants.customCard;
 
+    protected componentRef: CustomCardInputRef | undefined;
+
     protected static readonly defaultProps = {
         onBinLookup: () => {},
         brandsConfiguration: {}
     };
 
-    private brand = TxVariants.card;
+    private readonly brand = TxVariants.card;
 
     formatProps(props: CustomCardConfiguration) {
         return {
@@ -36,10 +39,11 @@ export class CustomCard extends UIElement<CustomCardConfiguration> {
      */
     formatData() {
         const sfBrand = this.state.selectedBrandValue;
+        const securedFieldsData = this.state.data as Record<string, string>;
         return {
             paymentMethod: {
                 type: 'scheme',
-                ...this.state.data,
+                ...securedFieldsData,
                 ...(sfBrand && { brand: sfBrand })
             },
             browserInfo: this.browserInfo,
@@ -115,7 +119,7 @@ export class CustomCard extends UIElement<CustomCardConfiguration> {
         return collectBrowserInfo();
     }
 
-    private onFocus = (obj: CardFocusData) => {
+    private readonly onFocus = (obj: CardFocusData) => {
         const event = new AnalyticsInfoEvent({
             component: this.type,
             type: obj.focus === true ? InfoEventType.focus : InfoEventType.unfocus,

--- a/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
@@ -1,52 +1,78 @@
-import { h } from 'preact';
+import { h, Ref } from 'preact';
 import { useState, useEffect, useRef, useMemo } from 'preact/hooks';
 import Language from '../../../language/Language';
 import SecuredFieldsProvider from '../../internal/SecuredFields/SFP/SecuredFieldsProvider';
 import { SFPState } from '../../internal/SecuredFields/SFP/types';
 import { BinLookupResponse, CardBrandsConfiguration, CardPlaceholders } from '../../Card/types';
 import SFExtensions from '../../internal/SecuredFields/binLookup/extensions';
-import { StylesObject } from '../../internal/SecuredFields/lib/types';
+import {
+    CardAllValidData,
+    CardAutoCompleteData,
+    CardBinValueData,
+    CardBrandData,
+    CardConfigSuccessData,
+    CardFieldValidData,
+    CardFocusData,
+    CardLoadData,
+    CardErrorData,
+    SFFieldType,
+    StylesObject
+} from '../../internal/SecuredFields/lib/types';
 import { Resources } from '../../../core/Context/Resources';
 import { SFError } from '../../Card/components/CardInput/types';
 import { ValidationError } from '../types';
 import type { AbstractAnalyticsEvent } from '../../../core/Analytics/events/AbstractAnalyticsEvent';
+import { AdyenCheckoutError, UIElement } from '../../../types';
+import type { ComponentMethodsRef } from '../../internal/UIElement/types';
+
+/**
+ * Methods that CustomCardInput exposes to the CustomCard element through the ref
+ */
+export interface CustomCardInputRef extends ComponentMethodsRef {
+    processBinLookupResponse(binLookupResponse: BinLookupResponse, isReset?: boolean): void;
+    dualBrandingChangeHandler(event: Event | string): void;
+    setFocusOn(frame: SFFieldType): void;
+    updateStyles(stylesObj: StylesObject): void;
+    handleUnsupportedCard(errObj: CardErrorData): boolean;
+}
 
 interface SecuredFieldsProps {
     autoFocus?: boolean;
     brand?: string;
     brands?: string[];
     brandsConfiguration?: CardBrandsConfiguration;
-    clientKey: string;
+    clientKey?: string;
     countryCode?: string;
     forceCompat?: boolean;
-    i18n: Language;
+    i18n?: Language;
     implementationType?: 'components' | 'custom';
     keypadFix?: boolean;
     loadingContext?: string;
     legacyInputMode?: boolean;
     minimumExpiryDate?: string;
-    onAdditionalSFConfig?: () => {};
-    onAdditionalSFRemoved?: () => {};
-    onAllValid?: () => {};
-    onAutoComplete?: () => {};
-    onBinValue?: () => {};
-    onBrand?: () => {};
-    onConfigSuccess?: () => {};
-    onChange: (data) => void;
+    onAdditionalSFConfig?: () => void;
+    onAdditionalSFRemoved?: () => void;
+    onAllValid?: (data: CardAllValidData) => void;
+    onAutoComplete?: (data: CardAutoCompleteData) => void;
+    onBinValue?: (data: CardBinValueData) => void;
+    onBrand?: (data: CardBrandData) => void;
+    onConfigSuccess?: (data: CardConfigSuccessData) => void;
+    onChange?: (data) => void;
     onSubmitAnalytics?: (event: AbstractAnalyticsEvent) => void;
     handleKeyDown?: (event: KeyboardEvent) => void;
-    onError?: () => {};
-    onFieldValid?: () => {};
-    onFocus?: (e) => {};
-    onLoad?: () => {};
+    onError?: (error: AdyenCheckoutError, component?: UIElement) => void;
+    onFieldValid?: (data: CardFieldValidData) => void;
+    onFocus?: (data: CardFocusData) => void;
+    onLoad?: (data: CardLoadData) => void;
     placeholders?: CardPlaceholders;
-    rootNode: HTMLElement;
-    resources: Resources;
+    rootNode?: HTMLElement;
+    resources?: Resources;
     showWarnings?: boolean;
     styles?: StylesObject;
     trimTrailingSeparator?: boolean;
-    type: string;
+    type?: string;
     maskSecurityCode?: boolean;
+    ref?: Ref<CustomCardInputRef>;
 }
 
 const defaultProps = {
@@ -97,25 +123,17 @@ function CustomCardInput(props: Readonly<SecuredFieldsProps>) {
 
     this.dualBrandingChangeHandler = extensions.handleDualBrandSelection;
 
-    /**
-     * EFFECT HOOKS
-     */
     useEffect(() => {
-        // componentDidMount
         this.setFocusOn = sfp.current.setFocusOn;
         this.updateStyles = sfp.current.updateStyles;
         this.showValidation = sfp.current.showValidation;
         this.handleUnsupportedCard = sfp.current.handleUnsupportedCard;
 
-        // componentWillUnmount
         return () => {
             sfp.current.destroy();
         };
     }, []);
 
-    /**
-     * Main 'componentDidUpdate' handler
-     */
     useEffect(() => {
         const sfStateErrorsObj = sfp.current.mapErrorsToValidationRuleResult();
 
@@ -142,10 +160,6 @@ function CustomCardInput(props: Readonly<SecuredFieldsProps>) {
         }
     }, [data, valid, errors, selectedBrandValue]);
 
-    /**
-     * RENDER
-     */
-    // prettier-ignore
     return (
         <SecuredFieldsProvider
             ref={sfp}

--- a/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
+++ b/packages/lib/src/components/CustomCard/CustomCardInput/CustomCardInput.tsx
@@ -22,7 +22,8 @@ import { Resources } from '../../../core/Context/Resources';
 import { SFError } from '../../Card/components/CardInput/types';
 import { ValidationError } from '../types';
 import type { AbstractAnalyticsEvent } from '../../../core/Analytics/events/AbstractAnalyticsEvent';
-import { AdyenCheckoutError, UIElement } from '../../../types';
+import type AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
+import type UIElement from '../../internal/UIElement';
 import type { ComponentMethodsRef } from '../../internal/UIElement/types';
 
 /**

--- a/packages/lib/src/components/CustomCard/CustomCardInput/index.ts
+++ b/packages/lib/src/components/CustomCard/CustomCardInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from './CustomCardInput';
+export type { CustomCardInputRef } from './CustomCardInput';

--- a/packages/lib/src/components/Donation/Donation.tsx
+++ b/packages/lib/src/components/Donation/Donation.tsx
@@ -143,10 +143,7 @@ class DonationElement extends UIElement<DonationConfiguration> {
         return (
             <DonationComponent
                 {...this.props}
-                // @ts-ignore ref is internal from the Component
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
+                setComponentRef={this.setComponentRef}
                 onChange={this.setState}
                 onDonate={this.donate}
                 onCancel={this.cancel}

--- a/packages/lib/src/components/Donation/components/DonationComponent.test.tsx
+++ b/packages/lib/src/components/Donation/components/DonationComponent.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import DonationComponent from './DonationComponent';
 import { CoreProvider } from '../../../core/Context/CoreProvider';
 import type { DonationComponentProps, FixedAmountsDonation, RoundupDonation } from './types';
+import { setupCoreMock } from '../../../../config/testMocks/setup-core-mock';
 
 const onDonate = jest.fn();
 const onCancel = jest.fn();
@@ -24,16 +25,19 @@ const roundUp: RoundupDonation = {
 
 const commercialTxAmount = 1000;
 
+const core = setupCoreMock();
+
 const renderComponent = (props: Partial<DonationComponentProps> = {}) => {
     const defaultProps: DonationComponentProps = {
         commercialTxAmount,
         onDonate,
         donation: fixedAmounts,
-        onAmountSelected
+        onAmountSelected,
+        setComponentRef: jest.fn()
     };
 
     return render(
-        <CoreProvider i18n={global.i18n} loadingContext="test" resources={global.resources}>
+        <CoreProvider i18n={core.modules.i18n} loadingContext="test" resources={core.modules.resources}>
             <DonationComponent {...defaultProps} {...props} />
         </CoreProvider>
     );

--- a/packages/lib/src/components/Donation/components/DonationComponent.tsx
+++ b/packages/lib/src/components/Donation/components/DonationComponent.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import CampaignContent from './CampaignContent';
 import Button from '../../internal/Button';
 import Img from '../../internal/Img';
@@ -11,6 +11,7 @@ import useImage from '../../../core/Context/useImage';
 import FixedAmounts from './FixedAmounts';
 import Roundup from './Roundup';
 import { getAmountLabel, getRoundupAmount, getRoundupAmountLabel } from './utils';
+import { ComponentMethodsRef } from '../../types';
 
 export default function DonationComponent(props: Readonly<DonationComponentProps>) {
     const { donation, commercialTxAmount, onAmountSelected, onCancel, onDonate, showCancelButton = true, termsAndConditionsUrl } = props;
@@ -25,9 +26,13 @@ export default function DonationComponent(props: Readonly<DonationComponentProps
         value: isRoundupDonation ? getRoundupAmount(donation.maxRoundupAmount, commercialTxAmount) : null
     });
 
-    this.setStatus = (status: Status) => {
-        setStatus(status);
-    };
+    const donationComponentRef = useRef<ComponentMethodsRef>({
+        setStatus: setStatus
+    });
+
+    useEffect(() => {
+        props.setComponentRef(donationComponentRef.current);
+    }, [props.setComponentRef]);
 
     const handleAmountSelected = ({ target }) => {
         const value = parseInt(target.value, 10);

--- a/packages/lib/src/components/Donation/components/types.ts
+++ b/packages/lib/src/components/Donation/components/types.ts
@@ -1,3 +1,4 @@
+import { ComponentMethodsRef } from '../../types';
 import type { CampaignContentProps } from './CampaignContent';
 
 export type Donation = RoundupDonation | FixedAmountsDonation;
@@ -41,4 +42,5 @@ export interface DonationComponentProps extends CampaignContentProps {
     onCancel?: (payload: DonationPayload) => void;
     onChange?: (payload: DonationPayload) => void;
     onAmountSelected: (payload: DonationPayload) => void;
+    setComponentRef: (ref: ComponentMethodsRef) => void;
 }

--- a/packages/lib/src/components/Dropin/Dropin.tsx
+++ b/packages/lib/src/components/Dropin/Dropin.tsx
@@ -12,6 +12,7 @@ import type { DropinComponentProps, DropinConfiguration, InstantPaymentTypes, Pa
 import type { PaymentAction, PaymentAmount, PaymentResponseData } from '../../types/global-types';
 import type { ICore } from '../../core/types';
 import type { IDropin } from './types';
+import { UIElementStatus } from '../types';
 
 const SUPPORTED_INSTANT_PAYMENTS = ['paywithgoogle', 'googlepay', 'applepay'];
 
@@ -22,7 +23,9 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
 
     public dropinRef = null;
 
-    private paymentMethodsConfiguration: PaymentMethodsConfiguration;
+    public elementRef: DropinElement;
+
+    private readonly paymentMethodsConfiguration: PaymentMethodsConfiguration;
     /**
      * Reference to the component created from `handleAction` (Ex.: ThreeDS2Challenge)
      */
@@ -51,7 +54,7 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
         this.core.storeElementReference(this);
     }
 
-    formatProps(props) {
+    formatProps(props: DropinConfiguration) {
         return {
             ...super.formatProps(props),
             instantPaymentTypes: Array.from<InstantPaymentTypes>(new Set(props.instantPaymentTypes)).filter(value =>
@@ -72,7 +75,12 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
         return this;
     }
 
-    public setStatus(status, props = {}): this {
+    public setElementStatus(status: UIElementStatus, props?: Record<string, unknown>): this {
+        this.elementRef?.setStatus?.(status, props);
+        return this;
+    }
+
+    public setStatus(status: UIElementStatus, props: Record<string, unknown> = {}): this {
         this.dropinRef?.setStatus(status, props);
         return this;
     }
@@ -153,7 +161,7 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
     /**
      * Creates the Drop-in elements
      */
-    private handleCreate = (): ReturnType<DropinComponentProps['onCreateElements']> => {
+    private readonly handleCreate = (): ReturnType<DropinComponentProps['onCreateElements']> => {
         const { paymentMethodsConfiguration, showStoredPaymentMethods, showPaymentMethods, instantPaymentTypes } = this.props;
 
         const { paymentMethods, storedPaymentMethods, instantPaymentMethods, fastlanePaymentMethod } = splitPaymentMethods(
@@ -214,7 +222,7 @@ class DropinElement extends UIElement<DropinConfiguration> implements IDropin {
         });
 
         if (paymentAction) {
-            this.setStatus(paymentAction.props.statusType, { component: paymentAction });
+            this.setStatus(paymentAction.props.statusType as UIElementStatus, { component: paymentAction });
             this.componentFromAction = paymentAction;
             return this;
         }

--- a/packages/lib/src/components/Dropin/components/DropinComponent.tsx
+++ b/packages/lib/src/components/Dropin/components/DropinComponent.tsx
@@ -193,6 +193,7 @@ export class DropinComponent extends Component<DropinComponentProps, DropinCompo
                 new Promise<{ amount: PaymentAmount }>((resolve, reject) => {
                     this.props.onOrderCancel({ order }, { resolve, reject });
                 })
+                    // @ts-ignore - handleAdvanceFlowPaymentMethodsUpdate is protected but we need to call it from here
                     .then(({ amount }) => this.props.elementRef.handleAdvanceFlowPaymentMethodsUpdate(null, amount))
                     .catch(error => {
                         throw new AdyenCheckoutError('NETWORK_ERROR', error);

--- a/packages/lib/src/components/Giftcard/Giftcard.tsx
+++ b/packages/lib/src/components/Giftcard/Giftcard.tsx
@@ -51,7 +51,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
         this.componentRef?.setBalanceCheckErrors?.(errorMessage);
     }
 
-    private handleBalanceCheck = (data: GiftCardElementData): Promise<balanceCheckResponseType> => {
+    private readonly handleBalanceCheck = (data: GiftCardElementData): Promise<balanceCheckResponseType> => {
         if (this.props.onBalanceCheck) {
             return new Promise((resolve, reject) => {
                 void this.props.onBalanceCheck(resolve, reject, data);
@@ -63,7 +63,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
         }
     };
 
-    private onOrderRequest = data => {
+    private readonly onOrderRequest = data => {
         if (this.props.onOrderRequest)
             return new Promise((resolve, reject) => {
                 void this.props.onOrderRequest(resolve, reject, data);
@@ -77,7 +77,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
         return this.onBalanceCheck();
     }
 
-    private onBalanceCheck = (): void => {
+    private readonly onBalanceCheck = (): void => {
         if (!this.isValid) {
             this.showValidation();
             return;
@@ -128,7 +128,7 @@ export class GiftcardElement extends UIElement<GiftCardConfiguration> {
     /**
      * Check if it should call onRequiringConfirmation
      */
-    private handleOnRequiringConfirmation = (balance: PaymentAmount, transactionLimit: PaymentAmount): Promise<void> | void => {
+    private readonly handleOnRequiringConfirmation = (balance: PaymentAmount, transactionLimit: PaymentAmount): Promise<void> | void => {
         this.componentRef.setBalance({ balance, transactionLimit });
         this.setStatus('ready');
 

--- a/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
+++ b/packages/lib/src/components/Giftcard/components/GiftcardComponent.tsx
@@ -62,7 +62,7 @@ class Giftcard extends Component<Readonly<GiftcardComponentProps>> {
         return this.sfp.mapErrorsToValidationRuleResult();
     };
 
-    private updateTransformedErrors = (balanceCheckErrors?: Record<string, GiftCardValidationError>) => {
+    private readonly updateTransformedErrors = (balanceCheckErrors?: Record<string, GiftCardValidationError>) => {
         const transformedErrors = this.mapErrorsToValidationObjects();
 
         const mergedErrors = { ...transformedErrors, ...balanceCheckErrors };

--- a/packages/lib/src/components/Giropay/Giropay.tsx
+++ b/packages/lib/src/components/Giropay/Giropay.tsx
@@ -19,9 +19,7 @@ class GiropayElement extends RedirectElement {
                     name={this.displayName}
                     onSubmit={this.submit}
                     payButton={this.payButton}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                 />
             );
         }

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -69,10 +69,6 @@ export class MBWayElement extends UIElement<AwaitConfiguration> {
 
         return (
             <MBWayInput
-                /* @ts-ignore ref handled internally by Component */
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
                 {...this.props}
                 setComponentRef={this.setComponentRef}
                 onChange={this.setState}

--- a/packages/lib/src/components/MBWay/MBWay.tsx
+++ b/packages/lib/src/components/MBWay/MBWay.tsx
@@ -5,6 +5,7 @@ import config from './components/MBWayAwait/config';
 import { Await } from '../../components/internal/Await';
 import { TxVariants } from '../tx-variants';
 import { AwaitConfiguration } from '../internal/Await/types';
+import { PaymentData } from '../../types';
 
 export class MBWayElement extends UIElement<AwaitConfiguration> {
     public static readonly type = TxVariants.mbway;
@@ -27,7 +28,7 @@ export class MBWayElement extends UIElement<AwaitConfiguration> {
     /**
      * Formats the component data output
      */
-    formatData(): object {
+    formatData(): PaymentData {
         return {
             paymentMethod: {
                 type: MBWayElement.type,

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -1,11 +1,12 @@
 import { h } from 'preact';
-import { useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { MBWayInputProps } from './types';
 import './MBWayInput.scss';
 import PhoneInputForm from '../../../internal/PhoneInput';
 import LoadingWrapper from '../../../internal/LoadingWrapper';
 import usePhonePrefixes from '../../../internal/PhoneInput/usePhonePrefixes';
+import { ComponentMethodsRef } from '../../../types';
 
 function MBWayInput(props: Readonly<MBWayInputProps>) {
     const { i18n, loadingContext } = useCoreContext();
@@ -15,6 +16,14 @@ function MBWayInput(props: Readonly<MBWayInputProps>) {
     const [status, setStatus] = useState<string>('ready');
 
     this.setStatus = setStatus;
+
+    const mbWayInputRef = useRef<ComponentMethodsRef>({
+        setStatus: setStatus
+    });
+
+    useEffect(() => {
+        props.setComponentRef(mbWayInputRef.current);
+    }, [props.setComponentRef]);
 
     const { loadingStatus: prefixLoadingStatus, phonePrefixes } = usePhonePrefixes({ allowedCountries, loadingContext, handleError: props.onError });
 

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -15,8 +15,6 @@ function MBWayInput(props: Readonly<MBWayInputProps>) {
 
     const [status, setStatus] = useState<string>('ready');
 
-    this.setStatus = setStatus;
-
     const mbWayInputRef = useRef<ComponentMethodsRef>({
         setStatus: setStatus
     });
@@ -34,7 +32,18 @@ function MBWayInput(props: Readonly<MBWayInputProps>) {
     return (
         <LoadingWrapper status={prefixLoadingStatus}>
             <div className="adyen-checkout__mb-way">
-                <PhoneInputForm setComponentRef={props.setComponentRef} {...props} items={phonePrefixes} onChange={onChange} data={props.data} />
+                <PhoneInputForm
+                    setComponentRef={ref => {
+                        mbWayInputRef.current = {
+                            ...mbWayInputRef.current,
+                            ...ref
+                        };
+                    }}
+                    {...props}
+                    items={phonePrefixes}
+                    onChange={onChange}
+                    data={props.data}
+                />
 
                 {props.showPayButton && props.payButton({ status, label: i18n.get('confirmPurchase') })}
             </div>

--- a/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
+++ b/packages/lib/src/components/MBWay/components/MBWayInput/MBWayInput.tsx
@@ -1,12 +1,12 @@
 import { h } from 'preact';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useRef, useState } from 'preact/hooks';
 import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import { MBWayInputProps } from './types';
 import './MBWayInput.scss';
 import PhoneInputForm from '../../../internal/PhoneInput';
 import LoadingWrapper from '../../../internal/LoadingWrapper';
 import usePhonePrefixes from '../../../internal/PhoneInput/usePhonePrefixes';
-import { ComponentMethodsRef } from '../../../types';
+import type { ComponentMethodsRef } from '../../../internal/UIElement/types';
 
 function MBWayInput(props: Readonly<MBWayInputProps>) {
     const { i18n, loadingContext } = useCoreContext();
@@ -15,35 +15,29 @@ function MBWayInput(props: Readonly<MBWayInputProps>) {
 
     const [status, setStatus] = useState<string>('ready');
 
-    const mbWayInputRef = useRef<ComponentMethodsRef>({
-        setStatus: setStatus
-    });
-
-    useEffect(() => {
-        props.setComponentRef(mbWayInputRef.current);
-    }, [props.setComponentRef]);
-
     const { loadingStatus: prefixLoadingStatus, phonePrefixes } = usePhonePrefixes({ allowedCountries, loadingContext, handleError: props.onError });
+
+    const mbwayRef = useRef<ComponentMethodsRef>({
+        setStatus,
+        showValidation: () => {}
+    });
 
     const onChange = ({ data, valid, errors, isValid }) => {
         props.onChange({ data, valid, errors, isValid });
     };
 
+    const setPhoneInputRef = useCallback(
+        (ref: ComponentMethodsRef) => {
+            mbwayRef.current.showValidation = ref.showValidation;
+            props.setComponentRef(mbwayRef.current);
+        },
+        [props.setComponentRef]
+    );
+
     return (
         <LoadingWrapper status={prefixLoadingStatus}>
             <div className="adyen-checkout__mb-way">
-                <PhoneInputForm
-                    setComponentRef={ref => {
-                        mbWayInputRef.current = {
-                            ...mbWayInputRef.current,
-                            ...ref
-                        };
-                    }}
-                    {...props}
-                    items={phonePrefixes}
-                    onChange={onChange}
-                    data={props.data}
-                />
+                <PhoneInputForm {...props} setComponentRef={setPhoneInputRef} items={phonePrefixes} onChange={onChange} data={props.data} />
 
                 {props.showPayButton && props.payButton({ status, label: i18n.get('confirmPurchase') })}
             </div>

--- a/packages/lib/src/components/Multibanco/Multibanco.tsx
+++ b/packages/lib/src/components/Multibanco/Multibanco.tsx
@@ -42,9 +42,7 @@ export class MultibancoElement extends UIElement<VoucherConfiguration> {
                     name={this.displayName}
                     payButton={this.payButton}
                     onSubmit={this.submit}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                 />
             );
         }

--- a/packages/lib/src/components/PayByBankPix/PayByBankPix.tsx
+++ b/packages/lib/src/components/PayByBankPix/PayByBankPix.tsx
@@ -225,9 +225,7 @@ class PayByBankPixElement extends UIElement<PayByBankPixConfiguration> {
                     label={this.props.i18n.get('paybybankpix.redirectBtn.label')}
                     payButton={this.payButton}
                     onSubmit={this.submit}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                 />
             );
         }

--- a/packages/lib/src/components/PayByBankUS/PayByBankUS.tsx
+++ b/packages/lib/src/components/PayByBankUS/PayByBankUS.tsx
@@ -6,8 +6,8 @@ import getIssuerImageUrl from '../../utils/get-issuer-image';
 import PayButton from '../internal/PayButton';
 import { payAmountLabel } from '../internal/PayButton/utils';
 import { PaymentMethodBrand } from '../../types/global-types';
-
 import './PayByBankUS.scss';
+
 export default class PayByBankUS extends RedirectElement {
     public static override readonly type: TxVariants = TxVariants.paybybank_AIS_DD;
 
@@ -85,9 +85,7 @@ export default class PayByBankUS extends RedirectElement {
                         name={this.displayName}
                         onSubmit={this.submit}
                         payButton={this.payButton}
-                        ref={ref => {
-                            this.componentRef = ref;
-                        }}
+                        setComponentRef={this.setComponentRef}
                     />
                 )}
             </Fragment>

--- a/packages/lib/src/components/Pix/Pix.tsx
+++ b/packages/lib/src/components/Pix/Pix.tsx
@@ -66,15 +66,13 @@ class PixElement extends QRLoaderContainer<PixConfiguration> {
 
         return (
             <PixInput
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
                 {...this.props}
                 showPayButton={this.props.showPayButton}
                 personalDetailsRequired={this.props.personalDetailsRequired}
                 name={this.displayName}
                 onChange={this.setState}
                 payButton={this.payButton}
+                setComponentRef={this.setComponentRef}
             />
         );
     }

--- a/packages/lib/src/components/Pix/components/PixInput/PixInput.tsx
+++ b/packages/lib/src/components/Pix/components/PixInput/PixInput.tsx
@@ -1,13 +1,14 @@
 import { h } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { pixValidationRules } from './validate';
 import { pixFormatters } from './utils';
 import { useCoreContext } from '../../../../core/Context/CoreProvider';
 import useForm from '../../../../utils/useForm';
 import { BrazilPersonalDetail } from '../../../internal/SocialSecurityNumberBrazil/BrazilPersonalDetail';
 import { PixInputDataState, PixInputProps } from './types';
+import { ComponentMethodsRef } from '../../../types';
 
-function PixInput({ name, data: dataProps, personalDetailsRequired, showPayButton, onChange, payButton }: Readonly<PixInputProps>) {
+function PixInput({ name, data: dataProps, personalDetailsRequired, showPayButton, onChange, payButton, setComponentRef }: Readonly<PixInputProps>) {
     const { i18n } = useCoreContext();
     const formSchema = ['firstName', 'lastName', 'socialSecurityNumber'];
 
@@ -25,17 +26,23 @@ function PixInput({ name, data: dataProps, personalDetailsRequired, showPayButto
     }, [personalDetailsRequired]);
 
     const [status, setStatus] = useState('ready');
-    this.setStatus = setStatus;
 
-    this.showValidation = () => {
-        triggerValidation();
-    };
+    const pixInputRef = useRef<ComponentMethodsRef>({
+        setStatus: setStatus,
+        showValidation: () => {
+            triggerValidation();
+        }
+    });
+
+    useEffect(() => {
+        setComponentRef(pixInputRef.current);
+    }, [setComponentRef]);
 
     useEffect(() => {
         onChange({ data, valid, errors, isValid });
     }, [onChange, data, valid, errors]);
 
-    const buttonModifiers = !personalDetailsRequired ? ['standalone'] : [];
+    const buttonModifiers = personalDetailsRequired ? [] : ['standalone'];
 
     return (
         <div className="adyen-checkout__pix-input__field" style={!showPayButton && !personalDetailsRequired ? { display: 'none' } : null}>

--- a/packages/lib/src/components/Pix/components/PixInput/types.ts
+++ b/packages/lib/src/components/Pix/components/PixInput/types.ts
@@ -1,6 +1,6 @@
-import { h, RefObject } from 'preact';
-import PixInput from './PixInput';
+import { h } from 'preact';
 import { PayButtonProps } from '../../../internal/PayButton/PayButton';
+import { ComponentMethodsRef } from '../../../types';
 
 export interface PixInputDataState {
     firstName?: string;
@@ -19,5 +19,5 @@ export interface PixInputProps {
     showPayButton: boolean;
     onChange({ data, valid, errors, isValid }): void;
     payButton(props: PayButtonProps): h.JSX.Element;
-    ref(ref: RefObject<typeof PixInput>): void;
+    setComponentRef: (ref: ComponentMethodsRef) => void;
 }

--- a/packages/lib/src/components/PreAuthorizedDebitCanada/PreAuthorizedDebitCanada.tsx
+++ b/packages/lib/src/components/PreAuthorizedDebitCanada/PreAuthorizedDebitCanada.tsx
@@ -73,9 +73,7 @@ export class PreAuthorizedDebitCanada extends UIElement<PreAuthorizedDebitCanada
                     name={this.displayName}
                     payButton={this.payButton}
                     onSubmit={this.submit}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                 />
             </Fragment>
         ) : (

--- a/packages/lib/src/components/Redirect/Redirect.tsx
+++ b/packages/lib/src/components/Redirect/Redirect.tsx
@@ -64,9 +64,7 @@ class RedirectElement extends UIElement<RedirectConfiguration> {
                     name={this.displayName}
                     onSubmit={this.submit}
                     payButton={this.payButton}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                 />
             );
         }

--- a/packages/lib/src/components/Sepa/Sepa.tsx
+++ b/packages/lib/src/components/Sepa/Sepa.tsx
@@ -17,7 +17,7 @@ class SepaElement extends UIElement<SepaConfiguration> {
     /**
      * Formats props on construction time
      */
-    formatProps(props) {
+    formatProps(props: SepaConfiguration): SepaConfiguration & { holderName: boolean } {
         return {
             holderName: true,
             ...props
@@ -49,14 +49,12 @@ class SepaElement extends UIElement<SepaConfiguration> {
             <Fragment>
                 <FormInstruction />
 
-                {/* @ts-ignore TODO: add props */}
                 <IbanInput
                     ref={ref => {
                         this.componentRef = ref;
                     }}
                     {...this.props}
                     onChange={this.setState}
-                    // onSubmit={this.submit}
                     payButton={this.payButton}
                 />
             </Fragment>

--- a/packages/lib/src/components/Sepa/types.ts
+++ b/packages/lib/src/components/Sepa/types.ts
@@ -1,3 +1,4 @@
+import { IbanData } from '../internal/IbanInput/IbanInput';
 import { UIElementProps } from '../internal/UIElement/types';
 
 export interface SepaElementData {
@@ -8,4 +9,6 @@ export interface SepaElementData {
     };
 }
 
-export interface SepaConfiguration extends UIElementProps {}
+export interface SepaConfiguration extends UIElementProps {
+    data?: IbanData;
+}

--- a/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
+++ b/packages/lib/src/components/ThreeDS2/ThreeDS2DeviceFingerprint.tsx
@@ -10,6 +10,7 @@ import { THREEDS2_FINGERPRINT, THREEDS2_FINGERPRINT_ERROR } from './constants';
 import { ActionHandledReturnObject } from '../../types/global-types';
 import { AnalyticsLogEvent, LogEventSubtype, LogEventType } from '../../core/Analytics/events/AnalyticsLogEvent';
 import { AnalyticsErrorEvent, ErrorEventCode, ErrorEventType } from '../../core/Analytics/events/AnalyticsErrorEvent';
+import { AdditionalDetailsData } from '../../types';
 
 class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintConfiguration> {
     public static readonly type = TxVariants.threeDS2Fingerprint;
@@ -19,7 +20,7 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintConfi
         type: THREEDS2_FINGERPRINT
     };
 
-    private callSubmit3DS2Fingerprint = callSubmit3DS2Fingerprint.bind(this); // New 3DS2 flow
+    private readonly callSubmit3DS2Fingerprint = callSubmit3DS2Fingerprint.bind(this); // New 3DS2 flow
 
     protected override beforeRender() {
         /* Do not send rendered events for ThreeDS2DeviceFingerprint - it will have the same timestamp as the "threeDSMethodData sent" event */
@@ -45,7 +46,7 @@ class ThreeDS2DeviceFingerprint extends UIElement<ThreeDS2DeviceFingerprintConfi
         if (this.props.isMDFlow) {
             this.props.on3DS2RedirectFlowComplete?.(state, this.elementRef);
         } else {
-            super.onComplete(state);
+            super.onComplete(state as AdditionalDetailsData);
         }
 
         this.unmount(); // re. fixing issue around back to back fingerprinting calls

--- a/packages/lib/src/components/ThreeDS2/types.ts
+++ b/packages/lib/src/components/ThreeDS2/types.ts
@@ -139,12 +139,9 @@ type CheckoutThreeDS2Action = {
     authorisationToken: string;
 };
 
-export interface FingerprintResolveData {
-    data: {
-        [key: string]: string;
-        paymentData: string;
-    };
-}
+export type FingerprintResolveData = {
+    data: Omit<AdditionalDetailsData['data'], 'details'>;
+};
 
 export interface ChallengeResolveData {
     data: {

--- a/packages/lib/src/components/Trustly/Trustly.tsx
+++ b/packages/lib/src/components/Trustly/Trustly.tsx
@@ -29,9 +29,7 @@ class TrustlyElement extends RedirectElement {
                         name={this.displayName}
                         onSubmit={this.submit}
                         payButton={this.payButton}
-                        ref={ref => {
-                            this.componentRef = ref;
-                        }}
+                        setComponentRef={this.setComponentRef}
                     />
                 )}
             </Fragment>

--- a/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
@@ -101,9 +101,7 @@ class IssuerListContainer<TProps extends IssuerListConfiguration = IssuerListCon
                 {...this.props}
                 onSubmit={this.submit}
                 payButton={this.payButton}
-                ref={ref => {
-                    this.componentRef = ref;
-                }}
+                setComponentRef={this.setComponentRef}
             />
         );
     }

--- a/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
+++ b/packages/lib/src/components/helpers/IssuerListContainer/IssuerListContainer.tsx
@@ -6,10 +6,13 @@ import { FALLBACK_CONTEXT } from '../../../core/config';
 import RedirectButton from '../../internal/RedirectButton';
 import { IssuerListConfiguration, IssuerListData } from './types';
 import type { ICore } from '../../../core/types';
-import { PaymentMethodBrand } from '../../../types/global-types';
+import { PaymentData, PaymentMethodBrand } from '../../../types/global-types';
 import { ImageOptions } from '../../../core/Context/Resources';
 
-class IssuerListContainer<TProps extends IssuerListConfiguration = IssuerListConfiguration, TData = IssuerListData> extends UIElement<TProps> {
+class IssuerListContainer<
+    TProps extends IssuerListConfiguration = IssuerListConfiguration,
+    TData extends PaymentData = IssuerListData
+> extends UIElement<TProps> {
     protected static readonly defaultProps = {
         showImage: true,
         issuers: [],
@@ -49,7 +52,7 @@ class IssuerListContainer<TProps extends IssuerListConfiguration = IssuerListCon
                 type: this.type,
                 issuer: this.state?.data?.issuer
             }
-        } as TData;
+        } as unknown as TData;
     }
 
     /**

--- a/packages/lib/src/components/helpers/QRLoaderContainer/QRLoaderContainer.tsx
+++ b/packages/lib/src/components/helpers/QRLoaderContainer/QRLoaderContainer.tsx
@@ -56,9 +56,7 @@ class QRLoaderContainer<T extends QRLoaderConfiguration = QRLoaderConfiguration>
                     name={this.displayName}
                     onSubmit={this.submit}
                     payButton={this.payButton}
-                    ref={ref => {
-                        this.componentRef = ref;
-                    }}
+                    setComponentRef={this.setComponentRef}
                 />
             );
         }

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -3,7 +3,7 @@ import uuid from '../../../utils/uuid';
 import AdyenCheckoutError from '../../../core/Errors/AdyenCheckoutError';
 import { NO_CHECKOUT_ATTEMPT_ID } from '../../../core/Analytics/constants';
 import type { ICore } from '../../../core/types';
-import type { BaseElementProps, IBaseElement } from './types';
+import type { BaseElementProps, BaseElementState, IBaseElement } from './types';
 import type { PaymentData } from '../../../types/global-types';
 import { off, on } from '../../../utils/listenerUtils';
 import { AbstractAnalyticsEvent } from '../../../core/Analytics/events/AbstractAnalyticsEvent';
@@ -22,13 +22,13 @@ function assertIsCoreInstance(checkout: ICore): checkout is ICore {
     return isCoreObject;
 }
 
-abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
+abstract class BaseElement<P extends BaseElementProps, S extends BaseElementState = BaseElementState> implements IBaseElement<P> {
     public readonly _id = `${this.constructor['type']}-${uuid()}`;
     public readonly core: ICore;
 
     public props: P;
-    public state: any = {};
-    public _component;
+    public state: S = {} as S;
+    public _component: ComponentChild | undefined;
 
     protected _node: HTMLElement = null;
 
@@ -66,7 +66,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
      * Executed on the `data` getter.
      * Returns the component data necessary for the /payments request
      */
-    protected formatData(): any {
+    protected formatData(): Partial<PaymentData> {
         return {};
     }
 
@@ -86,7 +86,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
      * Returns the component payment data ready to submit to the Checkout API
      * Note: this does not ensure validity, check isValid first
      */
-    public get data(): PaymentData {
+    public get data(): Partial<PaymentData> {
         const order = this.state.order || this.props.order;
         const componentData = this.formatData();
         const doesPaymentMethodHaveNativeComponent = Boolean(getComponentNameOfPaymentType(componentData.paymentMethod?.type));
@@ -160,7 +160,7 @@ abstract class BaseElement<P extends BaseElementProps> implements IBaseElement {
      */
     public update(props: Partial<P>): this {
         this.props = this.formatProps({ ...this.props, ...props });
-        this.state = {};
+        this.state = {} as S;
 
         return this.unmount().mount(this._node); // for new mount fny
     }

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -78,7 +78,7 @@ abstract class BaseElement<P extends BaseElementProps, S extends BaseElementStat
         return null;
     }
 
-    protected setState(newState: object): void {
+    protected setState(newState: S): void {
         this.state = { ...this.state, ...newState };
     }
 

--- a/packages/lib/src/components/internal/BaseElement/BaseElement.ts
+++ b/packages/lib/src/components/internal/BaseElement/BaseElement.ts
@@ -66,8 +66,8 @@ abstract class BaseElement<P extends BaseElementProps, S extends BaseElementStat
      * Executed on the `data` getter.
      * Returns the component data necessary for the /payments request
      */
-    protected formatData(): Partial<PaymentData> {
-        return {};
+    protected formatData(): PaymentData {
+        return {} as PaymentData;
     }
 
     protected submitAnalytics(_analyticsObj?: AbstractAnalyticsEvent) {
@@ -86,7 +86,7 @@ abstract class BaseElement<P extends BaseElementProps, S extends BaseElementStat
      * Returns the component payment data ready to submit to the Checkout API
      * Note: this does not ensure validity, check isValid first
      */
-    public get data(): Partial<PaymentData> {
+    public get data(): PaymentData {
         const order = this.state.order || this.props.order;
         const componentData = this.formatData();
         const doesPaymentMethodHaveNativeComponent = Boolean(getComponentNameOfPaymentType(componentData.paymentMethod?.type));

--- a/packages/lib/src/components/internal/BaseElement/types.ts
+++ b/packages/lib/src/components/internal/BaseElement/types.ts
@@ -1,9 +1,10 @@
-import { Order } from '../../../types/global-types';
+import { Order, PaymentData } from '../../../types/global-types';
 import { SRPanel } from '../../../core/Errors/SRPanel';
 import { Resources } from '../../../core/Context/Resources';
 import RiskElement from '../../../core/RiskModule';
 import { ComponentChild } from 'preact';
 import type { IAnalytics } from '../../../core/Analytics/Analytics';
+import type { OnChangeData } from '../../../types';
 
 export interface BaseElementProps {
     order?: Order;
@@ -19,15 +20,17 @@ export interface BaseElementProps {
     isDropin?: boolean;
 }
 
-export interface IBaseElement {
-    data: object;
-    state: any;
-    props: any;
+export type BaseElementState = { order?: Order } & Pick<OnChangeData, 'valid' | 'errors'> & Record<string, unknown>;
+
+export interface IBaseElement<P extends BaseElementProps = BaseElementProps, S extends BaseElementState = BaseElementState> {
+    data: Partial<PaymentData>;
+    state: S;
+    props: P;
     _id: string;
-    _component: any;
+    _component: ComponentChild;
     render(): ComponentChild | Error;
     mount(domNode: HTMLElement | string): IBaseElement;
-    update(props): IBaseElement;
+    update(props: Partial<P>): IBaseElement;
     unmount(): IBaseElement;
     remove(): void;
     activate(): void;

--- a/packages/lib/src/components/internal/BaseElement/types.ts
+++ b/packages/lib/src/components/internal/BaseElement/types.ts
@@ -20,7 +20,8 @@ export interface BaseElementProps {
     isDropin?: boolean;
 }
 
-export type BaseElementState = { order?: Order } & Pick<OnChangeData, 'valid' | 'errors'> & Record<string, unknown>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type BaseElementState = { order?: Order } & Pick<OnChangeData, 'valid' | 'errors'> & Record<string, any>;
 
 export interface IBaseElement<P extends BaseElementProps = BaseElementProps, S extends BaseElementState = BaseElementState> {
     data: Partial<PaymentData>;

--- a/packages/lib/src/components/internal/BaseElement/types.ts
+++ b/packages/lib/src/components/internal/BaseElement/types.ts
@@ -24,7 +24,7 @@ export interface BaseElementProps {
 export type BaseElementState = { order?: Order } & Pick<OnChangeData, 'valid' | 'errors'> & Record<string, any>;
 
 export interface IBaseElement<P extends BaseElementProps = BaseElementProps, S extends BaseElementState = BaseElementState> {
-    data: Partial<PaymentData>;
+    data: PaymentData;
     state: S;
     props: P;
     _id: string;

--- a/packages/lib/src/components/internal/BaseElement/types.ts
+++ b/packages/lib/src/components/internal/BaseElement/types.ts
@@ -20,6 +20,7 @@ export interface BaseElementProps {
     isDropin?: boolean;
 }
 
+// TODO: Remove any when the state data of all components have been typed
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type BaseElementState = { order?: Order } & Pick<OnChangeData, 'valid' | 'errors'> & Record<string, any>;
 

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
@@ -6,6 +6,8 @@ import { electronicFormat, formatIban, getCountryCode, getNextCursorPosition } f
 import Fieldset from '../FormFields/Fieldset';
 import { GenericError } from '../../../core/Errors/types';
 import InputText from '../FormFields/InputText';
+import { UIElementStatus } from '../UIElement/types';
+import { OnChangeData } from '../../../types';
 
 interface IbanInputProps {
     holderName?: boolean;
@@ -13,12 +15,12 @@ interface IbanInputProps {
     countryCode?: string;
     showPayButton?: boolean;
     payButton?: any;
-    onChange: (data) => void;
+    onChange: (data: OnChangeData) => void;
     label: string;
-    data: IbanData;
+    data?: IbanData;
 }
 
-interface IbanData {
+export interface IbanData {
     ownerName?: string;
     ibanNumber?: string;
     countryCode?: string;
@@ -70,8 +72,8 @@ class IbanInput extends Component<Readonly<IbanInputProps>, IbanInputState> {
         }
 
         if (this.state.data['ibanNumber'] || this.state.data['ownerName']) {
-            const holderNameValid = this.props.holderName ? isValidHolder(this.state.data['ownerName']) : '';
-            const ibanValid = this.state.data['ibanNumber'] ? checkIbanStatus(this.state.data['ibanNumber']).status === 'valid' : '';
+            const holderNameValid = this.props.holderName ? isValidHolder(this.state.data['ownerName']) : false;
+            const ibanValid = this.state.data['ibanNumber'] ? checkIbanStatus(this.state.data['ibanNumber']).status === 'valid' : false;
             const isValid = ibanValid && holderNameValid;
             const data = { data: this.state.data, isValid };
 
@@ -87,7 +89,7 @@ class IbanInput extends Component<Readonly<IbanInputProps>, IbanInputState> {
         label: null
     };
 
-    setStatus(status) {
+    setStatus(status: UIElementStatus) {
         this.setState({ status });
     }
 

--- a/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
+++ b/packages/lib/src/components/internal/IbanInput/IbanInput.tsx
@@ -72,7 +72,7 @@ class IbanInput extends Component<Readonly<IbanInputProps>, IbanInputState> {
         }
 
         if (this.state.data['ibanNumber'] || this.state.data['ownerName']) {
-            const holderNameValid = this.props.holderName ? isValidHolder(this.state.data['ownerName']) : false;
+            const holderNameValid = this.props.holderName ? isValidHolder(this.state.data['ownerName']) : true;
             const ibanValid = this.state.data['ibanNumber'] ? checkIbanStatus(this.state.data['ibanNumber']).status === 'valid' : false;
             const isValid = ibanValid && holderNameValid;
             const data = { data: this.state.data, isValid };
@@ -119,10 +119,7 @@ class IbanInput extends Component<Readonly<IbanInputProps>, IbanInputState> {
             prevState => ({ data: { ...prevState.data, ownerName: holder } }),
             () => {
                 const holderStatus = isValidHolder(this.state.data['ownerName']);
-                const holderErr =
-                    holderStatus != null && !holderStatus // *don't* consider null, i.e. a value that has just been deleted, to be in error
-                        ? ibanHolderNameErrorObj
-                        : null;
+                const holderErr = holderStatus && !holderStatus ? ibanHolderNameErrorObj : null;
 
                 this.setError('holder', holderErr, this.onChange);
             }
@@ -163,7 +160,7 @@ class IbanInput extends Component<Readonly<IbanInputProps>, IbanInputState> {
 
         if (currentIban.length > 0) {
             const validationStatus = checkIbanStatus(currentIban).status;
-            this.setError('iban', validationStatus !== 'valid' ? ibanErrorObj : null, this.onChange);
+            this.setError('iban', validationStatus === 'valid' ? null : ibanErrorObj, this.onChange);
         } else {
             // Empty field is not in error
             this.setError('iban', null, this.onChange);
@@ -173,11 +170,9 @@ class IbanInput extends Component<Readonly<IbanInputProps>, IbanInputState> {
     showValidation() {
         const validationStatus = checkIbanStatus(this.state.data['ibanNumber']).status;
         const holderStatus = isValidHolder(this.state.data['ownerName']);
-        this.setError('iban', validationStatus !== 'valid' ? ibanErrorObj : null);
+        this.setError('iban', validationStatus === 'valid' ? null : ibanErrorObj);
 
-        const holderErr = !holderStatus // *do* consider null, i.e. an empty field, to be in error
-            ? ibanHolderNameErrorObj
-            : null;
+        const holderErr = holderStatus ? null : ibanHolderNameErrorObj;
 
         this.setError('holder', holderErr, this.onChange); // add callback param to force propagation of state to parent comp
     }

--- a/packages/lib/src/components/internal/IbanInput/validate.test.ts
+++ b/packages/lib/src/components/internal/IbanInput/validate.test.ts
@@ -39,12 +39,12 @@ describe('IBAN Validations', () => {
             expect(isValidHolder('John Doe')).toBe(true);
         });
 
-        test('Returns null for an empty account Holder Name', () => {
-            expect(isValidHolder('')).toBe(null);
+        test('Returns false for an empty account Holder Name', () => {
+            expect(isValidHolder('')).toBe(false);
         });
 
-        test('Returns null for an undefined account Holder Name', () => {
-            expect(isValidHolder(undefined)).toBe(null);
+        test('Returns false for an undefined account Holder Name', () => {
+            expect(isValidHolder(undefined)).toBe(false);
         });
     });
 

--- a/packages/lib/src/components/internal/IbanInput/validate.ts
+++ b/packages/lib/src/components/internal/IbanInput/validate.ts
@@ -72,4 +72,4 @@ export const checkIbanStatus = iban => {
 /**
  * Checks validity of a holder name
  */
-export const isValidHolder = value => (isEmpty(value) ? null : true); // true, if there are chars other than spaces
+export const isValidHolder = (value: string) => !isEmpty(value);

--- a/packages/lib/src/components/internal/IssuerList/types.ts
+++ b/packages/lib/src/components/internal/IssuerList/types.ts
@@ -7,7 +7,7 @@ export interface IssuerListProps {
     items: IssuerItem[];
     // Component type (e.g. onlineBanking)
     type: string;
-    showPayButton: boolean;
+    showPayButton?: boolean;
     payButton(props: PayButtonProps): ComponentChildren;
     onChange(payload: any): void;
     highlightedIds?: string[];

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -1,5 +1,6 @@
 import { h } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
+import classNames from 'classnames';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
 import CompanyDetails from '../CompanyDetails';
 import PersonalDetails from '../PersonalDetails';
@@ -15,14 +16,13 @@ import {
     OpenInvoiceStateError,
     OpenInvoiceStateValid
 } from './types';
-import './OpenInvoice.scss';
 import IbanInput from '../IbanInput';
 import { GenericError } from '../../../core/Errors/types';
 import Field from '../FormFields/Field';
 import FormInstruction from '../FormInstruction';
 import { ComponentMethodsRef } from '../UIElement/types';
 import useSRPanelForOpenInvoiceErrors from './useSRPanelForOpenInvoiceErrors';
-import classNames from 'classnames';
+import './OpenInvoice.scss';
 
 const consentCBErrorObj: GenericError = {
     isValid: false,
@@ -33,13 +33,6 @@ const consentCBErrorObj: GenericError = {
 export default function OpenInvoice(props: Readonly<OpenInvoiceProps>) {
     const { countryCode, visibility } = props;
     const { i18n } = useCoreContext();
-
-    /** An object by which to expose 'public' members to the parent UIElement */
-    const openInvoiceRef = useRef<ComponentMethodsRef>({});
-    // Just call once
-    if (!Object.keys(openInvoiceRef.current).length) {
-        props.setComponentRef?.(openInvoiceRef.current);
-    }
 
     const isValidating = useRef(false);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -69,19 +62,23 @@ export default function OpenInvoice(props: Readonly<OpenInvoiceProps>) {
     const [valid, setValid] = useState<OpenInvoiceStateValid>({});
     const [status, setStatus] = useState('ready');
 
-    // Expose methods expected by parent
-    openInvoiceRef.current.showValidation = () => {
-        isValidating.current = true;
-        fieldsetsSchema.forEach(fieldset => {
-            if (fieldsetsRefs[fieldset].current) fieldsetsRefs[fieldset].current.showValidation();
-        });
+    const openInvoiceRef = useRef<ComponentMethodsRef>({
+        setStatus,
+        showValidation: () => {
+            isValidating.current = true;
+            fieldsetsSchema.forEach(fieldset => {
+                if (fieldsetsRefs[fieldset].current) fieldsetsRefs[fieldset].current.showValidation();
+            });
 
-        setErrors({
-            ...(hasConsentCheckbox && { consentCheckbox: data.consentCheckbox ? null : consentCBErrorObj })
-        });
-    };
+            setErrors({
+                ...(hasConsentCheckbox && { consentCheckbox: data.consentCheckbox ? null : consentCBErrorObj })
+            });
+        }
+    });
 
-    openInvoiceRef.current.setStatus = setStatus;
+    useEffect(() => {
+        props.setComponentRef?.(openInvoiceRef.current);
+    }, [props.setComponentRef]);
 
     useSRPanelForOpenInvoiceErrors({ errors, data, props, isValidating, containerRef });
 

--- a/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
+++ b/packages/lib/src/components/internal/OpenInvoice/OpenInvoice.tsx
@@ -64,17 +64,19 @@ export default function OpenInvoice(props: Readonly<OpenInvoiceProps>) {
 
     const openInvoiceRef = useRef<ComponentMethodsRef>({
         setStatus,
-        showValidation: () => {
-            isValidating.current = true;
-            fieldsetsSchema.forEach(fieldset => {
-                if (fieldsetsRefs[fieldset].current) fieldsetsRefs[fieldset].current.showValidation();
-            });
-
-            setErrors({
-                ...(hasConsentCheckbox && { consentCheckbox: data.consentCheckbox ? null : consentCBErrorObj })
-            });
-        }
+        showValidation: () => {}
     });
+
+    openInvoiceRef.current.showValidation = () => {
+        isValidating.current = true;
+        fieldsetsSchema.forEach(fieldset => {
+            if (fieldsetsRefs[fieldset].current) fieldsetsRefs[fieldset].current.showValidation();
+        });
+
+        setErrors({
+            ...(hasConsentCheckbox && { consentCheckbox: data.consentCheckbox ? null : consentCBErrorObj })
+        });
+    };
 
     useEffect(() => {
         props.setComponentRef?.(openInvoiceRef.current);

--- a/packages/lib/src/components/internal/OpenInvoice/types.ts
+++ b/packages/lib/src/components/internal/OpenInvoice/types.ts
@@ -23,9 +23,9 @@ export interface BankDetailsSchema {
 
 export interface OpenInvoiceProps extends UIElementProps {
     allowedCountries?: string[];
-    consentCheckboxLabel: any;
+    consentCheckboxLabel?: any;
     countryCode?: string;
-    data: {
+    data?: {
         companyDetails?: CompanyDetailsSchema;
         personalDetails?: PersonalDetailsSchema | null;
         billingAddress?: AddressData;

--- a/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
+++ b/packages/lib/src/components/internal/RedirectButton/RedirectButton.tsx
@@ -1,10 +1,9 @@
-import { h, Fragment, Ref } from 'preact';
+import { h, Fragment } from 'preact';
 import { useCoreContext } from '../../../core/Context/CoreProvider';
-import { useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { useAmount } from '../../../core/Context/AmountProvider';
+import { ComponentMethodsRef } from '../UIElement/types';
 
-// TODO this should ideally be remove but we need let prop propagate down
-//  probably not worth changing this behaviour now
 export interface RedirectButtonProps {
     label?: string;
     icon?: string;
@@ -12,17 +11,30 @@ export interface RedirectButtonProps {
     onSubmit: Function;
     name: string;
     showPayButton: boolean;
-    ref?: Ref<typeof RedirectButton>;
+    setComponentRef: (ref: ComponentMethodsRef) => void;
 }
 
-function RedirectButton({ label = null, icon = null, payButton, onSubmit, name, showPayButton, ...props }: Readonly<RedirectButtonProps>) {
+function RedirectButton({
+    label = null,
+    icon = null,
+    payButton,
+    onSubmit,
+    name,
+    showPayButton,
+    setComponentRef,
+    ...props
+}: Readonly<RedirectButtonProps>) {
     const { i18n } = useCoreContext();
     const [status, setStatus] = useState('ready');
     const { amount } = useAmount();
 
-    this.setStatus = newStatus => {
-        setStatus(newStatus);
-    };
+    const redirectButtonRef = useRef<ComponentMethodsRef>({
+        setStatus: setStatus
+    });
+
+    useEffect(() => {
+        setComponentRef(redirectButtonRef.current);
+    }, [setComponentRef]);
 
     const payButtonLabel = () => {
         const isZeroAuth = amount && {}.hasOwnProperty.call(amount, 'value') && amount.value === 0;

--- a/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
+++ b/packages/lib/src/components/internal/SecuredFields/SFP/SecuredFieldsProvider.ts
@@ -32,7 +32,7 @@ import { TxVariants } from '../../../tx-variants';
  * Initialises & handles the client-side part of SecuredFields
  */
 class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
-    private csfLoadFailTimeout: number;
+    private readonly csfLoadFailTimeout: number;
     private readonly csfLoadFailTimeoutMS: number;
     private readonly csfConfigFailTimeout: number;
     private readonly csfConfigFailTimeoutMS: number;
@@ -397,7 +397,7 @@ class SecuredFieldsProvider extends Component<SFPProps, SFPState> {
         if (this.csf) this.csf.brandsFromBinLookup(binLookupResponse, mustResetDedicatedBrand ? resetObject : null);
     }
 
-    private setRootNode = (input: HTMLElement): void => {
+    private readonly setRootNode = (input: HTMLElement): void => {
         this.rootNode = input;
     };
 

--- a/packages/lib/src/components/internal/UIElement/UIElement.test.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.test.tsx
@@ -26,7 +26,7 @@ class MyElement extends UIElement<MyElementProps> {
         return false;
     }
     public callOnComplete() {
-        super.onComplete({});
+        super.onComplete({ data: { details: {} } });
     }
     public callOnChange() {
         super.onChange();

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -367,7 +367,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         // };
     }
 
-    protected onComplete(state): void {
+    protected onComplete(state: AdditionalDetailsData): void {
         this.handleAdditionalDetails(state);
     }
 

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -237,7 +237,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     protected onChange(): void {
         this.props.onChange?.(
             {
-                data: this.data as PaymentData,
+                data: this.data,
                 isValid: this.isValid,
                 errors: this.state.errors,
                 valid: this.state.valid
@@ -299,12 +299,12 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         if (this.core.session) {
             const beforeSubmitEvent: Promise<PaymentData> = this.props.beforeSubmit
                 ? new Promise((resolve, reject) => {
-                      void this.props.beforeSubmit(this.data as PaymentData, this.elementRef, {
+                      void this.props.beforeSubmit(this.data, this.elementRef, {
                           resolve,
                           reject: () => reject(new CancelError('beforeSubmitRejected'))
                       });
                   })
-                : Promise.resolve(this.data as PaymentData);
+                : Promise.resolve(this.data);
 
             return beforeSubmitEvent.then(this.submitUsingSessionsFlow);
         }
@@ -328,7 +328,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         return new Promise<CheckoutAdvancedFlowResponse>((resolve, reject) => {
             this.props.onSubmit(
                 {
-                    data: this.data as PaymentData,
+                    data: this.data,
                     isValid: this.isValid
                 },
                 this.elementRef,

--- a/packages/lib/src/components/internal/UIElement/UIElement.tsx
+++ b/packages/lib/src/components/internal/UIElement/UIElement.tsx
@@ -41,7 +41,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     /**
      * componentRef is a ref to the primary component inside the subclass that extends UIElement e.g. CardInput.tsx (which sits inside Card.tsx)
      */
-    protected componentRef: any;
+    protected componentRef: ComponentMethodsRef | undefined;
 
     protected resources: Resources;
 
@@ -104,7 +104,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     private createBeforeRenderHook(configSetByMerchant: P): void {
         const originalRender = this.render;
 
-        this.render = (...args: any[]) => {
+        this.render = (...args: unknown[]) => {
             this.beforeRender(configSetByMerchant);
             return originalRender.apply(this, args);
         };
@@ -195,7 +195,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
     }
 
     public showValidation(): this {
-        if (this.componentRef && this.componentRef.showValidation) this.componentRef.showValidation();
+        this.componentRef?.showValidation?.();
         return this;
     }
 
@@ -221,25 +221,23 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
      * - If Drop-in, will set status for Dropin component, and then it will propagate the new status for the active payment method component
      * - If Component, it will set its own status
      */
-    public setElementStatus(status: UIElementStatus, props?: any): this {
-        this.elementRef?.setStatus(status, props);
+    public setElementStatus(status: UIElementStatus): this {
+        this.elementRef?.setStatus?.(status);
         return this;
     }
 
     /**
      * componentRef is a ref to the primary component inside that subclass e.g. CardInput.tsx
      */
-    public setStatus(status: UIElementStatus, props?): this {
-        if (this.componentRef?.setStatus) {
-            this.componentRef.setStatus(status, props);
-        }
+    public setStatus(status: UIElementStatus): this {
+        this.componentRef?.setStatus?.(status);
         return this;
     }
 
     protected onChange(): void {
         this.props.onChange?.(
             {
-                data: this.data,
+                data: this.data as PaymentData,
                 isValid: this.isValid,
                 errors: this.state.errors,
                 valid: this.state.valid
@@ -301,12 +299,12 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         if (this.core.session) {
             const beforeSubmitEvent: Promise<PaymentData> = this.props.beforeSubmit
                 ? new Promise((resolve, reject) => {
-                      void this.props.beforeSubmit(this.data, this.elementRef, {
+                      void this.props.beforeSubmit(this.data as PaymentData, this.elementRef, {
                           resolve,
                           reject: () => reject(new CancelError('beforeSubmitRejected'))
                       });
                   })
-                : Promise.resolve(this.data);
+                : Promise.resolve(this.data as PaymentData);
 
             return beforeSubmitEvent.then(this.submitUsingSessionsFlow);
         }
@@ -330,7 +328,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         return new Promise<CheckoutAdvancedFlowResponse>((resolve, reject) => {
             this.props.onSubmit(
                 {
-                    data: this.data,
+                    data: this.data as PaymentData,
                     isValid: this.isValid
                 },
                 this.elementRef,
@@ -423,7 +421,7 @@ export abstract class UIElement<P extends UIElementProps = UIElementProps> exten
         );
     }
 
-    private async submitAdditionalDetailsUsingSessionsFlow(data: any): Promise<CheckoutSessionDetailsResponse> {
+    private async submitAdditionalDetailsUsingSessionsFlow(data: AdditionalDetailsData['data']): Promise<CheckoutSessionDetailsResponse> {
         try {
             return await this.core.session.submitDetails(data);
         } catch (error: unknown) {

--- a/packages/lib/src/components/internal/UIElement/types.ts
+++ b/packages/lib/src/components/internal/UIElement/types.ts
@@ -3,7 +3,7 @@ import Session from '../../../core/CheckoutSession';
 import Language from '../../../language';
 import UIElement from './UIElement';
 import type { PaymentAction, PaymentAmount } from '../../../types/global-types';
-import type { BaseElementProps } from '../BaseElement/types';
+import type { BaseElementProps, BaseElementState } from '../BaseElement/types';
 import type { CoreConfiguration } from '../../../core/types';
 import { PayButtonProps } from '../PayButton/PayButton';
 
@@ -35,7 +35,7 @@ export type UIElementProps = {
         environment?: string;
         session?: Session;
 
-        onComplete?: (state, element: UIElement) => void;
+        onComplete?: (state: BaseElementState, element: UIElement) => void;
 
         isInstantPayment?: boolean;
 
@@ -89,7 +89,7 @@ export type UIElementProps = {
         clientKey?: string;
 
         /** @internal */
-        elementRef?: any;
+        elementRef?: UIElement;
 
         /** @internal */
         i18n?: Language;

--- a/packages/lib/src/components/internal/UIElement/utils.ts
+++ b/packages/lib/src/components/internal/UIElement/utils.ts
@@ -1,4 +1,4 @@
-import { UIElementStatus } from './types';
+import UIElement from '.';
 import { RawPaymentResponse, PaymentResponseData, Order } from '../../../types/global-types';
 import { IDropin } from '../../Dropin/types';
 
@@ -36,21 +36,6 @@ export function cleanupFinalResult(paymentResponse?: PaymentResponseData): void 
     }
 }
 
-export function resolveFinalResult(result: PaymentResponseData): [status: UIElementStatus, statusProps?: any] {
-    switch (result.resultCode) {
-        case 'Authorised':
-        case 'Received':
-            return ['success'];
-        case 'Pending':
-            return ['success'];
-        case 'Cancelled':
-        case 'Error':
-        case 'Refused':
-            return ['error'];
-        default:
-    }
-}
-
 export function verifyPaymentDidNotFail(response: PaymentResponseData): Promise<PaymentResponseData> {
     if (['Cancelled', 'Error', 'Refused'].includes(response.resultCode)) {
         return Promise.reject(response);
@@ -59,14 +44,18 @@ export function verifyPaymentDidNotFail(response: PaymentResponseData): Promise<
     return Promise.resolve(response);
 }
 
-export function assertIsDropin(element: any): element is IDropin {
+export function assertIsDropin(element?: UIElement): element is UIElement & IDropin {
     if (!element) return false;
 
-    const isDropin = typeof element.activePaymentMethod === 'object' && typeof element.closeActivePaymentMethod === 'function';
+    const isDropin =
+        `activePaymentMethod` in element &&
+        typeof element.activePaymentMethod === 'object' &&
+        `closeActivePaymentMethod` in element &&
+        typeof element.closeActivePaymentMethod === 'function';
     return isDropin;
 }
 
-export function getRegulatoryDefaults(countryCode: string, isDropinInstance: boolean): Record<string, any> {
+export function getRegulatoryDefaults(countryCode: string, isDropinInstance: boolean) {
     switch (countryCode) {
         // Finnish regulations state that no payment method can be open by default
         case 'FI':

--- a/packages/lib/src/types/global-types.ts
+++ b/packages/lib/src/types/global-types.ts
@@ -291,7 +291,7 @@ export interface PaymentData extends PaymentMethodData {
         orderData: string;
         pspReference: string;
     };
-    clientStateDataIndicator: boolean;
+    clientStateDataIndicator?: boolean;
     sessionData?: string;
     storePaymentMethod?: boolean;
     billingAddress?: AddressData;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [x] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

Tightens the typing of the core `BaseElement`/`UIElement` hierarchy so the base classes no longer rely on implicit or explicit `any`, and removes both from the ESLint `no-explicit-any` exemption list.

### Key changes

- `BaseElement` is now generic over its state (`BaseElement<P, S>`), with `state`, `_component`, and `formatData()` properly typed instead of `any`. `IBaseElement` is likewise parameterised by props and state.
- `UIElement.componentRef` is typed as `ComponentMethodsRef`, and ref access is narrowed via optional chaining rather than truthiness checks.
- The unused second `props` argument was dropped from `setStatus()` / `setElementStatus()`, and the dead `resolveFinalResult()` helper was removed.
- `assertIsDropin()` now narrows with `in` checks against a typed `UIElement` instead of accepting `any`.
- Payment method components were updated to match the stricter base signatures, mostly by typing callback payloads and component refs.
- Components that previously assigned methods onto `this` from a function component (e.g. `RedirectButton`, `BacsInput`) now expose their imperative API through the standard `setComponentRef` + `useRef` pattern.
- `PaymentData.clientStateDataIndicator` is now optional, matching how it is actually populated.

### Notes

- `setStatus(status, props)` and `setElementStatus(status, props)` silently ignored the second argument, so dropping it is behaviour-preserving for JS callers, but it is a signature change for TypeScript users passing it. Released as a patch.
- Unit tests for Bacs were updated alongside the ref refactor; the full suite passes

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

