### PR TITLE
feat: add CSP nonce support for Google Pay

### DIFF
--- a/.changeset/googlepay-nonce.md
+++ b/.changeset/googlepay-nonce.md
@@ -1,0 +1,5 @@
+---
+"@adyen/adyen-web": minor
+---
+
+New: Support Content Security Policy (CSP) nonce in Google Pay configuration and upgrade `@types/googlepay` to `0.7.12`.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,3 +8,4 @@ npmMinimalAgeGate: "21d"
 npmPreapprovedPackages:
   - "vite@6.4.3"
   - "@adyen/*"
+  - "@types/googlepay@0.7.12"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,4 +8,3 @@ npmMinimalAgeGate: "21d"
 npmPreapprovedPackages:
   - "vite@6.4.3"
   - "@adyen/*"
-  - "@types/googlepay@0.7.12"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -139,7 +139,7 @@
     "dependencies": {
         "@paypal/paypal-js": "10.1.0",
         "@types/applepayjs": "14.0.9",
-        "@types/googlepay": "0.7.11",
+        "@types/googlepay": "0.7.12",
         "classnames": "2.5.1",
         "preact": "10.29.8"
     },

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -72,6 +72,17 @@ describe('GooglePay', () => {
             expect(googlepay.props.configuration.merchantId).toBe('merchant-id');
             expect(googlepay.props.configuration.gatewayMerchantId).toBe('gateway-id');
         });
