### PR TITLE
Fix/select improvements

### DIFF
--- a/.changeset/lucky-pans-smile.md
+++ b/.changeset/lucky-pans-smile.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Select dropdown spacing and secondary text color

--- a/packages/lib/src/components/internal/FormFields/Select/Select.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.scss
@@ -227,7 +227,7 @@
     flex-direction: column;
     flex-grow: 1;
     min-width: 0;
-    gap: variable-generator.token(spacer-040);
+    gap: variable-generator.token(spacer-020);
 }
 
 .adyen-checkout__dropdown__element__primary {
@@ -246,6 +246,10 @@
     &:not(:last-child) {
         margin-right: variable-generator.token(spacer-040);
     }
+}
+
+.adyen-checkout__dropdown__element__secondary-text {
+    color: variable-generator.token(color-label-secondary);
 }
 
 .adyen-checkout__dropdown + .adyen-checkout-input__inline-validation {

--- a/packages/lib/src/components/internal/FormFields/Select/Select.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.scss
@@ -155,6 +155,7 @@
 
     [dir='rtl'] & {
         margin-right: 0;
+        margin-left: variable-generator.token(spacer-090);
     }
 }
 

--- a/packages/lib/src/components/internal/FormFields/Select/Select.scss
+++ b/packages/lib/src/components/internal/FormFields/Select/Select.scss
@@ -149,6 +149,15 @@
     }
 }
 
+.adyen-checkout__dropdown__button__text:last-child,
+.adyen-checkout__filter-input:last-child {
+    margin-right: variable-generator.token(spacer-090);
+
+    [dir='rtl'] & {
+        margin-right: 0;
+    }
+}
+
 .adyen-checkout__dropdown__list {
     overflow-y: auto;
     display: none;


### PR DESCRIPTION
## 📋 Pull Request Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [ ] I have tested the changes manually in the local environment.
- [ ] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [ ] All interfaces and types introduced or updated are strictly typed.
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR.

---

## 📝 Summary

Visual fixes for the Select component.

- **Dropdown button text overlapped the chevron** when no tags were rendered. Only `__button__tags` reserved space for the chevron, so without tags the text/filter input ran underneath it. Added a `:last-child` rule on `__button__text` and `__filter-input` applying the same `spacer-090` right margin, reset in RTL where the button padding already clears the chevron.
- **List item spacing and contrast**: reduced the primary/secondary text gap from `spacer-040` to `spacer-020`, and set `__element__secondary-text` to `color-label-secondary` so secondary text is visually de-emphasised.

---

## 🧪 Tested scenarios

- Dropdown with and without tags, filterable and non-filterable variants
- LTR and RTL
- List items with and without secondary text

---

## 🔗 Related GitHub Issue / Internal Ticket number

**Closes**:

---
