### PR TITLE
Drop-in - Payment methods no longer lose their state when another payment method is selected

### DIFF
--- a/.changeset/quiet-moons-rest.md
+++ b/.changeset/quiet-moons-rest.md
@@ -1,0 +1,5 @@
+---
+'@adyen/adyen-web': patch
+---
+
+Fixed: Drop-in payment methods no longer lose their state when another payment method is selected in the list.

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodDetails.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodDetails.test.tsx
@@ -1,0 +1,100 @@
+import { h } from 'preact';
+import { render, screen } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
+import userEvent from '@testing-library/user-event';
+import { mock } from 'jest-mock-extended';
+
+import { PaymentMethodDetails } from './PaymentMethodDetails';
+import UIElement from '../../../internal/UIElement/UIElement';
+
+function StatefulInput({ testId }: Readonly<{ testId: string }>) {
+    const [value, setValue] = useState('');
+    return <input data-testid={testId} value={value} onInput={event => setValue((event.target as HTMLInputElement).value)} />;
+}
+
+function createPaymentMethodMock(id: string) {
+    return mock<UIElement>({ type: 'scheme', _id: id, render: jest.fn(() => <StatefulInput testId={`${id}-input`} />) });
+}
+
+/** Mimics Drop-in list, where at most one payment method is selected at a time */
+function PaymentMethodListWrapper({ paymentMethodComponents }: Readonly<{ paymentMethodComponents: UIElement[] }>) {
+    const [selected, setSelected] = useState<UIElement>(null);
+    return (
+        <div>
+            {paymentMethodComponents.map(paymentMethodComponent => (
+                <div key={paymentMethodComponent._id}>
+                    <button onClick={() => setSelected(selected === paymentMethodComponent ? null : paymentMethodComponent)}>
+                        {`toggle ${paymentMethodComponent._id}`}
+                    </button>
+                    <PaymentMethodDetails paymentMethodComponent={paymentMethodComponent} isSelected={selected === paymentMethodComponent} />
+                </div>
+            ))}
+        </div>
+    );
+}
+
+test('should not render the payment method until it gets selected', async () => {
+    const user = userEvent.setup();
+    const paymentMethod = createPaymentMethodMock('card');
+
+    render(<PaymentMethodListWrapper paymentMethodComponents={[paymentMethod]} />);
+
+    expect(paymentMethod.render).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('card-input')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'toggle card' }));
+
+    expect(paymentMethod.render).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('card-input')).toBeVisible();
+});
+
+test('should reuse the previous render, keeping the payment method state, when it gets deselected', async () => {
+    const user = userEvent.setup();
+    const paymentMethod = createPaymentMethodMock('card');
+
+    render(<PaymentMethodListWrapper paymentMethodComponents={[paymentMethod]} />);
+
+    await user.click(screen.getByRole('button', { name: 'toggle card' }));
+    await user.type(screen.getByTestId('card-input'), 'hello');
+
+    // deselect
+    await user.click(screen.getByRole('button', { name: 'toggle card' }));
+
+    expect(paymentMethod.render).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('card-input')).toHaveValue('hello');
+});
+
+test('should render again, keeping the payment method state, when it gets selected once more', async () => {
+    const user = userEvent.setup();
+    const paymentMethod = createPaymentMethodMock('card');
+
+    render(<PaymentMethodListWrapper paymentMethodComponents={[paymentMethod]} />);
+
+    await user.click(screen.getByRole('button', { name: 'toggle card' }));
+    await user.type(screen.getByTestId('card-input'), 'hello');
+
+    // deselect and select again
+    await user.click(screen.getByRole('button', { name: 'toggle card' }));
+    await user.click(screen.getByRole('button', { name: 'toggle card' }));
+
+    expect(paymentMethod.render).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('card-input')).toHaveValue('hello');
+});
+
+test('should keep the state of the first payment method after selecting the other ones and coming back to it', async () => {
+    const user = userEvent.setup();
+    const paymentMethods = ['first', 'second', 'third'].map(createPaymentMethodMock);
+
+    render(<PaymentMethodListWrapper paymentMethodComponents={paymentMethods} />);
+
+    await user.click(screen.getByRole('button', { name: 'toggle first' }));
+    await user.type(screen.getByTestId('first-input'), 'hello');
+
+    await user.click(screen.getByRole('button', { name: 'toggle second' }));
+    await user.click(screen.getByRole('button', { name: 'toggle third' }));
+    await user.click(screen.getByRole('button', { name: 'toggle first' }));
+
+    expect(screen.getByTestId('first-input')).toHaveValue('hello');
+    expect(screen.getByTestId('second-input')).toHaveValue('');
+    expect(screen.getByTestId('third-input')).toHaveValue('');
+});

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodDetails.test.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodDetails.test.tsx
@@ -18,7 +18,7 @@ function createPaymentMethodMock(id: string) {
 
 /** Mimics Drop-in list, where at most one payment method is selected at a time */
 function PaymentMethodListWrapper({ paymentMethodComponents }: Readonly<{ paymentMethodComponents: UIElement[] }>) {
-    const [selected, setSelected] = useState<UIElement>(null);
+    const [selected, setSelected] = useState<UIElement | null>(null);
     return (
         <div>
             {paymentMethodComponents.map(paymentMethodComponent => (

--- a/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodDetails.tsx
+++ b/packages/lib/src/components/Dropin/components/PaymentMethod/PaymentMethodDetails.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { memo } from 'preact/compat';
+import { useRef } from 'preact/hooks';
 import UIElement from '../../../internal/UIElement';
 
 interface PaymentMethodDetailsProps {
@@ -8,25 +8,24 @@ interface PaymentMethodDetailsProps {
 }
 
 /**
- * The payment method 'render()' trigger analytics. If a Component is removed from the DOM, the state is reset.
- * In order to preserve the state and also trigger analytics when a Component is selected, we cache renders when
- * the 'isSelect' changes from true -> false
+ * The payment method 'render()' triggers analytics, therefore it must be called only when the payment method gets
+ * selected by the shopper. On any other re-render we re-use the vnode created by the previous 'render()' call, so that
+ * analytics events aren't duplicated and the Component isn't unmounted (which would reset its state).
  */
-function isComponentCached(oldProps: PaymentMethodDetailsProps, newProps: PaymentMethodDetailsProps) {
-    const isInitialRender = oldProps.isSelected === null;
+const PaymentMethodDetails = ({ paymentMethodComponent, isSelected }: Readonly<PaymentMethodDetailsProps>) => {
+    const renderedComponent = useRef<h.JSX.Element>(null);
+    const wasSelected = useRef<boolean>(false);
 
-    if (isInitialRender) return false;
+    if (isSelected && !wasSelected.current) {
+        renderedComponent.current = paymentMethodComponent.render();
+    }
+    wasSelected.current = isSelected;
 
-    const componentIsDeselected = oldProps.isSelected === true && newProps.isSelected === false;
-    return componentIsDeselected;
-}
-
-const PaymentMethodDetails = memo(({ paymentMethodComponent, isSelected }: Readonly<PaymentMethodDetailsProps>) => {
-    if (!isSelected) {
+    if (!renderedComponent.current) {
         return null;
     }
 
-    return <div className={'adyen-checkout__payment-method__details__content'}>{paymentMethodComponent.render()}</div>;
-}, isComponentCached);
+    return <div className={'adyen-checkout__payment-method__details__content'}>{renderedComponent.current}</div>;
+};
 
 export { PaymentMethodDetails };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## 📋 Pull Request Checklist
<!--
Check the checkboxes that are relevant for your pull request.
-->

- [x] I have added unit tests to cover my changes.
- [ ] I have added or updated Storybook stories where applicable.
- [x] I have tested the changes manually in the local environment.
- [x] I have checked that no PII data is being sent on analytics events
- [ ] If adding new analytics events: I have verified the structure of these events with the Data team; and asked the API team to make the necessary backend changes
- [ ] All E2E tests are passing, and I have added new tests if necessary.
- [x] All interfaces and types introduced or updated are strictly typed. 
- [ ] If new translation keys are required: I have created these, had them translated & published; and have generated the new files and added them to this PR. 
---

## 📝 Summary

The usage of `memo` was flaky and it was leading to a scenario where the rendered payment method content would be totally dismissed and re-created, losing its existing state. The code was also hard to read and understand.

This PR makes `PaymentMethodDetails` cache the result of `render()` differently, without using the `memo`:
 
- `render()` is invoked only on a `false -> true` selection transition, so the `rendered` event is sent when the shopper actually opens a payment method, and never on incidental re-renders.
- While the payment method is deselected (or re-rendered while still selected), the previously produced vnode is returned instead of `null`. The whole subtree, including its DOM and component state, is retained untouched.
- Payment methods that have never been selected still render nothing, keeping the list lazy.

---

## 🧪 Tested scenarios
 
Unit tests added in `PaymentMethodDetails.test.tsx` (4 tests), all of which were confirmed to fail against the naive `return null` implementation:
 
- A payment method is not rendered until it gets selected (`render()` not called, no DOM output).
- Deselecting a payment method keeps its state and does not trigger another `render()` call.
- Re-selecting a payment method calls `render()` again (so analytics is sent per selection) while keeping its state.
- **Regression case:** with three payment methods, filling in the first, selecting the second and third, then returning to the first preserves the filled-in value, and the other two remain empty.

---

