### PR TITLE
feat: add CSP nonce support for Google Pay

### DIFF
--- a/.changeset/googlepay-nonce.md
+++ b/.changeset/googlepay-nonce.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": minor
+---
+
+New: Support Content Security Policy (CSP) nonce in Google Pay configuration and upgrade `@types/googlepay` to `0.7.12`.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,3 +8,4 @@ npmMinimalAgeGate: "21d"
 npmPreapprovedPackages:
   - "vite@6.4.3"
   - "@adyen/*"
+  - "@types/googlepay@0.7.12"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -139,7 +139,7 @@
     "dependencies": {
         "@paypal/paypal-js": "10.0.3",
         "@types/applepayjs": "14.0.9",
-        "@types/googlepay": "0.7.11",
+        "@types/googlepay": "0.7.12",
         "classnames": "2.5.1",
         "preact": "10.29.7"
     },

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -72,6 +72,17 @@ describe('GooglePay', () => {
             expect(googlepay.props.configuration.merchantId).toBe('merchant-id');
             expect(googlepay.props.configuration.gatewayMerchantId).toBe('gateway-id');
         });
+
+        test('should forward nonce to GooglePayService', () => {
+            new GooglePay(global.core, {
+                configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
+                nonce: 'test-csp-nonce'
+            });
+
+            const [, , callbacks, nonce] = (GooglePayService as unknown as jest.Mock).mock.calls[0];
+            expect(nonce).toBe('test-csp-nonce');
+            expect(callbacks).toHaveProperty('onPaymentAuthorized');
+        });
     });
 
     describe('onClick()', () => {

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -45,10 +45,15 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
             );
         }
 
