### PR TITLE
chore: support manual snapshot releases without a pull request

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,13 +1,18 @@
-# Triggered by adding the `release-snapshot` label to an approved pull request to
-# build a one off preview of the PR's source branch, e.g.
-# 6.43.0-alpha.{commit-hash}. The label is removed again when the run finishes,
-# whether it succeeded or failed, so it can be added again for a new build.
+# Builds a one off preview of a feature branch, e.g. 6.43.0-alpha.{commit-hash}.
+#
+# Two ways to trigger it:
+#   1. Add the `release-snapshot` label to an approved pull request. The label is
+#      removed again when the run finishes, whether it succeeded or failed, so it
+#      can be added again for a new build.
+#   2. Run the workflow manually on the source branch. This needs no pull request,
+#      which is useful when the PR has conflicts with main and should not be
+#      rebased yet.
 #
 # It does NOT commit any version or changelog change back to the branch. It
 # creates a prerelease GitHub Release with the UMD build attached and a git tag
-# for the snapshot version, then comments the release link on the PR. npm is NOT
-# published here; trigger .github/workflows/npm-publish.yml manually on the tag
-# it creates.
+# for the snapshot version, and on the pull request flow comments the release
+# link on the PR. npm is NOT published here; trigger
+# .github/workflows/npm-publish.yml manually on the tag it creates.
 #
 # Requires at least one changeset on the branch so the snapshot can be computed.
 name: Release | Snapshot
@@ -15,17 +20,19 @@ name: Release | Snapshot
 on:
   pull_request:
     types: [labeled]
+  workflow_dispatch:
 
-# One snapshot build per PR at a time. Runs are queued rather than cancelled: a
-# cancelled run can leave a pushed tag with no GitHub Release behind it. Builds
-# for different PRs are independent and may run in parallel.
+# One snapshot build per PR or branch at a time. Runs are queued rather than
+# cancelled: a cancelled run can leave a pushed tag with no GitHub Release behind
+# it. Builds for different PRs or branches are independent and may run in
+# parallel.
 concurrency:
-  group: release-snapshot-pr-${{ github.event.pull_request.number }}
+  group: release-snapshot-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
   release-snapshot:
-    if: github.repository == 'adyen/adyen-web' && github.event.label.name == 'release-snapshot'
+    if: github.repository == 'adyen/adyen-web' && github.event_name == 'pull_request' && github.event.label.name == 'release-snapshot'
     name: Build Snapshot
     runs-on: ubuntu-latest
     permissions:
@@ -133,3 +140,75 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label release-snapshot
+
+  # Same build as above, but triggered manually on a branch. Use this when the
+  # branch has no pull request, or when the pull request conflicts with main and
+  # should not be rebased yet.
+  release-snapshot-manual:
+    if: github.repository == 'adyen/adyen-web' && github.event_name == 'workflow_dispatch'
+    name: Build Snapshot (manual)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create git tag and GitHub Release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Project Dependencies
+        run: yarn install
+
+      - name: Version snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn changeset version --snapshot alpha.${GITHUB_SHA::7}
+
+      - name: Read SDK version
+        id: sdk-version
+        run: echo "version=$(node -p "require('./packages/lib/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        run: cd packages/lib && yarn build
+        env:
+          CI: true
+
+      - name: Bundle UMD and translations
+        run: |
+          cp packages/server/translations/ packages/lib/dist/umd -r
+          cd packages/lib/dist/umd && zip -r /tmp/adyen-web-sdk-umd-and-translations-${{ steps.sdk-version.outputs.version }}.zip .
+
+      - name: Upload UMD and translations artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: adyen-web-sdk-umd-and-translations-${{ steps.sdk-version.outputs.version }}
+          path: packages/lib/dist/umd
+
+      # Tag the snapshot version. This commits the version bump only to a detached
+      # commit that the tag points at, so the feature branch itself stays clean.
+      - name: Create Git tag
+        run: |
+          TAG="v${{ steps.sdk-version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "[ci] snapshot ${TAG}"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub Prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.sdk-version.outputs.version }}" \
+            --title "${{ steps.sdk-version.outputs.version }}" \
+            --notes "Snapshot preview build from branch [${{ github.ref_name }}](${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }})." \
+            --prerelease \
+            "/tmp/adyen-web-sdk-umd-and-translations-${{ steps.sdk-version.outputs.version }}.zip"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

The snapshot release workflow could only be triggered by labelling a pull request, which blocks a preview build whenever the PR has conflicts with main and we don't want to rebase it yet. This restores the manual, branch-only trigger alongside the existing PR flow.

- Added `workflow_dispatch` to the workflow triggers so a snapshot can be built from any branch.
- Added a `release-snapshot-manual` job that checks out the dispatched ref, versions the snapshot from `GITHUB_SHA`, and creates the tag, artifact and GitHub prerelease. It needs only `contents: write` and skips the approval check, PR comment and label removal.
- Scoped the existing `release-snapshot` job to `github.event_name == 'pull_request'` so it doesn't run with empty PR fields on a manual dispatch.
- Changed the concurrency group to `release-snapshot-${{ github.event.pull_request.number || github.ref }}` so PR runs and branch runs serialise on their own key.

Note: the manual job has no approval gate — unlike the PR flow, it relies on who is permitted to dispatch workflows. This matches the behaviour before the PR-only trigger was introduced.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

---

## 🧪 Tested scenarios

<!-- Description of tested scenarios -->

---

## 🔗 Related GitHub Issue / Internal Ticket number

<!--
Link the GitHub issue or internal ticket number this PR addresses.
-->

**Closes**:  <!-- #-prefixed issue number -->

---