+
+        test('should forward nonce to GooglePayService', () => {
+            new GooglePay(global.core, {
+                configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
+                nonce: 'test-csp-nonce'
+            });
+
+            const [, , callbacks, nonce] = (GooglePayService as unknown as jest.Mock).mock.calls[0];
+            expect(nonce).toBe('test-csp-nonce');
+            expect(callbacks).toHaveProperty('onPaymentAuthorized');
+        });
     });
 
     describe('onClick()', () => {

--- a/packages/lib/src/components/GooglePay/GooglePay.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePay.test.ts
@@ -9,16 +9,29 @@ import { ICore } from '../../types';
 
 jest.mock('./GooglePayService');
 
+const googlePayServiceMock = jest.mocked(GooglePayService);
+
+/**
+ * Retrieves the 'onPaymentAuthorized' callback that the component registers on the GooglePayService
+ */
+function getOnPaymentAuthorizedCallback(): google.payments.api.PaymentAuthorizedHandler {
+    const paymentDataCallbacks = googlePayServiceMock.mock.calls[0][2];
+    if (!paymentDataCallbacks.onPaymentAuthorized) {
+        throw new Error('onPaymentAuthorized callback was not passed to the GooglePayService');
+    }
+    return paymentDataCallbacks.onPaymentAuthorized;
+}
+
+let core: ICore;
+let googlePaymentData: google.payments.api.PaymentData;
+
 beforeEach(() => {
-    // @ts-ignore 'mockClear' is provided by jest.mock
-    GooglePayService.mockClear();
+    googlePayServiceMock.mockClear();
     jest.resetModules();
     jest.resetAllMocks();
-});
 
-let googlePaymentData: Partial<google.payments.api.PaymentData> = {};
+    core = setupCoreMock();
 
-beforeEach(() => {
     googlePaymentData = {
         apiVersionMinor: 0,
         apiVersion: 2,
@@ -58,7 +71,7 @@ beforeEach(() => {
 describe('GooglePay', () => {
     describe('Supporting "paywithgoogle" type as standalone Component', () => {
         test('should load the configuration from payment methods response', () => {
-            const core = setupCoreMock({
+            const coreWithPaymentMethods = setupCoreMock({
                 paymentMethods: new PaymentMethods({
                     paymentMethods: [
                         { name: 'Google Pay', type: 'paywithgoogle', configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } }
@@ -66,20 +79,20 @@ describe('GooglePay', () => {
                 })
             });
 
-            const googlepay = new GooglePay(core);
+            const googlepay = new GooglePay(coreWithPaymentMethods);
 
             expect(googlepay.type).toBe('paywithgoogle');
-            expect(googlepay.props.configuration.merchantId).toBe('merchant-id');
-            expect(googlepay.props.configuration.gatewayMerchantId).toBe('gateway-id');
+            expect(googlepay.props.configuration?.merchantId).toBe('merchant-id');
+            expect(googlepay.props.configuration?.gatewayMerchantId).toBe('gateway-id');
         });
 
         test('should forward nonce to GooglePayService', () => {
-            new GooglePay(global.core, {
+            new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
                 nonce: 'test-csp-nonce'
             });
 
-            const [, , callbacks, nonce] = (GooglePayService as unknown as jest.Mock).mock.calls[0];
+            const [, , callbacks, nonce] = googlePayServiceMock.mock.calls[0];
             expect(nonce).toBe('test-csp-nonce');
             expect(callbacks).toHaveProperty('onPaymentAuthorized');
         });
@@ -87,7 +100,7 @@ describe('GooglePay', () => {
 
     describe('onClick()', () => {
         test('should not call "initiatePayment" if the onClick reject() is called', async () => {
-            const googlepay = new GooglePay(global.core, {
+            const googlepay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
                 onClick(resolve, reject) {
                     reject();
@@ -97,14 +110,12 @@ describe('GooglePay', () => {
             googlepay.submit();
 
             await new Promise(process.nextTick);
-
-            // @ts-ignore GooglePayService is mocked
-            const googlePayServiceInstance = GooglePayService.mock.instances[0];
+            const googlePayServiceInstance = googlePayServiceMock.mock.instances[0];
             expect(googlePayServiceInstance.initiatePayment).not.toHaveBeenCalled();
         });
 
         test('should call "initiatePayment" if the onClick resolve() is called', async () => {
-            const googlepay = new GooglePay(global.core, {
+            const googlepay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
                 onClick(resolve) {
                     resolve();
@@ -113,19 +124,12 @@ describe('GooglePay', () => {
             googlepay.submit();
 
             await new Promise(process.nextTick);
-
-            // @ts-ignore GooglePayService is mocked
-            const googlePayServiceInstance = GooglePayService.mock.instances[0];
+            const googlePayServiceInstance = googlePayServiceMock.mock.instances[0];
             expect(googlePayServiceInstance.initiatePayment).toHaveBeenCalled();
         });
     });
 
     describe('isExpress flag', () => {
-        let core: ICore;
-        beforeEach(() => {
-            core = setupCoreMock();
-        });
-
         test('should add subtype: express when isExpress is configured', () => {
             const googlepay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
@@ -153,7 +157,6 @@ describe('GooglePay', () => {
 
     describe('submit()', () => {
         test('should make the payments call passing deliveryAddress and billingAddress', async () => {
-            const core = setupCoreMock();
             const onSubmitMock = jest.fn().mockImplementation((data, component, actions) => {
                 actions.resolve({
                     resultCode: 'Authorized'
@@ -165,11 +168,9 @@ describe('GooglePay', () => {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
                 onSubmit: onSubmitMock,
                 onPaymentCompleted: onPaymentCompletedMock,
-                i18n: global.i18n
+                i18n: core.modules.i18n
             });
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
             const promise = onPaymentAuthorized(googlePaymentData);
 
             await new Promise(process.nextTick);
@@ -222,7 +223,6 @@ describe('GooglePay', () => {
         });
 
         test('should not add deliveryAddress and billingAddress if they are not available', async () => {
-            const core = setupCoreMock();
             const onSubmitMock = jest.fn().mockImplementation((data, component, actions) => {
                 actions.resolve({
                     resultCode: 'Authorized'
@@ -231,16 +231,14 @@ describe('GooglePay', () => {
 
             const gpay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
-                i18n: global.i18n,
+                i18n: core.modules.i18n,
                 onSubmit: onSubmitMock
             });
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
             const googlePaymentDataWithoutAddresses = { ...googlePaymentData };
             delete googlePaymentDataWithoutAddresses.shippingAddress;
-            delete googlePaymentDataWithoutAddresses.paymentMethodData.info.billingAddress;
-            onPaymentAuthorized(googlePaymentDataWithoutAddresses);
+            delete googlePaymentDataWithoutAddresses.paymentMethodData.info?.billingAddress;
+            void onPaymentAuthorized(googlePaymentDataWithoutAddresses);
 
             await new Promise(process.nextTick);
             expect(onSubmitMock).toHaveBeenCalledTimes(1);
@@ -262,7 +260,6 @@ describe('GooglePay', () => {
         });
 
         test('should pass error to GooglePay if payment failed', async () => {
-            const core = setupCoreMock();
             const onSubmitMock = jest.fn().mockImplementation((data, component, actions) => {
                 actions.resolve({
                     resultCode: 'Refused',
@@ -275,13 +272,11 @@ describe('GooglePay', () => {
 
             const gpay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
-                i18n: global.i18n,
+                i18n: core.modules.i18n,
                 onSubmit: onSubmitMock,
                 onPaymentFailed: onPaymentFailedMock
             });
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
             const promise = onPaymentAuthorized(googlePaymentData);
 
             await new Promise(process.nextTick);
@@ -311,7 +306,6 @@ describe('GooglePay', () => {
         });
 
         test('should pass error to GooglePay when action.reject is called without parameters', async () => {
-            const core = setupCoreMock();
             const onSubmitMock = jest.fn().mockImplementation((data, component, actions) => {
                 actions.reject();
             });
@@ -319,13 +313,11 @@ describe('GooglePay', () => {
 
             const gpay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
-                i18n: global.i18n,
+                i18n: core.modules.i18n,
                 onSubmit: onSubmitMock,
                 onPaymentFailed: onPaymentFailedMock
             });
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
             const promise = onPaymentAuthorized(googlePaymentData);
 
             await new Promise(process.nextTick);
@@ -401,14 +393,12 @@ describe('GooglePay', () => {
 
         test('should provide GooglePay auth event and formatted data', () => {
             const onAuthorizedMock = jest.fn();
-            new GooglePay(global.core, {
+            new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
                 onAuthorized: onAuthorizedMock
             });
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
-            onPaymentAuthorized(googlePaymentData);
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
+            void onPaymentAuthorized(googlePaymentData);
 
             expect(onAuthorizedMock.mock.calls[0][0]).toStrictEqual(event);
         });
@@ -419,15 +409,13 @@ describe('GooglePay', () => {
             });
             const onPaymentFailedMock = jest.fn();
 
-            new GooglePay(global.core, {
+            new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
-                i18n: global.i18n,
+                i18n: core.modules.i18n,
                 onAuthorized: onAuthorizedMock,
                 onPaymentFailed: onPaymentFailedMock
             });
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
             const promise = onPaymentAuthorized(googlePaymentData);
 
             await expect(promise).resolves.toEqual({
@@ -449,34 +437,30 @@ describe('GooglePay', () => {
             });
             const onPaymentCompletedMock = jest.fn();
 
-            const gpay = new GooglePay(global.core, {
+            const gpay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
-                i18n: global.i18n,
+                i18n: core.modules.i18n,
                 onAuthorized: onAuthorizedMock,
                 onPaymentCompleted: onPaymentCompletedMock
             });
 
             const paymentCall = jest.spyOn(gpay as any, 'makePaymentsCall');
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
-            onPaymentAuthorized(googlePaymentData);
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
+            void onPaymentAuthorized(googlePaymentData);
 
             await new Promise(process.nextTick);
             expect(paymentCall).toHaveBeenCalledTimes(1);
         });
 
         test('should make the payments call if onAuthorized is not provided', async () => {
-            const gpay = new GooglePay(global.core, {
+            const gpay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
-                i18n: global.i18n
+                i18n: core.modules.i18n
             });
 
             const paymentCall = jest.spyOn(gpay as any, 'makePaymentsCall');
-
-            // @ts-ignore GooglePayService is mocked
-            const onPaymentAuthorized = GooglePayService.mock.calls[0][2].onPaymentAuthorized;
-            onPaymentAuthorized(googlePaymentData);
+            const onPaymentAuthorized = getOnPaymentAuthorizedCallback();
+            void onPaymentAuthorized(googlePaymentData);
 
             await new Promise(process.nextTick);
             expect(paymentCall).toHaveBeenCalledTimes(1);
@@ -485,7 +469,7 @@ describe('GooglePay', () => {
 
     describe('isAvailable()', () => {
         test('should resolve if GooglePay is available', async () => {
-            const gpay = new GooglePay(global.core, { configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } });
+            const gpay = new GooglePay(core, { configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } });
             gpay.isReadyToPay = jest.fn(() => {
                 return Promise.resolve({ result: true });
             });
@@ -494,7 +478,7 @@ describe('GooglePay', () => {
         });
 
         test('should reject if is not available', async () => {
-            const gpay = new GooglePay(global.core, { configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } });
+            const gpay = new GooglePay(core, { configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } });
             gpay.isReadyToPay = jest.fn(() => {
                 return Promise.resolve({ result: false });
             });
@@ -503,7 +487,7 @@ describe('GooglePay', () => {
         });
 
         test('should reject if "paymentMethodPresent" is false', async () => {
-            const gpay = new GooglePay(global.core, { configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } });
+            const gpay = new GooglePay(core, { configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' } });
             gpay.isReadyToPay = jest.fn(() => {
                 return Promise.resolve({ result: true, paymentMethodPresent: false });
             });
@@ -515,7 +499,7 @@ describe('GooglePay', () => {
     describe('Process CA based configuration data', () => {
         describe('brands', () => {
             test('should parse "brands" from configuration if available', () => {
-                const gpay = new GooglePay(global.core, {
+                const gpay = new GooglePay(core, {
                     configuration: {
                         merchantId: 'adyen',
                         gatewayMerchantId: 'adyen'
@@ -526,7 +510,7 @@ describe('GooglePay', () => {
             });
 
             test('should ignore "brands" from configuration if "allowedCardNetworks" is set', () => {
-                const gpay = new GooglePay(global.core, {
+                const gpay = new GooglePay(core, {
                     configuration: {
                         merchantId: 'adyen',
                         gatewayMerchantId: 'adyen'
@@ -538,7 +522,7 @@ describe('GooglePay', () => {
             });
 
             test('should set default "allowedCardNetworks" values if "brands" and "allowedCardNetworks" props are not set', () => {
-                const gpay = new GooglePay(global.core, {
+                const gpay = new GooglePay(core, {
                     configuration: {
                         merchantId: 'adyen',
                         gatewayMerchantId: 'adyen'
@@ -549,33 +533,31 @@ describe('GooglePay', () => {
         });
 
         test('Retrieves merchantId from configuration', () => {
-            const gpay = new GooglePay(global.core, { configuration: { merchantId: 'abcdef', gatewayMerchantId: 'TestMerchant' } });
-            expect(gpay.props.configuration.merchantId).toEqual('abcdef');
+            const gpay = new GooglePay(core, { configuration: { merchantId: 'abcdef', gatewayMerchantId: 'TestMerchant' } });
+            expect(gpay.props.configuration?.merchantId).toEqual('abcdef');
         });
 
         test('Retrieves merchantOrigin from configuration', () => {
-            const gpay = new GooglePay(global.core, {
+            const gpay = new GooglePay(core, {
                 configuration: {
                     merchantId: 'abcdef',
                     gatewayMerchantId: 'TestMerchant',
                     merchantOrigin: 'example.com'
                 }
             });
-            expect(gpay.props.configuration.merchantOrigin).toEqual('example.com');
+            expect(gpay.props.configuration?.merchantOrigin).toEqual('example.com');
         });
 
         test('Retrieves authJwt from configuration', () => {
-            const gpay = new GooglePay(global.core, {
+            const gpay = new GooglePay(core, {
                 configuration: { merchantId: 'abcdef', gatewayMerchantId: 'TestMerchant', authJwt: 'jwt.code' }
             });
-            expect(gpay.props.configuration.authJwt).toEqual('jwt.code');
+            expect(gpay.props.configuration?.authJwt).toEqual('jwt.code');
         });
     });
 
     describe('Analytics', () => {
         test('should send rendered event', () => {
-            const core = setupCoreMock();
-
             const googlepay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
                 showPayButton: false,
@@ -602,8 +584,6 @@ describe('GooglePay', () => {
         });
 
         test('should send "selected" event if payment flow is triggered when using instant payment button', () => {
-            const core = setupCoreMock();
-
             const googlepay = new GooglePay(core, {
                 configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
                 type: 'googlepay',

--- a/packages/lib/src/components/GooglePay/GooglePay.tsx
+++ b/packages/lib/src/components/GooglePay/GooglePay.tsx
@@ -45,10 +45,15 @@ class GooglePay extends UIElement<GooglePayConfiguration> {
             );
         }
 
-        this.googlePay = new GooglePayService(this.props.environment, this.analytics, {
-            ...(isExpress && paymentDataCallbacks?.onPaymentDataChanged && { onPaymentDataChanged: paymentDataCallbacks.onPaymentDataChanged }),
-            onPaymentAuthorized: this.onPaymentAuthorized
-        });
+        this.googlePay = new GooglePayService(
+            this.props.environment,
+            this.analytics,
+            {
+                ...(isExpress && paymentDataCallbacks?.onPaymentDataChanged && { onPaymentDataChanged: paymentDataCallbacks.onPaymentDataChanged }),
+                onPaymentAuthorized: this.onPaymentAuthorized
+            },
+            this.props.nonce
+        );
     }
 
     /**

--- a/packages/lib/src/components/GooglePay/GooglePayEnvironment.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayEnvironment.test.ts
@@ -83,4 +83,35 @@ describe('GooglePay environment resolution', () => {
 
         expect(getGooglePaymentsClientSpy).toHaveBeenCalledWith(expect.objectContaining({ environment: 'TEST' }));
     });
+
+    test('should pass nonce to getGooglePaymentsClient when nonce is provided', async () => {
+        const checkout = new AdyenCheckout({
+            environment: 'test',
+            clientKey: 'test_123456',
+            countryCode: 'US'
+        });
+        await checkout.initialize();
+
+        new GooglePay(checkout, {
+            configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' },
+            nonce: 'csp-test-nonce'
+        });
+
+        expect(getGooglePaymentsClientSpy).toHaveBeenCalledWith(expect.objectContaining({ environment: 'TEST', nonce: 'csp-test-nonce' }));
+    });
+
+    test('should not include nonce in getGooglePaymentsClient when nonce is not provided', async () => {
+        const checkout = new AdyenCheckout({
+            environment: 'test',
+            clientKey: 'test_123456',
+            countryCode: 'US'
+        });
+        await checkout.initialize();
+
+        new GooglePay(checkout, {
+            configuration: { merchantId: 'merchant-id', gatewayMerchantId: 'gateway-id' }
+        });
+
+        expect(getGooglePaymentsClientSpy).toHaveBeenCalledWith(expect.not.objectContaining({ nonce: expect.anything() }));
+    });
 });

--- a/packages/lib/src/components/GooglePay/GooglePayService.test.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayService.test.ts
@@ -1,0 +1,68 @@
+import GooglePayService from './GooglePayService';
+import Script from '../../utils/Script';
+import { mock } from 'jest-mock-extended';
+import type { IAnalytics } from '../../core/Analytics/Analytics';
+
+jest.mock('../../utils/Script');
+
+const mockAnalytics = mock<IAnalytics>();
+
+describe('GooglePayService', () => {
+    const mockPaymentsClientConstructor = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // @ts-ignore Mock Script load method
+        (Script as jest.Mock).mockImplementation(() => ({
+            load: jest.fn().mockImplementation(() => {
+                (window as any).google = {
+                    payments: {
+                        api: {
+                            PaymentsClient: mockPaymentsClientConstructor
+                        }
+                    }
+                };
+                return Promise.resolve();
+            })
+        }));
+        delete (window as any).google;
+    });
+
+    test('should pass nonce to Script attributes and PaymentOptions when nonce is provided', async () => {
+        const service = new GooglePayService('test', mockAnalytics, {}, 'csp-nonce-123');
+        await service.paymentsClient;
+
+        expect(Script).toHaveBeenCalledWith(
+            expect.objectContaining({
+                component: 'googlepay',
+                attributes: {
+                    nonce: 'csp-nonce-123'
+                }
+            })
+        );
+
+        expect(mockPaymentsClientConstructor).toHaveBeenCalledWith(
+            expect.objectContaining({
+                environment: 'TEST',
+                nonce: 'csp-nonce-123'
+            })
+        );
+    });
+
+    test('should not include nonce in Script attributes or PaymentOptions when nonce is omitted', async () => {
+        const service = new GooglePayService('test', mockAnalytics, {});
+        await service.paymentsClient;
+
+        expect(Script).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                attributes: expect.anything()
+            })
+        );
+
+        expect(mockPaymentsClientConstructor).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                nonce: expect.anything()
+            })
+        );
+    });
+});

--- a/packages/lib/src/components/GooglePay/GooglePayService.ts
+++ b/packages/lib/src/components/GooglePay/GooglePayService.ts
@@ -10,13 +10,14 @@ class GooglePayService {
 
     public readonly paymentsClient: Promise<google.payments.api.PaymentsClient>;
 
-    constructor(environment: string, analytics: IAnalytics, paymentDataCallbacks: google.payments.api.PaymentDataCallbacks) {
+    constructor(environment: string, analytics: IAnalytics, paymentDataCallbacks: google.payments.api.PaymentDataCallbacks, nonce?: string) {
         const googlePayEnvironment = resolveEnvironment(environment);
 
         this.analytics = analytics;
         this.paymentsClient = this.getGooglePaymentsClient({
             environment: googlePayEnvironment,
-            paymentDataCallbacks
+            paymentDataCallbacks,
+            ...(nonce && { nonce })
         });
     }
 
@@ -28,7 +29,12 @@ class GooglePayService {
      */
     async getGooglePaymentsClient(paymentOptions: google.payments.api.PaymentOptions): Promise<google.payments.api.PaymentsClient> {
         if (!window.google?.payments) {
-            const script = new Script({ src: config.URL, component: 'googlepay', analytics: this.analytics });
+            const script = new Script({
+                src: config.URL,
+                component: 'googlepay',
+                analytics: this.analytics,
+                ...(paymentOptions.nonce && { attributes: { nonce: paymentOptions.nonce } })
+            });
             await script.load();
         }
 

--- a/packages/lib/src/components/GooglePay/types.ts
+++ b/packages/lib/src/components/GooglePay/types.ts
@@ -6,6 +6,13 @@ export interface GooglePayConfiguration extends UIElementProps {
     type?: 'googlepay' | 'paywithgoogle';
 
     /**
+     * Optional Content Security Policy (CSP) nonce to apply to all dynamically injected styles and scripts.
+     *
+     * @see https://developers.google.com/pay/api/web/reference/request-objects#PaymentOptions
+     */
+    nonce?: string;
+
+    /**
      * List of brands accepted by the component. Values are configured on the Backoffice and returned in the /paymentMethodsResponse data
      * @internal
      */

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,7 +99,7 @@ __metadata:
     "@testing-library/preact-hooks": "npm:1.1.0"
     "@testing-library/user-event": "npm:14.6.3"
     "@types/applepayjs": "npm:14.0.9"
-    "@types/googlepay": "npm:0.7.11"
+    "@types/googlepay": "npm:0.7.12"
     "@types/jest": "npm:30.0.0"
     autoprefixer: "npm:10.5.4"
     classnames: "npm:2.5.1"
@@ -4435,10 +4435,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/googlepay@npm:0.7.11":
-  version: 0.7.11
-  resolution: "@types/googlepay@npm:0.7.11"
-  checksum: 10c0/50c4dde745e0da9614037677d313af755285612260e5585eb9a8c918900ca45e236c51c721b52d6e15c3b89193cddb05ad09d0db5c8203c2d1489ef714cc3c64
+"@types/googlepay@npm:0.7.12":
+  version: 0.7.12
+  resolution: "@types/googlepay@npm:0.7.12"
+  checksum: 10c0/0700728c4482dd7f293344a9620c5c6fd4be9f24433a9f8250550f23c039892b998983b8de075aeed289076922f8cfc6699de5be34edc21bf0844b9ed4babf76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [x] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- ~~[] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes~~
- ~~[] All E2E tests are passing, and I have added new tests if necessary.~~
- [x] All interfaces and types introduced or updated are strictly typed. 
- ~~[ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR.~~
---

## 📝 Summary

### Motivation

Google Pay now supports Content Security Policy (CSP) nonces in the [PaymentOptions](https://developers.google.com/pay/api/web/reference/request-objects#PaymentOptions) object to allow seamless integration on websites enforcing strict CSP headers (without requiring `'unsafe-inline'`).

### Problem Solved

Previously, merchants implementing strict CSP policies could not supply a nonce to Google Pay. This could lead to CSP violations when loading Google's pay.js script and when Google Pay dynamically injected inline styles or iframes for the Google Pay button and payment sheets.

---

## 🧪 Tested scenarios

- **Script Tag Nonce Injection**: Verified via unit tests that providing a `nonce` populates the `attributes.nonce` property when loading the `pay.js` bundle via the `Script` utility.
- **PaymentsClient Options Propagation**: Verified via unit tests that `PaymentOptions` supplied to `new google.payments.api.PaymentsClient()` includes `{ nonce: '...' }` when configured.
- **Backwards Compatibility / Nonce Omission**: Verified that when `nonce` is not provided in `GooglePayConfiguration`, neither the script attributes nor `PaymentOptions` contain a `nonce` key.
- **Component Forwarding**: Verified that instantiating `new GooglePay(checkout, { nonce: '...' })` forwards the nonce correctly to `GooglePayService`.
---

cherry-pick from #4155 