-        this.googlePay = new GooglePayService(this.props.environment, this.analytics, {
-            ...(isExpress && paymentDataCallbacks?.onPaymentDataChanged && { onPaymentDataChanged: paymentDataCallbacks.onPaymentDataChanged }),
-            onPaymentAuthorized: this.onPaymentAuthorized
-        });
+        this.googlePay = new GooglePayService(
+            this.props.environment,
+            this.analytics,
+            {
+                ...(isExpress && paymentDataCallbacks?.onPaymentDataChanged && { onPaymentDataChanged: paymentDataCallbacks.onPaymentDataChanged }),
+                onPaymentAuthorized: this.onPaymentAuthorized
+            },
+            this.props.nonce
+        );
     }
 
     /**

--- a/packages/lib/src/components/GooglePay/GooglePayEnvironment.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayEnvironment.test.ts
@@ -83,4 +83,35 @@ describe('GooglePay environment resolution', () => {
 
         expect(getGooglePaymentsClientSpy).toHaveBeenCalledWith(expect.objectContaining({ environment: 'TEST' }));
     });
+
+    test('should pass nonce to getGooglePaymentsClient when nonce is provided', async () => {
+        const checkout = new AdyenCheckout({
+            environment: 'test',
+            clientKey: 'test_123456',
+            countryCode: 'US'
+        });
+        await checkout.initialize();
+
+        new GooglePay(checkout, {
+            configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
+            nonce: 'csp-test-nonce'
+        });
+
+        expect(getGooglePaymentsClientSpy).toHaveBeenCalledWith(expect.objectContaining({ environment: 'TEST', nonce: 'csp-test-nonce' }));
+    });
+
+    test('should not include nonce in getGooglePaymentsClient when nonce is not provided', async () => {
+        const checkout = new AdyenCheckout({
+            environment: 'test',
+            clientKey: 'test_123456',
+            countryCode: 'US'
+        });
+        await checkout.initialize();
+
+        new GooglePay(checkout, {
+            configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' }
+        });
+
+        expect(getGooglePaymentsClientSpy).toHaveBeenCalledWith(expect.not.objectContaining({ nonce: expect.anything() }));
+    });
 });

--- a/packages/lib/src/components/GooglePay/GooglePayService.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayService.test.ts
@@ -1,0 +1,68 @@
+import GooglePayService from './GooglePayService';
+import Script from '../../utils/Script';
+import { mock } from 'jest-mock-extended';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
+
+jest.mock('../../utils/Script');
+
+const mockAnalytics = mock<IAnalytics>();
+
+describe('GooglePayService', () => {
+    const mockPaymentsClientConstructor = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // @ts-ignore Mock Script load method
+        (Script as jest.Mock).mockImplementation(() => ({
+            load: jest.fn().mockImplementation(() => {
+                (window as any).google = {
+                    payments: {
+                        api: {
+                            PaymentsClient: mockPaymentsClientConstructor
+                        }
+                    }
+                };
+                return Promise.resolve();
+            })
+        }));
+        delete (window as any).google;
+    });
+
+    test('should pass nonce to Script attributes and PaymentOptions when nonce is provided', async () => {
+        const service = new GooglePayService('test', mockAnalytics, {}, 'csp-nonce-123');
+        await service.paymentsClient;
+
+        expect(Script).toHaveBeenCalledWith(
+            expect.objectContaining({
+                component: 'googlepay',
+                attributes: {
+                    nonce: 'csp-nonce-123'
+                }
+            })
+        );
+
+        expect(mockPaymentsClientConstructor).toHaveBeenCalledWith(
+            expect.objectContaining({
+                environment: 'TEST',
+                nonce: 'csp-nonce-123'
+            })
+        );
+    });
+
+    test('should not include nonce in Script attributes or PaymentOptions when nonce is omitted', async () => {
+        const service = new GooglePayService('test', mockAnalytics, {});
+        await service.paymentsClient;
+
+        expect(Script).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                attributes: expect.anything()
+            })
+        );
+
+        expect(mockPaymentsClientConstructor).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                nonce: expect.anything()
+            })
+        );
+    });
+});

--- a/packages/lib/src/components/GooglePay/GooglePayService.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayService.ts
@@ -10,13 +10,14 @@ class GooglePayService {
 
     public readonly paymentsClient: Promise<google.payments.api.PaymentsClient>;
 
-    constructor(environment: string, analytics: IAnalytics, paymentDataCallbacks: google.payments.api.PaymentDataCallbacks) {
+    constructor(environment: string, analytics: IAnalytics, paymentDataCallbacks: google.payments.api.PaymentDataCallbacks, nonce?: string) {
         const googlePayEnvironment = resolveEnvironment(environment);
 
         this.analytics = analytics;
         this.paymentsClient = this.getGooglePaymentsClient({
             environment: googlePayEnvironment,
-            paymentDataCallbacks
+            paymentDataCallbacks,
+            ...(nonce && { nonce })
         });
     }
 
@@ -28,7 +29,12 @@ class GooglePayService {
      */
     async getGooglePaymentsClient(paymentOptions: google.payments.api.PaymentOptions): Promise<google.payments.api.PaymentsClient> {
         if (!window.google?.payments) {
-            const script = new Script({ src: config.URL, component: 'googlepay', analytics: this.analytics });
+            const script = new Script({
+                src: config.URL,
+                component: 'googlepay',
+                analytics: this.analytics,
+                ...(paymentOptions.nonce && { attributes: { nonce: paymentOptions.nonce } })
+            });
             await script.load();
         }
 

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -6,6 +6,13 @@ export interface GooglePayConfiguration extends UIElementProps {
     type?: 'googlepay' | 'paywithgoogle';
 
     /**
+     * Optional Content Security Policy (CSP) nonce to apply to all dynamically injected styles and scripts.
+     *
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#PaymentOptions
+     */
+    nonce?: string;
+
+    /**
      * List of brands accepted by the component. Values are configured on the Backoffice and returned in the /paymentMethodsResponse data
      * @internal
      */

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,7 +99,7 @@ __metadata:
     "@testing-library/preact-hooks": "npm:1.1.0"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/applepayjs": "npm:14.0.9"
-    "@types/googlepay": "npm:0.7.11"
+    "@types/googlepay": "npm:0.7.12"
     "@types/jest": "npm:30.0.0"
     autoprefixer: "npm:10.5.4"
     classnames: "npm:2.5.1"
@@ -4366,10 +4366,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/googlepay@npm:0.7.11":
-  version: 0.7.11
-  resolution: "@types/googlepay@npm:0.7.11"
-  checksum: 10c0/50c4dde745e0da9614037677d313af755285612260e5585eb9a8c918900ca45e236c51c721b52d6e15c3b89193cddb05ad09d0db5c8203c2d1489ef714cc3c64
+"@types/googlepay@npm:0.7.12":
+  version: 0.7.12
+  resolution: "@types/googlepay@npm:0.7.12"
+  checksum: 10c0/0700728c4482dd7f293344a9620c5c6fd4be9f24433a9f8250550f23c039892b998983b8de075aeed289076922f8cfc6699de5be34edc21bf0844b9ed4babf76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- ~~[] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes~~
- ~~[] All E2E tests are passing, and I have added new tests if necessary.~~
- [x] All interfaces and types introduced or updated are strictly typed. 
- ~~[ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR.~~
---

## 📝 Summary

### Motivation

Google Pay now supports Content Security Policy (CSP) nonces in the [PaymentOptions](https://developers.google.com/pay/api/web/reference/request-objects#PaymentOptions) object to allow seamless integration on websites enforcing strict CSP headers (without requiring `'unsafe-inline'`).

### Problem Solved

Previously, merchants implementing strict CSP policies could not supply a nonce to Google Pay. This could lead to CSP violations when loading Google's pay.js script and when Google Pay dynamically injected inline styles or iframes for the Google Pay button and payment sheets.

---

## 🧪 Tested scenarios

- **Script Tag Nonce Injection**: Verified via unit tests that providing a `nonce` populates the `attributes.nonce` property when loading the `pay.js` bundle via the `Script` utility.
- **PaymentsClient Options Propagation**: Verified via unit tests that `PaymentOptions` supplied to `new google.payments.api.PaymentsClient()` includes `{ nonce: '...' }` when configured.
- **Backwards Compatibility / Nonce Omission**: Verified that when `nonce` is not provided in `GooglePayConfiguration`, neither the script attributes nor `PaymentOptions` contain a `nonce` key.
- **Component Forwarding**: Verified that instantiating `new GooglePay(checkout, { nonce: '...' })` forwards the nonce correctly to `GooglePayService`.
---

## 🔗 Related GitHub Issue / Internal Ticket number
N/A
---

## 🔗 Related GitHub Issue / Internal Ticket number
N/A
---

